### PR TITLE
Inclusion of data projection classes

### DIFF
--- a/src/odemis/acq/stream/__init__.py
+++ b/src/odemis/acq/stream/__init__.py
@@ -32,6 +32,7 @@ from ._helper import *
 from ._live import *
 from ._static import *
 from ._sync import *
+from ._projection import *
 
 from abc import ABCMeta
 
@@ -143,7 +144,7 @@ class StreamTree(object):
         return False
 
     def add_stream(self, stream):
-        if isinstance(stream, (Stream, StreamTree)):
+        if isinstance(stream, (Stream, StreamTree, RGBSpatialProjection)):
             self.streams.append(stream)
             self.size.value = len(self.streams)
             if hasattr(stream, 'should_update'):
@@ -183,7 +184,7 @@ class StreamTree(object):
         streams = []
 
         for s in self.streams:
-            if isinstance(s, Stream) and s not in streams:
+            if isinstance(s, (Stream, RGBSpatialProjection)) and s not in streams:
                 streams.append(s)
             elif isinstance(s, StreamTree):
                 sub_streams = s.getStreams()

--- a/src/odemis/acq/stream/_projection.py
+++ b/src/odemis/acq/stream/_projection.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+'''
+Created on 24 Jan 2017
+
+@author: Guilherme Stiebler
+
+Copyright © 2017 Guilherme Stiebler, Éric Piel, Delmic
+
+This file is part of Odemis.
+
+Odemis is free software: you can redistribute it and/or modify it under the terms
+of the GNU General Public License version 2 as published by the Free Software
+Foundation.
+
+Odemis is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+Odemis. If not, see http://www.gnu.org/licenses/.
+'''
+
+from __future__ import division
+
+import threading
+import weakref
+import logging
+import time
+import math
+import gc
+
+from odemis import model
+from odemis.util import img
+
+
+class DataProjection(object):
+
+    def __init__(self, stream):
+        '''
+        stream (Stream): the Stream to project
+        '''
+        self.stream = stream
+        self._im_needs_recompute = threading.Event()
+        weak = weakref.ref(self)
+        self._imthread = threading.Thread(target=self._image_thread,
+                                          args=(weak,),
+                                          name="Image computation")
+        self._imthread.daemon = True
+        self._imthread.start()
+
+        # DataArray or None: RGB projection of the raw data
+        self.image = model.VigilantAttribute(None)
+
+    @staticmethod
+    def _image_thread(wprojection):
+        """ Called as a separate thread, and recomputes the image whenever it receives an event
+        asking for it.
+
+        Args:
+            wprojection (Weakref to a DataProjection): the data projection to follow
+
+        """
+
+        try:
+            projection = wprojection()
+            stream = projection.stream
+            name = stream.name.value
+            im_needs_recompute = projection._im_needs_recompute
+            # Only hold a weakref to allow the stream to be garbage collected
+            # On GC, trigger im_needs_recompute so that the thread can end too
+            wprojection = weakref.ref(projection, lambda o: im_needs_recompute.set())
+
+            tnext = 0
+            while True:
+                del projection
+                im_needs_recompute.wait()  # wait until a new image is available
+                projection = wprojection()
+
+                if projection is None:
+                    logging.debug("Projection %s disappeared so ending image update thread", name)
+                    break
+
+                tnow = time.time()
+
+                # sleep a bit to avoid refreshing too fast
+                tsleep = tnext - tnow
+                if tsleep > 0.0001:
+                    time.sleep(tsleep)
+
+                tnext = time.time() + 0.1  # max 10 Hz
+                im_needs_recompute.clear()
+                projection._updateImage()
+        except Exception:
+            logging.exception("image update thread failed")
+
+        gc.collect()
+
+
+class RGBSpatialProjection(DataProjection):
+
+    def __init__(self, stream):
+        '''
+        stream (Stream): the Stream to project
+        '''
+        super(RGBSpatialProjection, self).__init__(stream)
+
+        self.should_update = model.BooleanVA(False)
+        self.name = stream.name
+        self.image = model.VigilantAttribute(None)
+
+        # Don't call at init, so don't set metadata if default value
+        self.stream.tint.subscribe(self.needImageUpdate)
+        self.stream.intensityRange.subscribe(self.needImageUpdate)
+        self.stream.auto_bc.subscribe(self.needImageUpdate)
+        self.stream.auto_bc_outliers.subscribe(self.needImageUpdate)
+
+        if hasattr(stream, '_das'):
+            raw = stream._das
+            md = raw.metadata
+            # get the pixel size of the full image
+            ps = md[model.MD_PIXEL_SIZE]
+            max_mpp = ps[0] * (2 ** raw.maxzoom)
+            # sets the mpp as the X axis of the pixel size of the full image
+            mpp_rng = (ps[0], max_mpp)
+            self.mpp = model.FloatContinuous(max_mpp, mpp_rng, setter=self._set_mpp)
+
+            full_rect = img._getBoundingBox(raw)
+            l, t, r, b = full_rect
+            rect_range = ((l, b, l, b), (r, t, r, t))
+            self.rect = model.TupleContinuous(full_rect, rect_range)
+
+            self.mpp.subscribe(self._onMpp)
+            self.rect.subscribe(self._onRect)
+
+            # initialize the projected tiles cache
+            self._projectedTilesCache = {}
+            # initialize the raw tiles cache
+            self._rawTilesCache = {}
+
+            # When True, the projected tiles cache should be invalidated
+            self._projectedTilesInvalid = True
+
+        self._shouldUpdateImage()
+
+    @property
+    def raw(self):
+        return self.stream.raw
+
+    def needImageUpdate(self, param):
+        self._projectedTilesInvalid = True
+        self._shouldUpdateImage()
+
+    def _onMpp(self, mpp):
+        self._shouldUpdateImage()
+
+    def _onRect(self, rect):
+        self._shouldUpdateImage()
+
+    def _set_mpp(self, mpp):
+        ps0 = self.mpp.range[0]
+        exp = math.log(mpp / ps0, 2)
+        exp = round(exp)
+        return ps0 * 2 ** exp
+
+    def onTint(self, value):
+        if isinstance(self.raw, list):
+            if len(self.stream.raw) > 0:
+                raw = self.stream.raw[0]
+            else:
+                raw = None
+        elif isinstance(self.stream.raw, tuple):
+            raw = self.stream._das
+        else:
+            raise AttributeError(".raw must be a list of DA/DAS or a tuple of tuple of DA")
+
+        if raw is not None:
+            # If the image is pyramidal, the exported image is based on tiles from .raw.
+            # And the metadata from raw will be used to generate the metadata of the merged
+            # image from the tiles. So, in the end, the exported image metadata will be based
+            # on the raw metadata
+            raw.metadata[model.MD_USER_TINT] = value
+
+        self._shouldUpdateImage()
+
+    def _projectXY2RGB(self, data, tint=(255, 255, 255)):
+        """
+        Project a 2D spatial DataArray into a RGB representation
+        data (DataArray): 2D DataArray
+        tint ((int, int, int)): colouration of the image, in RGB.
+        return (DataArray): 3D DataArray
+        """
+        # TODO replace by local irange
+        irange = self.stream._getDisplayIRange()
+        rgbim = img.DataArray2RGB(data, irange, tint)
+        rgbim.flags.writeable = False
+        # Commented to prevent log flooding
+        # if model.MD_ACQ_DATE in data.metadata:
+        #     logging.debug("Computed RGB projection %g s after acquisition",
+        #                    time.time() - data.metadata[model.MD_ACQ_DATE])
+        md = self.stream._find_metadata(data.metadata)
+        md[model.MD_DIMS] = "YXC" # RGB format
+        return model.DataArray(rgbim, md)
+
+    def _shouldUpdateImage(self):
+        """
+        Ensures that the image VA will be updated in the "near future".
+        """
+        # If the previous request is still being processed, the event
+        # synchronization allows to delay it (without accumulation).
+        self._im_needs_recompute.set()
+
+    def getBoundingBox(self):
+        ''' Get the bounding box of the whole image, whether it`s tiled or not.
+        return (tuple of floats(l,t,r,b)): Tuple with the bounding box
+        Raises:
+            ValueError: If the .image member is not set
+        '''
+        if hasattr(self, 'rect'):
+            rng = self.rect.range
+            return (rng[0][0], rng[0][1], rng[1][0], rng[1][1])
+        else:
+            md = self.image.value.metadata
+            if self.image.value is None:
+                raise ValueError("Stream's image not defined")
+            shape = self.image.value.shape
+            im_scale = md[model.MD_PIXEL_SIZE]
+            w, h = shape[1] * im_scale[0], shape[0] * im_scale[1]
+            c = md[model.MD_POS]
+            return [c[0] - w / 2, c[1] - h / 2, c[0] + w / 2, c[1] + h / 2]
+
+    def _zFromMpp(self):
+        """
+        Return the zoom level based on the current .mpp value
+        return (int): The zoom level based on the current .mpp value
+        """
+        md = self.stream._das.metadata
+        ps = md[model.MD_PIXEL_SIZE]
+        return int(math.log(self.mpp.value / ps[0], 2))
+
+    def _rectWorldToPixel(self, rect):
+        """
+        Convert rect from world coordinates to pixel coordinates
+        rect (tuple containing x1, y1, x2, y2): Rect on world coordinates
+        return (tuple containing x1, y1, x2, y2): Rect on pixel coordinates
+        """
+        md = self.stream._das.metadata
+        ps = md.get(model.MD_PIXEL_SIZE, (1e-6, 1e-6))
+        pos = md.get(model.MD_POS, (0.0, 0.0))
+        # Removes the center coordinates of the image. After that, rect will be centered on 0, 0
+        rect = (
+            rect[0] - pos[0],
+            rect[1] - pos[1],
+            rect[2] - pos[0],
+            rect[3] - pos[1]
+        )
+        dims = md.get(model.MD_DIMS, "CTZYX"[-self.stream._das.ndim::])
+        img_shape = (self.stream._das.shape[dims.index('X')], self.stream._das.shape[dims.index('Y')])
+
+        # Converts rect from physical to pixel coordinates.
+        # The received rect is relative to the center of the image, but pixel coordinates
+        # are relative to the top-left corner. So it also needs to sum half image.
+        # The -1 are necessary on the right and bottom sides, as the coordinates of a pixel
+        # are -1 relative to the side of the pixel
+        # The '-' before ps[1] is necessary due to the fact that 
+        # Y in pixel coordinates grows down, and Y in physical coordinates grows up
+        return (
+            int(round(rect[0] / ps[0] + img_shape[0] / 2)),
+            int(round(rect[1] / (-ps[1]) + img_shape[1] / 2)),
+            int(round(rect[2] / ps[0] + img_shape[0] / 2)) - 1,
+            int(round(rect[3] / (-ps[1]) + img_shape[1] / 2)) - 1,
+        )
+
+    def _getTile(self, x, y, z, prev_raw_cache, prev_proj_cache):
+        """
+        Get a tile from a DataArrayShadow. Uses cache.
+        The cache for projected tiles and the cache for raw tiles has always the same tiles
+        x (int): X coordinate of the tile
+        y (int): Y coordinate of the tile
+        z (int): zoom level where the tile is
+        prev_raw_cache (dictionary): raw tiles cache from the
+            last execution of _updateImage
+        prev_proj_cache (dictionary): projected tiles cache from the
+            last execution of _updateImage
+        return (tuple(DataArray, DataArray)): raw tile and projected tile
+        """
+        # the key of the tile on the cache
+        tile_key = "%d-%d-%d" % (x, y, z)
+
+        # if the raw tile has been already cached, read it from the cache
+        if tile_key in prev_raw_cache:
+            raw_tile = prev_raw_cache[tile_key]
+        elif tile_key in self._rawTilesCache:
+            raw_tile = self._rawTilesCache[tile_key]
+        else:
+            # The tile was not cached, so it must be read from the file
+            raw_tile = self.stream._das.getTile(x, y, z)
+
+        # if the projected tile has been already cached, read it from the cache
+        if tile_key in prev_proj_cache:
+            proj_tile = prev_proj_cache[tile_key]
+        elif tile_key in self._projectedTilesCache:
+            proj_tile = self._projectedTilesCache[tile_key]
+        else:
+            # The tile was not cached, so it must be projected again
+            proj_tile = self._projectTile(raw_tile)
+
+        # cache raw and projected tiles
+        self._rawTilesCache[tile_key] = raw_tile
+        self._projectedTilesCache[tile_key] = proj_tile
+        return (raw_tile, proj_tile)
+
+    def _projectTile(self, tile):
+        """
+        Project the tile
+        tile (DataArray): Raw tile
+        return (DataArray): Projected tile
+        """
+        dims = tile.metadata.get(model.MD_DIMS, "CTZYX"[-tile.ndim::])
+        ci = dims.find("C")  # -1 if not found
+        # is RGB
+        if dims in ("CYX", "YXC") and tile.shape[ci] in (3, 4):
+            # Just pass the RGB data on
+            tile = img.ensureYXC(tile)
+            tile.flags.writeable = False
+            # merge and ensures all the needed metadata is there
+            tile.metadata = self.stream._find_metadata(tile.metadata)
+            tile.metadata[model.MD_DIMS] = "YXC" # RGB format
+            return tile
+        else:
+            if tile.ndim != 2:
+                tile = img.ensure2DImage(tile)  # Remove extra dimensions (of length 1)
+            return self._projectXY2RGB(tile, self.stream.tint.value)
+
+    def _getTilesFromSelectedArea(self):
+        """
+        Get the tiles inside the region defined by .rect and .mpp
+        return ((DataArray, DataArray)): Raw tiles and projected tiles
+        """
+
+        # This custom exception is used when the .mpp or .rect values changes while
+        # generating the tiles. If the values changes, everything needs to be recomputed
+        class NeedRecomputeException(Exception):
+            pass
+
+        # store the previous cache to use in this execution
+        prev_raw_cache = self._rawTilesCache
+        prev_proj_cache = self._projectedTilesCache
+        # Execute at least once. If mpp and rect changed in
+        # the last execution of the loops, execute again
+        need_recompute = True
+        while need_recompute:
+            z = self._zFromMpp()
+            rect = self._rectWorldToPixel(self.rect.value)
+            # convert the rect coords to tile indexes
+            rect = [l / (2 ** z) for l in rect]
+            rect = [int(math.floor(l / self.stream._das.tile_shape[0])) for l in rect]
+            x1, y1, x2, y2 = rect
+            curr_mpp = self.mpp.value
+            curr_rect = self.rect.value
+            # the 4 lines below avoids that lots of old tiles
+            # stays in instance caches
+            prev_raw_cache.update(self._rawTilesCache)
+            prev_proj_cache.update(self._projectedTilesCache)
+            # empty current caches
+            self._rawTilesCache = {}
+            self._projectedTilesCache = {}
+
+            raw_tiles = []
+            projected_tiles = []
+            need_recompute = False
+            try:
+                for x in range(x1, x2 + 1):
+                    rt_column = []
+                    pt_column = []
+
+                    for y in range(y1, y2 + 1):
+                        # the projected tiles cache is invalid
+                        if self._projectedTilesInvalid:
+                            self._projectedTilesCache = {}
+                            prev_proj_cache = {}
+                            self._projectedTilesInvalid = False
+                            raise NeedRecomputeException()
+
+                        # check if the image changed in the middle of the process
+                        if self._im_needs_recompute.is_set():
+                            self._im_needs_recompute.clear()
+                            # Raise the exception, so everything will be calculated again,
+                            # but using the cache from the last execution
+                            raise NeedRecomputeException()
+
+                        raw_tile, proj_tile = \
+                                self._getTile(x, y, z, prev_raw_cache, prev_proj_cache)
+                        rt_column.append(raw_tile)
+                        pt_column.append(proj_tile)
+
+                    raw_tiles.append(tuple(rt_column))
+                    projected_tiles.append(tuple(pt_column))
+
+            except NeedRecomputeException:
+                # image changed
+                need_recompute = True
+
+        return (tuple(raw_tiles), tuple(projected_tiles))
+
+    def _updateImage(self):
+        """ Recomputes the image with all the raw data available
+        """
+        # logging.debug("Updating image")
+        if not self.stream.raw and isinstance(self.stream.raw, list):
+            return
+
+        try:
+            # if .raw is a list of DataArray, .image is a complete image
+            if isinstance(self.stream.raw, list):
+                raw = self.stream.raw[0]
+                self.image.value = self._projectTile(raw)
+            elif isinstance(self.stream.raw, tuple):
+                # .raw is an instance of DataArrayShadow, so .image is
+                # a tuple of tuple of tiles
+                raw_tiles, projected_tiles = self._getTilesFromSelectedArea()
+                self.image.value = projected_tiles
+                self.stream.raw = raw_tiles
+            else:
+                raise AttributeError(".raw must be a list of DA/DAS or a tuple of tuple of DA")
+
+        except Exception:
+            logging.exception("Updating %s %s image", self.__class__.__name__, self.name.value)

