### PR TITLE
gui util img: fix legend export chopping on non UTF8 text

### DIFF
--- a/src/odemis/gui/util/img.py
+++ b/src/odemis/gui/util/img.py
@@ -1385,10 +1385,10 @@ def draw_export_legend(legend_ctx, images, buffer_size, buffer_scale,
         legend_ctx.paint()
         legend_ctx.restore()
 
-    # write stream data
+    # Write stream data, sorted by acquisition date (and fallback on stable order)
     legend_ctx.set_font_size(small_font)
     legend_y_pos = big_cell_height
-    sorted_data = sorted(streams_data.items(), key=operator.itemgetter(1))
+    sorted_data = sorted(streams_data.items(), key=lambda d: (d[1][0], hash(d[0])))
     for s, (_, data) in sorted_data:
         legend_ctx.set_font_size(small_font)
         if s == stream:


### PR DESCRIPTION
On some data with some specific metadata, the stream sorting would fail with such error:
ERROR   log:37: Failed to export a spatial view as PNG
:
  File "/usr/lib/python2.7/dist-packages/odemis/gui/util/img.py", line 1843, in images_to_export_data
    view_hfw[1], last_image.metadata['date'], streams_data, last_image.metadata['stream'] if (not rgb) else None, logo=logo)
  File "/usr/lib/python2.7/dist-packages/odemis/gui/util/img.py", line 1395, in draw_export_legend
    sorted_data = sorted(streams_data.items(), key=operator.itemgetter(1))
UnicodeDecodeError: 'utf8' codec can't decode byte 0x8e in position 0: invalid start byte

It seems to only happen when multiple stream have the same acquisition time and the metadata was directly
set from an acquisition (instead of being read from a file).

I couldn't find out yet which text contains some non unicode value,
but anyway, it doesn't make sense to sort based on the text.

=> explicitly sort just on the date (with a fallback on the hash stream to keep the order constant between calls)