### PR TITLE
gui cont acquisition SnapshotController: don't show a success message if saving failed

### DIFF
--- a/src/odemis/gui/cont/acquisition.py
+++ b/src/odemis/gui/cont/acquisition.py
@@ -222,12 +222,12 @@ class SnapshotController(object):
 
                     raw_images.append(d)
 
-            popup.show_message(self._main_frame,
-                                 "Snapshot saved in %s" % (filepath,),
-                                 timeout=3
-                                 )
             # record everything to a file
             exporter.export(filepath, raw_images, thumbnail)
+            popup.show_message(self._main_frame,
+                               "Snapshot saved in %s" % (filepath,),
+                               timeout=3
+                               )
 
             logging.info("Snapshot saved as file '%s'.", filepath)
         except Exception:


### PR DESCRIPTION
Only show the message after exporting, so if the export fails, the message is not shown.