### PR TITLE
gui cont tabs: Sparc2Align tab should also show syncDiv setting for the labcube

### DIFF
--- a/src/odemis/gui/conf/data.py
+++ b/src/odemis/gui/conf/data.py
@@ -500,6 +500,8 @@ HW_SETTINGS_CONFIG = {
             }),
             ("syncDiv", {
                 "label": "Sync divider",
+                "tooltip": u"Internally reduce sync signal rate to handle higher frequencies.\n"
+                           u"Use only if the frequency is very high (see hardware documentation).",
             }),
         )),
 }

--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -3458,6 +3458,16 @@ class Sparc2AlignTab(Tab):
                                        )
                 speccnt_spe = self._stream_controller.addStream(speccnts,
                                     add_to_view=self.panel.vp_align_fiber.view)
+                # Special for the time-correlator: some of its settings also affect
+                # the photo-detectors.
+                if main_data.time_correlator:
+                    if model.hasVA(main_data.time_correlator, "syncDiv"):
+                        speccnt_spe.add_setting_entry("syncDiv",
+                                                      main_data.time_correlator.syncDiv,
+                                                      main_data.time_correlator,
+                                                      main_data.hw_settings_config["time-correlator"].get("syncDiv")
+                                                      )
+
                 if main_data.tc_od_filter:
                     speccnt_spe.add_axis_entry("density", main_data.tc_od_filter)
                     speccnt_spe.add_axis_entry("band", main_data.tc_filter)


### PR DESCRIPTION
On the time-correlator some of the main settings (ie, syncDiv) affect the output of the sub detectors (photo-detector*).
So show the syncDiv setting also on the alignment tab.