### PR TITLE
plugins tileacq: fix memory estimation

### DIFF
--- a/plugins/tileacq.py
+++ b/plugins/tileacq.py
@@ -736,7 +736,7 @@ class TileAcqPlugin(Plugin):
 
         if self.stitch.value:
             # Number of pixels for acquisition
-            pxs = sum(self._estimateStreamPixels(ss[1]) for ss in self._get_acq_streams())
+            pxs = sum(self._estimateStreamPixels(s) for s in self._get_acq_streams()[1])
             pxs *= self.nx.value * self.ny.value
 
             # Memory calculation


### PR DESCRIPTION
Commit c4aa101d ("fine alignment and other additions") modified the return value
of _get_acq_streams(). However, the caller was incorrectly adjusted. It caused
the memory check to not take into account the right streams. In some corner case, it would even fail.

=> Fix to use the "stitch_ss" part of _get_acq_streams()