### PR TITLE
python3 migration: long, part 2

### DIFF
--- a/plugins/ar_spectral.py
+++ b/plugins/ar_spectral.py
@@ -41,7 +41,7 @@ other dealings in the software.
 
 from __future__ import division
 
-from builtins import int
+from past.builtins import long
 from collections import OrderedDict
 from concurrent.futures._base import CancelledError, CANCELLED, FINISHED, RUNNING
 import logging
@@ -95,7 +95,7 @@ class SpectralARScanStream(stream.Stream):
                                                unit="s")
         self.emtTranslation = model.TupleContinuous((0, 0),
                                                     range=self._emitter.translation.range,
-                                                    cls=(int, float),
+                                                    cls=(int, long, float),
                                                     unit="px")
 
         # Distance between the center of each pixel
@@ -104,12 +104,12 @@ class SpectralARScanStream(stream.Stream):
         # Region of acquisition. ROI form is LEFT Top RIGHT Bottom, relative to full field size
         self.roi = model.TupleContinuous((0, 0, 1, 1),
                                          range=((0, 0, 0, 0), (1, 1, 1, 1)),
-                                         cls=(int, float))
+                                         cls=(int, long, float))
 
         # For drift correction
         self.dcRegion = model.TupleContinuous(UNDEFINED_ROI,
                                               range=((0, 0, 0, 0), (1, 1, 1, 1)),
-                                              cls=(int, float))
+                                              cls=(int, long, float))
         self.dcDwellTime = model.FloatContinuous(emitter.dwellTime.range[0],
                                                  range=emitter.dwellTime.range, unit="s")
 

--- a/plugins/cl_tcorr_acq.py
+++ b/plugins/cl_tcorr_acq.py
@@ -25,7 +25,7 @@ see http://www.gnu.org/licenses/.
 
 from __future__ import division
 
-from builtins import int
+from past.builtins import long
 from collections import OrderedDict
 from concurrent.futures._base import CancelledError, CANCELLED, FINISHED, RUNNING
 import logging
@@ -89,7 +89,7 @@ class CorrelatorScanStream(stream.Stream):
         # Region of acquisition. ROI form is LEFT Top RIGHT Bottom, relative to full field size
         self.roi = model.TupleContinuous((0, 0, 1, 1),
                                          range=((0, 0, 0, 0), (1, 1, 1, 1)),
-                                         cls=(int, float))
+                                         cls=(int, long, float))
 
         # Cropvalue that  can be used to crop the data for better visualization in odemis
         self.cropvalue = model.IntContinuous(1024, (1, 65536), unit="px")
@@ -97,7 +97,7 @@ class CorrelatorScanStream(stream.Stream):
         # For drift correction
         self.dcRegion = model.TupleContinuous(UNDEFINED_ROI,
                                               range=((0, 0, 0, 0), (1, 1, 1, 1)),
-                                              cls=(int, float))
+                                              cls=(int, long, float))
         self.dcDwellTime = model.FloatContinuous(emitter.dwellTime.range[0],
                                                  range=emitter.dwellTime.range, unit="s")
         #number of drift corrections per scanning pixel

--- a/scripts/monochromator-scan.py
+++ b/scripts/monochromator-scan.py
@@ -18,7 +18,7 @@ select spot mode, and pick the point you're interested.
 
 from __future__ import division, print_function
 
-from builtins import int
+from past.builtins import long
 from collections import OrderedDict
 from concurrent.futures._base import CancelledError, CANCELLED, FINISHED, RUNNING
 import logging
@@ -73,7 +73,7 @@ class MonochromatorScanStream(stream.Stream):
                                                unit="s")
         self.emtTranslation = model.TupleContinuous((0, 0),
                                                     range=self._emitter.translation.range,
-                                                    cls=(int, float),
+                                                    cls=(int, long, float),
                                                     unit="px")
 
         # For acquisition

--- a/src/odemis/acq/leech.py
+++ b/src/odemis/acq/leech.py
@@ -22,7 +22,7 @@ You should have received a copy of the GNU General Public License along with Ode
 
 from __future__ import division
 
-from builtins import int
+from past.builtins import long
 import logging
 import math
 import numpy
