### PR TITLE
acq stream projection: fix subclass of RGBSpatialProjection not initialised

### DIFF
--- a/src/odemis/acq/stream/_projection.py
+++ b/src/odemis/acq/stream/_projection.py
@@ -828,7 +828,7 @@ class RGBSpatialProjection(RGBProjection):
         if isinstance(stream, StaticSpectrumStream):
             return super(RGBSpatialProjection, cls).__new__(RGBSpatialSpectrumProjection)
         else:
-            return super(RGBSpatialProjection, cls).__new__(RGBSpatialProjection)
+            return super(RGBSpatialProjection, cls).__new__(cls)
 
     def __init__(self, stream):
         '''


### PR DESCRIPTION
If a __new__ returns an instance of an object which is not of the same
class as the actual class, __init__ is not called. As
RGBSpatialProjection always returned RGBSpatialProjection as a fallback,
subclasses would still get a RGBSpatialProjection, which meant they were
not initialised.

In particular, this happened in the auto_align plugin, for AlignmentProjection.

=> As fallback, return the current class type.