### PR TITLE
Extension of StaticStream objects to support pyramidal data update

### DIFF
--- a/src/odemis/acq/stream/__init__.py
+++ b/src/odemis/acq/stream/__init__.py
@@ -228,7 +228,13 @@ class StreamTree(object):
                 images.extend(s.getImages())
             elif isinstance(s, Stream):
                 if hasattr(s, "image"):
-                    im = s.image.value
+                    # if .raw is a list of DataArray, .image is a complete image
+                    if isinstance(s.image.value, model.DataArray):
+                        im = s.image.value
+                    else:
+                        # TODO This is a "hack" in order to temporarily properly already
+                        # display the pyramidal streams before the GUI classes are changed
+                        im = util.img.mergeTiles(s.image.value)
                     if im is not None:
                         images.append(im)
 

--- a/src/odemis/dataio/tiff.py
+++ b/src/odemis/dataio/tiff.py
@@ -1769,13 +1769,16 @@ class DataArrayShadowTIFF(DataArrayShadow):
 
         self.tiff_info = tiff_info
 
-        sub_ifds = tiff_handle.GetField(T.TIFFTAG_SUBIFD)
-        if sub_ifds:
-            # add the number of subdirectories, and the main image
-            maxzoom = len(sub_ifds)
+        num_tcols = tiff_handle.GetField(T.TIFFTAG_TILEWIDTH)
+        num_trows = tiff_handle.GetField(T.TIFFTAG_TILELENGTH)
+        if num_tcols and num_trows:
+            sub_ifds = tiff_handle.GetField(T.TIFFTAG_SUBIFD)
+             # add the number of subdirectories, and the main image
+            if sub_ifds:
+                maxzoom = len(sub_ifds)
+            else:
+                maxzoom = 0
 
-            num_tcols = tiff_handle.GetField(T.TIFFTAG_TILEWIDTH)
-            num_trows = tiff_handle.GetField(T.TIFFTAG_TILELENGTH)
             if num_tcols is None or num_trows is None:
                 raise RuntimeError("The image is not tiled")
 
@@ -2174,4 +2177,3 @@ class AcquisitionDataTIFF(AcquisitionData):
             dir_index += 1
             yield dir_index
         tiff_file.SetDirectory(0)
-

--- a/src/odemis/gui/comp/miccanvas.py
+++ b/src/odemis/gui/comp/miccanvas.py
@@ -36,6 +36,7 @@ from odemis.gui.comp.canvas import CAN_ZOOM, CAN_DRAG, CAN_FOCUS, BitmapCanvas
 from odemis.gui.comp.overlay.view import HistoryOverlay, PointSelectOverlay, MarkingLineOverlay, CurveOverlay
 from odemis.gui.util import wxlimit_invocation, ignore_dead, img
 from odemis.gui.util.img import format_rgba_darray
+from odemis.util.img import mergeTiles
 from odemis.model import VigilantAttributeBase
 from odemis.util import units
 import time
@@ -381,14 +382,19 @@ class DblMicroscopeCanvas(canvas.DraggableCanvas):
             if not hasattr(s, "image") or s.image.value is None:
                 continue
 
+            if isinstance(s.raw, list):
+                image = s.image.value
+            else:
+                image = mergeTiles(s.image.value)
+
             # FluoStreams are merged using the "Screen" method that handles colour
             # merging without decreasing the intensity.
             if isinstance(s, stream.OpticalStream):
-                images_opt.append((s.image.value, BLEND_SCREEN, s.name.value))
+                images_opt.append((image, BLEND_SCREEN, s.name.value))
             elif isinstance(s, (stream.SpectrumStream, stream.CLStream)):
-                images_spc.append((s.image.value, BLEND_DEFAULT, s.name.value))
+                images_spc.append((image, BLEND_DEFAULT, s.name.value))
             else:
-                images_std.append((s.image.value, BLEND_DEFAULT, s.name.value))
+                images_std.append((image, BLEND_DEFAULT, s.name.value))
 
         # Sort by size, so that the biggest picture is first drawn (no opacity)
         def get_area(d):

--- a/src/odemis/gui/cont/acquisition.py
+++ b/src/odemis/gui/cont/acquisition.py
@@ -48,6 +48,7 @@ from odemis.gui.util.widgets import ProgressiveFutureConnector, EllipsisAnimator
 from odemis.gui.win.acquisition import AcquisitionDialog, \
     ShowAcquisitionFileDialog
 from odemis.util import units
