### PR TITLE
Also log the Python interpreter version

### DIFF
--- a/src/odemis/gui/main.py
+++ b/src/odemis/gui/main.py
@@ -137,7 +137,8 @@ class OdemisGUIApp(wx.App):
                     gui.legend_logo = "legend_logo_delphi.png"
 
         logging.info("\n\n************  Starting Odemis GUI  ************\n")
-        logging.info("Odemis GUI v%s (from %s)", odemis.__version__, __file__)
+        logging.info("Odemis GUI v%s (from %s) using Python %d.%d",
+                     odemis.__version__, __file__, sys.version_info[0], sys.version_info[1])
         logging.info("wxPython v%s", wx.version())
 
         # TODO: if microscope.ghost is not empty => wait and/or display a special

--- a/src/odemis/odemisd/main.py
+++ b/src/odemis/odemisd/main.py
@@ -712,7 +712,8 @@ def main(args):
         pyrolog.setLevel(min(pyrolog.getEffectiveLevel(), logging.INFO))
 
     # Useful to debug cases of multiple conflicting installations
-    logging.info("Starting Odemis back-end v%s (from %s)", odemis.__version__, __file__)
+    logging.info("Starting Odemis back-end v%s (from %s) using Python %d.%d",
+                 odemis.__version__, __file__, sys.version_info[0], sys.version_info[1])
 
     if options.validate and (options.kill or options.check or options.daemon):
         logging.error("Impossible to validate a model and manage the daemon simultaneously")


### PR DESCRIPTION
Now that we support both Python 2 & 3, it'll probably come in handy to
know which interpreter was used when facing a bug.