### PR TITLE
gui comp text: Don't set None as value if the text is empty

### DIFF
--- a/src/odemis/gui/comp/text.py
+++ b/src/odemis/gui/comp/text.py
@@ -740,15 +740,20 @@ class _NumberTextCtrl(wx.TextCtrl):
 
         prev_num = self._number_value
         if str_number is None or str_number == "":
-            self._number_value = None
+            num = None
         else:
             # set new value even if not validated, so that we reach the boundaries
-            self._number_value = self.GetValidator().get_validated_number(str_number)
+            num = self.GetValidator().get_validated_number(str_number)
             # TODO: turn the text red temporarily if not valid?
             # if not validated:
             # logging.debug("Converted '%s' into '%s'", str_number, self._number_value)
 
-        if prev_num != self._number_value:
+        if num is None:
+            logging.debug("Skipping number field set to %r as it would be None, and reverting to %s", str_number, prev_num)
+            return
+
+        if prev_num != num:
+            self._number_value = num
             self._send_change_event()
 
     # Event handlers


### PR DESCRIPTION
None is not a number. It doesn't help anything to set a value to None.
Instead, all non valid text should be discared and reset to the previous value.

This avoids issues like:
 Traceback (most recent call last):
  File "/home/piel/development/odemis/src/odemis/gui/comp/slider.py", line 586, in _update_slider
    Slider._SetValue(self, text_val) # avoid to update link field again
  File "/home/piel/development/odemis/src/odemis/gui/comp/slider.py", line 457, in _SetValue
    raise TypeError("Illegal data type %s" % type(value))
TypeError: Illegal data type <type 'NoneType'>