### PR TITLE
bugreporter: don't fail if the config dir doesn't exists

### DIFF
--- a/src/bugreporter/odemis_bugreporter.py
+++ b/src/bugreporter/odemis_bugreporter.py
@@ -466,12 +466,19 @@ class BugreporterFrame(wx.Frame):
         self.make_suggestion = True
 
         # Load known users, if not available make tsv file
+        self.known_users = OrderedDict()
         self.conf_path = os.path.join(os.path.expanduser(u"~"), '.config', 'odemis', 'bugreporter_users.tsv')
-        with open(self.conf_path, 'a+') as f:
-            reader = csv.reader(f, delimiter='\t')
-            self.known_users = OrderedDict()
-            for name, email in reader:
-                self.known_users[name.decode("utf-8")] = email.decode("utf-8")
+        conf_dir = os.path.dirname(self.conf_path)
+        try:
+            if not os.path.exists(conf_dir):
+                # create the directory so that we can store the config later
+                os.makedirs(conf_dir)
+            with open(self.conf_path, 'a+') as f:
+                reader = csv.reader(f, delimiter='\t')
+                for name, email in reader:
+                    self.known_users[name.decode("utf-8")] = email.decode("utf-8")
+        except OSError as ex:
+            logging.error("Failed to read known users: %s", ex)
 
     def store_user_info(self, name, email):
         """
@@ -641,4 +648,3 @@ class BugreporterFrame(wx.Frame):
 if __name__ == '__main__':
     bugreporter = OdemisBugreporter()
     bugreporter.run()
-    


### PR DESCRIPTION
If the Odemis GUI has never run (because there's a bug?), then the config
directory is not present. The bug reporter wouldn't even start.

=> create the dir ourselves if needed.