--- a/src/odemis/acq/test/stream_test.py
+++ b/src/odemis/acq/test/stream_test.py
@@ -1871,13 +1871,14 @@ class StaticStreamsTestCase(unittest.TestCase):
         da[15] = 2 ** 10
 
         fls = stream.StaticFluoStream(md[model.MD_DESCRIPTION], da)
+        pj = stream.RGBSpatialProjection(fls)
 
         self.assertEqual(fls.excitation.value, md[model.MD_IN_WL])
         self.assertEqual(fls.emission.value, md[model.MD_OUT_WL])
         self.assertEqual(tuple(fls.tint.value), md[model.MD_USER_TINT])
 
         time.sleep(0.5)  # wait a bit for the image to update
-        im = fls.image.value
+        im = pj.image.value
         self.assertEqual(im.shape, (512, 1024, 3))
         numpy.testing.assert_equal(im[0, 0], [0, 0, 0])
         numpy.testing.assert_equal(im[12, 1], md[model.MD_USER_TINT])
@@ -1902,10 +1903,11 @@ class StaticStreamsTestCase(unittest.TestCase):
         da = model.DataArray(1500 + numpy.zeros((512, 1024), dtype=numpy.uint16), md)
 
         cls = stream.StaticCLStream("test", da)
+        pj = stream.RGBSpatialProjection(cls)
         time.sleep(0.5)  # wait a bit for the image to update
 
         self.assertEqual(cls.emission.value, md[model.MD_OUT_WL])
