### PR TITLE
Export of pyramidal picture in higher resolution and update of unit-test

### DIFF
--- a/src/odemis/gui/util/img.py
+++ b/src/odemis/gui/util/img.py
@@ -26,6 +26,7 @@ from __future__ import division
 
 from past.builtins import basestring
 from odemis.gui.util import wx_adapter
+import threading
 import cairo
 import logging
 import math
@@ -37,12 +38,15 @@ from odemis.util import intersect, fluo, conversion, img, units
 import time
 import wx
 
+import cv2 as cv
+
 import odemis.acq.stream as acqstream
 from odemis.util import spectrum
 import odemis.gui.img as guiimg
-from odemis.acq.stream import RGBProjection, \
+from odemis.acq.stream import RGBProjection, RGBSpatialProjection, \
     SinglePointTemporalProjection, DataProjection
 from odemis.model import DataArrayShadow
+from odemis.util.img import mergeTiles
 
 BAR_PLOT_COLOUR = (0.5, 0.5, 0.5)
 CROP_RES_LIMIT = 1024
@@ -2228,8 +2232,27 @@ def images_to_export_data(streams, view_hfw, view_pos,
     return (list of DataArray)
     raise LookupError: if no data visible in the selected FoV
     """
+    max_res = (MAX_RES_FACTOR * CROP_RES_LIMIT) ** 2
+    mpp = math.sqrt( (view_hfw[0]*view_hfw[1]) / max_res) # Area = [meters per pixel]^2 * number_of_pixels
+
+    def img_callback(da):
+        img_received.set()
+
+    for stream_idx, projection in enumerate(streams):
+        if hasattr(projection, 'mpp'):
+            img_received = threading.Event()
+            new_proj = RGBSpatialProjection(projection.stream)
+            new_proj.rect.value = projection.rect.value
+            new_proj.mpp.value = new_proj.mpp.clip(mpp) # set pixel size to desired number
+            streams[stream_idx] = new_proj
+
+            #Update new projection
+            new_proj.image.subscribe(img_callback)
+            img_received.wait()
+            new_proj.image.unsubscribe(img_callback)
 
     images, im_min_type = convert_streams_to_images(streams, raw)
+
     if not images:
         raise LookupError("There is no stream data to be exported")
 

--- a/src/odemis/gui/util/test/img_test.py
+++ b/src/odemis/gui/util/test/img_test.py
@@ -1048,11 +1048,20 @@ class TestSpatialExport(test.GuiTestCase):
                         msg="Canvas are equal, which means there in no drawn ruler to be shown in the export")
 
 class TestSpatialExportPyramidal(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # expected max number of pixels with a safety margin, derived from the MAX_RES_FACTOR in img.py
+        cls.expected_max_nmr_pixels = 23004160 * 0.95
 
-    def setUp(self):
+
+    def setUp_custom(self, fluo_stream_resolution, SEM_stream_resolution):
+        '''
+        :param fluo_stream_resolution (tuple): resolution of StaticFluoStream x,y
+        :param SEM_stream_resolution(tuple): resolution of StaticSEMStream x,y
+        '''
         self.app = wx.App()
-        data = numpy.zeros((2160, 2560), dtype=numpy.uint16)
-        dataRGB = numpy.zeros((2160, 2560, 4))
+
+        data = numpy.zeros((fluo_stream_resolution[0], fluo_stream_resolution[1]), dtype=numpy.uint16)
         metadata = {'Hardware name': 'Andor ZYLA-5.5-USB3 (s/n: VSC-01959)',
                     'Exposure time': 0.3, 'Pixel size': (1.59604600574173e-07, 1.59604600574173e-07),
                     'Acquisition date': 1441361559.258568, 'Hardware version': "firmware: '14.9.16.0' (driver 3.10.30003.5)",
@@ -1065,12 +1074,12 @@ class TestSpatialExportPyramidal(unittest.TestCase):
         fluo_stream = stream.StaticFluoStream(metadata['Description'], image)
         fluo_stream_pj = stream.RGBSpatialProjection(fluo_stream)
 
-        data = numpy.zeros((1024, 1024), dtype=numpy.uint16)
-        dataRGB = numpy.zeros((1024, 1024, 4))
+        data = numpy.zeros((SEM_stream_resolution[0], SEM_stream_resolution[1]), dtype=numpy.uint16)
         metadata = {'Hardware name': 'pcie-6251', 'Description': 'Secondary electrons',
                     'Exposure time': 3e-06, 'Pixel size': (1e-6, 1e-6),
                     'Acquisition date': 1441361562.0, 'Hardware version': 'Unknown (driver 2.1-160-g17a59fb (driver ni_pcimio v0.7.76))',
                     'Centre position': (-0.001203511795256, -0.000295338300158), 'Lens magnification': 5000.0, 'Rotation': 0.0}
+
         image = model.DataArray(data, metadata)
 
         # export
@@ -1083,12 +1092,18 @@ class TestSpatialExportPyramidal(unittest.TestCase):
         sem_stream_pj.mpp.value = 1e-6
 
         self.streams = [fluo_stream_pj, sem_stream_pj]
-        self.min_res = (623, 432)
+        self.image_ratio = [[] for _ in self.streams]
+        self.image_ratio[0] = fluo_stream_resolution[0] / fluo_stream_resolution[1]
+        self.image_ratio[1] = SEM_stream_resolution[0] / SEM_stream_resolution[1]
 
         # Wait for all the streams to get an RGB image
         time.sleep(0.5)
 
-    def test_first(self):
+    def test_normal_resolution(self):
+        '''
+        unit test for a normal picture size significantly SMALLER than the MAXRESOLUTION
+        '''
+        self.setUp_custom((2160, 2560), (1024, 1024))
         orig_md = [s.raw[0][0].metadata.copy() for s in self.streams]
 
         # Print ready format
@@ -1100,6 +1115,37 @@ class TestSpatialExportPyramidal(unittest.TestCase):
         self.assertEqual(len(exp_data_rgb), 1)
         self.assertEqual(len(exp_data_rgb[0].shape), 3)  # RGB
 
+        # Post-process forma12t
+        exp_data_gray = img.images_to_export_data(self.streams, view_hfw, view_pos, draw_merge_ratio, True)
+        self.assertEqual(len(exp_data_gray), 2)
+        self.assertEqual(len(exp_data_gray[0].shape), 2)  # grayscale
+        self.assertEqual(exp_data_rgb[0].shape[:2], exp_data_gray[0].shape)  # all exported images must have the same shape
+
+        for s, md in zip(self.streams, orig_md):
+            self.assertEqual(md, s.raw[0][0].metadata)
+
+    def test_aprox_max_resolution(self):
+        '''
+        The resolution which will be exported is approximately the maximum resolution as defined the MAX_RES_FACTOR
+        in img.py
+        '''
+        self.setUp_custom((10000, 10000), (10000, 10000))
+        time.sleep(2.5) #Extra waiting time cause loading of large picture takes longer
+        orig_md = [s.raw[0][0].metadata.copy() for s in self.streams]
+
+        # Print ready format
+        view_hfw = (8.191282393266523e-04, 6.205915392651362e-04)
+        view_pos = [-0.001203511795256, -0.000295338300158]
+        draw_merge_ratio = 0.3
+        self.streams[1]._updateImage()
+        exp_data_rgb = img.images_to_export_data(self.streams, view_hfw, view_pos, draw_merge_ratio, False)
+        self.assertEqual(len(exp_data_rgb), 1)
+        self.assertEqual(len(exp_data_rgb[0].shape), 3)  # RGB
+        self.assertGreater(exp_data_rgb[0][:, :, 0].size, self.expected_max_nmr_pixels)
+        new_image_ratio = exp_data_rgb[0].shape[0] /exp_data_rgb[0].shape[1]
+        # Works only for streams with similair ratio (height/width) of images in both fluo_stream and SEM_stream
+        self.assertLess(abs(new_image_ratio - self.image_ratio[0]) / self.image_ratio[0], 0.3)
+
         # Post-process format
         exp_data_gray = img.images_to_export_data(self.streams, view_hfw, view_pos, draw_merge_ratio, True)
         self.assertEqual(len(exp_data_gray), 2)
@@ -1108,6 +1154,84 @@ class TestSpatialExportPyramidal(unittest.TestCase):
 
         for s, md in zip(self.streams, orig_md):
             self.assertEqual(md, s.raw[0][0].metadata)
+
+        # Checking the ratio between height/width of each stream
+        for data_gray, ratio in zip(exp_data_gray, self.image_ratio):
+            new_image_ratio = data_gray.shape[0] / data_gray.shape[1]
+            self.assertLess(abs(new_image_ratio - ratio) / ratio, 0.3)
+
+    def test_twice_max_resolution(self):
+        '''
+        Input stream has approximately twice the maximum resolution to export an image of
+        '''
+        self.setUp_custom((10000, 10000), (10000, 10000))
+        time.sleep(2.5) #Extra waiting time cause loading of large picture takes longer
+        orig_md = [s.raw[0][0].metadata.copy() for s in self.streams]
+
+        # Print ready format
+        view_hfw = (2*8.191282393266523e-04, 2*6.205915392651362e-04)
+        view_pos = [-0.001203511795256, -0.000295338300158]
+        draw_merge_ratio = 0.3
+        self.streams[1]._updateImage()
+        exp_data_rgb = img.images_to_export_data(self.streams, view_hfw, view_pos, draw_merge_ratio, False)
+        self.assertEqual(len(exp_data_rgb), 1)
+        self.assertEqual(len(exp_data_rgb[0].shape), 3)  # RGB
+        self.assertGreater(exp_data_rgb[0][:, :, 0].size , self.expected_max_nmr_pixels)
+        new_image_ratio = exp_data_rgb[0].shape[0] /exp_data_rgb[0].shape[1]
+        # Works only for streams with similair ratio (height/width) of images in both fluo_stream and SEM_stream
+        self.assertLess(abs(new_image_ratio - self.image_ratio[0]) / self.image_ratio[0], 0.3)
+
+        # Post-process format
+        exp_data_gray = img.images_to_export_data(self.streams, view_hfw, view_pos, draw_merge_ratio, True)
+        self.assertEqual(len(exp_data_gray), 2)
+        self.assertEqual(len(exp_data_gray[0].shape), 2)  # grayscale
+        self.assertEqual(exp_data_rgb[0].shape[:2], exp_data_gray[0].shape)  # all exported images must have the same shape
+
+        for s, md in zip(self.streams, orig_md):
+            self.assertEqual(md, s.raw[0][0].metadata)
+
+        # Checking the ratio between height/width of each stream
+        for data_gray, ratio in zip(exp_data_gray, self.image_ratio):
+            new_image_ratio = data_gray.shape[0] / data_gray.shape[1]
+            self.assertLess(abs(new_image_ratio - ratio) / ratio, 0.3)
+
+    def test_narrow_rectangular(self):
+        '''
+        Test printing an stream which has an high resolution an is an extremely narrow rectangular image
+        '''
+        self.setUp_custom((1000, 10000), (1000, 10000))
+        time.sleep(2.5)  # Extra waiting time cause loading of large picture takes longer
+        orig_md = [s.raw[0][0].metadata.copy() for s in self.streams]
+
+        # Print ready format
+        view_hfw = (8.191282393266523e-03/3, 6.205915392651362e-04/3)
+        view_pos = [-0.001203511795256, -0.000295338300158]
+
+        draw_merge_ratio = 0.3
+        self.streams[1]._updateImage()
+        exp_data_rgb = img.images_to_export_data(self.streams, view_hfw, view_pos, draw_merge_ratio, False)
+        self.assertEqual(len(exp_data_rgb), 1)
+        self.assertEqual(len(exp_data_rgb[0].shape), 3)  # RGB
+        # This stream has ten times less pixel than others, however legend is later added on bottom
+        self.assertGreater(exp_data_rgb[0][:, :, 0].size , self.expected_max_nmr_pixels*0.1)
+        new_image_ratio = exp_data_rgb[0].shape[0] /exp_data_rgb[0].shape[1]
+        # Works only for streams with similair ratio (height/width) of images in both fluo_stream and SEM_stream
+        self.assertLess(abs(new_image_ratio - self.image_ratio[0]) / self.image_ratio[0], 1.5)
+
+        # Post-process format
+        exp_data_gray = img.images_to_export_data(self.streams, view_hfw, view_pos, draw_merge_ratio, True)
+        self.assertEqual(len(exp_data_gray), 2)
+        self.assertEqual(len(exp_data_gray[0].shape), 2)  # grayscale
+        self.assertEqual(exp_data_rgb[0].shape[:2],
+                         exp_data_gray[0].shape)  # all exported images must have the same shape
+
+        for s, md in zip(self.streams, orig_md):
+            self.assertEqual(md, s.raw[0][0].metadata)
+
+        # Checking the ratio between height/width of each stream
+        for data_gray, ratio in zip(exp_data_gray, self.image_ratio):
+            new_image_ratio = data_gray.shape[0] / data_gray.shape[1]
+            self.assertLess(abs(new_image_ratio - ratio) / ratio, 1.5)
 
 
 class TestOverviewFunctions(unittest.TestCase):


### PR DESCRIPTION
Upgraded unit-test, made it a bit more fancier but not nicely depended on input data. Since mpp calculation and determination of pixels makes predicting the outcome size (resolution) of the export function complicated this is currently not done. Furthermore this is also complicated by the fact that a legend is added which results in big error margins in testing the ratio between the width and the height of the output image.