### PR TITLE
Fix for CSV Test

### DIFF
--- a/src/odemis/dataio/test/csv_test.py
+++ b/src/odemis/dataio/test/csv_test.py
@@ -108,6 +108,29 @@ class TestCSVIO(unittest.TestCase):
             raised = True
         self.assertFalse(raised, 'Failed to read csv file')
 
+    def testExportChronogram(self):
+        """Try simple chronogram export"""
+        size = (150,)
+        dtype = numpy.uint16
+        md = {model.MD_TIME_LIST: numpy.linspace(536e-9, 650e-9, size[0]).tolist(),
+              model.MD_ACQ_TYPE: model.MD_AT_SPECTRUM,
+              model.MD_DIMS: "T"}
+        data = model.DataArray(numpy.zeros(size, dtype), md)
+        data += 56
+
+        # export
+        csv.export(FILENAME, data)
+
+        # check it's here
+        st = os.stat(FILENAME)  # this test also that the file is created
+        self.assertGreater(st.st_size, 150)
+        raised = False
+        try:
+            pycsv.reader(open(FILENAME, 'rb'))
+        except IOError:
+            raised = True
+        self.assertFalse(raised, 'Failed to read csv file')
+
     def testExportSpectrumNoWL(self):
         """Try simple spectrum export"""
         size = (10,)

--- a/src/odemis/dataio/test/csv_test.py
+++ b/src/odemis/dataio/test/csv_test.py
@@ -90,7 +90,8 @@ class TestCSVIO(unittest.TestCase):
         size = (150,)
         dtype = numpy.uint16
         md = {model.MD_WL_LIST: numpy.linspace(536e-9, 650e-9, size[0]).tolist(),
-              model.MD_ACQ_TYPE: model.MD_AT_SPECTRUM}
+              model.MD_ACQ_TYPE: model.MD_AT_SPECTRUM,
+              model.MD_DIMS: "C"}
         data = model.DataArray(numpy.zeros(size, dtype), md)
         data += 56
 
@@ -111,7 +112,7 @@ class TestCSVIO(unittest.TestCase):
         """Try simple spectrum export"""
         size = (10,)
         dtype = numpy.uint16
-        md = {model.MD_ACQ_TYPE: model.MD_AT_SPECTRUM}
+        md = {model.MD_ACQ_TYPE: model.MD_AT_SPECTRUM, model.MD_DIMS: "C"}
         data = model.DataArray(numpy.zeros(size, dtype), md)
         data += 56486
 
@@ -134,7 +135,8 @@ class TestCSVIO(unittest.TestCase):
         dtype = numpy.float
         md = {model.MD_WL_LIST: numpy.linspace(536e-9, 650e-9, size[0]).tolist(),
               model.MD_PIXEL_SIZE: (None, 4.2e-06),
-              model.MD_ACQ_TYPE: model.MD_AT_SPECTRUM}
+              model.MD_ACQ_TYPE: model.MD_AT_SPECTRUM,
+              model.MD_DIMS: "XC"}
         data = model.DataArray(numpy.zeros(size, dtype), md)
 
         # export
@@ -155,7 +157,8 @@ class TestCSVIO(unittest.TestCase):
         size = (1340, 6)
         dtype = numpy.float
         md = {model.MD_PIXEL_SIZE: (None, 4.2e-06),
-              model.MD_ACQ_TYPE: model.MD_AT_SPECTRUM}
+              model.MD_ACQ_TYPE: model.MD_AT_SPECTRUM,
+              model.MD_DIMS: "XC"}
         data = model.DataArray(numpy.zeros(size, dtype), md)
 
         # export


### PR DESCRIPTION
This fix works, since the test data had no dimension metadata and this is now needed (and provided by projections) to determine what data is exported. 