### PR TITLE
A bit more of Python3 syntax compatibility

### DIFF
--- a/src/odemis/acq/stream/__init__.py
+++ b/src/odemis/acq/stream/__init__.py
@@ -34,11 +34,17 @@ from ._static import *
 from ._sync import *
 from ._projection import *
 
-from abc import ABCMeta
+import sys
+import abc
+
+if sys.version_info >= (3, 4):
+    ABC = abc.ABC
+else:
+    ABC = abc.ABCMeta('ABC', (object,), {'__slots__': ()})
 
 # Generic cross-cut types
-class OpticalStream:
-    __metaclass__ = ABCMeta
+class OpticalStream(ABC):
+    pass
 
 OpticalStream.register(CameraStream)
 OpticalStream.register(StaticFluoStream)
@@ -46,44 +52,44 @@ OpticalStream.register(StaticBrightfieldStream)
 OpticalStream.register(ScannedFluoMDStream)
 
 
-class EMStream:
+class EMStream(ABC):
     """All the stream types related to electron microscope"""
-    __metaclass__ = ABCMeta
+    pass
 
 EMStream.register(SEMStream)
 EMStream.register(SpotSEMStream)
 EMStream.register(StaticSEMStream)
 
 
-class CLStream:
+class CLStream(ABC):
     """
     All the stream types related to cathodoluminescence with one C dimension
     (otherwise, it's a SpectrumStream)
     """
-    __metaclass__ = ABCMeta
+    pass
 
 CLStream.register(CLSettingsStream)
 CLStream.register(StaticCLStream)
 # TODO, also include MonochromatorSettingsStream and SEMMDStream?
 
 
-class SpectrumStream:
-    __metaclass__ = ABCMeta
+class SpectrumStream(ABC):
+    pass
 
 SpectrumStream.register(SpectrumSettingsStream)
 SpectrumStream.register(StaticSpectrumStream)
 SpectrumStream.register(SEMSpectrumMDStream)
 
 
-class TemporalSpectrumStream:
-    __metaclass__ = ABCMeta
+class TemporalSpectrumStream(ABC):
+    pass
 
 TemporalSpectrumStream.register(TemporalSpectrumSettingsStream)
 TemporalSpectrumStream.register(SEMTemporalSpectrumMDStream)
 
 
-class ARStream:
-    __metaclass__ = ABCMeta
+class ARStream(ABC):
+    pass
 
 ARStream.register(ARSettingsStream)
 ARStream.register(StaticARStream)

--- a/src/odemis/acq/stream/_sync.py
+++ b/src/odemis/acq/stream/_sync.py
@@ -39,7 +39,10 @@ from odemis.acq import leech
 from odemis.acq.leech import AnchorDriftCorrector
 from odemis.acq.stream._live import LiveStream
 import random
-import Queue
+try:
+    import Queue
+except ImportError:  # Python 3 naming
+    import queue as Queue
 from odemis.model import MD_POS, MD_DESCRIPTION, MD_PIXEL_SIZE, MD_ACQ_DATE, MD_AD_LIST, \
     MD_DWELL_TIME
 

--- a/src/odemis/cli/test/main_test.py
+++ b/src/odemis/cli/test/main_test.py
@@ -80,7 +80,7 @@ class TestWithoutBackend(unittest.TestCase):
         try:
             cmdline = "cli --set-attr light power"
             ret = main.main(cmdline.split())
-        except SystemExit, exc: # because it's handled by argparse
+        except SystemExit as exc: # because it's handled by argparse
             ret = exc.code
         self.assertNotEqual(ret, 0, "trying to run erroneous '%s'" % cmdline)
 
@@ -107,7 +107,7 @@ class TestWithoutBackend(unittest.TestCase):
         try:
             cmdline = "cli --scan bar.foo"
             ret = main.main(cmdline.split())
-        except SystemExit, exc: # because it's handled by argparse
+        except SystemExit as exc: # because it's handled by argparse
             ret = exc.code
         self.assertNotEqual(ret, 0, "Wrongly succeeded trying to run scan with unknown class: '%s'" % cmdline)
 

