### PR TITLE
gui util img: fix export of FM stream having no info in legend

### DIFF
--- a/src/odemis/gui/util/img.py
+++ b/src/odemis/gui/util/img.py
@@ -1928,7 +1928,7 @@ def draw_legend_multi_streams(images, buffer_size, buffer_scale,
                                  legend_y_pos - small_font,
                                  tint_box_size, tint_box_size)
             legend_ctx.fill()
-            legend_ctx.set_source_rgb(*bg_color)
+            legend_ctx.set_source_rgb(*text_color)
 
         legend_x_pos += cell_x_step
         legend_y_pos_store = legend_y_pos


### PR DESCRIPTION
It turned out that the metadata was properly exported... but the same colour as the background.
Typo introduced in commit 6a015fd7 (polarimetry: export for tiff, png and csv).

Can be backported to v2.10