-        self.assertEqual(cls.image.value.shape, (512, 1024, 3))
+        self.assertEqual(pj.image.value.shape, (512, 1024, 3))
 
     def test_small_hist(self):
         """Test small histogram computation"""
@@ -2276,32 +2278,33 @@ class StaticStreamsTestCase(unittest.TestCase):
 
         acd = tiff.open_data(FILENAME)
         ss = stream.StaticSEMStream("test", acd.content[0])
+        pj = stream.RGBSpatialProjection(ss)
 
         # out of bounds
         with self.assertRaises(IndexError):
-            ss.mpp.value = 1.0
-        ss.mpp.value = 2e-6 # second zoom level
+            pj.mpp.value = 1.0
+        pj.mpp.value = 2e-6 # second zoom level
 
         # out of bounds
         with self.assertRaises(IndexError):
-            ss.rect.value = (0.0, 0.0, 10e10, 10e10)
+            pj.rect.value = (0.0, 0.0, 10e10, 10e10)
         # full image
-        ss.rect.value = (POS[0] - 0.001, POS[1] + 0.0005, POS[0] + 0.001, POS[1] - 0.0005)
+        pj.rect.value = (POS[0] - 0.001, POS[1] + 0.0005, POS[0] + 0.001, POS[1] - 0.0005)
 
         # Wait a little bit to make sure the image has been generated
         time.sleep(0.5)
