### PR TITLE
util transform: rewrote einsum to be able to get rid of the check for…

### DIFF
--- a/src/odemis/util/transform.py
+++ b/src/odemis/util/transform.py
@@ -213,12 +213,7 @@ class GeometricTransform(with_metaclass(ABCMeta, object)):
 
         """
         x = numpy.asarray(x)
-        if x.ndim == 1:
-            return (numpy.einsum('ik,k->i', self.transformation_matrix, x) +
-                    self.translation)
-        else:
-            return (numpy.einsum('ik,jk->ji', self.transformation_matrix, x) +
-                    self.translation)
+        return numpy.einsum('ik,...k->...i', self.transformation_matrix, x) + self.translation
 
     @abstractmethod
     def inverse(self):


### PR DESCRIPTION
… one dimension.

By using ... in einsum you can indicate that the length of that axes is 0 or higher.
In case of a single coordinate the first axes has length 0.