### PR TITLE
dataio hdf5: store the odemis version directly in the metadata

### DIFF
--- a/src/odemis/dataio/hdf5.py
+++ b/src/odemis/dataio/hdf5.py
@@ -26,6 +26,7 @@ import collections
 import h5py
 import logging
 import numpy
+import odemis
 from odemis import model
 from odemis.util import spectrum, img, fluo
 import os
@@ -1135,6 +1136,7 @@ def _add_svi_info(group):
     gi["Company"] = "Delmic"
     gi["FileSpecificationCompatibility"] = "0.01p0"
     gi["FileSpecificationVersion"] = "0.02"  # SVI has typically 0.01d8
+    gi["WriterVersion"] = "%s %s" % (odemis.__shortname__, odemis.__version__)
     gi["ImageHistory"] = ""
     gi["URL"] = "www.delmic.com"
 


### PR DESCRIPTION
Normally all future Odemis versions should support reading back the old
format, and we should use just the file structure and the
FileSpecificationVersion.

Nevertheless, it's useful for debugging to know which exact version of
Odemis generated the file.