-        self.assertEqual(len(ss.image.value), 4)
-        self.assertEqual(len(ss.image.value[0]), 2)
+        self.assertEqual(len(pj.image.value), 4)
+        self.assertEqual(len(pj.image.value[0]), 2)
         # the corner tile should be smaller
-        self.assertEqual(ss.image.value[3][1].shape, (244, 232, 3))
+        self.assertEqual(pj.image.value[3][1].shape, (244, 232, 3))
 
         # half image
-        ss.rect.value = (POS[0] - 0.001, POS[1] + 0.0005, POS[0], POS[1])
+        pj.rect.value = (POS[0] - 0.001, POS[1] + 0.0005, POS[0], POS[1])
 
         # Wait a little bit to make sure the image has been generated
         time.sleep(0.5)
-        self.assertEqual(len(ss.image.value), 2)
-        self.assertEqual(len(ss.image.value[0]), 1)
+        self.assertEqual(len(pj.image.value), 2)
+        self.assertEqual(len(pj.image.value[0]), 1)
 
     def test_rgb_tiled_stream(self):
         POS = (5.0, 7.0)
@@ -2321,33 +2324,34 @@ class StaticStreamsTestCase(unittest.TestCase):
 
         acd = tiff.open_data(FILENAME)
         ss = stream.RGBStream("test", acd.content[0])
