### PR TITLE
changed project id 2 to 1 and stack id 2 to 1 for virtualflybrain url

### DIFF
--- a/src/odemis/dataio/test/catmaid_test.py
+++ b/src/odemis/dataio/test/catmaid_test.py
@@ -55,7 +55,7 @@ class TestCatmaid(unittest.TestCase):
         Test requesting different tiles from the virtualflybrain server.
         """
         # test for a url with a specified project id and stack id
-        url = 'catmaids://fafb.catmaid.virtualflybrain.org/?pid=2&sid0=2'
+        url = 'catmaids://fafb.catmaid.virtualflybrain.org/?pid=1&sid0=1'
         acquisition = open_data(url)
         acquisition = acquisition.content[0]
         size = (1024, 1024)


### PR DESCRIPTION
The test was failing with ValueError: No stack info at this url https://fafb.catmaid.virtualflybrain.org/2/stack/2/info, check project id 2 and stack id 2
virtualflybrain.org moved the project from project id 2 to project id 1 and from stack id 2 to stack id 1