### PR TITLE
Newport ESP301 identifier fix

### DIFF
--- a/src/odemis/driver/npmc.py
+++ b/src/odemis/driver/npmc.py
@@ -294,6 +294,9 @@ class ESP(model.Actuator):
 
                 try:
                     ve = self.GetVersion()
+                    if not re.match(r"ESP301 Version \d\.\d\.\d (1[0-2]|[1-9])\/(3[01]|[12][0-9]|[1-9])\/(99|[0-9]?[0-9])", ve):
+                        raise IOError("Device at %s is not an ESP301 controller" % ports)
+
                 except ESPError as e:
                     # Can happen if the device has received some weird characters
                     # => try again (now that it's flushed)
@@ -871,7 +874,7 @@ class ESPSimulator(object):
         msg = b"".join(msg.split())  # remove all space characters
         
         if msg == b"VE?":
-            self._sendAnswer(b"1.0")
+            self._sendAnswer(b"ESP301 Version 3.0.1 6/1/99")
             
         elif msg == b"SM":
             # save memory to non-volatile RAM

--- a/src/odemis/driver/npmc.py
+++ b/src/odemis/driver/npmc.py
@@ -294,7 +294,7 @@ class ESP(model.Actuator):
 
                 try:
                     ve = self.GetVersion()
-                    if ve.upper().find("ESP301") == -1:
+                    if not "ESP301" in ve.upper():
                         raise IOError("Device at %s is not an ESP301 controller. Reported version string: %s" % (ports, ve))
 
                 except ESPError as e:

--- a/src/odemis/driver/npmc.py
+++ b/src/odemis/driver/npmc.py
@@ -294,8 +294,8 @@ class ESP(model.Actuator):
 
                 try:
                     ve = self.GetVersion()
-                    if not re.match(r"ESP301 Version \d\.\d\.\d (1[0-2]|[1-9])\/(3[01]|[12][0-9]|[1-9])\/(99|[0-9]?[0-9])", ve):
-                        raise IOError("Device at %s is not an ESP301 controller" % ports)
+                    if ve.upper().find("ESP301") == -1:
+                        raise IOError("Device at %s is not an ESP301 controller. Reported version string: %s" % (ports, ve))
 
                 except ESPError as e:
                     # Can happen if the device has received some weird characters


### PR DESCRIPTION
Not tested yet.

Checks the identifier of the Newport to determine if it is the right device. 