+        pj = stream.RGBSpatialProjection(ss)
 
         # out of bounds
         with self.assertRaises(IndexError):
-            ss.mpp.value = 1.0
-        ss.mpp.value = 2e-6 # second zoom level
+            pj.mpp.value = 1.0
+        pj.mpp.value = 2e-6 # second zoom level
 
         # out of bounds
         with self.assertRaises(IndexError):
-            ss.rect.value = (0.0, 0.0, 10e10, 10e10)
+            pj.rect.value = (0.0, 0.0, 10e10, 10e10)
 
         # full image
-        ss.rect.value = (POS[0] - 0.001, POS[1] + 0.0005, POS[0] + 0.001, POS[1] - 0.0005)
+        pj.rect.value = (POS[0] - 0.001, POS[1] + 0.0005, POS[0] + 0.001, POS[1] - 0.0005)
 
         # Wait a little bit to make sure the image has been generated
         time.sleep(0.5)
-        self.assertEqual(len(ss.image.value), 4)
-        self.assertEqual(len(ss.image.value[0]), 2)
+        self.assertEqual(len(pj.image.value), 4)
+        self.assertEqual(len(pj.image.value[0]), 2)
         # the corner tile should be smaller
-        self.assertEqual(ss.image.value[3][1].shape, (244, 232, 3))
+        self.assertEqual(pj.image.value[3][1].shape, (244, 232, 3))
 
         # half image
-        ss.rect.value = (POS[0] - 0.001, POS[1] + 0.0005, POS[0], POS[1])
+        pj.rect.value = (POS[0] - 0.001, POS[1] + 0.0005, POS[0], POS[1])
 
         # Wait a little bit to make sure the image has been generated
         time.sleep(0.5)
-        self.assertEqual(len(ss.image.value), 2)
-        self.assertEqual(len(ss.image.value[0]), 1)
+        self.assertEqual(len(pj.image.value), 2)
+        self.assertEqual(len(pj.image.value[0]), 1)
 
     def test_rgb_tiled_stream_pan(self):
         read_tiles = []
@@ -2376,6 +2380,7 @@ class StaticStreamsTestCase(unittest.TestCase):
 
         acd = tiff.open_data(FILENAME)
         ss = stream.RGBStream("test", acd.content[0])
+        pj = stream.RGBSpatialProjection(ss)
         time.sleep(0.5)
 
         # the maxzoom image has 2 tiles. So far 4 was read: 2 on the constructor, for
@@ -2385,42 +2390,43 @@ class StaticStreamsTestCase(unittest.TestCase):
 
         full_image_rect = (POS[0] - 0.0015, POS[1] + 0.001, POS[0] + 0.0015, POS[1] - 0.001)
 
-        ss.mpp.value = 2e-6 # second zoom level
+        pj.mpp.value = 2e-6 # second zoom level
         # full image
-        ss.rect.value = full_image_rect
+        pj.rect.value = full_image_rect
         # Wait a little bit to make sure the image has been generated
         time.sleep(0.5)
         self.assertEqual(28, len(read_tiles))
-        self.assertEqual(len(ss.image.value), 6)
-        self.assertEqual(len(ss.image.value[0]), 4)
+        self.assertEqual(len(pj.image.value), 6)
+        self.assertEqual(len(pj.image.value[0]), 4)
 
         # half image (left side), all tiles are cached
-        ss.rect.value = (POS[0] - 0.0015, POS[1] + 0.001, POS[0], POS[1] - 0.001)
+        pj.rect.value = (POS[0] - 0.0015, POS[1] + 0.001, POS[0], POS[1] - 0.001)
         # Wait a little bit to make sure the image has been generated
         time.sleep(0.5)
         self.assertEqual(28, len(read_tiles))
-        self.assertEqual(len(ss.image.value), 3)
-        self.assertEqual(len(ss.image.value[0]), 4)
+        self.assertEqual(len(pj.image.value), 3)
+        self.assertEqual(len(pj.image.value[0]), 4)
 
         # half image (right side), only the center tiles will are cached
-        ss.rect.value = (POS[0], POS[1] + 0.001, POS[0] + 0.0015, POS[1] - 0.001)
+        pj.rect.value = (POS[0], POS[1] + 0.001, POS[0] + 0.0015, POS[1] - 0.001)
         # Wait a little bit to make sure the image has been generated
         time.sleep(0.5)
         self.assertEqual(40, len(read_tiles))
-        self.assertEqual(len(ss.image.value), 4)
-        self.assertEqual(len(ss.image.value[0]), 4)
+        self.assertEqual(len(pj.image.value), 4)
+        self.assertEqual(len(pj.image.value[0]), 4)
 
         # really small rect on the center, the tile is in the cache
-        ss.rect.value = (POS[0], POS[1] + 0.00001, POS[0] + 0.00001, POS[1])
+        pj.rect.value = (POS[0], POS[1] + 0.00001, POS[0] + 0.00001, POS[1])
+        
         # Wait a little bit to make sure the image has been generated
         time.sleep(0.5)
         self.assertEqual(40, len(read_tiles))
