### PR TITLE
util test: new assert_array_not_equal() helper function

### DIFF
--- a/src/odemis/acq/test/stream_test.py
+++ b/src/odemis/acq/test/stream_test.py
@@ -38,6 +38,7 @@ from odemis.acq.stream import RGBSpatialSpectrumProjection, \
 from odemis.dataio import tiff
 from odemis.driver import simcam
 from odemis.util import test, conversion, img, spectrum, find_closest
+from odemis.util.test import assert_array_not_equal
 import os
 import threading
 import time
@@ -1168,10 +1169,10 @@ class SPARCTestCase(unittest.TestCase):
         time.sleep(1)  # Wait long enough so that there is a new image
         im1 = specs.image.value
         self.assertIsInstance(im1, model.DataArray)
-        self.assertRaises(AssertionError, numpy.testing.utils.assert_array_equal, im0, im1)
+        assert_array_not_equal(im0, im1)
         time.sleep(2)
         im2 = specs.image.value
-        self.assertRaises(AssertionError, numpy.testing.utils.assert_array_equal, im1, im2)
+        assert_array_not_equal(im1, im2)
 
         # wait until it's over
         data = f.result(timeout)
@@ -2580,7 +2581,7 @@ class SPARC2StreakCameraTestCase(unittest.TestCase):
         data = f.result(timeout)
 
         # Check if the image changed (live update is working)
-        self.assertRaises(AssertionError, numpy.testing.utils.assert_array_equal, im1, im2)
+        assert_array_not_equal(im1, im2)
 
     def test_streak_acq(self):
         """Test acquisition with streak camera"""
@@ -3036,7 +3037,7 @@ class SPARC2PolAnalyzerTestCase(unittest.TestCase):
                 im2 = ars.image.value
                 logging.debug("New live image is of shape %s", im2.shape)
                 # Check if the image changed (live update is working)
-                self.assertRaises(AssertionError, numpy.testing.utils.assert_array_equal, im1, im2)
+                assert_array_not_equal(im1, im2)
 
             # sas.raw: array containing as first entry the sem scan image for the scanning positions,
             # rest are ar images
@@ -3580,7 +3581,7 @@ class TimeCorrelatorTestCase(unittest.TestCase):
         data = f.result()
 
         # Check if the image changed (live update is working)
-        self.assertRaises(AssertionError, numpy.testing.utils.assert_array_equal, im1, im2)
+        assert_array_not_equal(im1, im2)
 
 
 # @skip("faster")
@@ -4640,7 +4641,7 @@ class StaticStreamsTestCase(unittest.TestCase):
         # Check it's a RGB DataArray
         self.assertEqual(im2d_effcorr.shape, spec.shape[-2:] + (3,))
         # check image different from previous image after bg correction, and different from efficiency corr. image
-        self.assertTrue(numpy.any(im2d_effcorr != prev_im2d))
+        assert_array_not_equal(im2d_effcorr, prev_im2d)
 
         # apply background image correction
         specs.background.value = bckg
@@ -4650,8 +4651,8 @@ class StaticStreamsTestCase(unittest.TestCase):
         # Check it's a RGB DataArray
         self.assertEqual(im2d_bgcorr.shape, spec.shape[-2:] + (3,))
         # check image different from previous image after bg correction, and different from efficiency corr. image
-        self.assertTrue(numpy.any(im2d_bgcorr != im2d_effcorr))
-        self.assertTrue(numpy.any(im2d_bgcorr != prev_im2d))
+        assert_array_not_equal(im2d_bgcorr, im2d_effcorr)
+        assert_array_not_equal(im2d_bgcorr, prev_im2d)
 
     def _create_temporal_spectrum_data(self):
         """Create temporal spectrum data."""
@@ -4761,7 +4762,7 @@ class StaticStreamsTestCase(unittest.TestCase):
         # Check it's a RGB DataArray
         self.assertEqual(im2d_effcorr.shape, temporalspectrum.shape[-2:] + (3,))
         # check image different from previous image after efficiency correction
-        self.assertTrue(numpy.any(im2d_effcorr != prev_im2d))
+        assert_array_not_equal(im2d_effcorr, prev_im2d)
 
         # apply bg correction
         tss.background.value = bckg
@@ -4771,8 +4772,8 @@ class StaticStreamsTestCase(unittest.TestCase):
         # Check it's a RGB DataArray
         self.assertEqual(im2d_bgcorr.shape, temporalspectrum.shape[-2:] + (3,))
         # check image different from previous image after bg correction, and different from efficiency corr. image
