### PR TITLE
remove catmaid import from dataio init

### DIFF
--- a/src/odemis/dataio/__init__.py
+++ b/src/odemis/dataio/__init__.py
@@ -28,7 +28,7 @@ import logging
 import os
 
 from ._base import *
-from odemis.dataio import tiff, catmaid
+from odemis.dataio import tiff
 
 # The interface of a "format manager" is as follows:
 #  * one module


### PR DESCRIPTION
Removed the catmaid specific code in the previous PR but forgot to remove the import.