### PR TITLE
Reorganization of DataArrayShadow and AcquisitionData

### DIFF
--- a/src/odemis/model/_dataio.py
+++ b/src/odemis/model/_dataio.py
@@ -27,8 +27,18 @@ class DataArrayShadow(object):
     """
     This class contains information about a DataArray.
     It has all the useful attributes of a DataArray, but not the actual data.
+    If the image represented by an instance of this class is tiled, it should have a
+    method called 'getTile', that fetches one tile from the image. 
+    It should have the following parameters, and return:
+        x (0<=int): X index of the tile.
+        y (0<=int): Y index of the tile
+        zoom (0<=int): zoom level to use. The total shape of the image is shape / 2**zoom.
+            The number of tiles available in an image is ceil((shape//zoom)/tile_shape)
+        return (DataArray): the shape of the DataArray is typically of shape
     """
-    def __init__(self, shape, dtype, metadata=None, maxzoom=None):
+    __metaclass__ = ABCMeta
+
+    def __init__(self, shape, dtype, metadata=None, maxzoom=None, tile_shape=None):
         """
         Constructor
         shape (tuple of int): The shape of the corresponding DataArray
@@ -39,6 +49,8 @@ class DataArrayShadow(object):
             The shape of the images in each zoom level is as following:
             (shape of full image) // (2**z)
             where z is the index of the zoom level
+        tile_shape (tuple): the shape of the tile, if the image is tiled. It is only present
+            when maxzoom is also present
         """
         self.shape = shape
         self.ndim = len(shape)
@@ -46,6 +58,18 @@ class DataArrayShadow(object):
         self.metadata = metadata if metadata else {}
         if maxzoom is not None:
             self.maxzoom = maxzoom
+            self.tile_shape = tile_shape
+
+    @abstractmethod
+    def getData(self, n):
+        """
+        Fetches the whole data (at full resolution) of image at index n.
+        n (0<=int): index of the image
+        return DataArray: the data, with its metadata (ie, identical to .content[n] but
+            with the actual data)
+        """
+        pass
+
 
 class AcquisitionData(object):
     """
@@ -58,47 +82,3 @@ class AcquisitionData(object):
     def __init__(self, content, thumbnails=None):
         self.content = content
         self.thumbnails = thumbnails if thumbnails else ()
-
-    @abstractmethod
-    def getData(self, n):
-        """
-        Fetches the whole data (at full resolution) of image at index n.
-        n (0<=int): index of the image
-        return DataArray: the data, with its metadata (ie, identical to .content[n] but
-            with the actual data)
-        """
-        pass
-
-    @abstractmethod
-    def getSubData(self, n, z, rect):
-        """
-        Fetches a part of the data, for a given zoom. If the (complete) data has more
-        than two dimensions, all the extra dimensions (ie, non-spatial) are always fully
-        returned for the given part.
-        n (int): index of the image
-        z (0 <= int) : zoom level. The data returned will be with MD_PIXEL_SIZE * 2^z.
-            So 0 means to use the highest zoom, with the original pixel size. 1 will
-            return data half the width and heigh (The maximum possible value depends
-            on the data).
-        rect (4 ints): left, top, right, bottom coordinates (in px, at zoom=0) of the
-            area of interest.
-        return (tuple of tuple of DataArray): all the tiles in X&Y dimension, so that
-            the area of interest is fully covered (so the area can be larger than requested).
-            The first dimension is X, and second is Y. For example, if returning 3x7 tiles,
-            the most bottom-right tile will be accessed as ret[2][6]. For each
-            DataArray.metadata, MD_POS and MD_PIXEL_SIZE are updated appropriately
-            (if MD_POS is not present, (0,0) is used as default for the entire image, and if
-            MD_PIXEL_SIZE is not present, it will not be updated).
-        raise ValueError: if the area or z is out of range, or if the raw data is not pyramidal.
-        """
-        pass
-
-    @abstractmethod
-    def getThumbnail(self, n):
-        """
-        Fetches the whole data (at full resolution) of a thumbnail image at index n.
-        n (0<=int): index of the image
-        return DataArray: the data, with its metadata (ie, identical to .thumbnail[n] but
-            with the actual data)
-        """
-        pass


### PR DESCRIPTION
and AcquisitionData, and creation of DataArrayShadowTIFF class.
DataArrayShadow inherited much of the functionality from the
AcquisitionData class.
Public function of the new DataArrayShadow are:
getData: reads an entire image.
getTile: reads a tile, given a X, Y, and a zoom level.
The DataArrayShadowTIFF instance now has the handles of the tiff files.