--- a/src/odemis/dataio/catmaid.py
+++ b/src/odemis/dataio/catmaid.py
@@ -23,13 +23,21 @@ see http://www.gnu.org/licenses/.
 """
 from __future__ import division
 
-import ConfigParser
+try:
+    import ConfigParser
+except ImportError:  # Python 3 naming
+    import configparser as ConfigParser
+
 import logging
 import math
 import numpy
 import re
 import requests
-import urlparse
+try:
+    import urlparse
+except ImportError:  # Python 3 naming
+    import urllib.parse as urlparse
+
 from PIL import Image
 from io import BytesIO
 from requests import HTTPError

--- a/src/odemis/dataio/test/hdf5_test.py
+++ b/src/odemis/dataio/test/hdf5_test.py
@@ -45,6 +45,7 @@ class TestHDF5IO(unittest.TestCase):
     def tearDown(self):
         # clean up
         try:
+            pass
             os.remove(FILENAME)
         except Exception:
             pass
@@ -238,8 +239,8 @@ class TestHDF5IO(unittest.TestCase):
         im = f["Acquisition0/ImageData/Image"]
         self.assertEqual(im[1, 0, 0, 1, 1], step)
         self.assertEqual(im.shape, data3d.shape)
-        self.assertEqual(im.attrs["CLASS"], "IMAGE")
-        self.assertEqual(im.attrs["IMAGE_SUBCLASS"], "IMAGE_GRAYSCALE")
+        self.assertEqual(im.attrs["CLASS"], b"IMAGE")
+        self.assertEqual(im.attrs["IMAGE_SUBCLASS"], b"IMAGE_GRAYSCALE")
 
         # check basic metadata
         self.assertEqual(im.dims[4].label, "X")
@@ -400,7 +401,7 @@ class TestHDF5IO(unittest.TestCase):
 
         # check format
         im = f["Acquisition0/ImageData/Image"]
-        self.assertEqual(im.attrs["IMAGE_SUBCLASS"], "IMAGE_GRAYSCALE")
+        self.assertEqual(im.attrs["IMAGE_SUBCLASS"], b"IMAGE_GRAYSCALE")
 
         # check basic metadata
         self.assertEqual(im.dims[4].label, "X")

--- a/src/odemis/dataio/tiff.py
+++ b/src/odemis/dataio/tiff.py
@@ -812,7 +812,7 @@ def _updateMDFromOME(root, das):
 
         # Update metadata of each da, so that they will be merged
         if deltats:
-            time_list = [v for k, v in sorted(deltats.items(), key=lambda (k, v): k)]
+            time_list = [v for k, v in sorted(deltats.items(), key=lambda k, v: k)]
             if len(time_list) != len(deltats.keys()):
                 logging.warning("TIME_LIST has length %d, while expected %d",
                                 len(time_list), len(deltats.keys()))

--- a/src/odemis/driver/andorshrk.py
+++ b/src/odemis/driver/andorshrk.py
@@ -79,15 +79,12 @@ SHUTTER_OPEN = 1
 SHUTTER_BNC = 2  # = driven by external signal
 
 
-class ShamrockError(Exception):
+class ShamrockError(IOError):
     def __init__(self, errno, strerror, *args, **kwargs):
         super(ShamrockError, self).__init__(errno, strerror, *args, **kwargs)
-        self.args = (errno, strerror)
-        self.errno = errno
-        self.strerror = strerror
 
     def __str__(self):
-        return self.args[1]
+        return self.strerror
 
 
 class ShamrockDLL(CDLL):
@@ -694,8 +691,8 @@ class Shamrock(model.Actuator):
             while True:
                 try:
                     self._dll.ShamrockSetGrating(self._device, grating)
-                except ShamrockError as (errno, strerr):
-                    if errno != 20201 or retry >= 5: # SHAMROCK_COMMUNICATION_ERROR
+                except ShamrockError as ex:
+                    if ex.errno != 20201 or retry >= 5: # SHAMROCK_COMMUNICATION_ERROR
                         raise
                     # just try again
                     retry += 1
@@ -776,8 +773,8 @@ class Shamrock(model.Actuator):
                 try:
                     # set in nm
                     self._dll.ShamrockSetWavelength(self._device, c_float(wavelength * 1e9))
-                except ShamrockError as (errno, strerr):
-                    if errno != 20201 or retry >= 5: # SHAMROCK_COMMUNICATION_ERROR
+                except ShamrockError as ex:
+                    if ex.errno != 20201 or retry >= 5: # SHAMROCK_COMMUNICATION_ERROR
                         raise
                     # just try again
                     retry += 1

--- a/src/odemis/driver/hamamatsurx.py
+++ b/src/odemis/driver/hamamatsurx.py
@@ -17,7 +17,10 @@ You should have received a copy of the GNU General Public License along with Ode
 
 from __future__ import division
 
-import Queue
+try:
+    import Queue
+except ImportError:  # Python 3 naming
+    import queue as Queue
 import logging
 import math
 

--- a/src/odemis/driver/phenom.py
+++ b/src/odemis/driver/phenom.py
@@ -21,7 +21,10 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 '''
 from __future__ import division
 
-import Queue
+try:
+    import Queue
+except ImportError:  # Python 3 naming
+    import queue as Queue
 from abc import abstractmethod, ABCMeta
 import base64
 import collections

--- a/src/odemis/driver/picoquant.py
+++ b/src/odemis/driver/picoquant.py
@@ -17,7 +17,10 @@ You should have received a copy of the GNU General Public License along with Ode
 
 from __future__ import division
 
-import Queue
+try:
+    import Queue
+except ImportError:  # Python 3 naming
+    import queue as Queue
 from ctypes import *
 import ctypes
 import logging

--- a/src/odemis/driver/pigcs.py
+++ b/src/odemis/driver/pigcs.py
@@ -21,7 +21,10 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 '''
 from __future__ import division
 
-import Queue
+try:
+    import Queue
+except ImportError:  # Python 3 naming
+    import queue as Queue
 from concurrent.futures import CancelledError
 import glob
 import logging

--- a/src/odemis/driver/pigcs.py
+++ b/src/odemis/driver/pigcs.py
@@ -131,16 +131,16 @@ import time
 # hidden command (which must be followed by the reconfiguration of the parameters):
 # zzz 100 parameter
 
-class PIGCSError(StandardError):
+class PIGCSError(IOError):
 
     def __init__(self, errno, *args, **kwargs):
         # Needed for pickling, cf https://bugs.python.org/issue1692335 (fixed in Python 3.3)
-        StandardError.__init__(self, errno, *args, **kwargs)
-        self.errno = errno
+        desc = self._errordict.get(errno, "Unknown error")
+        strerror = "PIGCS error %d: %s" % (errno, desc)
+        IOError.__init__(self, errno, strerror, *args, **kwargs)
 
     def __str__(self):
-        desc = self._errordict.get(self.errno, "Unknown error")
-        return "PIGCS error %d: %s" % (self.errno, desc)
+        return self.strerror
 
     _errordict = {
         0: "No error",

--- a/src/odemis/driver/scpi.py
+++ b/src/odemis/driver/scpi.py
@@ -296,7 +296,7 @@ class Ammeter(model.Detector):
 
         try:
             val, ts, err = float(values[0][:-1]), float(values[1]), int(float(values[2]))
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             raise IOError("Failed to read measurement (got %s)" % (res,))
 
         return val, ts, err

--- a/src/odemis/driver/semcomedi.py
+++ b/src/odemis/driver/semcomedi.py
@@ -21,7 +21,10 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 '''
 from __future__ import division
 
-import Queue
+try:
+    import Queue
+except ImportError:  # Python 3 naming
+    import queue as Queue
 import collections
 import functools
 import gc

--- a/src/odemis/driver/simcam.py
+++ b/src/odemis/driver/simcam.py
@@ -21,7 +21,10 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 '''
 from __future__ import division
 
-import Queue
+try:
+    import Queue
+except ImportError:  # Python 3 naming
+    import queue as Queue
 import logging
 import numpy
 from odemis import model, util, dataio

--- a/src/odemis/driver/simsem.py
+++ b/src/odemis/driver/simsem.py
@@ -22,7 +22,10 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 
 from __future__ import division
 
-import Queue
+try:
+    import Queue
+except ImportError:  # Python 3 naming
+    import queue as Queue
 import logging
 import math
 import numpy

--- a/src/odemis/driver/simstreakcam.py
+++ b/src/odemis/driver/simstreakcam.py
@@ -17,7 +17,10 @@ You should have received a copy of the GNU General Public License along with Ode
 
 from __future__ import division
 
-import Queue
+try:
+    import Queue
+except ImportError:  # Python 3 naming
+    import queue as Queue
 import logging
 from odemis import model, util, dataio
 from odemis.model import oneway

--- a/src/odemis/driver/spectrapro.py
+++ b/src/odemis/driver/spectrapro.py
@@ -55,7 +55,7 @@ def hextof(s):
         for c in s.split(","):
             d += chr(int(c, 16))
         return struct.unpack("<d", d)[0]
-    except ValueError, struct.error:
+    except (ValueError, struct.error):
         raise ValueError("Cannot convert %s to a float" % (s,))
 
 

--- a/src/odemis/driver/tescan.py
+++ b/src/odemis/driver/tescan.py
@@ -271,7 +271,7 @@ class SEM(model.HwComponent):
                     # write and read the raw data
                     try:
                         rdas = self._acquire_detectors(detectors)
-                    except CancelledError, e:
+                    except CancelledError as e:
                         # either because must terminate or just need to rest
                         logging.debug("Acquisition was cancelled %s", e)
                         continue

--- a/src/odemis/driver/tescan.py
+++ b/src/odemis/driver/tescan.py
@@ -22,7 +22,10 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 
 from __future__ import absolute_import, division
 
-import Queue
+try:
+    import Queue
+except ImportError:  # Python 3 naming
+    import queue as Queue
 import gc
 import logging
 import math

--- a/src/odemis/driver/test/spectrometer_test.py
+++ b/src/odemis/driver/test/spectrometer_test.py
@@ -21,7 +21,10 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 '''
 from __future__ import division
 
-import Queue
+try:
+    import Queue
+except ImportError:  # Python 3 naming
+    import queue as Queue
 import logging
 from odemis import model
 from odemis.driver import spectrometer, spectrapro, pvcam, andorcam2, andorshrk

--- a/src/odemis/driver/tmcm.py
+++ b/src/odemis/driver/tmcm.py
@@ -49,7 +49,6 @@ import serial
 import struct
 import threading
 import time
-from types import NoneType
 
 
 class TMCLError(Exception):
@@ -344,7 +343,7 @@ class TMCLController(model.Actuator):
                 continue
 
             self._abs_encoder[i] = abs_encoder[i]
-            if not isinstance(abs_encoder[i], (bool, NoneType)):
+            if not abs_encoder[i] in {True, False, None}:
                 raise ValueError("abs_encoder argument must only contain True, False, or None")
             # If abs_encoder is False (ie, there is a encoder, but it's not absolute),
             # it might be referenced or not, and it might be the same as the

--- a/src/odemis/driver/ueye.py
+++ b/src/odemis/driver/ueye.py
@@ -16,7 +16,10 @@ You should have received a copy of the GNU General Public License along with Ode
 '''
 from __future__ import division
 
-import Queue
+try:
+    import Queue
+except ImportError:  # Python 3 naming
+    import queue as Queue
 from ctypes import *
 import ctypes
 import gc

--- a/src/odemis/gui/comp/text.py
+++ b/src/odemis/gui/comp/text.py
@@ -26,6 +26,7 @@ Content:
 
 """
 from __future__ import division
