### PR TITLE
odemisd modelgen: on module import error, indicate which module failed to load

### DIFF
--- a/src/odemis/odemisd/modelgen.py
+++ b/src/odemis/odemisd/modelgen.py
@@ -114,9 +114,9 @@ def get_class(name):
 
     try:
         mod = __import__(module_name, fromlist=[class_name])
-    except ImportError:
+    except ImportError as ex:
         raise SemanticError("Error in microscope file: "
-            "no module '%s' exists (class '%s')." % (module_name, class_name))
+            "fail loading module '%s' (class '%s'): %s." % (module_name, class_name, ex))
 #        return None # DEBUG
 
     try:


### PR DESCRIPTION
In case a driver fails to load because one of its import failed, the message
was (incorrectly) implying that the driver itself was missing.
=> pass the import error message as-is to be more precise in the log.