### PR TITLE
gui comp popup: use the standard system message

### DIFF
--- a/src/odemis/gui/comp/popup.py
+++ b/src/odemis/gui/comp/popup.py
@@ -1,7 +1,7 @@
 #-*- coding: utf-8 -*-
 """
-:author:    Rinze de Laat
-:copyright: © 2014 Rinze de Laat, Delmic
+:author:    Éric Piel
+:copyright: © 2019 Éric Piel, Delmic
 
 .. license::
 
@@ -23,84 +23,25 @@
 
 from __future__ import division
 
-from odemis.gui import BG_COLOUR_NOTIFY
+import logging
 from odemis.gui.util import call_in_wx_main
 import wx
-
-# TODO: use standard Ubuntu popup on Ubuntu?
+from wx.adv import NotificationMessage
 
 
 @call_in_wx_main
-def show_message(parent, title, message=None, timeout=3.0, bgcolour=BG_COLOUR_NOTIFY):
+def show_message(parent, title, message=None, timeout=3.0, level=logging.INFO):
     """ Show a small message popup for a short time
 
-    :param parent: (wxWindow)
+    :param parent: (wxWindow or None)
     :param title: (str) The title of the message
     :param message: (str or None) Extra text that will be displayed below the title
     :param timeout: (float) Timeout in seconds after which the message will automatically vanish
-    :param bgcolour: (str) The background colour of the window
+    :param level: (logging.*) The error level
     """
-
-    mo = Message(parent, title, message, bgcolour)
-    mo.Flash(timeout)
-    # TODO: destroy the window after it's not used, or does wxPython do it automatically?
-
-
-class Message(wx.PopupTransientWindow):
-    """ Display short messages and warning to the user """
-
-    def __init__(self, parent, title, message=None, bgcolour=BG_COLOUR_NOTIFY, style=wx.SIMPLE_BORDER):
-        wx.PopupTransientWindow.__init__(self, parent, style)
-
-        self.panel = wx.Panel(self)
-        self.panel.SetBackgroundColour(bgcolour)
-        self.sizer = wx.BoxSizer(wx.VERTICAL)
-
-        self.title_txt = wx.StaticText(self.panel, -1,)
-        font = wx.Font(
-            16,
-            wx.FONTFAMILY_DEFAULT,
-            wx.FONTSTYLE_NORMAL,
-            wx.FONTWEIGHT_BOLD
-        )
-        self.title_txt.SetFont(font)
-        self.title_txt.SetLabel(title)
-        self.sizer.Add(self.title_txt, 0, wx.ALL, 16)
-
-        if message:
-            self.message_txt = wx.StaticText(self.panel, -1,)
-            font = wx.Font(
-                8,
-                wx.FONTFAMILY_DEFAULT,
-                wx.FONTSTYLE_NORMAL,
-                wx.FONTWEIGHT_NORMAL
-            )
-            self.message_txt.SetFont(font)
-            self.message_txt.SetLabel(message)
-            self.sizer.Add(self.message_txt, 0, wx.RIGHT | wx.BOTTOM | wx.LEFT, 16)
-
-        self.panel.SetSizer(self.sizer)
-
-        self.sizer.Fit(self.panel)
-        self.sizer.Fit(self)
-        self.Layout()
-
-    def Flash(self, timeout):
-        """
-        Display the Message window for a given amount of time
-        timeout (float): display duration in s
-        """
-
-        ox, oy = self.Parent.GetPosition()
-        pw, ph = self.Parent.GetSize()
-        mw, mh = self.GetSize()
-        pos = ox + (pw - mw) // 2, oy + (ph - mh) // 2
-
-        self.Position(pos, (0, 0))
-
-        self.Popup()
-        wx.CallLater(timeout * 1000, self.Dismiss)
-
-        # The Yield call forces wxPython to take control and process any event (i.e. the preceding
-        # Refresh call), making sure the Message is shown before the data loading begins.
-        wx.Yield()
+    message = message or ""
+    flags = {logging.INFO: wx.ICON_INFORMATION,
+             logging.WARNING: wx.ICON_WARNING,
+             logging.ERROR: wx.ICON_ERROR}[level]
+    m = NotificationMessage(title, message, parent=parent, flags=flags)
+    m.Show(timeout)

--- a/src/odemis/gui/cont/acquisition.py
+++ b/src/odemis/gui/cont/acquisition.py
@@ -227,7 +227,8 @@ class SnapshotController(object):
             # record everything to a file
             exporter.export(filepath, raw_images, thumbnail)
             popup.show_message(self._main_frame,
-                               "Snapshot saved in %s" % (filepath,),
+                               "Snapshot saved as %s" % (os.path.basename(filepath),),
+                               message="In %s" % (os.path.dirname(filepath),),
                                timeout=3
                                )
 
@@ -1058,8 +1059,12 @@ class FineAlignController(object):
                                     u"mag correction: %f, rotation: %f°, shear: %f, X/Y scale: %f",
                                     opt_scale, rot_deg, shear, scaling_xy)
 
+                title = "Fine alignment probably incorrect"
+                lvl = logging.WARNING
                 self._tab_panel.lbl_fine_align.Label = "Probably incorrect"
             else:
+                title = "Fine alignment successful"
+                lvl = logging.INFO
                 self._tab_panel.lbl_fine_align.Label = "Successful"
 
             # Rotation is compensated in software on the FM image, but the user
@@ -1069,11 +1074,13 @@ class FineAlignController(object):
             timeout = max(2, min(abs(rot_deg), 10))
             popup.show_message(
                 self._tab_panel,
+                title,
                 u"Rotation applied: %s\nShear applied: %s\nX/Y Scaling applied: %s"
                 % (units.readable_str(rot_deg, unit=u"°", sig=3),
                    units.readable_str(shear, sig=3),
                    units.readable_str(scaling_xy, sig=3)),
-                timeout=timeout
+                timeout=timeout,
+                level=lvl
             )
             logging.info(u"Fine alignment computed mag correction of %f, rotation of %f°, "
                          u"shear needed of %s, and X/Y scaling needed of %s.",


### PR DESCRIPTION
wxPython/GTK3 is broken with respect to the StaticText, which caused the
popup to only show the first few characters, cropped.

There might be way to fix/workaround these issues. However, the
wx.adv.NotificationMessage works very well now, so let's just use that.