### PR TITLE
Fix the generation of the rectangle that determines which tiles should be loaded from file.

### DIFF
--- a/src/odemis/acq/stream/_base.py
+++ b/src/odemis/acq/stream/_base.py
@@ -868,9 +868,9 @@ class Stream(object):
         # are -1 relative to the side of the pixel
         return (
             int(round(rect[0] / ps[0] + img_shape[0] / 2)),
-            int(round(rect[1] / ps[1] + img_shape[1] / 2)),
+            int(round(rect[1] / (-ps[1]) + img_shape[1] / 2)),
             int(round(rect[2] / ps[0] + img_shape[0] / 2)) - 1,
-            int(round(rect[3] / ps[1] + img_shape[1] / 2)) - 1,
+            int(round(rect[3] / (-ps[1]) + img_shape[1] / 2)) - 1,
         )
 
     def _getMergedRawImage(self, z):

--- a/src/odemis/acq/stream/_static.py
+++ b/src/odemis/acq/stream/_static.py
@@ -65,7 +65,7 @@ class StaticStream(Stream):
 
                 full_rect = img._getBoundingBox(raw)
                 l, t, r, b = full_rect
-                mpp_range = ((l, t, l, t), (r, b, r, b))
+                mpp_range = ((l, b, l, b), (r, t, r, t))
                 self.rect = model.TupleContinuous(full_rect, mpp_range, setter=self._set_rect)
             else:
                 # If raw does not have maxzoom,

--- a/src/odemis/acq/stream/_static.py
+++ b/src/odemis/acq/stream/_static.py
@@ -58,7 +58,7 @@ class StaticStream(Stream):
                 md = raw.metadata
                 # get the pixel size of the full image
                 ps = md[model.MD_PIXEL_SIZE]
-                default_mpp = ps[0] * raw.maxzoom ** 2
+                default_mpp = ps[0] * (2 ** raw.maxzoom)
                 # sets the mpp as the X axis of the pixel size of the full image
                 mpp_rng = (ps[0], default_mpp)
                 self.mpp = model.FloatContinuous(default_mpp, mpp_rng, setter=self._set_mpp)

--- a/src/odemis/acq/test/stream_test.py
+++ b/src/odemis/acq/test/stream_test.py
@@ -2169,7 +2169,7 @@ class StaticStreamsTestCase(unittest.TestCase):
         with self.assertRaises(IndexError):
             ss.rect.value = (0.0, 0.0, 10e10, 10e10)
         # full image
-        ss.rect.value = (POS[0] - 0.001, POS[1] - 0.0005, POS[0] + 0.001, POS[1] + 0.0005)
+        ss.rect.value = (POS[0] - 0.001, POS[1] + 0.0005, POS[0] + 0.001, POS[1] - 0.0005)
 
         # Wait a little bit to make sure the image has been generated
         time.sleep(0.5)
@@ -2179,7 +2179,7 @@ class StaticStreamsTestCase(unittest.TestCase):
         self.assertEqual(ss.image.value[3][1].shape, (244, 232, 3))
 
         # half image
-        ss.rect.value = (POS[0] - 0.001, POS[1] - 0.0005, POS[0], POS[1])
+        ss.rect.value = (POS[0] - 0.001, POS[1] + 0.0005, POS[0], POS[1])
 
         # Wait a little bit to make sure the image has been generated
         time.sleep(0.5)
@@ -2219,7 +2219,7 @@ class StaticStreamsTestCase(unittest.TestCase):
             ss.rect.value = (0.0, 0.0, 10e10, 10e10)
 
         # full image
-        ss.rect.value = (POS[0] - 0.001, POS[1] - 0.0005, POS[0] + 0.001, POS[1] + 0.0005)
+        ss.rect.value = (POS[0] - 0.001, POS[1] + 0.0005, POS[0] + 0.001, POS[1] - 0.0005)
 
         # Wait a little bit to make sure the image has been generated
         time.sleep(0.5)
@@ -2229,7 +2229,7 @@ class StaticStreamsTestCase(unittest.TestCase):
         self.assertEqual(ss.image.value[3][1].shape, (244, 232, 3))
 
         # half image
-        ss.rect.value = (POS[0] - 0.001, POS[1] - 0.0005, POS[0], POS[1])
+        ss.rect.value = (POS[0] - 0.001, POS[1] + 0.0005, POS[0], POS[1])
 
         # Wait a little bit to make sure the image has been generated
         time.sleep(0.5)