+from odemis.util.img import mergeTiles
 import os
 import re
 import subprocess
@@ -197,7 +198,10 @@ class SnapshotController(object):
             # for each stream seen in the viewport
             raw_images = []
             for s in streams:
-                data = s.raw # list of raw images for this stream (with metadata)
+                data = s.raw
+                if isinstance(data, tuple): # 2D tuple = tiles
+                    data = mergeTiles(data)
+
                 for d in data:
                     # add the stream name to the image
                     if not hasattr(d, "metadata"):

--- a/src/odemis/model/_vattributes.py
+++ b/src/odemis/model/_vattributes.py
@@ -211,6 +211,14 @@ class VigilantAttribute(VigilantAttributeBase):
                 # => just check it's the same object
                 if prev_value is not self._value or value is not self._value:
                     must_notify = True
+            # tuple of tuple of numpy.array
+            elif isinstance(self._value, tuple) and len(self._value) > 0 and \
+                    isinstance(self._value[0], tuple) and len(self._value[0]) > 0 and \
+                    isinstance(self._value[0][0], numpy.ndarray):
+                # For numpy arrays, it's not possible to use !=
+                # => just check it's the same object
+                if prev_value is not self._value or value is not self._value:
+                    must_notify = True
             elif any(isinstance(v, numpy.ndarray) for v in (prev_value, value)):
                 # the new value is _not_ a numpy array => it's different
                 must_notify = True

--- a/src/odemis/model/test/vattributes_test.py
+++ b/src/odemis/model/test/vattributes_test.py
@@ -28,6 +28,7 @@ import pickle
 import unittest
 from unittest.case import skip
 import weakref
+import numpy
 
 logging.getLogger().setLevel(logging.DEBUG)
 
@@ -402,6 +403,26 @@ class VigilantAttributeTest(unittest.TestCase):
         self.assertEqual(prop.value, 2.0)
         prop.value = 10.0
         self.assertEqual(prop.value, 11.0)
+
+    def test_tuple_of_tuple_of_numpyarray(self):
+        prop = model.VigilantAttribute(None)
+
+        self.called = 0
+        # now count
+        prop.subscribe(self.callback_test_notify)
+        first_value = ((numpy.zeros(42),),)
+        # first value
+        prop.value = first_value # +1
+        # the same object as first value
+        prop.value = first_value
+        # test passing the same values, but with a different object
+        prop.value = ((numpy.zeros(42),),) # +1
+        self.assertEqual(self.called, 2, "Called has value %s" % self.called)
+        # empty tuple
+        prop.value = () # +1
+        # empty tuple inside e tuple
+        prop.value = ((),) # +1
+        self.assertEqual(self.called, 4, "Called has value %s" % self.called)
 
 class LittleObject(object):
     def __init__(self):

--- a/src/odemis/util/dataio.py
+++ b/src/odemis/util/dataio.py
@@ -26,13 +26,16 @@ import logging
 import numpy
 from odemis import model
 from odemis.acq import stream