-        self.assertEqual(len(ss.image.value), 1)
-        self.assertEqual(len(ss.image.value[0]), 1)
+        self.assertEqual(len(pj.image.value), 1)
+        self.assertEqual(len(pj.image.value[0]), 1)
 
         # rect out of the image
         with self.assertRaises(IndexError): # "rect out of bounds"
-            ss.rect.value = (POS[0] - 15, POS[1] + 15, POS[0] + 16, POS[1] - 16)
+            pj.rect.value = (POS[0] - 15, POS[1] + 15, POS[0] + 16, POS[1] - 16)
             # Wait a little bit to make sure the image has been generated
             time.sleep(0.5)
 
@@ -2452,9 +2458,9 @@ class StaticStreamsTestCase(unittest.TestCase):
         line = numpy.linspace(0, 255, num_cols, dtype=dtype)
         column = numpy.linspace(0, 255, num_rows, dtype=dtype)
 
-        # each line has values from 0 to 255, linearly distributed
-        arr[:, :, 0] = numpy.tile(line, (num_rows, 1))
         # each row has values from 0 to 255, linearly distributed
+        arr[:, :, 0] = numpy.tile(line, (num_rows, 1))
+        # each column has values from 0 to 255, linearly distributed
         arr[:, :, 1] = numpy.tile(column, (num_cols, 1)).transpose()
 
         data = model.DataArray(arr, metadata=md)
@@ -2464,6 +2470,7 @@ class StaticStreamsTestCase(unittest.TestCase):
 
         acd = tiff.open_data(FILENAME)
         ss = stream.RGBStream("test", acd.content[0])
+        pj = stream.RGBSpatialProjection(ss)
         time.sleep(0.5)
 
         # the maxzoom image has 2 tiles. So far 4 was read: 2 on the constructor, for
@@ -2477,58 +2484,58 @@ class StaticStreamsTestCase(unittest.TestCase):
 
         # change both .rect and .mpp at the same time, to the same values
         # that are set on Stream constructor
-        ss.rect.value = full_image_rect # full image
-        ss.mpp.value = ss.mpp.range[1]  # maximum zoom level
+        pj.rect.value = full_image_rect # full image
+        pj.mpp.value = pj.mpp.range[1]  # maximum zoom level
 
         # Wait a little bit to make sure the image has been generated
         time.sleep(0.2)
         # no tiles are read from the disk
         self.assertEqual(4, len(read_tiles))
-        self.assertEqual(len(ss.image.value), 2)
-        self.assertEqual(len(ss.image.value[0]), 1)
+        self.assertEqual(len(pj.image.value), 2)
+        self.assertEqual(len(pj.image.value[0]), 1)
         # top-left pixel of the left tile
-        numpy.testing.assert_array_equal([0, 0, 0], ss.image.value[0][0][0, 0, :])
+        numpy.testing.assert_array_equal([0, 0, 0], pj.image.value[0][0][0, 0, :])
         # top-right pixel of the left tile
-        numpy.testing.assert_array_equal([173, 0, 0], ss.image.value[0][0][0, 255, :])
+        numpy.testing.assert_array_equal([173, 0, 0], pj.image.value[0][0][0, 255, :])
         # bottom-left pixel of the left tile
-        numpy.testing.assert_array_equal([0, 255, 0], ss.image.value[0][0][249, 0, :])
+        numpy.testing.assert_array_equal([0, 254, 0], pj.image.value[0][0][249, 0, :])
         # bottom-right pixel of the right tile
-        numpy.testing.assert_array_equal([254, 255, 0], ss.image.value[1][0][249, 117, :])
+        numpy.testing.assert_array_equal([254, 254, 0], pj.image.value[1][0][249, 117, :])
 
         # really small rect on the center, the tile is in the cache
-        ss.rect.value = (POS[0], POS[1], POS[0] + 0.00001, POS[1] + 0.00001)
+        pj.rect.value = (POS[0], POS[1], POS[0] + 0.00001, POS[1] + 0.00001)
 
         # Wait a little bit to make sure the image has been generated
         time.sleep(0.5)
         # no tiles are read from the disk
         self.assertEqual(4, len(read_tiles))
-        self.assertEqual(len(ss.image.value), 1)
-        self.assertEqual(len(ss.image.value[0]), 1)
+        self.assertEqual(len(pj.image.value), 1)
+        self.assertEqual(len(pj.image.value[0]), 1)
         # top-left pixel of the only tile
-        numpy.testing.assert_array_equal([0, 0, 0], ss.image.value[0][0][0, 0, :])
+        numpy.testing.assert_array_equal([0, 0, 0], pj.image.value[0][0][0, 0, :])
         # top-right pixel of the only tile
-        numpy.testing.assert_array_equal([173, 0, 0], ss.image.value[0][0][0, 255, :])
+        numpy.testing.assert_array_equal([173, 0, 0],pj.image.value[0][0][0, 255, :])
         # bottom-left pixel of the only tile
-        numpy.testing.assert_array_equal([0, 255, 0], ss.image.value[0][0][249, 0, :])
+        numpy.testing.assert_array_equal([0, 254, 0], pj.image.value[0][0][249, 0, :])
 
         # Now, just the tiny rect again, but at the minimum mpp (= fully zoomed in)
         # => should just need one new tile
-        ss.mpp.value = ss.mpp.range[0]
+        pj.mpp.value = pj.mpp.range[0]
 
         # Wait a little bit to make sure the image has been generated
         time.sleep(0.5)
         # only one tile is read
         self.assertEqual(5, len(read_tiles))
