### PR TITLE
acq: automatically unblank the beam during calibration too

### DIFF
--- a/src/odemis/gui/cont/streams.py
+++ b/src/odemis/gui/cont/streams.py
@@ -1614,13 +1614,29 @@ class StreamBarController(object):
                 shiftebeam=acqstream.MTD_EBEAM_SHIFT
             )
         else:
+            # Hack: If the blanker doesn't support "automatic" mode (None),
+            # we have a trick to control the blanker in the stream. Ideally,
+            # this would be done by the optical-path manager, or by the e-beam
+            # driver (by always providing a None option).
+            # We only do this on the SECOM, because on the SPARC it's less of an
+            # issue, and we would need to change a lot more streams.
+            # TODO: remove once the CompositedScanner supports automatic blanker.
+            if (self._main_data_model.role == "secom" and
+                model.hasVA(self._main_data_model.ebeam, "blanker") and
+                None not in self._main_data_model.ebeam.blanker.choices
+               ):
+                blanker = self._main_data_model.ebeam.blanker
+            else:
+                blanker = None
+
             s = acqstream.SEMStream(
                 name,
                 detector,
                 detector.data,
                 self._main_data_model.ebeam,
                 focuser=self._main_data_model.ebeam_focus,
-                opm=self._main_data_model.opm
+                opm=self._main_data_model.opm,
+                blanker=blanker
             )
 
         # If the detector already handles brightness and contrast, don't do it by default

--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -2336,6 +2336,15 @@ class SecomAlignTab(Tab):
         # force this view to never follow the tool mode (just standard view)
         panel.vp_align_ccd.canvas.allowed_modes = {TOOL_NONE}
 
+        # To control the blanker if it's not automatic (None)
+        # TODO: remove once the CompositedScanner supports automatic blanker.
+        if (model.hasVA(main_data.ebeam, "blanker") and
+            None not in main_data.ebeam.blanker.choices
+           ):
+            blanker = main_data.ebeam.blanker
+        else:
+            blanker = None
+
         # No streams controller, because it does far too much (including hiding
         # the only stream entry when SEM view is focused)
         # Use all VAs as HW VAs, so the values are shared with the streams tab
@@ -2344,7 +2353,8 @@ class SecomAlignTab(Tab):
                                          main_data.ebeam,
                                          hwdetvas=get_local_vas(main_data.sed, main_data.hw_settings_config),
                                          hwemtvas=get_local_vas(main_data.ebeam, main_data.hw_settings_config),
-                                         acq_type=model.MD_AT_EM
+                                         acq_type=model.MD_AT_EM,
+                                         blanker=blanker
                                          )
         sem_stream.should_update.value = True
         self.tab_data_model.streams.value.append(sem_stream)
@@ -2356,7 +2366,8 @@ class SecomAlignTab(Tab):
         sem_spe.stream_panel.flatten()  # removes the expander header
 
         spot_stream = acqstream.SpotSEMStream("Spot", main_data.sed,
-                                              main_data.sed.data, main_data.ebeam)
+                                              main_data.sed.data, main_data.ebeam,
+                                              blanker=blanker)
         self.tab_data_model.streams.value.append(spot_stream)
         self._spot_stream = spot_stream
 


### PR DESCRIPTION
Also make the hack even more hacky by only activating it on the SECOM.
On the SPARCs with blanker support, this would work "fine" for the SEM streams,
but as the MDStreams are not aware of the blanker, they would always leave it active.

Eventually, it's clear that this approach is not really right, and it's just a hack.
It should be changed to have the CompositedScanner to take care of automatically turning
on/off the blanker.