### PR TITLE
acq stream ScannedTCSettingsStream: detector and tc_detector are the …

### DIFF
--- a/src/odemis/acq/stream/_helper.py
+++ b/src/odemis/acq/stream/_helper.py
@@ -1054,26 +1054,27 @@ class OverlayStream(Stream):
 class ScannedTCSettingsStream(RepetitionStream):
 
     def __init__(self, name, detector, emitter, scanner, time_correlator,
-                 tc_dectector, scanner_extra, tc_detector_live=None, **kwargs):
+                 scanner_extra, tc_detector_live=None, **kwargs):
         """
         A helper stream used to define FLIM acquisition settings and run a live setting stream
         that gets a time-series from an APD (tc_detector)
 
-        detector: (model.Detector) typically a photo-detector
-        emitter: (model.Light) Typically an extended light (pulsed laser)
+        detector: (model.Detector) a photo-detector, synchronized with the scanner
+        emitter: (model.Light) The light (typically a pulsed laser)
         scanner: (model.Emitter) typically laser-mirror
         time_correlator: (model.Detector) typically Symphotime controller
-        tc_detector: (model.Detector)Typically an APD
-        scanner_extra: (model.Emitter) The Symphotime scanner device wrapped by the Symphotime controller
-        tc_detector_live: (model.Detector) typically a Symphotime Live detector - gets apd counts
+        scanner_extra: (model.Emitter or None) extra scanner that receives the same
+           settings as the scanner. Typically, the Symphotime scanner, as it
+           needs the information to reconstruct the image.
+        tc_detector_live: (model.Detector or None) the detector to use in the
+          live mode. Typically a Symphotime Live detector - gets apd counts
 
         Warning: do not use local .dwellTime, but use the one provided by the stream.
         """
-        self.tc_detector = tc_dectector
         if tc_detector_live:
             det_live = tc_detector_live
         else:
-            det_live = tc_dectector
+            det_live = detector
         RepetitionStream.__init__(self, name, det_live, det_live.data, scanner, **kwargs)
 
         # Fuzzing is not handled for FLIM streams (and doesn't make much
@@ -1090,12 +1091,10 @@ class ScannedTCSettingsStream(RepetitionStream):
 
         # Child devices
         self.lemitter = emitter
-        self.tc_scanner = scanner_extra
-
         self.scanner = scanner
         self.time_correlator = time_correlator
-        self.dataflow = tc_dectector.data
-        self.pdetector = detector
+        self.tc_detector = detector
+        self.tc_scanner = scanner_extra
 
         # VA's
         # TODO: Change these to Local VA's (emtPower and emtPeriod), but this

--- a/src/odemis/acq/stream/_sync.py
+++ b/src/odemis/acq/stream/_sync.py
@@ -2031,7 +2031,6 @@ class ScannedRemoteTCStream(LiveStream):
         self._emitter = helper_stream.lemitter  # TODO: Should be emitter
         self._tc_scanner = helper_stream.tc_scanner
         self._tc_detector = helper_stream.tc_detector
-        self._pdetector = helper_stream.pdetector
         self._scanner = helper_stream.scanner
         self._time_correlator = helper_stream.time_correlator
 
@@ -2155,7 +2154,7 @@ class ScannedRemoteTCStream(LiveStream):
             self._setEmission(1)
 
             # Start the acquisition
-            self._pdetector.data.subscribe(self._onNewData)
+            self._tc_detector.data.subscribe(self._onNewData)
 
             # For each frame
             for i in range(nfr):
@@ -2196,7 +2195,7 @@ class ScannedRemoteTCStream(LiveStream):
             logging.debug("FLIM acquisition ended")
 
             # Ensure all the detectors are stopped
-            self._pdetector.data.unsubscribe(self._onNewData)
+            self._tc_detector.data.unsubscribe(self._onNewData)
             self._time_correlator.data.unsubscribe(self._onAcqStop)
             self._stream._unlinkHwVAs()
             # turn off the light
@@ -2279,7 +2278,7 @@ class ScannedRemoteTCStream(LiveStream):
             self._acq_state = CANCELLED
 
         logging.debug("Cancelling acquisition of components %s and %s",
-                      self._pdetector.name, self._time_correlator.name)
+                      self._tc_detector.name, self._time_correlator.name)
 
         # Wait for the thread to be complete (and hardware state restored)
         if self._acq_thread:

--- a/src/odemis/acq/test/flim_test.py
+++ b/src/odemis/acq/test/flim_test.py
@@ -111,8 +111,8 @@ class TestFlim(unittest.TestCase):
     def test_flim_acq_simple(self):
         logging.debug("Testing acquisition")
 
