### PR TITLE
driver tmcm: fix to the reference switch initialisation

### DIFF
--- a/src/odemis/driver/tmcm.py
+++ b/src/odemis/driver/tmcm.py
@@ -396,14 +396,6 @@ class TMCLController(model.Actuator):
             if pos not in self._do_axes[channel][1:3]:
                 raise ValueError("led_prot_do of channel %d has position %s, not in do_axes" % (channel, pos))
 
-        # Check state of refswitch on startup
-        self._expected_do_pos = {}  # do positions before referencing, will be reset after refswitch is released
-        self._leds_on = any(self.GetIO(2, rs) for rs in self._refswitch)
-        if self._leds_on:
-            logging.debug("Refswitch is on during initialization, releasing refswitch for all axes.")
-            for ax in self._name_to_axis.values():
-                self._releaseRefSwitch(ax)
-
         model.Actuator.__init__(self, name, role, axes=axes_def, **kwargs)
 
         driver_name = driver.getSerialDriver(self._portpattern)
@@ -425,11 +417,13 @@ class TMCLController(model.Actuator):
             if self._accel[n] == 0:
                 logging.warning("Acceleration of axis %s is null, most probably due to a bad hardware configuration", n)
 
-        # TODO: store whether the axes have been referenced in a user variable
-        # which is automatically reset to 0 on init. (maybe with one bit per
-        # axis + inverted bit on the high byte to double check). Might also
-        # want to check that the device has been running for long enough if
-        # the bits are set (see timer in global axis 0/132)
+        # Check state of refswitch on startup
+        self._expected_do_pos = {}  # do positions before referencing, will be reset after refswitch is released
+        self._leds_on = any(self.GetIO(2, rs) for rs in self._refswitch.values())
+        if self._leds_on:
+            logging.debug("Refswitch is on during initialization, releasing refswitch for all axes.")
+            for ax in self._name_to_axis.values():
+                self._releaseRefSwitch(ax)
 
         if refproc is None:
             # Only the axes which are "absolute"
@@ -2258,7 +2252,7 @@ class TMCMSimulator(object):
                            197: 10,  # previous position before referencing (unused directly)
         }
         self._astates = [dict(self._orig_axis_state) for i in range(self._naxes)]
-        self._do_states = [0] * 8  # state of digital outputs on bank 2 (0 or 1)
+        self._do_states = [1, 0, 0, 0, 0, 0, 0, 0]  # state of digital outputs on bank 2 (0 or 1)
 
         # (float, float, int) for each axis
         # start, end, start position of a move


### PR DESCRIPTION
It hasn't ever been properly tested. If a switch was on, it would actually
fail because some attributes are missing so early. In addition, it
would not even look for the correct switches (mixed up between axis number and
switch number).

=> The simulator now reports such a switch being turned on, to force the code
to be run during testing.
=> Move the code later in the init.

Also remove old TODO already implemented.