@@ -164,7 +164,7 @@ class AnchorDriftCorrector(LeechAcquirer):
         #  still not scanning too many pixels.
         self.roi = model.TupleContinuous(UNDEFINED_ROI,
                                          range=((0, 0, 0, 0), (1, 1, 1, 1)),
-                                         cls=(int, float),
+                                         cls=(int, long, float),
                                          setter=self._setROI)
         self.dwellTime = model.FloatContinuous(scanner.dwellTime.range[0],
                                                range=scanner.dwellTime.range, unit="s")

--- a/src/odemis/acq/stream/_base.py
+++ b/src/odemis/acq/stream/_base.py
@@ -17,7 +17,7 @@ You should have received a copy of the GNU General Public License along with Ode
 
 from __future__ import division
 
-from builtins import int
+from past.builtins import long
 import collections
 import functools
 import gc
@@ -187,7 +187,7 @@ class Stream(object):
         # black/white. Its range is ._drange (will be updated by _updateDRange)
         self.intensityRange = model.TupleContinuous((0, 0),
                                                     range=((0, 0), (1, 1)),
-                                                    cls=(int, float),
+                                                    cls=(int, long, float),
                                                     setter=self._setIntensityRange)
         # Make it so that the value gets clipped when its range is updated and
         # the value is outside of it.

--- a/src/odemis/acq/stream/_helper.py
+++ b/src/odemis/acq/stream/_helper.py
@@ -21,7 +21,7 @@ You should have received a copy of the GNU General Public License along with Ode
 
 from __future__ import division
 
-from builtins import int
+from past.builtins import long
 from abc import abstractmethod
 from concurrent.futures._base import CancelledError
 from functools import wraps
@@ -99,7 +99,7 @@ class RepetitionStream(LiveStream):
         # We overwrite the VA provided by LiveStream to define a setter.
         self.roi = model.TupleContinuous((0, 0, 1, 1),
                                          range=((0, 0, 0, 0), (1, 1, 1, 1)),
-                                         cls=(int, float),
+                                         cls=(int, long, float),
                                          setter=self._setROI)
 
         # Start with pixel size to fit 1024 px, as it's typically a sane value

--- a/src/odemis/acq/stream/_live.py
+++ b/src/odemis/acq/stream/_live.py
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License along with Ode
 
 from __future__ import division
 
-from builtins import int
+from past.builtins import long
 from concurrent.futures.thread import ThreadPoolExecutor
 import gc
 import logging
@@ -56,7 +56,7 @@ class LiveStream(Stream):
         # whole area of the emitter => between 0 and 1)
         self.roi = model.TupleContinuous((0, 0, 1, 1),
                                          range=((0, 0, 0, 0), (1, 1, 1, 1)),
-                                         cls=(int, float))
+                                         cls=(int, long, float))
 
         self._ht_needs_recompute = threading.Event()
         self._hthread = threading.Thread(target=self._histogram_thread,
@@ -1024,7 +1024,7 @@ class ScannerSettingsStream(Stream):
         # Resolution assumes that we scan the whole roi. For smaller ROIs, the
         # actual hardware setting is proportional.
         self.resolution = model.TupleContinuous(hwres.value, range=hwres.range,
-                                                cls=int,
+                                                cls=(int, long, float),
                                                 setter=self._setResolution)
         self.resolution.subscribe(self._onResolution)
 
@@ -1032,7 +1032,7 @@ class ScannerSettingsStream(Stream):
         # whole area of the scanner => between 0 and 1)
         self.roi = model.TupleContinuous((0, 0, 1, 1),
                                          range=((0, 0, 0, 0), (1, 1, 1, 1)),
-                                         cls=(int, float))
+                                         cls=(int, long, float))
         self.roi.subscribe(self._onROI)
 
         mxzoom = min(1 / hwscale.range[0][0], 1 / hwscale.range[0][1])

--- a/src/odemis/acq/stream/_static.py
+++ b/src/odemis/acq/stream/_static.py
@@ -25,8 +25,7 @@ see http://www.gnu.org/licenses/.
 
 from __future__ import division
 
-from builtins import int
-from past.builtins import basestring
+from past.builtins import basestring, long
 import collections
 import logging
 import gc
@@ -733,7 +732,7 @@ class StaticSpectrumStream(StaticStream):
                                         (cwl - width, cwl + width),
                                         range=((min_bw, min_bw), (max_bw, max_bw)),
                                         unit=unit_bw,
-                                        cls=(int, float))
+                                        cls=(int, long, float))
             self.spectrumBandwidth.subscribe(self.onSpectrumBandwidth)
 
             # Whether the (per bandwidth) display should be split intro 3 sub-bands

