### PR TITLE
model ParallelThreadPoolExecutor: fix (rare) IndexError when ending a task

### DIFF
--- a/src/odemis/model/_futures.py
+++ b/src/odemis/model/_futures.py
@@ -134,8 +134,8 @@ class ParallelThreadPoolExecutor(ThreadPoolExecutor):
         self._set_remove = threading.Lock()
 
     def _schedule_work(self):
-        while self._waiting_work:
-            with self._set_remove:
+        with self._set_remove:
+            while self._waiting_work:
                 w, f, dependences = self._waiting_work.pop()
                 if f not in self._queue:
                     # the future has already been cancelled => forget about it


### PR DESCRIPTION
If several tasks finish at the same time, in some rare cases, there can be a race condition
which cause the _waiting_work.pop() to fail because the deque has already been emptied.

It show up like this:
2018-04-22 17:28:01,493 (_base) ERROR: exception calling callback for <Future at 0x7f460406f810 state=finished returned NoneType>
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/concurrent/futures/_base.py", line 300, in _invoke_callbacks
    callback(self)
  File "/home/sparc/development/odemis/src/odemis/model/_futures.py", line 200, in _on_done
    self._schedule_work()
  File "/home/sparc/development/odemis/src/odemis/model/_futures.py", line 139, in _schedule_work
    w, f, dependences = self._waiting_work.pop()
IndexError: pop from an empty deque

=> Take the lock before looping through the queue.