-        self.assertTrue(numpy.any(im2d_bgcorr != im2d_effcorr))
-        self.assertTrue(numpy.any(im2d_bgcorr != prev_im2d))
+        assert_array_not_equal(im2d_bgcorr, im2d_effcorr)
+        assert_array_not_equal(im2d_bgcorr, prev_im2d)
 
     def test_temporal_spectrum_false_calib_bg(self):
         """Test StaticSpectrumStream background image correction

--- a/src/odemis/acq/test/stream_test.py
+++ b/src/odemis/acq/test/stream_test.py
@@ -4046,7 +4046,7 @@ class StaticStreamsTestCase(unittest.TestCase):
         self.assertEqual(im2d1.shape[2], 3)
         self.assertFalse(im2d0 is im2d1)
 
-        assert not numpy.array_equal(im2d0, im2d1)
+        assert_array_not_equal(im2d0, im2d1)
 
         logging.info("testing image background correction")
         # test background correction from image
@@ -4066,7 +4066,7 @@ class StaticStreamsTestCase(unittest.TestCase):
         self.assertFalse(im2d1 is im2d2)
 
         # check if the .image VA has been updated
-        assert not numpy.array_equal(im2d1, im2d2)
+        assert_array_not_equal(im2d1, im2d2)
 
     def test_ar_das(self):
         """Test StaticARStream with a DataArrayShadow"""
@@ -4191,7 +4191,7 @@ class StaticStreamsTestCase(unittest.TestCase):
         # Check it's a RGB DataArray
         self.assertEqual(im2d1.shape[2], 3)
         # check if the .image VA has been updated
-        assert not numpy.array_equal(im2d0, im2d1)
+        assert_array_not_equal(im2d0, im2d1)
 
         ###################################################################
         # testing background correction
@@ -4220,7 +4220,7 @@ class StaticStreamsTestCase(unittest.TestCase):
         # Check it's a RGB DataArray
         self.assertEqual(im2d2.shape[2], 3)
         # check if the bg image has been applied and the .image VA has been updated
-        assert not numpy.array_equal(im2d1, im2d2)
+        assert_array_not_equal(im2d1, im2d2)
 
         ###################################################################
         # test bg correction passing only 1 bg image but have six images -> should raise an error
@@ -4281,7 +4281,7 @@ class StaticStreamsTestCase(unittest.TestCase):
         im2d1 = ars_raw_pj.image.value
         time.sleep(0.5)  # wait shortly as .image is updated multiple times
         # check if the bg image has been applied and the .image VA has been updated
-        assert not numpy.array_equal(im2d0, im2d1)
+        assert_array_not_equal(im2d0, im2d1)
 
     def test_arpolarimetry(self):
         """Test StaticARStream with ARPolarimetryProjection projection."""
@@ -4356,7 +4356,7 @@ class StaticStreamsTestCase(unittest.TestCase):
         # Check it's a RGB DataArray
         self.assertEqual(img_vis_2.shape[2], 3)
         # check if the .image VA has been updated
-        assert not numpy.array_equal(img_vis_1, img_vis_2)
+        assert_array_not_equal(img_vis_1, img_vis_2)
 
         ###################################################################
         # testing background correction is applied visualized data
@@ -4377,7 +4377,7 @@ class StaticStreamsTestCase(unittest.TestCase):
         # Check it's a RGB DataArray
         self.assertEqual(img_vis_3.shape[2], 3)
         # check if the bg image has been applied and the .image VA has been updated
-        assert not numpy.array_equal(img_vis_2, img_vis_3)
+        assert_array_not_equal(img_vis_2, img_vis_3)
 
     def test_ar_large_image(self):
         """Test StaticARStream with a large image to trigger resizing."""
@@ -4426,7 +4426,7 @@ class StaticStreamsTestCase(unittest.TestCase):
         im2d1 = ars_raw_pj.image.value
         time.sleep(0.5)  # wait shortly as .image is updated multiple times
         # check if the bg image has been applied and the .image VA has been updated
-        assert not numpy.array_equal(im2d0, im2d1)
+        assert_array_not_equal(im2d0, im2d1)
 
     def _create_spectrum_data(self):
         """Create spectrum data."""

--- a/src/odemis/driver/test/simcam_test.py
+++ b/src/odemis/driver/test/simcam_test.py
@@ -22,6 +22,7 @@ import logging
 import numpy
 from odemis import model
 from odemis.driver import simcam, simulated
+from odemis.util.test import assert_array_not_equal
 import time
 import unittest
 from unittest.case import skip
@@ -361,7 +362,7 @@ class TestSimCamWithPolarization(unittest.TestCase):
         im_rhc = self.camera.data.get()
 
         # test the two images are different from each other (different txt was written on top)
-        self.assertFalse(numpy.all(im_lhc == im_rhc))
+        assert_array_not_equal(im_lhc, im_rhc)
 
         # change binning
         self.camera.binning.value = (2, 2)
@@ -374,7 +375,8 @@ class TestSimCamWithPolarization(unittest.TestCase):
         im_vertical = self.camera.data.get()
 
         # test the two images are different from each other (different txt was written on top)
-        self.assertFalse(numpy.all(im_horizontal == im_vertical))
+        assert_array_not_equal(im_horizontal, im_vertical)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/odemis/util/test.py
+++ b/src/odemis/util/test.py
@@ -18,14 +18,15 @@ You should have received a copy of the GNU General Public License along with Ode
 from __future__ import division, print_function
 
 import logging
+import numpy
 from odemis import model, util
 import odemis
 from odemis.util import driver
 import os
 import resource
 import subprocess
-import time
 import sys
+import time
 
 
 # ODEMISD_CMD = ["/usr/bin/python2", "-m", "odemis.odemisd.main"]
@@ -118,3 +119,20 @@ def assert_pos_almost_equal(actual, expected, *args, **kwargs):
     for k in expected.keys():
         if not util.almost_equal(actual[k], expected[k], *args, **kwargs):
             raise AssertionError("Position %s != %s" % (actual, expected))
+
+
+def assert_array_not_equal(a, b, msg="Arrays are equal"):
+    """
+    Asserts that two numpy arrays are not equal (where NaN are considered equal)
+    """
+    # TODO: an option to check that the shapes are equal, but the values different?
+
+    # Using numpy.any(a != b) would almost work, but NaN are always considered
+    # unequal, so instead, use numpy's assert_array_equal to do the work.
+    try:
+        numpy.testing.assert_array_equal(a, b)
+    except AssertionError:
+        # Perfect, they are not equal
+        return
+
+    raise AssertionError(msg)


### PR DESCRIPTION
Unfortunately, numpy doesn't provide such function, and it's not really
obvious/easy to implement. We have at least 3 open-coded way to do it
now, so let's consolidate it.