### PR TITLE
util img findOptimalRange: handle better empty histogram

### DIFF
--- a/src/odemis/util/img.py
+++ b/src/odemis/util/img.py
@@ -97,6 +97,10 @@ def findOptimalRange(hist, edges, outliers=0):
       discards no value, 0.5 discards every value (and so returns the median).
     return (tuple of 2 values): the range (min and max values)
     """
+    # If we got an histogram with only one value, don't try too hard.
+    if len(hist) < 2:
+        return edges
+
     if outliers == 0:
         # short-cut if no outliers: find first and last non null value
         inz = numpy.flatnonzero(hist)
@@ -110,9 +114,8 @@ def findOptimalRange(hist, edges, outliers=0):
         cum_hist = hist.cumsum()
         nval = cum_hist[-1]
 
-        # if we got a histogram of an empty array, or histogram with only one
-        # value, don't try too hard.
-        if nval == 0 or len(hist) < 2:
+        # If it's an histogram of an empty array, don't try too hard.
+        if nval == 0:
             return edges
 
         # trick: if there are lots (>1%) of complete black and not a single

--- a/src/odemis/util/test/img_test.py
+++ b/src/odemis/util/test/img_test.py
@@ -177,6 +177,18 @@ class TestFindOptimalRange(unittest.TestCase):
         self.assertEqual(rgb[5, 1].tolist(), [255, 255, 255])
         self.assertTrue(0 < rgb[50, 50, 0] < 255)
 
+    def test_empty_hist(self):
+        # Empty histogram
+        edges = (0, 0)
+        irange = img.findOptimalRange(numpy.array([]), edges, 1 / 256)
+        self.assertEqual(irange, edges)
+
+        # histogram from an array with a single point
+        edges = (10, 10)
+        irange = img.findOptimalRange(numpy.array([1]), edges, 1 / 256)
+        self.assertEqual(irange, edges)
+
+
 class TestHistogram(unittest.TestCase):
     # 8 and 16 bit short-cuts test
     def test_uint8(self):


### PR DESCRIPTION
Very corner case. Still happened sometimes, causing such traces:
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/odemis/model/_vattributes.py", line 97, in notify
    l(v)
  File "/usr/lib/python2.7/dist-packages/odemis/util/weak.py", line 37, in __call__
    return self.f(ins, *arg, **kwargs)
  File "/usr/lib/python2.7/dist-packages/odemis/acq/stream/_base.py", line 969, in _onOutliers
    self._recomputeIntensityRange()
  File "/usr/lib/python2.7/dist-packages/odemis/acq/stream/_base.py", line 974, in _recomputeIntensityRange
    self.auto_bc_outliers.value / 100)
  File "/usr/lib/python2.7/dist-packages/odemis/util/img.py", line 111, in findOptimalRange
    nval = cum_hist[-1]
IndexError: index -1 is out of bounds for axis 0 with size 0