+from builtins import str, chr # For Python 2 & 3
 
 import locale
 import logging
@@ -278,7 +279,7 @@ class SuggestTextCtrl(wx.TextCtrl, listmix.ColumnSorterMixin):
         self._updateDataList(self._choices)
         self.dropdownlistbox.InsertColumn(0, "")
         for num, colVal in enumerate(self._choices):
-            index = self.dropdownlistbox.InsertItem(sys.maxint, colVal, -1)
+            index = self.dropdownlistbox.InsertItem(sys.maxsize, colVal, -1)
             self.dropdownlistbox.SetItem(index, 0, colVal)
             self.dropdownlistbox.SetItemData(index, num)
         self._setListSize()
@@ -314,7 +315,7 @@ class SuggestTextCtrl(wx.TextCtrl, listmix.ColumnSorterMixin):
             if self._select_callback:
                 dd = self.dropdownlistbox
                 values = [dd.GetItem(sel, x).GetText()
-                          for x in xrange(dd.GetColumnCount())]
+                          for x in range(dd.GetColumnCount())]
                 self._select_callback(values)
             self.SetValue(itemtext)
             self.SetToolTip(itemtext)
@@ -497,9 +498,9 @@ class _NumberValidator(ValidatorClass):
             event.Skip()
             return
 