-        self.assertEqual(len(ss.image.value), 1)
-        self.assertEqual(len(ss.image.value[0]), 1)
+        self.assertEqual(len(pj.image.value), 1)
+        self.assertEqual(len(pj.image.value[0]), 1)
         # top-left pixel of the only tile
-        numpy.testing.assert_array_equal([108, 97, 0], ss.image.value[0][0][0, 0, :])
+        numpy.testing.assert_array_equal([108, 97, 0], pj.image.value[0][0][0, 0, :])
         # top-right pixel of the only tile
-        numpy.testing.assert_array_equal([130, 97, 0], ss.image.value[0][0][0, 255, :])
+        numpy.testing.assert_array_equal([130, 97, 0], pj.image.value[0][0][0, 255, :])
         # bottom-left pixel of the only tile
-        numpy.testing.assert_array_equal([108, 130, 0], ss.image.value[0][0][255, 0, :])
+        numpy.testing.assert_array_equal([108, 130, 0], pj.image.value[0][0][255, 0, :])
         # bottom-right pixel of the only tile
-        numpy.testing.assert_array_equal([130, 130, 0], ss.image.value[0][0][255, 255, :])
+        numpy.testing.assert_array_equal([130, 130, 0], pj.image.value[0][0][255, 255, :])
 
         # changing .rect and .mpp simultaneously
         # Note: the recommended way is to first change mpp and then rect, as it
@@ -2536,9 +2543,9 @@ class StaticStreamsTestCase(unittest.TestCase):
         # However, we do the opposite here, to check it doesn't go too wrong
         # (ie, first load the entire image at min mpp, and then load again at
         # max mpp). It should at worse have loaded one tile at the min mpp.
-        ss.rect.value = full_image_rect # full image
+        pj.rect.value = full_image_rect # full image
         # time.sleep(0.0001) # uncomment to test with slight delay between VA changes
-        ss.mpp.value = ss.mpp.range[1]  # maximum zoom level
+        pj.mpp.value = pj.mpp.range[1]  # maximum zoom level
 
         # Wait a little bit to make sure the image has been generated
         time.sleep(0.5)
@@ -2550,15 +2557,15 @@ class StaticStreamsTestCase(unittest.TestCase):
                             "gone very fast.")
         else:
             self.assertEqual(7, len(read_tiles))
-        self.assertEqual(len(ss.image.value), 2)
-        self.assertEqual(len(ss.image.value[0]), 1)
+        self.assertEqual(len(pj.image.value), 2)
+        self.assertEqual(len(pj.image.value[0]), 1)
 
         # top-left pixel of the left tile
-        numpy.testing.assert_array_equal([0, 0, 0], ss.image.value[0][0][0, 0, :])
+        numpy.testing.assert_array_equal([0, 0, 0], pj.image.value[0][0][0, 0, :])
         # bottom-right pixel of the left tile
-        numpy.testing.assert_array_equal([173, 0, 0], ss.image.value[0][0][0, 255, :])
+        numpy.testing.assert_array_equal([173, 0, 0], pj.image.value[0][0][0, 255, :])
         # bottom-right pixel of right right
-        numpy.testing.assert_array_equal([254, 255, 0], ss.image.value[1][0][249, 117, :])
+        numpy.testing.assert_array_equal([254, 254, 0], pj.image.value[1][0][249, 117, :])
 
         read_tiles = []  # reset, to keep the numbers simple
 
@@ -2567,48 +2574,48 @@ class StaticStreamsTestCase(unittest.TestCase):
         rect = (POS[0] + delta[0], POS[1] + delta[1],
                 POS[0] + delta[2], POS[1] + delta[3])
         # changes .rect and .mpp simultaneously, simulating a GUI zoom
-        ss.rect.value = rect
+        pj.rect.value = rect
         # zoom 2
-        ss.mpp.value = 4e-6
+        pj.mpp.value = 4e-6
         # Wait a little bit to make sure the image has been generated
         time.sleep(0.3)
 
         # reads 6 tiles from the disk, no tile is cached because the zoom changed
         self.assertEqual(6, len(read_tiles))
-        self.assertEqual(len(ss.image.value), 3)
-        self.assertEqual(len(ss.image.value[0]), 2)
+        self.assertEqual(len(pj.image.value), 3)
+        self.assertEqual(len(pj.image.value[0]), 2)
         # top-left pixel of a center tile
-        numpy.testing.assert_array_equal([87, 0, 0], ss.image.value[1][0][0, 0, :])
+        numpy.testing.assert_array_equal([87, 0, 0], pj.image.value[1][0][0, 0, :])
         # top-right pixel of a center tile
-        numpy.testing.assert_array_equal([173, 0, 0], ss.image.value[1][0][0, 255, :])
+        numpy.testing.assert_array_equal([173, 0, 0], pj.image.value[1][0][0, 255, :])
         # bottom-left pixel of a center tile
-        numpy.testing.assert_array_equal([87, 130, 0], ss.image.value[1][0][255, 0, :])
+        numpy.testing.assert_array_equal([87, 130, 0], pj.image.value[1][0][255, 0, :])
         # bottom pixel of a center tile