@@ -2268,7 +2268,7 @@ class StaticStreamsTestCase(unittest.TestCase):
         acd = tiff.open_data(FILENAME)
         ss = stream.RGBStream("test", acd.content[0])
 
-        full_image_rect = (POS[0] - 0.0015, POS[1] - 0.001, POS[0] + 0.0015, POS[1] + 0.001)
+        full_image_rect = (POS[0] - 0.0015, POS[1] + 0.001, POS[0] + 0.0015, POS[1] - 0.001)
 
         ss.mpp.value = 2e-6 # second zoom level
         # full image
@@ -2281,7 +2281,7 @@ class StaticStreamsTestCase(unittest.TestCase):
         self.assertEqual(len(ss.image.value[0]), 4)
 
         # half image (left side), all tiles are cached
-        ss.rect.value = (POS[0] - 0.0015, POS[1] - 0.001, POS[0], POS[1] + 0.001)
+        ss.rect.value = (POS[0] - 0.0015, POS[1] + 0.001, POS[0], POS[1] - 0.001)
         # Wait a little bit to make sure the image has been generated
         time.sleep(0.5)
         self.assertEqual(26, len(read_tiles))
@@ -2289,7 +2289,7 @@ class StaticStreamsTestCase(unittest.TestCase):
         self.assertEqual(len(ss.image.value[0]), 4)
 
         # half image (right side), only the center tiles will are cached
-        ss.rect.value = (POS[0], POS[1] - 0.001, POS[0] + 0.0015, POS[1] + 0.001)
+        ss.rect.value = (POS[0], POS[1] + 0.001, POS[0] + 0.0015, POS[1] - 0.001)
         # Wait a little bit to make sure the image has been generated
         time.sleep(0.5)
         self.assertEqual(38, len(read_tiles))
@@ -2297,7 +2297,7 @@ class StaticStreamsTestCase(unittest.TestCase):
         self.assertEqual(len(ss.image.value[0]), 4)
 
         # really small rect on the center, the tile is in the cache
-        ss.rect.value = (POS[0], POS[1], POS[0] + 0.00001, POS[1] + 0.00001)
+        ss.rect.value = (POS[0], POS[1] + 0.00001, POS[0] + 0.00001, POS[1])
         # Wait a little bit to make sure the image has been generated
         time.sleep(0.5)
         self.assertEqual(38, len(read_tiles))
@@ -2306,7 +2306,7 @@ class StaticStreamsTestCase(unittest.TestCase):
 
         # rect out of the image
         with self.assertRaises(IndexError): # "rect out of bounds"
-            ss.rect.value = (POS[0] - 15, POS[1] - 15, POS[0] + 16, POS[1] + 16)
+            ss.rect.value = (POS[0] - 15, POS[1] + 15, POS[0] + 16, POS[1] - 16)
             # Wait a little bit to make sure the image has been generated
             time.sleep(0.5)
 
@@ -2362,7 +2362,7 @@ class StaticStreamsTestCase(unittest.TestCase):
         self.assertEqual(4, len(read_tiles))
 
         # delta full rect
-        dfr = [ -0.0015, -0.001, 0.0015, 0.001]
+        dfr = [ -0.0015, 0.001, 0.0015, -0.001]
         full_image_rect = (POS[0] + dfr[0], POS[1] + dfr[1], POS[0] + dfr[2], POS[1] + dfr[3])
 
         # change both .rect and .mpp at the same time, to the same values

--- a/src/odemis/util/img.py
+++ b/src/odemis/util/img.py
@@ -686,10 +686,11 @@ def _getBoundingBox(content):
         img_shape[1] * ps[1] / 2,
     )
     md_pos = md.get(model.MD_POS, (0.0, 0.0))
+    # in physical coordinates, Y goes up. So top > bottom
     rect = (
         md_pos[0] - half_shape_wc[0],
-        md_pos[1] - half_shape_wc[1],
-        md_pos[0] + half_shape_wc[0],
         md_pos[1] + half_shape_wc[1],
+        md_pos[0] + half_shape_wc[0],
+        md_pos[1] - half_shape_wc[1],
     )
     return rect


### PR DESCRIPTION
Fix the generation of the rectangle that determines which tiles should be loaded from file.
The generation was not considering that, in physical coordinates, Y grows up, and in pixel coordinates, Y grows down.