+from odemis import dataio
+import odemis.gui.util as guiutil
+import os
 
 
 def data_to_static_streams(data):
     """ Split the given data into static streams
 
     Args:
-        data: (list of DataArrays) Data to be split
+        data: (list of DataArrays or DataArrayShadows) Data to be split
 
     Returns:
         (list) A list of Stream instances
@@ -144,7 +147,8 @@ def data_to_static_streams(data):
                                 name, d.shape)
                 d = d[-2, -1]
 
-        result_streams.append(klass(name, d))
+        stream_instance = klass(name, d)
+        result_streams.append(stream_instance)
 
     # Add one global AR stream
     if ar_data:
@@ -189,3 +193,28 @@ def _split_planes(data):
         das.append(plane)
 
     return das
+
+def open_acquisition(filename, fmt=None):
+    """
+    Opens the data acording to the type of file, and returns the openend data. 
+    If it's a pyramidal image, do not fetch the whole data from the image. If the image
+    is not pyramidal, it reads the entire image and returns it
+    filename (string): Name of the file where the image is
+    fmt (string): The format of the file
+    return (list of DataArrays or DataArrayShadows): The opened acquisition source
+    """
+    if fmt:
+        converter = dataio.get_converter(fmt)
+    else:
+        converter = dataio.find_fittest_converter(filename, mode=os.O_RDONLY)
+    data = []
+    try:
+        if hasattr(converter, 'open_data'):
+            acd = converter.open_data(filename)
+            data = acd.content
+        else:
+            data = converter.read_data(filename)
+    except Exception:
+        logging.exception("Failed to open file '%s' with format %s", filename, fmt)
+
+    return data

--- a/src/odemis/util/test/dataio_test.py
+++ b/src/odemis/util/test/dataio_test.py
@@ -21,7 +21,7 @@ import numpy
 from odemis import model
 from odemis.acq import stream
 from odemis.dataio import tiff
-from odemis.util.dataio import data_to_static_streams
+from odemis.util.dataio import data_to_static_streams, open_acquisition
 import time
 import unittest
 
@@ -135,6 +135,78 @@ class TestDataIO(unittest.TestCase):
         self.assertEqual(fluo, 3)
         self.assertEqual(bright, 1)
         self.assertEqual(sem, 1)
+
+    def test_data_to_stream_pyramidal(self):
+        """
+        Check data_to_static_streams with pyramidal images using DataArrayShadows
+        """
+        FILENAME = u"test" + tiff.EXTENSIONS[0]
+
+        # Create fake data of flurorescence acquisition
+        metadata = [{model.MD_SW_VERSION: "1.0-test",
+                     model.MD_HW_NAME: "fake hw",
+                     model.MD_DESCRIPTION: "sem",
+                     model.MD_ACQ_DATE: time.time() - 1,
+                     model.MD_BPP: 16,
+                     model.MD_PIXEL_SIZE: (1e-7, 1e-7),  # m/px
+                     model.MD_POS: (1e-3, -30e-3),  # m
+                     model.MD_DWELL_TIME: 100e-6,  # s
+                     model.MD_LENS_MAG: 1200,  # ratio
+                    },
+                    {model.MD_SW_VERSION: "1.0-test",
+                     model.MD_HW_NAME: "fake hw",
+                     model.MD_DESCRIPTION: "blue dye",
+                     model.MD_ACQ_DATE: time.time() + 1,
+                     model.MD_BPP: 12,
+                     model.MD_BINNING: (1, 1),  # px, px
+                     model.MD_PIXEL_SIZE: (1e-6, 1e-6),  # m/px
+                     model.MD_POS: (13.7e-3, -30e-3),  # m
+                     model.MD_EXP_TIME: 1.2,  # s
+                     model.MD_IN_WL: (500e-9, 520e-9),  # m
+                     model.MD_OUT_WL: (650e-9, 660e-9, 675e-9, 678e-9, 680e-9),  # m
+                     model.MD_USER_TINT: (255, 0, 65),  # purple
+                     model.MD_LIGHT_POWER: 100e-3  # W
+                    },
+                    {model.MD_SW_VERSION: "1.0-test",
+                     model.MD_HW_NAME: "fake hw",
+                     model.MD_DESCRIPTION: "green dye",
+                     model.MD_ACQ_DATE: time.time() + 2,
+                     model.MD_BPP: 12,
+                     model.MD_BINNING: (1, 1),  # px, px
+                     model.MD_PIXEL_SIZE: (1e-6, 1e-6),  # m/px
+                     model.MD_POS: (13.7e-3, -30e-3),  # m
+                     model.MD_EXP_TIME: 1,  # s
+                     model.MD_IN_WL: (600e-9, 620e-9),  # m
+                     model.MD_OUT_WL: (620e-9, 650e-9),  # m
+                     model.MD_ROTATION: 0.1,  # rad
+                     model.MD_SHEAR: 0,
+                    },
+                    ]
+        # create 3 greyscale images of same size
+        size = (512, 256)
+        dtype = numpy.dtype("uint16")
+        ldata = []
+        for i, md in enumerate(metadata):
+            a = model.DataArray(numpy.zeros(size[::-1], dtype), md.copy())
+            a[i, i] = i  # "watermark" it
+            ldata.append(a)
+
+        tiff.export(FILENAME, ldata, pyramid=True)
+
+        # check data
+        rdata = open_acquisition(FILENAME)
+        sts = data_to_static_streams(rdata)
+        # There should be 3 streams: 2 fluo + 1 SEM
+        fluo = sem = 0
+        for s in sts:
+            if isinstance(s, stream.StaticFluoStream):
+                fluo += 1
+            elif isinstance(s, stream.EMStream):
+                sem += 1
+
+        self.assertEqual(fluo, 2)
+        self.assertEqual(sem, 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The StaticStream class and the derived classes now can receive
DataArrayShadows.
The Stream class now has .rect and .mpp members. .rect stores the region
of the image that is being viewed by the GUI. .mpp stores meters per
pixel of the current viewer.