-        numpy.testing.assert_array_equal([173, 130, 0], ss.image.value[1][0][255, 255, :])
+        numpy.testing.assert_array_equal([173, 130, 0], pj.image.value[1][0][255, 255, :])
 
         delta = [d / 8 for d in dfr]
         # this rect is 1/8 the size of the full image, in the center of the image
         rect = (POS[0] + delta[0], POS[1] + delta[1],
                 POS[0] + delta[2], POS[1] + delta[3])
         # changes .rect and .mpp simultaneously, simulating a GUI zoom
-        ss.rect.value = rect
+        pj.rect.value = rect
         # zoom 0
-        ss.mpp.value = ss.mpp.range[0]
+        pj.mpp.value = pj.mpp.range[0]
         # Wait a little bit to make sure the image has been generated
         time.sleep(0.5)
 
         # reads 4 tiles from the disk, no tile is cached becase the zoom changed
         self.assertEqual(10, len(read_tiles))
-        self.assertEqual(len(ss.image.value), 2)
-        self.assertEqual(len(ss.image.value[0]), 2)
+        self.assertEqual(len(pj.image.value), 2)
+        self.assertEqual(len(pj.image.value[0]), 2)
         # top-left pixel of the top-left tile
-        numpy.testing.assert_array_equal([108, 97, 0], ss.image.value[0][0][0, 0, :])
+        numpy.testing.assert_array_equal([108, 97, 0], pj.image.value[0][0][0, 0, :])
         # top-right pixel of top-left tile
-        numpy.testing.assert_array_equal([130, 97, 0], ss.image.value[0][0][0, 255, :])
+        numpy.testing.assert_array_equal([130, 97, 0], pj.image.value[0][0][0, 255, :])
         # bottom-left pixel of top-left tile
-        numpy.testing.assert_array_equal([108, 130, 0], ss.image.value[0][0][255, 0, :])
+        numpy.testing.assert_array_equal([108, 130, 0], pj.image.value[0][0][255, 0, :])
         # bottom pixel of top-left tile
-        numpy.testing.assert_array_equal([130, 130, 0], ss.image.value[0][0][255, 255, :])
+        numpy.testing.assert_array_equal([130, 130, 0], pj.image.value[0][0][255, 255, :])
 
         # get the old function back to the class
         tiff.DataArrayShadowPyramidalTIFF.getTile = tiff.DataArrayShadowPyramidalTIFF._getTileOldSZ

--- a/src/odemis/gui/comp/canvas.py
+++ b/src/odemis/gui/comp/canvas.py
@@ -946,6 +946,9 @@ class BitmapCanvas(BufferedCanvas):
                 if isinstance(im, tuple):
                     first_tile = im[0][0]
                     md = first_tile.metadata
+                    tiles_merged_shape = util.img.getTilesSize(im)
+                    # the center of the image composed of the tiles
+                    center = util.img.getCenterOfTiles(im, tiles_merged_shape)
                 else:
                     md = im.metadata
 
@@ -963,7 +966,7 @@ class BitmapCanvas(BufferedCanvas):
                     self._draw_tiles(
                         ctx,
                         im,
-                        md['dc_center'],
+                        center,
                         merge_ratio,
                         im_scale=md['dc_scale'],
                         rotation=md['dc_rotation'],

--- a/src/odemis/gui/cont/acquisition.py
+++ b/src/odemis/gui/cont/acquisition.py
@@ -200,7 +200,7 @@ class SnapshotController(object):
             for s in streams:
                 data = s.raw
                 if isinstance(data, tuple): # 2D tuple = tiles
-                    data = mergeTiles(data)
+                    data = [mergeTiles(data)]
 
                 for d in data:
                     # add the stream name to the image

--- a/src/odemis/gui/cont/streams.py
+++ b/src/odemis/gui/cont/streams.py
@@ -1301,7 +1301,7 @@ class StreamBarController(object):
         self._prev_view = view
 
     def _on_visible_streams(self, flat):
-        visible_streams = flat
+        visible_streams = [s if isinstance(s, acqstream.Stream) else s.stream for s in flat]
 
         for e in self._stream_bar.stream_panels:
             e.set_visible(e.stream in visible_streams)

--- a/src/odemis/util/dataio.py
+++ b/src/odemis/util/dataio.py
@@ -147,6 +147,9 @@ def data_to_static_streams(data):
                                 name, d.shape)
                 d = d[-2, -1]
 
+        if not hasattr(d, 'maxzoom'):
+            d = d.getData()
+
         stream_instance = klass(name, d)
         result_streams.append(stream_instance)
 

--- a/src/odemis/util/img.py
+++ b/src/odemis/util/img.py
@@ -469,7 +469,7 @@ def rescale_hq(data, shape):
 
     scale = tuple(n / o for o, n in zip(data.shape, shape))
     if len(data.shape) <= 3:
-        out = cv2.resize(data, (shape[1], shape[0]))#, 'bilinear')
+        out = cv2.resize(data, (shape[1], shape[0]))
     else:
         out = numpy.empty(shape, dtype=data.dtype)
         scipy.ndimage.interpolation.zoom(data, zoom=scale, output=out, order=1, prefilter=False)


### PR DESCRIPTION
The goal of the DataProjection is to separate the projection process of
the Stream from the data and settings.
Separate the projection from the Stream is specially useful on tiled
images, providing the possibility of having different projections with
different selection of tiles (different mpps and viewports), with the
same stream.