### PR TITLE
driver andorcam2: fix complete failure if unexpected error happens during acquisition

### DIFF
--- a/src/odemis/driver/andorcam2.py
+++ b/src/odemis/driver/andorcam2.py
@@ -2028,7 +2028,7 @@ class AndorCam2(model.DigitalCamera):
                         self.Reinitialize()
                     else:
                         time.sleep(0.1)
-                        logging.warning("trying again to acquire image after error %s", ex.strerr)
+                        logging.warning("trying again to acquire image after error %s", ex)
                     need_reinit = True
                     continue
                 else:


### PR DESCRIPTION
The error message is not in ex.strerr, but ex.strerror (which can be
abreviated anyway to ex). So whenever an unexpected error happened,
instead of logging it nicely and retrying, it would immediately fail
hard.