### PR TITLE
Extension of Viewport widget to support

### DIFF
--- a/src/odemis/acq/stream/__init__.py
+++ b/src/odemis/acq/stream/__init__.py
@@ -229,10 +229,6 @@ class StreamTree(object):
             elif isinstance(s, Stream):
                 if hasattr(s, "image"):
                     im = s.image.value
-                    if isinstance(im, tuple):
-                        # TODO This is a "hack" in order to temporarily properly already
-                        # display the pyramidal streams before the GUI classes are changed
-                        im = util.img.mergeTiles(im)
                     if im is not None:
                         images.append(im)
 

--- a/src/odemis/acq/stream/_static.py
+++ b/src/odemis/acq/stream/_static.py
@@ -62,11 +62,13 @@ class StaticStream(Stream):
                 # sets the mpp as the X axis of the pixel size of the full image
                 mpp_rng = (ps[0], max_mpp)
                 self.mpp = model.FloatContinuous(max_mpp, mpp_rng, setter=self._set_mpp)
+                self.mpp.subscribe(self._on_mpp)
 
                 full_rect = img._getBoundingBox(raw)
                 l, t, r, b = full_rect
-                mpp_range = ((l, b, l, b), (r, t, r, t))
-                self.rect = model.TupleContinuous(full_rect, mpp_range, setter=self._set_rect)
+                rect_range = ((l, b, l, b), (r, t, r, t))
+                self.rect = model.TupleContinuous(full_rect, rect_range)
+                self.rect.subscribe(self._on_rect)
             else:
                 # If raw does not have maxzoom,
                 # StaticStream should behave as when raw is a DataArray
@@ -77,16 +79,16 @@ class StaticStream(Stream):
         super(StaticStream, self).__init__(name, None, None, None, raw=raw)
 
     def _set_mpp(self, mpp):
-        self._shouldUpdateImage()
-
         ps0 = self.mpp.range[0]
         exp = math.log(mpp / ps0, 2)
         exp = round(exp)
         return ps0 * 2 ** exp
 
-    def _set_rect(self, rect):
+    def _on_mpp(self, mpp):
         self._shouldUpdateImage()
-        return rect
+
+    def _on_rect(self, mpp):
+        self._shouldUpdateImage()
 
 
 class RGBStream(StaticStream):

--- a/src/odemis/dataio/tiff.py
+++ b/src/odemis/dataio/tiff.py
@@ -1737,7 +1737,6 @@ def open_data(filename):
     # see http://pytables.github.io/cookbook/inmemory_hdf5_files.html
     filename = _ensure_fs_encoding(filename)
     return AcquisitionDataTIFF(filename)
-    
 
 class DataArrayShadowTIFF(DataArrayShadow):
     """

--- a/src/odemis/gui/test/comp_canvas_cairo_test.py
+++ b/src/odemis/gui/test/comp_canvas_cairo_test.py
@@ -214,7 +214,7 @@ class TestCanvas(test.GuiTestCase):
         for mpp, scale, rect in zip(mpps, exp_scales, exp_b_rect):
             view.mpp.value = mpp
             self.assertAlmostEqual(scale, cnvs.scale)
-            calc_rect = cnvs._calc_img_buffer_rect(img, im_scale, im_pos)
+            calc_rect = cnvs._calc_img_buffer_rect(img.shape[:2], im_scale, im_pos)
             for ev, v in zip(rect, calc_rect):
                 self.assertAlmostEqual(ev, v)
             test.gui_loop(0.1)
@@ -255,7 +255,7 @@ class TestCanvas(test.GuiTestCase):
             logging.debug("Center: %s", im_center)
             for im_scale, rect in zip(im_scales, rects):
                 logging.debug("Scale: %s", im_scale)
-                b_rect = cnvs._calc_img_buffer_rect(darray, im_scale, im_center)
+                b_rect = cnvs._calc_img_buffer_rect(darray.shape[:2], im_scale, im_center)
 
                 for v in b_rect:
                     self.assertIsInstance(v, float)
@@ -288,7 +288,7 @@ class TestCanvas(test.GuiTestCase):
             logging.debug("Center: %s", im_center)
             for im_scale, rect in zip(im_scales, rects):
                 logging.debug("Scale: %s", im_scale)
-                b_rect = cnvs._calc_img_buffer_rect(darray, im_scale, im_center)
+                b_rect = cnvs._calc_img_buffer_rect(darray.shape[:2], im_scale, im_center)
 
                 for v in b_rect:
                     self.assertIsInstance(v, float)
@@ -322,7 +322,7 @@ class TestCanvas(test.GuiTestCase):
             logging.debug("Center: %s", im_center)
             for im_scale, rect in zip(im_scales, rects):
                 logging.debug("Scale: %s", im_scale)
-                b_rect = cnvs._calc_img_buffer_rect(darray, im_scale, im_center)
+                b_rect = cnvs._calc_img_buffer_rect(darray.shape[:2], im_scale, im_center)
 
                 for v in b_rect:
                     self.assertIsInstance(v, float)

--- a/src/odemis/util/test/img_test.py
+++ b/src/odemis/util/test/img_test.py
@@ -361,7 +361,7 @@ class TestDataArray2RGB(unittest.TestCase):
         self.assertEqual(out.shape, size + (3,))
         self.assertEqual(self.CountValues(out), 3)
         pixel = out[2, 2]
-        numpy.testing.assert_equal(pixel, [128, 128, 128])
+        numpy.testing.assert_equal(pixel, [127, 127, 127])
 
     def test_irange(self):
         """test with specific corner values of irange"""


### PR DESCRIPTION
Extension of Viewport widget to support pyramidal StaticStreams.
The information of the field of view and meters per pixel is getting to the Stream classes. This information is used to calculate which tiles will be read from the TIFF files (or other types of tiles that implement tiling).
So far, there's only one Stream for all the viewports. So changes in the field of view and meters per pixel of one view port is still affecting all the others viewports.