### PR TITLE
gui util img test: instantiate a wx.App() also for the TestARExport

### DIFF
--- a/src/odemis/gui/util/test/img_test.py
+++ b/src/odemis/gui/util/test/img_test.py
@@ -121,6 +121,11 @@ class TestARExport(unittest.TestCase):
     FILENAME_PNG = "test-ar.png"
     FILENAME_TIFF = "test-ar.tiff"
 
+    @classmethod
+    def setUpClass(cls):
+        cls.app = wx.App()  # needed for the gui font name
+        super(TestARExport, cls).setUpClass()
+
     def tearDown(self):
         # clean up
         try:
@@ -149,7 +154,6 @@ class TestARExport(unittest.TestCase):
         surface = cairo.ImageSurface.create_for_data(
             data_to_draw, cairo.FORMAT_ARGB32, ar_size[0], ar_size[1])
         ctx = cairo.Context(surface)
-        app = wx.App()  # needed for the gui font name
         font_name = wx.SystemSettings.GetFont(wx.SYS_DEFAULT_GUI_FONT).GetFaceName()
         ticksize = 10
         num_ticks = 6
@@ -624,7 +628,6 @@ class TestSpectrumExport(unittest.TestCase):
         self.spec_data = model.DataArray(data, md)
         self.spec_stream = stream.StaticSpectrumStream("test spec", self.spec_data)
         self.spec_stream.selected_pixel.value = (3, 1)
-        # self.app = wx.App()  # needed for the gui font name
 
     def test_spectrum_ready(self):
         self.spec_stream.selectionWidth.value = 1
@@ -815,7 +818,6 @@ class TestSpatialExport(test.GuiTestCase):
         super(TestSpatialExport, cls).tearDownClass()
 
     def setUp(self):
-        self.app = wx.App()
         data = numpy.zeros((2160, 2560), dtype=numpy.uint16)
         dataRGB = numpy.zeros((2160, 2560, 4))
         metadata = {'Hardware name': 'Andor ZYLA-5.5-USB3 (s/n: VSC-01959)',


### PR DESCRIPTION
It appears to have been broken by commit c620e5d9760b (Distance tool),
but that's probably just because the change to the test cases caused
a reorder of the run. Now TestARExport is run early, before any other
test create a wx.App(). This is necessary as some of the export functions
use wxPython calls (which require an App to be available).

=> create explicitely a wx.App() at class start-up.
Also remove a few of these creations where it is not necessary anymore, as
the GuiTestCase already create one.