--- a/src/odemis/acq/test/stream_test.py
+++ b/src/odemis/acq/test/stream_test.py
@@ -21,7 +21,7 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 # Test module for model.Stream classes
 from __future__ import division, print_function
 
-from builtins import int
+from past.builtins import long
 from concurrent.futures import CancelledError
 import gc
 import logging
@@ -72,9 +72,9 @@ class FakeEBeam(model.Emitter):
         self.pixelSize = model.VigilantAttribute((1e-9, 1e-9), unit="m", readonly=True)
         self.magnification = model.FloatVA(1000.)
         self.scale = model.TupleContinuous((1, 1), [(1, 1), self._shape],
-                                           cls=(int, float), unit="")
+                                           cls=(int, long, float), unit="")
         self.translation = model.TupleContinuous((0, 0), ((0, 0), (0, 0)),
-                                           cls=(int, float), unit="px")
+                                           cls=(int, long, float), unit="px")
 
 
 class FakeDetector(model.Detector):

--- a/src/odemis/driver/andorcam3.py
+++ b/src/odemis/driver/andorcam3.py
@@ -28,6 +28,8 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 
 from __future__ import division
 
+from past.builtins import long
+from builtins import str
 import collections
 from ctypes import *
 import gc
@@ -338,6 +340,7 @@ class AndorCam3(model.DigitalCamera):
             tran_rng = ((-uh_shape[0], -uh_shape[1]),
                         (uh_shape[0], uh_shape[1]))
             self.translation = model.ResolutionVA((0, 0), tran_rng, unit="px",
+                                                  cls=(int, long),
                                                   setter=self._setTranslation)
         else:
             # to keep it simple, provide a translation VA but fixed to 0,0

--- a/src/odemis/driver/phenom.py
+++ b/src/odemis/driver/phenom.py
@@ -23,7 +23,7 @@ from __future__ import division
 
 from future.utils import with_metaclass
 import queue
-from builtins import int
+from past.builtins import long
 from abc import abstractmethod, ABCMeta
 import base64
 import collections
@@ -327,7 +327,7 @@ class Scanner(model.Emitter):
         shift_rng = ((-1, -1),
                      (1, 1))
         self.shift = model.TupleContinuous((0, 0), shift_rng,
-                                              cls=(int, float), unit="m",
+                                              cls=(int, long, float), unit="m",
                                               setter=self._setShift)
         self.shift.subscribe(self._onShift, init=True)
 
@@ -339,7 +339,7 @@ class Scanner(model.Emitter):
         tran_rng = ((-self._shape[0] / 2, -self._shape[1] / 2),
                     (self._shape[0] / 2, self._shape[1] / 2))
         self.translation = model.TupleContinuous((0, 0), tran_rng,
-                                                 cls=(int, float), unit="px",
+                                                 cls=(int, long, float), unit="px",
                                                  setter=self._setTranslation)
 
         # .resolution is the number of pixels actually scanned. If it's less than
@@ -355,7 +355,7 @@ class Scanner(model.Emitter):
         # (Default to scan the whole area)
         self._scale = (self._shape[0] / resolution[0], self._shape[1] / resolution[1])
         self.scale = model.TupleContinuous(self._scale, ((0, 0), self._shape),
-                                           cls=(int, float),
+                                           cls=(int, long, float),
                                            unit="", setter=self._setScale)
         self.scale.subscribe(self._onScale, init=True)  # to update metadata
 

--- a/src/odemis/driver/semcomedi.py
+++ b/src/odemis/driver/semcomedi.py
@@ -22,7 +22,7 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 from __future__ import division
 
 import queue
-from builtins import int
+from past.builtins import long
 import collections
 import functools
 import gc
@@ -2769,7 +2769,7 @@ class Scanner(model.Emitter):
         tran_rng = ((-self._shape[0] / 2, -self._shape[1] / 2),
                     (self._shape[0] / 2, self._shape[1] / 2))
         self.translation = model.TupleContinuous((0, 0), tran_rng,
-                                              cls=(int, float), unit="px",
+                                              cls=(int, long, float), unit="px",
                                               setter=self._setTranslation)
 
         # .resolution is the number of pixels actually scanned. If it's less than
