### PR TITLE
driver omicronxx: fix incorrect channel if reseting the master

### DIFF
--- a/src/odemis/driver/omicronxx.py
+++ b/src/odemis/driver/omicronxx.py
@@ -256,11 +256,12 @@ class DevxX(object):
                               acc.port, error, lerror)
 
             # always reset the master, so temporarily do not send the channel
+            com_chan_orig = self._com_chan
+            self._com_chan = ""
             try:
-                self._com_chan = ""
                 self.ResetController()
             finally:
-                self._com_chan = "[%d]" % channel
+                self._com_chan = com_chan_orig
 
             # Check if that has helped
             error = self.GetFailureByte()


### PR DESCRIPTION
In the (very rare) case that a recoverable error is detected on the
master node, a reset is attempted. However, the hack to always reset
the master went wrong, and afterwards, the master is set as "child 0",
which doesn't exists, and confuses the rest of the communication.

=> copy the previous channel value, so we are certain to restore it
properly.

It would be shown in such trace:

2019-05-07 10:45:22,642 (omicronxx) INFO: Device (on port /dev/ttyFTDI0) reports error 0x1 (latched 0x801), will reset it
2019-05-07 10:45:22,642 (omicronxx) DEBUG: Sending: '?RsC\r'
2019-05-07 10:45:22,658 (omicronxx) DEBUG: Received: '!RsC'
2019-05-07 10:45:22,658 (omicronxx) WARNING: Answer too short after setting RsC: RsC
2019-05-07 10:45:23,658 (omicronxx) DEBUG: Received: ''
:
2019-05-07 10:45:31,666 (omicronxx) DEBUG: Received: ''
2019-05-07 10:45:32,558 (omicronxx) DEBUG: Received: '$RsC>'
2019-05-07 10:45:32,558 (omicronxx) DEBUG: Sending: '?GFB[0]\r'
2019-05-07 10:45:32,574 (omicronxx) DEBUG: Received: '!GFB[0]x'
2019-05-07 10:45:32,582 (modelgen) ERROR: Error while instantiating component Light Engine.
:
2019-05-07 10:45:32,583 (main) INFO: Remote exception Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/Pyro4/core.py", line 911, in handleRequest
    data=method(*vargs, **kwargs)   # this is the actual method call to the Pyro object
  File "/usr/lib/python2.7/dist-packages/odemis/model/_core.py", line 251, in instantiate
    return self.daemon.instantiate(klass, kwargs)
  File "/usr/lib/python2.7/dist-packages/odemis/model/_core.py", line 331, in instantiate
    comp = klass(**kwargs)
  File "/usr/lib/python2.7/dist-packages/odemis/driver/omicronxx.py", line 809, in __init__
    super(HubxX, self).__init__(name, role, ports=port, **kwargs)
  File "/usr/lib/python2.7/dist-packages/odemis/driver/omicronxx.py", line 633, in __init__
    self._master, self._devices = self._getAvailableDevices(ports)
  File "/usr/lib/python2.7/dist-packages/odemis/driver/omicronxx.py", line 847, in _getAvailableDevices
    mdevs = cls._getMasterDevices(ports)
  File "/usr/lib/python2.7/dist-packages/odemis/driver/omicronxx.py", line 829, in _getMasterDevices
    d = DevxX(acc, 0)
  File "/usr/lib/python2.7/dist-packages/odemis/driver/omicronxx.py", line 266, in __init__
    error = self.GetFailureByte()
  File "/usr/lib/python2.7/dist-packages/odemis/driver/omicronxx.py", line 532, in GetFailureByte
    return int(ans, 16)
ValueError: invalid literal for int() with base 16: 'x'