### PR TITLE
acq stream projection: also use float for 1D spectrum

### DIFF
--- a/src/odemis/acq/stream/_projection.py
+++ b/src/odemis/acq/stream/_projection.py
@@ -1359,7 +1359,7 @@ class LineSpectrumProjection(RGBProjection):
             # out of the original data, the outside pixels count as 0.
             # force the intermediate values to float, as mean() still needs to run
             spec1d_w = ndimage.map_coordinates(spec2d, coord, output=numpy.float, order=1)
-            spec1d = spec1d_w.mean(axis=0).astype(spec2d.dtype)
+            spec1d = spec1d_w.mean(axis=0)
         assert spec1d.shape == (n, spec2d.shape[0])
 
         # Use metadata to indicate spatial distance between pixel

--- a/src/odemis/acq/test/stream_test.py
+++ b/src/odemis/acq/test/stream_test.py
@@ -4442,7 +4442,7 @@ class StaticStreamsTestCase(unittest.TestCase):
         wl0d, _ = spectrum.get_spectrum_range(sp0d)
         self.assertEqual(len(sp0d), spec.shape[0])
         self.assertEqual(len(wl0d), spec.shape[0])
-        self.assertEqual(sp0d.dtype, spec.dtype)
+        self.assertIsInstance(sp0d.dtype.type(), numpy.floating)
         self.assertTrue(numpy.all(sp0d <= spec.max()))
 
         # Check with very large width
@@ -4453,7 +4453,7 @@ class StaticStreamsTestCase(unittest.TestCase):
         wl0d, _ = spectrum.get_spectrum_range(sp0d)
         self.assertEqual(len(sp0d), spec.shape[0])
         self.assertEqual(len(wl0d), spec.shape[0])
-        self.assertEqual(sp0d.dtype, spec.dtype)
+        self.assertIsInstance(sp0d.dtype.type(), numpy.floating)
         self.assertTrue(numpy.all(sp0d <= spec.max()))
 
     def test_spectrum_1d(self):
@@ -4528,6 +4528,10 @@ class StaticStreamsTestCase(unittest.TestCase):
         self.assertEqual(sp1d.shape[2], 3)
         self.assertEqual(sp1d.dtype, numpy.uint8)
         self.assertEqual(wl1d.shape, (spec.shape[0],))
+
+        # Check the raw data is a float
+        sp1d_raw = proj_line_spectrum.projectAsRaw()
+        self.assertIsInstance(sp1d_raw.dtype.type(), numpy.floating)
 
     def test_spectrum_calib_bg(self):
         """Test Static Spectrum Stream calibration and background image correction


### PR DESCRIPTION
The same as 0D spectrum, it's useful to use float for the average of 1D
spectra.

Also fix the test cases to expect a float now.