### PR TITLE
Fixes on the inclusion of a DataProjection

### DIFF
--- a/src/odemis/acq/stream/__init__.py
+++ b/src/odemis/acq/stream/__init__.py
@@ -124,6 +124,9 @@ class StreamTree(object):
         acc = 0
 
         for s in self.streams:
+            # if the stream is a DataProjection, get the internal stream
+            if isinstance(s, DataProjection):
+                s = s.stream
             if isinstance(s, Stream):
                 acc += 1
             elif isinstance(s, StreamTree):
@@ -242,9 +245,12 @@ class StreamTree(object):
         streams = []
 
         for s in self.streams:
-            if isinstance(s, StreamTree):
+            leaf = s
+            if isinstance(s, DataProjection):
+                leaf = s.stream
+            if isinstance(leaf, StreamTree):
                 streams.extend(s.get_streams_by_type(stream_types))
-            elif isinstance(s, stream_types):
+            elif isinstance(leaf, stream_types):
                 streams.append(s)
 
         return streams

--- a/src/odemis/acq/stream/_static.py
+++ b/src/odemis/acq/stream/_static.py
@@ -60,12 +60,13 @@ class RGBStream(StaticStream):
         Note: parameters are different from the base class.
         raw (DataArray, DataArrayShadow or list of DataArray): The data to display.
         """
-        # Check it's RGB
-        if isinstance(raw, (model.DataArray, model.DataArrayShadow)):
-            raw = [raw]
+        # if raw is a DataArrayShadow, but not pyramidal, read the data to a DataArray
+        if isinstance(raw, model.DataArrayShadow) and not hasattr(raw, 'maxzoom'):
+            raw = [raw.getData()]
         else:
-            raw = raw
+            raw = [raw]
 
+        # Check it's RGB
         for d in raw:
             dims = d.metadata.get(model.MD_DIMS, "CTZYX"[-d.ndim::])
             ci = dims.find("C")  # -1 if not found
@@ -96,7 +97,12 @@ class Static2DStream(StaticStream):
         Note: parameters are different from the base class.
         raw (DataArray or DataArrayShadow): The data to display.
         """
