### PR TITLE
driver omicronxx: also disable ad-hoc messages on the master

### DIFF
--- a/src/odemis/driver/omicronxx.py
+++ b/src/odemis/driver/omicronxx.py
@@ -281,6 +281,15 @@ class DevxX(object):
         if not (status & (1 << 6)):  # bit 6: "external" light enabler (=1)
             raise HwError("Electronic shutter active, open the shutter by pressing the button on the device")
 
+        # Disable ad-hoc mode (on the master device)
+        # (alternatively, we could listen to the messages, and update info such
+        # as the temperature)
+        # Also disable external modulation, to control fully by software
+        mode = self.GetOperatingMode()
+        # Disable: Ad-hoc mode (13), analog modulation (7), digital modulation (5)
+        mode &= ~((1 << 13) | (1 << 7) | (1 << 5))
+        self.SetOperatingMode(mode)
+
         if channel == 0:  # master
             return
 
@@ -291,15 +300,6 @@ class DevxX(object):
         else:
             # old style
             self.setLightPower = self.SetLevelPower
-
-        # Disable ad-hoc mode (on the master device)
-        # (alternatively, we could listen to the messages, and update info such
-        # as the temperature)
-        # Also disable external modulation, to control fully by software
-        mode = self.GetOperatingMode()
-        # Disable: Ad-hoc mode (13), analog modulation (7), digital modulation (5)
-        mode &= ~((1 << 13) | (1 << 7) | (1 << 5))
-        self.SetOperatingMode(mode)
 
         if devid in (19, 20):  # LEDMOD, LedHUB => led
             # The wavelength range is not precisely provided by the hardware,


### PR DESCRIPTION
The sending of ad-hoc messages seems to only be governed by the "master"
device. However, that was the only one were we didn't disable it.
So it had no effect. In most cases, it's not a big issue, as the ad-hoc
messages are automatically discarded next time a response is read.
However, if many ad-hoc messages have been sent, they fill up the queue
of the serial port (in the Linux kernel), and prevent to get the
responce corresponding to the latest command.