### PR TITLE
driver hamamatsurx: close the connection on init failure

### DIFF
--- a/src/odemis/driver/hamamatsurx.py
+++ b/src/odemis/driver/hamamatsurx.py
@@ -965,6 +965,8 @@ class StreakCamera(model.HwComponent):
                 self.AppEnd()
             except Exception:
                 logging.exception("AppEnd failed")
+            self.should_listen = False  # terminates receiver thread
+            self._closeConnection()
             raise
 
     def _openConnection(self):
@@ -988,7 +990,7 @@ class StreakCamera(model.HwComponent):
                 raise ValueError("Connection Hamamatsu RemoteEx via port %s not successful. "
                                  "Response %s from server is not as expected." % (self.port, message))
         except socket.timeout:
-            raise model.HwError("Hamamastu RemoteEx didn't respond. "
+            raise model.HwError("Hamamatsu RemoteEx didn't respond. "
                                 "Check that it is running properly, or restart the streak camera computer.")
 
         try:
@@ -997,7 +999,7 @@ class StreakCamera(model.HwComponent):
                 raise IOError("Connection Hamamatsu RemoteEx via port %s not successful. "
                               "Response %s from server is not as expected." % (self.port_d, message))
         except socket.timeout:
-            raise model.HwError("Hamamastu RemoteEx didn't respond. "
+            raise model.HwError("Hamamatsu RemoteEx didn't respond. "
                                 "Check that it is running properly, or restart the streak camera computer.")
 
         # set timeout


### PR DESCRIPTION
Without this, every time a new attempt to connect to the camera fails,
the connection thread would stay in the background waiting for some
message (which would never arrive).