### PR TITLE
driver smartact: fix MCS2 initialisation and Exceptions on Python 3

### DIFF
--- a/src/odemis/driver/test/smaract_test.py
+++ b/src/odemis/driver/test/smaract_test.py
@@ -361,6 +361,9 @@ class TestTMCS2(unittest.TestCase):
     def tearDownClass(cls):
         cls.dev.terminate()
 
+    def test_simple(self):
+        self.assertEqual(set(self.dev.axes.keys()), {"x", "y", "z"})
+
     def test_out_of_range(self):
         """
         Test sending a position that is out of range.


### PR DESCRIPTION
Reading the DLL version and hardware name hadn't been tested, and it
countained bugs.
=> Fix them to use the proper API.

Also fix issues with the Exceptions on Python 3.
=> use the same style as in the other drivers (eg andorcam2, avantes).

If the device is not found, raise a HwError, so that the backend shows
a nice error message and suggests the user to try again.

Also do a few minor clean-ups.