### PR TITLE
gui cont streams: Time Correlator stream should also have an OPM

### DIFF
--- a/src/odemis/gui/cont/streams.py
+++ b/src/odemis/gui/cont/streams.py
@@ -2803,6 +2803,7 @@ class SparcStreamsController(StreamBarController):
             main_data.time_correlator,
             main_data.time_correlator.data,
             main_data.ebeam,
+            opm=self._main_data_model.opm,
             detvas=get_local_vas(main_data.time_correlator, self._main_data_model.hw_settings_config)
         )
 


### PR DESCRIPTION
The optical path manager (OPM) is needed also for the
ScannedTemporalSettingsStreams, otherwise nothing in the optical path
is setup properly.

That's probably an omission from the very beginning when adding this
stream...