### PR TITLE
Pyramidal write tiff pr

### DIFF
--- a/src/odemis/util/img.py
+++ b/src/odemis/util/img.py
@@ -454,20 +454,17 @@ def ensureYXC(data):
     return model.DataArray(data, md)
 
 
-# FIXME: test it
 def rescale_hq(data, shape):
     """
     Resize the image to the new given shape (smaller or bigger). It tries to
     smooth the pixels. Metadata is updated.
-    data (DataArray of shape YX): data to be rescaled
-    shape (2 int>0): the new shape of the image (Y,X). The new data will fit
-      precisely, even if the ratio is different.
-    return (DataArray of shape YX): The image rescaled. If the metadata contains
-      information that is linked to the size (e.g, pixel size), it is also
-      updated.
+    data (DataArray or numpy.array): Data to be rescaled
+    shape (tuple): the new shape of the image. It needs to be the same size as the data.shape.
+    return (DataArray or numpy.array): The image rescaled. It has the same shape
+        as the 'shape' parameter. The returned object has the same type of the 'data' parameter
     """
-    # TODO: support RGB(A) images
     # TODO: make it faster
+
     out = numpy.empty(shape, dtype=data.dtype)
     scale = tuple(n / o for o, n in zip(data.shape, shape))
     scipy.ndimage.interpolation.zoom(data, zoom=scale, output=out, order=1, prefilter=False)

--- a/src/odemis/util/test/img_test.py
+++ b/src/odemis/util/test/img_test.py
@@ -678,6 +678,58 @@ class TestRGB2Greyscale(unittest.TestCase):
         self.assertEqual(gsim.shape, rgbim.shape[0:2])
         self.assertEqual(gsim[1, 1], 254)
 
+class TestRescaleHQ(unittest.TestCase):
+
+    def test_simple(self):
+        size = (1024, 512)
+        depth = 2 ** 12
+        img12 = numpy.zeros(size, dtype="uint16") + depth // 2
+        watermark = 538
+        # write a square of watermark
+        img12[20:40, 50:70] = watermark
+
+        # rescale
+        out = img.rescale_hq(img12, (512, 256))
+        self.assertEqual(out.shape, (512, 256))
+        # test if the watermark is in the right place
+        self.assertEqual(out[15, 30], watermark)
+        self.assertEqual(out[30, 60], depth // 2)
+
+    def test_data_array_metadata(self):
+        size = (1024, 512)
+        depth = 2 ** 12
+        img12 = numpy.zeros(size, dtype="uint16") + depth // 2
+        watermark = 538
+        # write a square of watermark
+        img12[20:40, 50:70] = watermark
+        metadata = {
+            model.MD_PIXEL_SIZE: (1e-6, 2e-5),
+            model.MD_BINNING: (1, 1),
+            model.MD_AR_POLE: (253.1, 65.1)
+        }
+        img12da = model.DataArray(img12, metadata)
+
+        # rescale
+        out = img.rescale_hq(img12da, (512, 256))
+        self.assertEqual(out.shape, (512, 256))
+        # test if the watermark is in the right place
+        self.assertEqual(out[15, 30], watermark)
+        self.assertEqual(out[30, 60], depth // 2)
+
+        # assert metadata
+        self.assertEqual(out.metadata[model.MD_PIXEL_SIZE], (2e-06, 4e-05))
+        self.assertEqual(out.metadata[model.MD_BINNING], (2.0, 2.0))
+        self.assertEqual(out.metadata[model.MD_AR_POLE], (126.55, 32.55))
+
+    def test_5d(self):
+        # C=3, T=2, Z=2, Y=1024, X=512
+        size = (3, 2, 2, 1024, 512)
+        background = 58
+        img_in = numpy.zeros(size, dtype="uint8") + background
+        img_in = model.DataArray(img_in)
+        out = img.rescale_hq(img_in, (3, 2, 2, 512, 256))
+        self.assertEqual(out.shape, (3, 2, 2, 512, 256))
+
 
 # TODO: test guessDRange()
 


### PR DESCRIPTION
Update the function util.img.rescale_hq to support RGB images and images with more than 2 dimensions in general.
Added the support to generate pyramidal images. Added the dataio.tiff.write_image function.