### PR TITLE
gui cont tabs SPARC2AlignTab: when leaving the tab, always ensure the calibration light is off

### DIFF
--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -4235,6 +4235,16 @@ class Sparc2AlignTab(Tab):
             # Cancel autofocus (if it happens to run)
             self.tab_data_model.autofocus_active.value = False
 
+            # Cancel manual focus: just reset the button, as the rest is just
+            # optical-path moves.
+            self.panel.btn_manualfocus.SetValue(False)
+
+            # Turn off the brightlight, if it was on
+            bl = main.brightlight
+            if bl:
+                bl.power.value = bl.power.range[0]
+                bl.emissions.value = [0] * len(bl.emissions.value)
+
             if main.lens_mover:
                 main.lens_mover.position.unsubscribe(self._onLensPos)
             main.mirror.position.unsubscribe(self._onMirrorPos)


### PR DESCRIPTION
The calibration light is turned during focusing.
It would normally be turned off automatically when cancelling the
autofocus. However, on the streak cam, if the manual focus was active,
the light would not be turned off.

=> When leaving the tab, reset the manual focus (so that when coming back to the tab
it doesn't look like we are in this mode), and turn off the light.