### PR TITLE
acq stream helper ScannedTemporalSettingsStream: don't crop the chronograms

### DIFF
--- a/src/odemis/acq/stream/_helper.py
+++ b/src/odemis/acq/stream/_helper.py
@@ -1537,13 +1537,6 @@ class ScannedTemporalSettingsStream(CCDSettingsStream):
         pass
 
     def _onNewData(self, dataflow, data):
-        # For now, the viewport cannot display large datasets, so we have to crop the temporal data
-        # TODO: remove cropping once PlotCanvas supports bigger data
-        cropvalue = 1024
-        data = data[..., :cropvalue]
-        if model.MD_TIME_LIST in data.metadata:
-            data.metadata[model.MD_TIME_LIST] = data.metadata[model.MD_TIME_LIST][:cropvalue]
-
         # Set POS and PIXEL_SIZE from the e-beam (which is in spot mode)
         epxs = self.emitter.pixelSize.value
         data.metadata[model.MD_PIXEL_SIZE] = epxs


### PR DESCRIPTION
Now that the GUI supports arbitrary long chronograms, no need to cropt the data.
It's actually useful to show extra data when the sync offset is large.