### PR TITLE
model vattribute: also accepts numpy integers in IntVA and ResolutionVA

### DIFF
--- a/src/odemis/model/_vattributes.py
+++ b/src/odemis/model/_vattributes.py
@@ -636,7 +636,7 @@ class IntVA(VigilantAttribute):
 
     def _check(self, value):
         # we really accept only int, to avoid hiding lose of precision
-        if not isinstance(value, (int, long)):
+        if not isinstance(value, (int, long, numpy.integer)):
             raise TypeError("Value '%r' is not a int." % value)
 
 # ListVA is difficult: not only change of the .value must be detected, but we
@@ -1165,5 +1165,5 @@ class ResolutionVA(TupleContinuous):
     # old name for TupleContinuous, when it was fixed to len == 2 and cls == int
     # and default unit == "px"
     def __init__(self, value, rng, unit="px", cls=None, **kwargs):
-        cls = cls or (int, long)
+        cls = cls or (int, long, numpy.integer)
         TupleContinuous.__init__(self, value, rng, unit=unit, cls=cls, **kwargs)

--- a/src/odemis/model/test/vattributes_test.py
+++ b/src/odemis/model/test/vattributes_test.py
@@ -361,6 +361,9 @@ class VigilantAttributeTest(unittest.TestCase):
         va.value = [11, 150]
         self.assertEqual(va.value, (11, 150))
 
+        # Numpy integers are also fine
+        va.value = (numpy.prod([10, 3]), numpy.uint64(1))
+
         # must not accept resolutions with float
         try:
             va.value = (8., 160)


### PR DESCRIPTION
Numpy integers easly creep everywhere. Normally that's fine because they
quack like an int (except for the over- under-flows of course, but that
typically doesn't happen in the number we handle).
So let's accept them also in the VAs.

Note: in Python 2, numpy.int* were a subclass of int, so it worked
fine (not for numpy.uint* though). In Python 3, this "link" has been removed,
that's why we have to explicitly add it