-        helper = stream.ScannedTCSettingsStream("FLIM settings", self.detector, self.ex_light, self.lscanner,
-                                                self.sft, self.apd, self.tc_scanner)
+        helper = stream.ScannedTCSettingsStream("FLIM settings", self.apd, self.ex_light, self.lscanner,
+                                                self.sft, self.tc_scanner)
 
         remote = stream.ScannedRemoteTCStream("Remote", helper)
         # Configure values and test acquisition for several short dwell times.
@@ -159,8 +159,8 @@ class TestFlim(unittest.TestCase):
     def test_repetitions_and_roi(self):
         logging.debug("Testing repetitions and roi")
 
-        helper = stream.ScannedTCSettingsStream('Stream', self.detector, self.ex_light, self.lscanner,
-                                                self.sft, self.apd, self.tc_scanner)
+        helper = stream.ScannedTCSettingsStream('Stream', self.apd, self.ex_light, self.lscanner,
+                                                self.sft, self.tc_scanner)
         
         remote = stream.ScannedRemoteTCStream("remote", helper)
 
@@ -210,8 +210,8 @@ class TestFlim(unittest.TestCase):
     def test_cancelling(self):
         logging.debug("Testing cancellation")
 
-        helper = stream.ScannedTCSettingsStream('Stream', self.detector, self.ex_light, self.lscanner,
-                                                self.sft, self.apd, self.tc_scanner)
+        helper = stream.ScannedTCSettingsStream('Stream', self.apd, self.ex_light, self.lscanner,
+                                                self.sft, self.tc_scanner)
 
         remote = stream.ScannedRemoteTCStream("remote", helper)
 
@@ -228,8 +228,8 @@ class TestFlim(unittest.TestCase):
 
     def test_setting_stream(self):
 
-        helper = stream.ScannedTCSettingsStream('Stream', self.detector, self.ex_light, self.lscanner,
-                                                self.sft, self.apd, self.tc_scanner)
+        helper = stream.ScannedTCSettingsStream('Stream', self.apd, self.ex_light, self.lscanner,
+                                                self.sft, self.tc_scanner)
         spots = stream.SpotScannerStream("spot", helper.tc_detector,
                                      helper.tc_detector.data, helper.scanner)
         # Test start and stop of the apd.
@@ -274,9 +274,8 @@ class TestFlim(unittest.TestCase):
         """
         Test live setting stream acquisition with the tc_detector_live
         """
-        helper = stream.ScannedTCSettingsStream('Stream', self.detector, self.ex_light, self.lscanner,
-                                                self.sft, self.apd, self.tc_scanner,
-                                                self.tcdl)
+        helper = stream.ScannedTCSettingsStream('Stream', self.apd, self.ex_light,
+                         self.lscanner, self.sft, self.tc_scanner, self.tcdl)
         spots = stream.SpotScannerStream("spot", helper.tc_detector,
                                      helper.tc_detector.data, helper.scanner)
         # Test start and stop of the apd.
@@ -324,8 +323,8 @@ class TestFlim(unittest.TestCase):
         when used on a confocal microscope, and especially the NikonC2
         """
         # Create the stream
-        tcs = stream.ScannedTCSettingsStream('Stream', self.detector, self.ex_light, self.lscanner,
-                                             self.sft, self.apd, self.tc_scanner)
+        tcs = stream.ScannedTCSettingsStream('Stream', self.apd, self.ex_light, self.lscanner,
+                                             self.sft, self.tc_scanner)
         self._image = None
         tcs.image.subscribe(self._on_image)
 

--- a/src/odemis/gui/cont/streams.py
+++ b/src/odemis/gui/cont/streams.py
@@ -1244,17 +1244,13 @@ class StreamBarController(object):
         Creates a new ScannedTCSettingStream and panel in the stream bar.
         returns (StreamPanel): the panel created
         """
-
-        detector = self._main_data_model.photo_ds[0]
-
         s = acqstream.ScannedTCSettingsStream(
-            "FLIM %s" % (detector.name,),
-            detector,
+            "FLIM",
+            self._main_data_model.tc_detector,
             self._main_data_model.light,
             self._main_data_model.laser_mirror,
             self._main_data_model.time_correlator,
-            self._main_data_model.tc_detector,
-            self._main_data_model.tc_scanner,
+            scanner_extra=self._main_data_model.tc_scanner,
             tc_detector_live=self._main_data_model.tc_detector_live,
             opm=self._main_data_model.opm,
             # emtvas={"power", "period"}


### PR DESCRIPTION
…same thing

The tc_detector should be passed as the detector. It shouldn't need both
a APD and a PMT, just the APD is enough.