### PR TITLE
Spectrum zoom fixes

### DIFF
--- a/src/odemis/gui/comp/legend.py
+++ b/src/odemis/gui/comp/legend.py
@@ -418,12 +418,15 @@ class AxisLegend(wx.Panel):
             return
 
         # shared function with the export method
-        self._tick_list, self._vtp_ratio = calculate_ticks(self._value_range, self.ClientSize, self._orientation, self._tick_spacing)
         csize = self.ClientSize
+        self._tick_list, self._vtp_ratio = calculate_ticks(self._value_range, csize, self._orientation, self._tick_spacing)
 
-        if self.lock_va is not None and self.lock_va.value == False:
+        if self.lock_va is not None:
             if self._orientation == wx.HORIZONTAL:
                 csize.x -= 24
+
+            elif self._orientation == wx.VERTICAL:
+                self._tick_list = [(pos, val) for (pos, val) in self._tick_list if pos > 24]
 
         # If min and max are very close, we need more significant numbers to
         # ensure the values displayed are different (ex 17999 -> 18003)

--- a/src/odemis/gui/comp/legend.py
+++ b/src/odemis/gui/comp/legend.py
@@ -451,10 +451,10 @@ class AxisLegend(wx.Panel):
             label = units.readable_str(val, self.unit, sig)
 
             if i == 0 and self._lo_ellipsis:
-                label = u"…" + label
+                label = u"…"
 
             if i == len(self._tick_list) - 1 and self._hi_ellipsis:
-                label = label + u"…"
+                label = u"…"
 
             _, _, lbl_width, lbl_height, _, _ = ctx.text_extents(label)
 

--- a/src/odemis/gui/comp/viewport.py
+++ b/src/odemis/gui/comp/viewport.py
@@ -1255,6 +1255,10 @@ class NavigablePlotViewport(PlotViewport):
             self.bottom_legend.lo_ellipsis = self.canvas.display_xrange[0] > self.canvas.data_xrange[0]
             self.bottom_legend.hi_ellipsis = self.canvas.display_xrange[1] < self.canvas.data_xrange[1]
 
+        # automatically disable autoscaling (by locking) when the user zooms in
+        if self.canvas.display_xrange != self.canvas.data_xrange:
+            self.hrange_lock.value = True
+
     def set_vrange(self, vrange):
         """
         Setter for VA vrange
@@ -1276,6 +1280,10 @@ class NavigablePlotViewport(PlotViewport):
         if self.canvas.has_data():
             self.left_legend.lo_ellipsis = self.canvas.display_yrange[0] > self.canvas.data_yrange[0]
             self.left_legend.hi_ellipsis = self.canvas.display_yrange[1] < self.canvas.data_yrange[1]
+
+        # automatically disable autoscaling (by locking) when the user zooms in
+        if self.canvas.display_yrange != self.canvas.data_yrange:
+            self.vrange_lock.value = True
 
     def on_hlegend_scroll(self, evt=None):
         """ Scroll event for the bottom legend.

--- a/src/odemis/gui/comp/viewport.py
+++ b/src/odemis/gui/comp/viewport.py
@@ -1435,37 +1435,39 @@ class NavigablePlotViewport(PlotViewport):
         down.
 
         """
-        if self._dragging:
+        if not self._dragging:
+            evt.Skip()
+            return
 
-            v_pos = (self.canvas.pos_x_to_val_x(evt.Position[0]),
-                     self.canvas.pos_y_to_val_y(evt.Position[1]))
+        v_pos = (self.canvas.pos_x_to_val_x(evt.Position[0]),
+                 self.canvas.pos_y_to_val_y(evt.Position[1]))
 
-            self.drag_shift = (v_pos[0] - self.drag_init_pos[0],
-                          v_pos[1] - self.drag_init_pos[1])
+        self.drag_shift = (v_pos[0] - self.drag_init_pos[0],
+                      v_pos[1] - self.drag_init_pos[1])
 
-            (lo, hi) = self.hrange.value
-            lo += (self.drag_shift[0] * self._hdrag_scale_factor)
-            hi += (self.drag_shift[0] * self._hdrag_scale_factor)
-            if lo < self.canvas.data_xrange[0]:
-                lo = self.canvas.data_xrange[0]
-                hi = self.canvas.display_xrange[1]
-            if hi > self.canvas.data_xrange[1]:
-                hi = self.canvas.data_xrange[1]
-                lo = self.canvas.display_xrange[0]
-            self.hrange.value = (lo, hi)
+        (lo, hi) = self.hrange.value
+        lo += (self.drag_shift[0] * self._hdrag_scale_factor)
+        hi += (self.drag_shift[0] * self._hdrag_scale_factor)
+        if lo < self.canvas.data_xrange[0]:
+            lo = self.canvas.data_xrange[0]
+            hi = self.canvas.display_xrange[1]
+        if hi > self.canvas.data_xrange[1]:
+            hi = self.canvas.data_xrange[1]
+            lo = self.canvas.display_xrange[0]
+        self.hrange.value = (lo, hi)
 
-            (lo, hi) = self.vrange.value
-            lo += (self.drag_shift[1] * self._vdrag_scale_factor)
-            hi += (self.drag_shift[1] * self._vdrag_scale_factor)
+        (lo, hi) = self.vrange.value
+        lo += (self.drag_shift[1] * self._vdrag_scale_factor)
+        hi += (self.drag_shift[1] * self._vdrag_scale_factor)
 
-            if lo < self.canvas.data_yrange[0]:
-                lo = self.canvas.data_yrange[0]
-                hi = self.canvas.display_yrange[1]
-            if hi > self.canvas.data_yrange[1] + self.canvas.data_yrange[1] * self._vmargin:
-                hi = self.canvas.data_yrange[1] + self.canvas.data_yrange[1] * self._vmargin
-                lo = self.canvas.display_yrange[0]
+        if lo < self.canvas.data_yrange[0]:
+            lo = self.canvas.data_yrange[0]
+            hi = self.canvas.display_yrange[1]
+        if hi > self.canvas.data_yrange[1] + self.canvas.data_yrange[1] * self._vmargin:
+            hi = self.canvas.data_yrange[1] + self.canvas.data_yrange[1] * self._vmargin
+            lo = self.canvas.display_yrange[0]
 
-            self.vrange.value = (lo, hi)
+        self.vrange.value = (lo, hi)
 
 
 class PointSpectrumViewport(NavigablePlotViewport):


### PR DESCRIPTION
Fixed:
* For the vertical legend, I'd suggest to change a little bit the rule
for displaying the "...". The problem currently is that it makes the
text really wide, and especially it tends to change when the character
is present or not (so the whole graph shifts). Instead of
appending/prepending the character, I'd suggest to just show that text
(and drop the original tick text).
 * As soon as an axis is zoomed-in, the scale-lock should be activated.
Currently, if you zoom on a live stream, pretty much nothing happens,
because the scale automatically unzooms on the next data received. You
can notice it for instance with a sparc backend, when you play the live
spectrum (in the acquisition tab). If you zoom in, it automatically
zooms out.
 * When dragging the mouse with the left button, the marking line
overlay doesn't follow the mouse. The line is only updated when the
mouse button is released.


Added one more fix: 
* the ticklist for the y display goes underneath the lock button, so added an offset to make sure that it displays correctly. 