-        field_val = unicode(self._get_str_value())
+        field_val = str(self._get_str_value())
         start, end = self.GetWindow().GetSelection()
-        field_val = field_val[:start] + unichr(ukey) + field_val[end:]
+        field_val = field_val[:start] + chr(ukey) + field_val[end:]
 
         if not field_val or self.entry_pattern.match(field_val):
             # logging.debug("Field value %s accepted using %s", "field_val", self.entry_regex)

--- a/src/odemis/gui/conf/file.py
+++ b/src/odemis/gui/conf/file.py
@@ -20,8 +20,12 @@ This file is part of Odemis.
 from __future__ import division
 
 from abc import ABCMeta, abstractproperty
-from ConfigParser import NoOptionError
-import ConfigParser
+try:
+    import ConfigParser
+    from ConfigParser import NoOptionError
+except ImportError:  # Python 3 naming
+    import configparser as ConfigParser
+    from configparser import NoOptionError
 import logging
 import math
 import os.path

--- a/src/odemis/gui/conf/util.py
+++ b/src/odemis/gui/conf/util.py
@@ -426,7 +426,7 @@ def process_setting_metadata(hw_comp, setting_va, conf):
             # TODO: handle iterables
             rng = setting_va.range
             choices = set(c for c in choices if rng[0] <= c <= rng[1])