-        super(Static2DStream, self).__init__(name, [raw])
+        # if raw is a DataArrayShadow, but not pyramidal, read the data to a DataArray
+        if isinstance(raw, model.DataArrayShadow) and not hasattr(raw, 'maxzoom'):
+            raw = [raw.getData()]
+        else:
+            raw = [raw]
+        super(Static2DStream, self).__init__(name, raw)
 
     def _init_projection_vas(self):
         ''' On Static2DStream, the projection is done on RGBSpatialProjection

--- a/src/odemis/dataio/test/tiff_test.py
+++ b/src/odemis/dataio/test/tiff_test.py
@@ -1277,11 +1277,12 @@ class TestTiffIO(unittest.TestCase):
         # read the subimage
         subimage = im.read_image()
         self.assertEqual(subimage.shape, (147, 128))
-        # checking the values in the corner of the tile
-        self.assertEqual(subimage[0][0], 0)
-        self.assertEqual(subimage[0][-1], 256)
-        self.assertEqual(subimage[-1][0], 10022)
-        self.assertEqual(subimage[-1][-1], 10278)
+        # Checking the values in the corner of the tile. The downsampling uses
+        # the neighbour pixels to calculate a pixel in the resized image.
+        self.assertEqual(subimage[0][0], 130)
+        self.assertEqual(subimage[0][-1], 385)
+        self.assertEqual(subimage[-1][0], 9893)
+        self.assertEqual(subimage[-1][-1], 10148)
 
     def testExportThinPyramid(self):           
         """

--- a/src/odemis/gui/comp/viewport.py
+++ b/src/odemis/gui/comp/viewport.py
@@ -29,7 +29,7 @@ from abc import abstractmethod, ABCMeta
 from concurrent.futures._base import CancelledError
 import logging
 from odemis import gui, model, util
-from odemis.acq.stream import OpticalStream, EMStream, SpectrumStream, StaticStream
+from odemis.acq.stream import OpticalStream, EMStream, SpectrumStream, StaticStream, DataProjection
 from odemis.gui import BG_COLOUR_LEGEND, FG_COLOUR_LEGEND
 from odemis.gui.comp import miccanvas, overlay
 from odemis.gui.comp.canvas import CAN_DRAG, CAN_FOCUS
@@ -401,9 +401,15 @@ class MicroscopeViewport(ViewPort):
                     self.bottom_legend.set_stream_type(wx.RIGHT, SpectrumStream)
                 else:
                     sc = self._microscope_view.stream_tree[0]
+                    # if sc is an instance of DataProjection, get the inner stream
+                    if isinstance(sc, DataProjection):
+                        sc = sc.stream
                     self.bottom_legend.set_stream_type(wx.LEFT, sc.__class__)
 
                     sc = self._microscope_view.stream_tree[1]
+                    # if sc is an instance of DataProjection, get the inner stream
+                    if isinstance(sc, DataProjection):
+                        sc = sc.stream
                     self.bottom_legend.set_stream_type(wx.RIGHT, sc.__class__)
 
                 self.ShowMergeSlider(True)

--- a/src/odemis/gui/util/img.py
+++ b/src/odemis/gui/util/img.py
@@ -1607,12 +1607,11 @@ def get_ordered_images(streams, raw=False):
             logging.error("StreamTree has a None stream")
             continue
 
-        if not hasattr(s, "image") or s.image.value is None:
-            continue
-
         # FluoStreams are merged using the "Screen" method that handles colour
         # merging without decreasing the intensity.
         if not raw:
+            if not hasattr(s, "image") or s.image.value is None:
+                continue
             data = s.image.value
             if isinstance(data, tuple): # 2D tuple = tiles
                 data = img.mergeTiles(data)

--- a/src/odemis/gui/util/test/img_test.py
+++ b/src/odemis/gui/util/test/img_test.py
@@ -410,7 +410,10 @@ class TestSpatialExport(unittest.TestCase):
         image = model.DataArray(data, metadata)
         sem_stream = stream.StaticSEMStream(metadata['Description'], image)
         #sem_stream.image.value = model.DataArray(dataRGB, metadata)
-        self.streams = [fluo_stream, sem_stream]
+        # create DataProjections for the streams
+        fluo_stream_pj = stream.RGBSpatialProjection(fluo_stream)
+        sem_stream_pj = stream.RGBSpatialProjection(sem_stream)
+        self.streams = [fluo_stream_pj, sem_stream_pj]
         self.min_res = (623, 432)
 
         # Spectrum stream
@@ -556,6 +559,7 @@ class TestSpatialExportAcquisitionData(unittest.TestCase):
                     'Output wavelength range': (6.990000000000001e-07, 7.01e-07)}
         image = model.DataArray(data, metadata)
         fluo_stream = stream.StaticFluoStream(metadata['Description'], image)
+        fluo_stream_pj = stream.RGBSpatialProjection(fluo_stream)
 
         data = numpy.zeros((1024, 1024), dtype=numpy.uint16)
         dataRGB = numpy.zeros((1024, 1024, 4))
@@ -571,9 +575,10 @@ class TestSpatialExportAcquisitionData(unittest.TestCase):
         # read back
         acd = tiff.open_data(FILENAME)
         sem_stream = stream.StaticSEMStream(metadata['Description'], acd.content[0])
-        sem_stream.mpp.value = 1e-6
+        sem_stream_pj = stream.RGBSpatialProjection(sem_stream)
+        sem_stream_pj.mpp.value = 1e-6
 
-        self.streams = [fluo_stream, sem_stream]
+        self.streams = [fluo_stream_pj, sem_stream_pj]
         self.min_res = (623, 432)
 
         # Wait for all the streams to get an RGB image

--- a/src/odemis/util/dataio.py
+++ b/src/odemis/util/dataio.py
@@ -147,9 +147,6 @@ def data_to_static_streams(data):
                                 name, d.shape)
                 d = d[-2, -1]
 
-        if not hasattr(d, 'maxzoom'):
-            d = d.getData()
-
         stream_instance = klass(name, d)
         result_streams.append(stream_instance)
 


### PR DESCRIPTION
- Addition of custom listeners to VAs on RGBSpatialProjection. 
- Getting the inner stream from DataProjection on some places.
- Fixes on the automated tests.
- Moved the extraction of the image data from the DataArrayShadow on the constructors of Static2DStream and RGBStream