### PR TITLE
FLIM Fixes

### DIFF
--- a/src/odemis/acq/stream/__init__.py
+++ b/src/odemis/acq/stream/__init__.py
@@ -82,7 +82,9 @@ ARStream.register(ARSettingsStream)
 ARStream.register(StaticARStream)
 ARStream.register(SEMARMDStream)
 
-NON_SPATIAL_STREAMS = (ARStream, SpectrumStream, MonochromatorSettingsStream, ScannedTCSettingsStream, ScannedFluoMDStream)
+NON_SPATIAL_STREAMS = (ARStream, SpectrumStream, MonochromatorSettingsStream,
+                       ScannedTCSettingsStream, ScannedFluoMDStream, OverlayStream)
+
 
 # TODO: make it like a VA, so that it's possible to know when it changes
 # TODO: move it to its own file

--- a/src/odemis/acq/stream/_sync.py
+++ b/src/odemis/acq/stream/_sync.py
@@ -40,7 +40,9 @@ from odemis.acq.leech import AnchorDriftCorrector
 from odemis.acq.stream._live import LiveStream
 import random
 import Queue
-from odemis.model import MD_POS, MD_DESCRIPTION, MD_PIXEL_SIZE, MD_ACQ_DATE, MD_AD_LIST, MD_POL_MODE, MD_DWELL_TIME
+from odemis.model import MD_POS, MD_DESCRIPTION, MD_PIXEL_SIZE, MD_ACQ_DATE, MD_AD_LIST, \
+    MD_DWELL_TIME
+
 from odemis.util import img, units, spot, executeAsyncTask
 import threading
 import time

--- a/src/odemis/gui/comp/grid.py
+++ b/src/odemis/gui/comp/grid.py
@@ -97,9 +97,24 @@ class ViewportGrid(wx.Panel):
         """ Hide all viewports """
         self.set_shown_viewports()
 
+    def get_4_viewports(self):
+        """
+        Gets the first 4 valid viewports to display in the 2 x 2 grid and returns them.
+        Does not show them - this is handled by other existing functions.
+        """
+        counter = 0
+        viewports = []
+        for v in self.viewports:
+            if counter >= 4: break
+            if v._microscope_view is not None:
+                viewports.append(v)
+                counter += 1
+
+        return viewports
+
     def show_grid_viewports(self):
         """ Show all grid viewports """
-        self.visible_viewports = self.viewports[:4]
+        self.visible_viewports = self.get_4_viewports()
         self._layout_viewports()
         self._show_hide_viewports()
 
@@ -142,7 +157,7 @@ class ViewportGrid(wx.Panel):
                 self.visible_viewports = self.viewports[:1]
 
             else:
-                self.visible_viewports = self.viewports[:4]
+                self.visible_viewports = self.get_4_viewports()
 
         self.grid_layout = AttrDict({
             'tl': AttrDict({
@@ -212,7 +227,7 @@ class ViewportGrid(wx.Panel):
             vvps[0].SetPosition((0, 0))
             # TODO: Make invisible ones small!
         else:
-            gvps = self.viewports[:4]
+            gvps = self.get_4_viewports()
             num_vis_grid = sum(vp in vvps for vp in gvps)
             if num_vis_grid != num_vis_total:
                 raise ValueError("If multiple viewports are visible, they should all reside in the "

--- a/src/odemis/gui/comp/miccanvas.py
+++ b/src/odemis/gui/comp/miccanvas.py
@@ -421,7 +421,7 @@ class DblMicroscopeCanvas(canvas.DraggableCanvas):
             # FluoStreams are merged using the "Screen" method that handles colour
             # merging without decreasing the intensity.
             ostream = s.stream if isinstance(s, DataProjection) else s
-            if isinstance(ostream, stream.OpticalStream):
+            if isinstance(ostream, (stream.FluoStream, stream.StaticFluoStream)):
                 images_opt.append((image, BLEND_SCREEN, s.name.value, s))
             elif isinstance(ostream, (stream.SpectrumStream, stream.CLStream)):
                 images_spc.append((image, BLEND_DEFAULT, s.name.value, s))
@@ -983,6 +983,12 @@ class OverviewCanvas(DblMicroscopeCanvas):
         # This canvas can have a special overlay for tracking position history
         self.history_overlay = None
 
+        # Disable certain tools in overview. Don't list ROA, ROI, or spot mode
+        self.allowed_modes = guimodel.ALL_TOOL_MODES - {guimodel.TOOL_SPOT,
+                                                        guimodel.TOOL_ROA,
+                                                        guimodel.TOOL_ROI,
+                                                        guimodel.TOOL_RO_ANCHOR}
+
         self.SetMinSize((400, 400))
 
     def _on_view_mpp(self, mpp):
@@ -1084,6 +1090,8 @@ class SparcARCanvas(DblMicroscopeCanvas):
     def __init__(self, *args, **kwargs):
         super(SparcARCanvas, self).__init__(*args, **kwargs)
         self.abilities -= {CAN_ZOOM, CAN_DRAG}
+        self.allowed_modes = {guimodel.TOOL_NONE}
+
         # same as flip argument of set_images(): int with wx.VERTICAL and/or wx.HORIZONTAL or just use MD_FLIP
         self.flip = 0
 

--- a/src/odemis/gui/comp/viewport.py
+++ b/src/odemis/gui/comp/viewport.py
@@ -30,7 +30,8 @@ from concurrent.futures._base import CancelledError
 import logging
 from odemis import gui, model, util
 from odemis.acq.stream import OpticalStream, EMStream, SpectrumStream, \
-                              StaticStream, DataProjection, CLStream
+                              StaticStream, DataProjection, CLStream, FluoStream, \
+                              StaticFluoStream
 from odemis.gui import BG_COLOUR_LEGEND, FG_COLOUR_LEGEND
 from odemis.gui.comp import miccanvas, overlay
 from odemis.gui.comp.canvas import CAN_DRAG, CAN_FOCUS
@@ -382,7 +383,7 @@ class MicroscopeViewport(ViewPort):
                 len(self._microscope_view.stream_tree) >= 2
         ):
             streams = self._microscope_view.getStreams()
-            all_opt = all(isinstance(s, OpticalStream) for s in streams)
+            all_opt = all(isinstance(s, (FluoStream, StaticFluoStream)) for s in streams)
 
             # If all images are optical, assume they are merged using screen blending and no
             # merge ratio is required
@@ -399,7 +400,7 @@ class MicroscopeViewport(ViewPort):
                 # never mixed with any other stream.
                 if (
                         any(isinstance(s, EMStream) for s in streams) and
-                        any(isinstance(s, OpticalStream) for s in streams)
+                        any(isinstance(s, (FluoStream, StaticFluoStream)) for s in streams)
                 ):
                     # TODO: don't hard-code MD_AT_FLUO and MD_AT_EM but use the
                     # acquisitionType of the corresponding streams.

--- a/src/odemis/gui/cont/acquisition.py
+++ b/src/odemis/gui/cont/acquisition.py
@@ -357,7 +357,9 @@ class SecomAcquiController(object):
         # under vacuum
         tab_data.streams.subscribe(self.on_stream_chamber)
         tab_data.main.chamberState.subscribe(self.on_stream_chamber)
-        tab_data.roa.subscribe(self.on_stream_chamber, init=True)
+
+        if hasattr(tab_data, "roa"):
+            tab_data.roa.subscribe(self.on_stream_chamber, init=True)
 
         # Disable the "acquire image" button while preparation is in progress
         self._main_data_model.is_preparing.subscribe(self.on_preparation)

--- a/src/odemis/gui/cont/views.py
+++ b/src/odemis/gui/cont/views.py
@@ -131,7 +131,7 @@ class ViewPortController(object):
     def _set_visible_views(self, visible_views):
         """ Set the order of the viewports so it will match the list of visible views
 
-        This method should normally ben called when the visible_views VA in the MicroscopeGUIData
+        This method should normally be called when the visible_views VA in the MicroscopeGUIData
         object gets changed.
 
         """

--- a/src/odemis/gui/model/__init__.py
+++ b/src/odemis/gui/model/__init__.py
@@ -71,6 +71,19 @@ TOOL_RO_ANCHOR = 8 # Select the region of the anchor region for drift correction
 # Auto-focus is handle by a separate VA, still needs an ID for the button
 TOOL_AUTO_FOCUS = 9 # Run auto focus procedure on the (active) stream
 
+ALL_TOOL_MODES = set((
+    TOOL_NONE,
+    TOOL_ZOOM,
+    TOOL_ROI,
+    TOOL_ROA,
+    TOOL_POINT,
+    TOOL_LINE,
+    TOOL_DICHO,
+    TOOL_SPOT,
+    TOOL_RO_ANCHOR,
+    TOOL_AUTO_FOCUS,
+    ))
+
 # "Actions" are also buttons on the toolbar, but with immediate effect:
 TOOL_ACT_ZOOM_FIT = 104  # Select a zoom to fit the current image content
 
@@ -454,19 +467,20 @@ class LiveViewGUIData(MicroscopyGUIData):
             if main.tc_detector:  # Can even show live settings
                 tools.add(TOOL_SPOT)
 
+                # The SpotConfocalstream, used to control spot mode.
+                # It is set at start-up by the tab controller.
+                self.spotStream = None
+              
+                # Component to which the (relative) ROIs and spot position refer to for
+                # the field-of-view.
+                self.fovComp = None
+
+                self.roa = model.TupleContinuous(acqstream.UNDEFINED_ROI,
+                                                 range=((0, 0, 0, 0), (1, 1, 1, 1)),
+                                                 cls=(int, long, float))
+
+        # Update the tool selection with the new tool list
         self.tool.choices = tools
-
-        # The SpotConfocalstream, used to control spot mode.
-        # It is set at start-up by the tab controller.
-        self.spotStream = None
-
-        # Component to which the (relative) ROIs and spot position refer to for
-        # the field-of-view.
-        self.fovComp = None
-
-        self.roa = model.TupleContinuous(acqstream.UNDEFINED_ROI,
-                                         range=((0, 0, 0, 0), (1, 1, 1, 1)),
-                                         cls=(int, long, float))
 
         # The position of the spot. Two floats 0->1. (None, None) if undefined.
         self.spotPosition = model.TupleVA((None, None))


### PR DESCRIPTION
Fixes for FLIM.
Fixes

- SPARC, SECOM, Delphi are working. Further ongoing testing is still ongoing.
- Rep control moved to stream controller
- Dwell time VA does not affect ROA overlay
- Dead object errors fixed
- FLIM stream merge ratio  fixed
- Overview working
- Incompatible tool modes disabled on some displays

Some issues still persist:
- It is possible to set a pixel size and refresh it, but somehow the ROA recalculation still hampers the ease of use
- ROI selected by default in SPARC