@@ -2784,7 +2784,7 @@ class Scanner(model.Emitter):
         # (Default to scan the whole area)
         self._scale = (self._shape[0] / resolution[0], self._shape[1] / resolution[1])
         self.scale = model.TupleContinuous(self._scale, ((1, 1), self._shape),
-                                           cls=(int, float),
+                                           cls=(int, long, float),
                                            unit="", setter=self._setScale)
         self.scale.subscribe(self._onScale, init=True) # to update metadata
 

--- a/src/odemis/driver/simcam.py
+++ b/src/odemis/driver/simcam.py
@@ -21,6 +21,7 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 '''
 from __future__ import division
 
+from past.builtins import long
 import queue
 import logging
 import numpy
@@ -96,7 +97,7 @@ class Camera(model.DigitalCamera):
                     (hlf_shape[0], hlf_shape[1])]
         self._translation = (0, 0)
         self.translation = model.ResolutionVA(self._translation, tran_rng, unit="px",
-                                              setter=self._setTranslation)
+                                              cls=(int, long), setter=self._setTranslation)
 
         self._orig_exp = self._img.metadata.get(model.MD_EXP_TIME, 0.1)  # s
         self.exposureTime = model.FloatContinuous(self._orig_exp, (1e-3, 1e3), unit="s")

--- a/src/odemis/driver/simsem.py
+++ b/src/odemis/driver/simsem.py
@@ -23,7 +23,7 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 from __future__ import division
 
 import queue
-from builtins import int
+from past.builtins import long
 import logging
 import math
 import numpy
@@ -168,14 +168,14 @@ class Scanner(model.Emitter):
         shift_rng = ((-50e-06, -50e-06),
                     (50e-06, 50e-06))
         self.shift = model.TupleContinuous((0, 0), shift_rng,
-                                              cls=(int, float), unit="m")
+                                              cls=(int, long, float), unit="m")
 
         # (float, float) in m => moves center of acquisition by this amount
         # independent of scale and rotation.
         tran_rng = [(-self._shape[0] / 2, -self._shape[1] / 2),
                     (self._shape[0] / 2, self._shape[1] / 2)]
         self.translation = model.TupleContinuous((0, 0), tran_rng,
-                                              cls=(int, float), unit="px",
+                                              cls=(int, long, float), unit="px",
                                               setter=self._setTranslation)
 
         # .resolution is the number of pixels actually scanned. If it's less than
@@ -190,7 +190,7 @@ class Scanner(model.Emitter):
         # (Default to scan the whole area)
         self._scale = (self._shape[0] / resolution[0], self._shape[1] / resolution[1])
         self.scale = model.TupleContinuous(self._scale, [(1, 1), self._shape],
-                                           cls=(int, float),
+                                           cls=(int, long, float),
                                            unit="", setter=self._setScale)
         self.scale.subscribe(self._onScale, init=True) # to update metadata
 

--- a/src/odemis/driver/spectrometer.py
+++ b/src/odemis/driver/spectrometer.py
@@ -21,7 +21,6 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 '''
 from __future__ import division
 
-from builtins import int
 import logging
 import math
 import numpy

--- a/src/odemis/driver/tescan.py
+++ b/src/odemis/driver/tescan.py
@@ -23,7 +23,7 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 from __future__ import absolute_import, division
 
 import queue
-from builtins import int
+from past.builtins import long
 import gc
 import logging
 import math
@@ -559,7 +559,7 @@ class Scanner(model.Emitter):
         tran_rng = [(-self._shape[0] / 2, -self._shape[1] / 2),
                     (self._shape[0] / 2, self._shape[1] / 2)]
         self.translation = model.TupleContinuous((0, 0), tran_rng,
-                                              cls=(int, float), unit="",
+                                              cls=(int, long, float), unit="",
                                               setter=self._setTranslation)
 
         # .resolution is the number of pixels actually scanned. If it's less than
@@ -574,7 +574,7 @@ class Scanner(model.Emitter):
         # (Default to scan the whole area)
         self._scale = (self._shape[0] / resolution[0], self._shape[1] / resolution[1])
         self.scale = model.TupleContinuous(self._scale, [(1, 1), self._shape],
-                                           cls=(int, float),
+                                           cls=(int, long, float),
                                            unit="", setter=self._setScale)
         self.scale.subscribe(self._onScale, init=True)  # to update metadata
 

--- a/src/odemis/gui/comp/slider.py
+++ b/src/odemis/gui/comp/slider.py
@@ -23,7 +23,7 @@
 
 from __future__ import division
 
