### PR TITLE
gui cont tabs: no RULER tool on the SECOM alignment tab

### DIFF
--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -2414,7 +2414,6 @@ class SecomAlignTab(Tab):
         tb = panel.lens_align_tb
         tb.add_tool(TOOL_DICHO, self.tab_data_model.tool)
         tb.add_tool(TOOL_SPOT, self.tab_data_model.tool)
-        tb.add_tool(TOOL_RULER, self.tab_data_model.tool)
 
         # Dichotomy mode: during this mode, the label & button "move to center" are
         # shown. If the sequence is empty, or a move is going, it's disabled.


### PR DESCRIPTION
Commit c620e5d976 (Distance tool) got a little bit too enthousiastic,
and added the ruler tool also in the alingment tab, for which it's not
useful, and the rest of the code doesn't support it.

=> remove it from the toolbar.