### PR TITLE
Adjust log format

### DIFF
--- a/src/odemis/gui/log.py
+++ b/src/odemis/gui/log.py
@@ -63,14 +63,12 @@ def init_logger(level=logging.DEBUG, log_file=None):
     logging.basicConfig(format=" - %(levelname)s \t%(message)s")
     l = logging.getLogger()
     l.setLevel(level)
-    frm = "%(asctime)s  %(levelname)-7s %(module)-15s: %(message)s"
+    frm = "%(asctime)s\t%(levelname)s\t%(module)s:%(lineno)d:\t%(message)s"
     l.handlers[0].setFormatter(logging.Formatter(frm))
 
     # Create file handler
     # Path to the log file
     logfile_path = log_file or os.path.join(get_home_folder(), LOG_FILE)
-    # Formatting string for logging messages to file
-    frm = "%(asctime)s %(levelname)-7s %(module)s:%(lineno)d: %(message)s"
     file_format = logging.Formatter(frm)
 
     # Max 5 log files of 10Mb

--- a/src/odemis/odemisd/main.py
+++ b/src/odemis/odemisd/main.py
@@ -692,7 +692,7 @@ def main(args):
             rotateLog(options.logtarget, maxBytes=50 * (2 ** 20), backupCount=5)
             handler = FileHandler(options.logtarget)
     logging.getLogger().setLevel(loglev)
-    handler.setFormatter(logging.Formatter('%(asctime)s (%(module)s) %(levelname)s: %(message)s'))
+    handler.setFormatter(logging.Formatter("%(asctime)s\t%(levelname)s\t%(module)s:%(lineno)d:\t%(message)s"))
     logging.getLogger().addHandler(handler)
 
     if loglev <= logging.DEBUG:


### PR DESCRIPTION
Use the same format for the GUI and the back-end.
Include the line number in the backend log too, as it's quite handy for debugging.
Use tabs, to separate and align the fields. It's easier to parse both for humans and machine.
Now the log looks like:
2019-10-25 10:27:15,433 WARNING actuator:1230:  Reporting axis x @ 0.0037107 (known position)
2019-10-25 10:27:15,534 DEBUG   tmcm:845:       Sending 1, 6, 8, 1, 0 (16)