-from builtins import int
+from past.builtins import long
 from odemis.util.conversion import hex_to_frgba
 from odemis.gui.util.conversion import wxcol_to_frgb, change_brightness
 from odemis.gui.comp.text import UnitFloatCtrl, UnitIntegerCtrl
@@ -453,7 +453,7 @@ class Slider(BaseSlider):
 
         The value will be clipped if it is out of range.
         """
-        if not isinstance(value, (int, float)):
+        if not isinstance(value, (int, long, float)):
             raise TypeError("Illegal data type %s" % type(value))
 
         if self.current_value == value:

--- a/src/odemis/gui/conf/util.py
+++ b/src/odemis/gui/conf/util.py
@@ -26,8 +26,8 @@ This module contains functions that help in the generation of dynamic configurat
 
 from __future__ import division
 
-from past.builtins import basestring
-from builtins import int
+from builtins import str
+from past.builtins import basestring, long
 from collections import OrderedDict
 import collections
 import logging
@@ -275,7 +275,7 @@ def determine_default_control(va):
             logging.debug("Found range %s", va.range)
 
             # TODO: if unit is "s" => scale=exp
-            if isinstance(va.value, (int, float)):
+            if isinstance(va.value, (int, long, float)):
                 # If the value is a number with a range, return the slider control
                 return odemis.gui.CONTROL_SLIDER
         except (AttributeError, NotApplicableError):
@@ -285,7 +285,7 @@ def determine_default_control(va):
         val = va.value
         if isinstance(val, bool):
             return odemis.gui.CONTROL_CHECK
-        elif isinstance(val, int):
+        elif isinstance(val, (int, long)):
             return odemis.gui.CONTROL_INT
         elif isinstance(val, float):
             return odemis.gui.CONTROL_FLT

--- a/src/odemis/gui/cont/settings.py
+++ b/src/odemis/gui/cont/settings.py
@@ -27,7 +27,7 @@ user interface.
 
 from __future__ import division
 
-from builtins import int
+from past.builtins import long
 from future.utils import with_metaclass
 from abc import ABCMeta
 import collections
@@ -202,11 +202,11 @@ class SettingsController(with_metaclass(ABCMeta, object)):
             else:
                 # Still try to beautify a bit if it's a number
                 if (
-                    isinstance(value, (int, float)) or
+                    isinstance(value, (int, long, float)) or
                     (
                         isinstance(value, collections.Iterable) and
                         len(value) > 0 and
-                        isinstance(value[0], (int, float))
+                        isinstance(value[0], (int, long, float))
                     )
                 ):
                     nice_str = readable_str(value, sig=3)

--- a/src/odemis/gui/cont/streams.py
+++ b/src/odemis/gui/cont/streams.py
@@ -23,8 +23,8 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 
 from __future__ import division
 
-from past.builtins import basestring
-from builtins import int
+from builtins import str
+from past.builtins import basestring, long
 from collections import OrderedDict
 import collections
 import functools
@@ -374,11 +374,11 @@ class StreamController(object):
             else:
                 # Still try to beautify a bit if it's a number
                 if (
-                    isinstance(value, (int, float)) or
+                    isinstance(value, (int, long, float)) or
                     (
                         isinstance(value, collections.Iterable) and
                         len(value) > 0 and
-                        isinstance(value[0], (int, float))
+                        isinstance(value[0], (int, long, float))
                     )
                 ):
                     nice_str = readable_str(value, unit, 3)

--- a/src/odemis/gui/model/__init__.py
+++ b/src/odemis/gui/model/__init__.py
@@ -22,9 +22,8 @@ This file is part of Odemis.
 """
 from __future__ import division
 
-from builtins import int
 from future.utils import with_metaclass
-from past.builtins import basestring
+from past.builtins import basestring, long
 import queue
 from abc import ABCMeta
 import collections
@@ -525,7 +524,7 @@ class LiveViewGUIData(MicroscopyGUIData):
 
             self.roa = model.TupleContinuous(acqstream.UNDEFINED_ROI,
                                              range=((0, 0, 0, 0), (1, 1, 1, 1)),
-                                             cls=(int, float))
+                                             cls=(int, long, float))
 
             # Component to which the (relative) ROIs and spot position refer to for
             # the field-of-view.