-    except (AttributeError, NotApplicableError), e:
+    except (AttributeError, NotApplicableError) as e:
         pass
 
     # Ensure the choices are within the range (if both are given)

--- a/src/odemis/gui/main.py
+++ b/src/odemis/gui/main.py
@@ -119,7 +119,7 @@ class OdemisGUIApp(wx.App):
             gui.name = odemis.__shortname__
             try:
                 microscope = model.getMicroscope()
-            except (IOError, Pyro4.errors.CommunicationError), e:
+            except (IOError, Pyro4.errors.CommunicationError) as e:
                 logging.exception("Failed to connect to back-end")
                 msg = ("The Odemis GUI could not connect to the Odemis back-end:"
                        "\n\n{0}\n\n"

--- a/src/odemis/gui/model/__init__.py
+++ b/src/odemis/gui/model/__init__.py
@@ -22,7 +22,10 @@ This file is part of Odemis.
 """
 from __future__ import division
 
-import Queue
+try:
+    import Queue
+except ImportError:  # Python 3 naming
+    import queue as Queue
 from abc import ABCMeta
 import collections
 import logging

--- a/src/odemis/gui/util/__init__.py
+++ b/src/odemis/gui/util/__init__.py
@@ -22,7 +22,10 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 
 from __future__ import division
 
-import Queue
+try:
+    import Queue
+except ImportError:  # Python 3 naming
+    import queue as Queue
 from decorator import decorator
 from functools import wraps
 import inspect

--- a/src/odemis/gui/util/raster.py
+++ b/src/odemis/gui/util/raster.py
@@ -22,13 +22,20 @@ This file is part of Odemis.
 """
 
 from __future__ import division
+from builtins import range  # For Python 2 & 3
 
 import math
 
 
-def rasterize_line((x0, y0), (x1, y1), width=1):
-    """ Return a list of points that form a line between the two given points """
-
+def rasterize_line(p0, p1, width=1):
+    """ Return a list of points that form a line between the two given points
+    p0 (int, int): x, y of the first point on the line
+    p1 (int, int): x, y of the last point on the line
+    return (list of (int, int)): all the points on the line segment, including p0,
+     and p1.
+    """
+    x0, y0 = p0
+    x1, y1 = p1
     points = []
 
     if width == 1:
@@ -41,7 +48,7 @@ def rasterize_line((x0, y0), (x1, y1), width=1):
         x, y = x0, y0
 
         while True:
-            points += [(x, y)]
+            points.append((x, y))
             if x == x1 and y == y1:
                 break
             e2 = err * 2
@@ -80,7 +87,10 @@ def rasterize_line((x0, y0), (x1, y1), width=1):
 
 
 def rasterize_rectangle(rectangle):
-    """ Return a list op points that form a rasterized rectangle """
+    """ Return a list of points that form a rasterized rectangle
+    retangle (4 x (int, int)): the x,y coordinates of each corner of the rectangle
+    return (list of (int, int)): all the points in the rectangle.
+    """
 
     if len(rectangle) != 4:
         raise ValueError("Incorrect number of vertices!")
@@ -98,16 +108,21 @@ def rasterize_rectangle(rectangle):
     points.extend(l3[:-1])
     points.extend(l4[:-1])
 
-    for x in xrange(min(r1[0], r2[0], r3[0], r4[0]), max(r1[0], r2[0], r3[0], r4[0])):
-        for y in xrange(min(r1[1], r2[1], r3[1], r4[1]), max(r1[1], r2[1], r3[1], r4[1])):
+    for x in range(min(r1[0], r2[0], r3[0], r4[0]), max(r1[0], r2[0], r3[0], r4[0])):
+        for y in range(min(r1[1], r2[1], r3[1], r4[1]), max(r1[1], r2[1], r3[1], r4[1])):
             if point_in_polygon((x, y), [r1, r2, r3, r4]):
                 points.append((x, y))
 
     return points
 
 
-def point_in_polygon((x, y), polygon):
-    """ Determine if the given x,y point is inside the polygon """
+def point_in_polygon(p, polygon):
+    """ Determine if the given point is inside the polygon
+    p (int, int): x, y of the point
+    polygon (4 x (int, int)): the x,y coordinates of each vertices of the polygon
+    return (bool): True if the point is within the polygon
+    """
+    x, y = p
 
     n = len(polygon)
     inside = False

--- a/src/odemis/gui/util/updater.py
+++ b/src/odemis/gui/util/updater.py
@@ -195,8 +195,8 @@ class WindowsUpdater:
     def run_installer(local_path):
         try:
             subprocess.call(local_path)
-        except WindowsError, (err_nr, _):
-            if err_nr == 740:
+        except WindowsError as ex:
+            if ex.winerror == 740:
                 os.startfile(local_path, "runas")
             else:
                 raise

--- a/src/odemis/model/_vattributes.py
+++ b/src/odemis/model/_vattributes.py
@@ -32,6 +32,7 @@ from odemis.util.weak import WeakMethod, WeakRefLostError
 import os
 import threading
 import types
+import sys
 import zmq
 from scipy.spatial import distance
 
@@ -692,9 +693,11 @@ class _NotifyingList(list):
     __iadd__ = _call_with_notifier(list.__iadd__)
     __imul__ = _call_with_notifier(list.__imul__)
     __setitem__ = _call_with_notifier(list.__setitem__)
-    __setslice__ = _call_with_notifier(list.__setslice__)
     __delitem__ = _call_with_notifier(list.__delitem__)
-    __delslice__ = _call_with_notifier(list.__delslice__)
+    if sys.version_info[0] < 3:
+        # unused since Python 3 (setitem and delitem are used)
+        __setslice__ = _call_with_notifier(list.__setslice__)
+        __delslice__ = _call_with_notifier(list.__delslice__)
 
     append = _call_with_notifier(list.append)
     extend = _call_with_notifier(list.extend)

--- a/src/odemis/model/_vattributes.py
+++ b/src/odemis/model/_vattributes.py
@@ -1008,7 +1008,7 @@ class VAEnumerated(VigilantAttribute, Enumerated):
             if not ls:
                 return self.value  # in case of all choices of type tuple and not containing only numbers
 
-            return min(ls, key=lambda (choice, distance): distance)[0]
+            return min(ls, key=lambda choice, distance: distance)[0]
 
         else:
             # if not possible to set the requested value, return the current value

--- a/src/odemis/model/_vattributes.py
+++ b/src/odemis/model/_vattributes.py
@@ -31,7 +31,6 @@ import numpy
 from odemis.util.weak import WeakMethod, WeakRefLostError
 import os
 import threading
-from types import NoneType
 import types
 import zmq
 from scipy.spatial import distance
@@ -782,7 +781,7 @@ class TupleVA(VigilantAttribute):
 
     def _check(self, value):
         # only accept tuple and None, to avoid hidden data changes, as can occur in lists
-        if not isinstance(value, (tuple, NoneType)):
+        if not (isinstance(value, tuple) or value is None):
             raise TypeError("Value '%r' is not a tuple." % value)
 
 

--- a/src/odemis/odemisd/modelgen.py
+++ b/src/odemis/odemisd/modelgen.py
@@ -56,7 +56,7 @@ class SafeLoader(yaml.SafeLoader):
             key = self.construct_object(key_node, deep=deep)
             try:
                 hash(key)
-            except TypeError, exc:
+            except TypeError as exc:
                 raise ConstructorError("while constructing a mapping", node.start_mark,
                         "found unacceptable key (%s)" % exc, key_node.start_mark)
             value = self.construct_object(value_node, deep=deep)

--- a/src/odemis/odemisd/test/main_test.py
+++ b/src/odemis/odemisd/test/main_test.py
@@ -135,7 +135,7 @@ class TestCommandLine(unittest.TestCase):
         try:
             cmdline = "odemisd --validate"
             ret = main.main(cmdline.split())
-        except SystemExit, exc: # because it's handled by argparse
+        except SystemExit as exc: # because it's handled by argparse
             ret = exc.code
         self.assertNotEqual(ret, 0, "trying to run erroneous '%s'" % cmdline)
 
@@ -160,7 +160,7 @@ class TestCommandLine(unittest.TestCase):
 
             cmdline = "odemisd --help"
             ret = main.main(cmdline.split())
-        except SystemExit, exc:
+        except SystemExit as exc:
             ret = exc.code
         self.assertEqual(ret, 0, "trying to run '%s'" % cmdline)
 

--- a/src/odemis/util/__init__.py
+++ b/src/odemis/util/__init__.py
@@ -26,7 +26,10 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 
 from __future__ import division, absolute_import
 
-import Queue
+try:
+    import Queue
+except ImportError:  # Python 3 naming
+    import queue as Queue
 import collections
 from concurrent.futures import CancelledError
 from decorator import decorator

--- a/src/odemis/util/fluo.py
+++ b/src/odemis/util/fluo.py
@@ -18,6 +18,7 @@ You should have received a copy of the GNU General Public License along with Ode
 # various functions to help with computations related to fluorescence microscopy
 
 from __future__ import division
+from past.builtins import basestring # For Python 2 & 3
 
 import collections
 import logging
@@ -232,7 +233,7 @@ def to_readable_band(band):
     # if multi-band => center, center... nm
     #   ex: 453, 568, 968 nm
     if isinstance(band, basestring):
-        return unicode(band)
+        return band
     if not isinstance(band[0], collections.Iterable):
         b = band
         center_nm = int(round(get_center(b) * 1e9))

--- a/src/odemis/util/peak.py
+++ b/src/odemis/util/peak.py
@@ -17,7 +17,6 @@ You should have received a copy of the GNU General Public License along with Ode
 from __future__ import division
 
 from concurrent.futures._base import CancelledError, CANCELLED, FINISHED, RUNNING
-from itertools import izip
 import logging
 import numpy
 from odemis import model
@@ -352,7 +351,7 @@ def _Grouped(iterable, n):
     """
     Iterate over the iterable, n elements at a time
     """
-    return izip(*[iter(iterable)] * n)
+    return zip(*[iter(iterable)] * n)
 
 
 def _Normalize(vector):

--- a/src/odemis/util/units.py
+++ b/src/odemis/util/units.py
@@ -167,10 +167,10 @@ def decompose_si_prefix(str_val, unit=None):
     """
 
     if unit:
-        match = re.match(ur"([+-]?[\d.]+(?:[eE][+-]?[\d]+)?)[ ]*([GMkmµunp])?(%s)?$" % unit,
+        match = re.match(u"([+-]?[\\d.]+(?:[eE][+-]?[\\d]+)?)[ ]*([GMkmµunp])?(%s)?$" % unit,
                          str_val.strip())
     else:  # Look for any unit
-        match = re.match(ur"([+-]?[\d.]+(?:[eE][+-]?[\d]+)?)[ ]*([GMkmµunp])?([A-Za-z]+)?$",
+        match = re.match(u"([+-]?[\\d.]+(?:[eE][+-]?[\\d]+)?)[ ]*([GMkmµunp])?([A-Za-z]+)?$",
                          str_val.strip())
 
     if match:


### PR DESCRIPTION
Go a little further to support Python 3. The goal is to get all the code working both on Python 2 and 3.
For now it should be possible to load `odemis.model.metadata` and `odemis.dataio.hdf5`, which is already quite handy for external scripts using Odemis. Mostly based on futurize and the summary at:
https://python-future.org/compatible_idioms.html

It relies on a extra package: python-future. Of course, for Python 3, all the current packages must be also installed in their python3 incarnation. So one would need to run first:
`sudo apt install python-future python3-future python3-numpy python3-wxgtk4.0 python3-opencv`
To run a test case:
`python3 src/odemis/dataio/test/hdf5_test.py --verbose`

To run the GUI:
`python3 src/odemis/gui/main.py --log-level 2 --standalone`  (of course, this one doesn't work)