### PR TITLE
streakcam: export tiff minor update

### DIFF
--- a/src/odemis/dataio/test/tiff_test.py
+++ b/src/odemis/dataio/test/tiff_test.py
@@ -765,6 +765,83 @@ class TestTiffIO(unittest.TestCase):
         self.assertEqual(im.shape, tshape)
         self.assertEqual(im[0, 0].tolist(), [0, 255, 0])
 
+    #    @skip("simple")
+    def testReadAndSaveMDSpecialDim(self):
+        """
+        Checks that we can save and read back the metadata of an image with dim CTZ=0.
+        Some older images still have a dimension CTZ=1. For newer images saved with Odemis, dimension=1
+        are initially already removed when saving.
+        """
+        # create 2 simple greyscale images (sem overview, tempSpec): XY, XYZTC (XY ebeam pos scanned, TCZ=0)
+        # simulate an image, which has only 2 dim but MD TIME_LIST
+        # (can happen for older images saved with Odemis, where CTZ=1)
+        sizes = [(512, 256), (50, 60)]  # different sizes to ensure different acquisitions
+
+        # Create fake current over time report
+        cot = [(time.time(), 1e-12)]
+        for i in range(1, 171):
+            cot.append((cot[0][0] + i, i * 1e-12))
+
+        metadata = [{model.MD_SW_VERSION: "1.0-test",
+                     model.MD_HW_NAME: "fake hw",
+                     model.MD_DESCRIPTION: "test TCZ=0",
+                     model.MD_ACQ_DATE: time.time(),
+                     model.MD_BPP: 12,
+                     model.MD_BINNING: (1, 2),  # px, px
+                     model.MD_PIXEL_SIZE: (1e-6, 2e-5),  # m/px
+                     model.MD_POS: (13.7e-3, -30e-3),  # m
+                     model.MD_EXP_TIME: 1.2,  # s
+                     model.MD_IN_WL: (500e-9, 520e-9),  # m
+                     model.MD_OUT_WL: (650e-9, 660e-9, 675e-9, 678e-9, 680e-9),  # m
+                     model.MD_EBEAM_CURRENT: 20e-6,  # A
+                     },
+                    {model.MD_SW_VERSION: "1.0-test",
+                     model.MD_HW_NAME: "fake TCZ=0",
+                     model.MD_DESCRIPTION: "test",
+                     model.MD_ACQ_DATE: time.time(),
+                     model.MD_BPP: 12,
+                     model.MD_BINNING: (1, 1),  # px, px
+                     model.MD_PIXEL_SIZE: (1e-6, 2e-5),  # m/px
+                     model.MD_POS: (13.7e-3, -30e-3),  # m
+                     model.MD_EXP_TIME: 1.2,  # s
+                     model.MD_EBEAM_CURRENT_TIME: cot,
+                     model.MD_WL_LIST: [0.0],  # explicitly append a WL_LIST MD
+                     model.MD_TIME_LIST: [0.0],  # explicitly append a TIME_LIST MD
+                     },
+                    ]
+        dtype = numpy.dtype("uint8")
+        ldata = []
+        for i, s in enumerate(sizes):
+            a = model.DataArray(numpy.zeros(s[::-1], dtype), metadata[i])
+            ldata.append(a)
+
+        # thumbnail : small RGB completely red
+        tshape = (sizes[0][1] // 8, sizes[0][0] // 8, 3)
+        tdtype = numpy.uint8
+        thumbnail = model.DataArray(numpy.zeros(tshape, tdtype))
+        thumbnail[:, :, 1] += 255  # green
+
+        # export image (MD_TIME_LIST should be not saved)
+        tiff.export(FILENAME, ldata, thumbnail)
+
+        # check it's here
+        st = os.stat(FILENAME)  # this test also that the file is created
+        self.assertGreater(st.st_size, 0)
+
+        # read back data and check
+        rdata = tiff.read_data(FILENAME)
+        self.assertEqual(len(rdata), len(ldata))
+        # check time and wl list are not in MD anymore
+        self.assertNotIn(model.MD_TIME_LIST, rdata[1].metadata)
+        self.assertNotIn(model.MD_WL_LIST, rdata[1].metadata)
+
+        # check thumbnail
+        rthumbs = tiff.read_thumbnail(FILENAME)
+        self.assertEqual(len(rthumbs), 1)
+        im = rthumbs[0]
+        self.assertEqual(im.shape, tshape)
+        self.assertEqual(im[0, 0].tolist(), [0, 255, 0])
+
     def testReadAndSaveMDAR(self):
         """
         Checks that we can read back the metadata of an Angular Resolved image

--- a/src/odemis/dataio/tiff.py
+++ b/src/odemis/dataio/tiff.py
@@ -1479,7 +1479,7 @@ def _addImageElement(root, das, ifd, rois, fname=None, fuuid=None):
             t = index[hdims.index("T")]
             deltat = da.metadata.get(model.MD_TIME_OFFSET) + da.metadata[model.MD_PIXEL_DUR] * t
             plane.attrib["DeltaT"] = "%.15f" % deltat
-        if model.MD_TIME_LIST in da.metadata:
+        if time_list:
             plane.attrib["DeltaT"] = "%.15f" % time_list[index[1]]
 
         if model.MD_EXP_TIME in da.metadata:
@@ -1746,7 +1746,7 @@ def _saveAsMultiTiffLT(filename, ldata, thumbnail, compressed=True, multiple_fil
         if data.metadata.get(model.MD_DIMS) == 'YXC' and data.shape[-1] in (3, 4):
             write_rgb = True
             hdim = data.shape[:-3]
-        # TODO: handle RGB for C at any posiion before and after XY, but iif TZ=11
+        # TODO: handle RGB for C at any position before and after XY, but iif TZ=11
         # for data > 2D: write as a sequence of 2D images or RGB images
         elif data.ndim == 5 and data.shape[0] == 3:  # RGB
             # Write an RGB image, instead of 3 images along C

--- a/src/odemis/util/spectrum.py
+++ b/src/odemis/util/spectrum.py
@@ -53,7 +53,14 @@ def get_wavelength_per_pixel(da):
     # MD_WL_LIST has priority
     if model.MD_WL_LIST in da.metadata:
         wl = da.metadata[model.MD_WL_LIST]
-        if len(wl) == da.shape[0]:
+        # check dimension of data
+        dims = da.metadata.get(model.MD_DIMS, "CTZYX"[-da.ndim:])
+        try:
+            ci = dims.index("C")  # get index of dimension C
+        except ValueError:
+            logging.debug("Dimension 'C' not in dimensions, so skip computing wavelength list.")
+            return None
+        if len(wl) == da.shape[ci]:
             return wl
         else:
             raise ValueError("Wavelength metadata (MD_WL_LIST) is not the same "
@@ -95,7 +102,14 @@ def get_time_per_pixel(da):
     # MD_WL_LIST has priority
     if model.MD_TIME_LIST in da.metadata:
         tl = da.metadata[model.MD_TIME_LIST]
-        if len(tl) == da.shape[1]:
+        # check available dimension of data
+        dims = da.metadata.get(model.MD_DIMS, "CTZYX"[-da.ndim:])
+        try:
+            ti = dims.index("T")  # get index of dimension T
+        except ValueError:
+            logging.debug("Dimension 'T' not in dimensions, so skip computing time list.")
+            return None
+        if len(tl) == da.shape[ti]:
             return tl
         else:
             raise ValueError("Time list metadata (MD_TIME_LIST) is not the same "


### PR DESCRIPTION
When reading older files saved with Odemis, the image might have higher dimensions
with CTZ=1. When reading the MD Odemis will add MD_TIME_LIST and MD_WL_LIST,
which one value. When exporting the data again, this was raising an issue.
MD_TIME_LIST and MD_WL_LIST are only saved now, if there are actually
higher dimensions of the image.