### PR TITLE
Don't use os.sys, but just sys

### DIFF
--- a/src/odemis/gui/dev/powermate.py
+++ b/src/odemis/gui/dev/powermate.py
@@ -22,6 +22,7 @@ from __future__ import division
 import logging
 import os
 import struct
+import sys
 import threading
 import time
 import wx
@@ -46,7 +47,7 @@ class Powermate(threading.Thread):
             LookupError: if no Powermate is found
         """
         # TODO: support other OS than Linux?
-        if not os.sys.platform.startswith('linux'):
+        if not sys.platform.startswith('linux'):
             raise NotImplementedError("Powermate only supported on Linux")
 
         # Find the Powermate device (will stop here if nothing is found)

--- a/src/odemis/odemisd/main.py
+++ b/src/odemis/odemisd/main.py
@@ -690,7 +690,7 @@ def main(args):
     if options.logtarget == "stderr":
         handler = logging.StreamHandler()
     else:
-        if os.sys.platform.startswith('linux'):
+        if sys.platform.startswith('linux'):
             # On Linux, we use logrotate, so nothing much to do
             handler = WatchedFileHandler(options.logtarget)
         else:

--- a/src/odemis/util/test/driver_test.py
+++ b/src/odemis/util/test/driver_test.py
@@ -25,9 +25,10 @@ import logging
 from odemis import model
 import odemis
 from odemis.util import test
-from odemis.util.driver import getSerialDriver, speedUpPyroConnect, readMemoryUsage,\
+from odemis.util.driver import getSerialDriver, speedUpPyroConnect, readMemoryUsage, \
     get_linux_version
 import os
+import sys
 import time
 import unittest
 
@@ -73,7 +74,7 @@ class TestDriver(unittest.TestCase):
 
     def test_linux_version(self):
 
-        if os.sys.platform.startswith('linux'):
+        if sys.platform.startswith('linux'):
             v = get_linux_version()
             self.assertGreaterEqual(v[0], 2)
             self.assertEqual(len(v), 3)


### PR DESCRIPTION
The os module happens to import "sys", so the standard sys module can be used as "os.sys"... but it's just weird and confusing.