@@ -863,7 +862,7 @@ class Sparc2AlignGUIData(ActuatorGUIData):
             # pixels from the top-left corner of the AR image.
             self.polePositionPhysical = model.TupleContinuous((0, 0),
                                            ((-1, -1), (1, 1)), unit="m",
-                                           cls=(int, float),
+                                           cls=(int, long, float),
                                            setter=self._setPolePosPhysical)
 
             main.lens.polePosition.subscribe(self._onPolePosCCD, init=True)

--- a/src/odemis/model/_vattributes.py
+++ b/src/odemis/model/_vattributes.py
@@ -19,10 +19,9 @@ PARTICULAR PURPOSE. See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along with
 Odemis. If not, see http://www.gnu.org/licenses/.
 """
-from __future__ import division
-from past.builtins import basestring
-from builtins import int
 
+from __future__ import division
+from past.builtins import basestring, long
 import Pyro4
 from Pyro4.core import oneway
 import collections
@@ -632,7 +631,7 @@ class IntVA(VigilantAttribute):
 
     def _check(self, value):
         # we really accept only int, to avoid hiding lose of precision
-        if not isinstance(value, int):
+        if not isinstance(value, (int, long)):
             raise TypeError("Value '%r' is not a int." % value)
 
 # ListVA is difficult: not only change of the .value must be detected, but we
@@ -1161,5 +1160,5 @@ class ResolutionVA(TupleContinuous):
     # old name for TupleContinuous, when it was fixed to len == 2 and cls == int
     # and default unit == "px"
     def __init__(self, value, rng, unit="px", cls=None, **kwargs):
-        cls = cls or int
+        cls = cls or (int, long)
         TupleContinuous.__init__(self, value, rng, unit=unit, cls=cls, **kwargs)

--- a/src/odemis/model/test/vattributes_test.py
+++ b/src/odemis/model/test/vattributes_test.py
@@ -22,7 +22,7 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 '''
 from __future__ import division
 
-from builtins import int
+from past.builtins import long
 import logging
 import numpy
 from odemis import model
@@ -384,7 +384,7 @@ class VigilantAttributeTest(unittest.TestCase):
         """
         TupleContinuous
         """
-        va = model.TupleContinuous((0.1, 10, .5), ((-1.3, 12, 0), (100., 150., 1.)), cls=(int, float))
+        va = model.TupleContinuous((0.1, 10, .5), ((-1.3, 12, 0), (100., 150., 1.)), cls=(int, long, float))
         self.assertEqual(va.value, (0.1,10,.5))
         self.assertEqual(va.range, ((-1.3,12,0), (100.,150.,1.)))
 

--- a/src/odemis/util/conversion.py
+++ b/src/odemis/util/conversion.py
@@ -20,8 +20,7 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 
 from __future__ import division
 
-from past.builtins import basestring
-from builtins import int
+from past.builtins import basestring, long
 import collections
 import logging
 import re
@@ -262,7 +261,7 @@ def reproduce_typed_value(typed_value, str_val):
 
         # Try to be open-minded if the sub-type is a number (so that things like
         # " 3 x 5 px" returns (3, 5)
-        if isinstance(typed_val_elm, int):
+        if isinstance(typed_val_elm, (int, long)):
             pattern = r"[+-]?[\d]+"  # ex: -15
         elif isinstance(typed_val_elm, float):
             pattern = r"[+-]?[\d.]+(?:[eE][+-]?[\d]+)?"  # ex: -156.41e-9

--- a/src/odemis/util/mock.py
+++ b/src/odemis/util/mock.py
@@ -18,7 +18,7 @@ You should have received a copy of the GNU General Public License along with Ode
 
 from __future__ import division
 
-from builtins import int
+from past.builtins import long
 import logging
 import time
 
@@ -92,7 +92,7 @@ class FakeCCD(model.HwComponent):
         self.exposureTime = model.FloatContinuous(0.1, (1e-6, 1000), unit="s")
         res = fake_img.shape[1], fake_img.shape[0]  # X, Y
         self.binning = model.TupleContinuous((1, 1), [(1, 1), (8, 8)],
-                                       cls=(int, float), unit="")
+                                       cls=(int, long, float), unit="")
         self.resolution = model.ResolutionVA(res, [(1, 1), res])
 
         self.data = CCDDataFlow(self)


### PR DESCRIPTION
* commit 96280d99eb6eb36a694b9e591aa4e8ee245fb0ef introduced some bugs due to unexpected behaviour of builtins.int
* the power operation is not working as it should in python2: 10 ** int(-9) = 0
* as a fix, we import past.builtins.long instead of builtins.int