### PR TITLE
acq path: don't queue OPM setPath() calls

### DIFF
--- a/src/odemis/acq/path.py
+++ b/src/odemis/acq/path.py
@@ -269,6 +269,7 @@ class OneTaskExecutor(ThreadPoolExecutor):
     def __init__(self, thread_name_prefix=''):
         super(OneTaskExecutor, self).__init__(max_workers=1, thread_name_prefix=thread_name_prefix)
 
+    # Override ThreadPoolExecutor.submit()
     def submit(self, fn, *args, **kwargs):
         # Cancels all the previous tasks which didn't start yet
         # Note: in practice, there should be only one task at most queued.
@@ -279,7 +280,8 @@ class OneTaskExecutor(ThreadPoolExecutor):
             except queue.Empty:
                 break
 
-        return ThreadPoolExecutor.submit(self, fn, *args, **kwargs)
+        # Add this new function call to the _work_queue
+        return super(OneTaskExecutor, self).submit(fn, *args, **kwargs)
 
 
 # TODO: Could be moved to util

--- a/src/odemis/acq/test/path_test.py
+++ b/src/odemis/acq/test/path_test.py
@@ -29,6 +29,7 @@ from odemis.acq.path import ACQ_QUALITY_BEST, ACQ_QUALITY_FAST
 from odemis.util import test
 from odemis.util.test import assert_pos_almost_equal
 import os
+import time
 import unittest
 from unittest.case import skip
 
@@ -475,6 +476,24 @@ class Sparc2PathTestCase(unittest.TestCase):
         """
         with self.assertRaises(ValueError):
             self.optmngr.setPath("ErrorMode").result()
+
+    def test_queue(self):
+        """
+        Test changing path multiple times without waiting for it to be complete
+        """
+        tstart = time.time()
+        self.optmngr.setPath("cli")
+
+        # All these ones should get discarded
+        for i in range(5):
+            self.optmngr.setPath("ar")
+            self.optmngr.setPath("mirror-align")
+            self.optmngr.setPath("cli")
+
+        self.optmngr.setPath("ar").result()
+        dur = time.time() - tstart
+
+        self.assertLess(dur, 20, "Changing to CLI then AR mode took %s s > 20 s" % (dur,))
 
     # @skip("simple")
     def test_set_path(self):


### PR DESCRIPTION
Sometimes, for instance when changing quickly between chamber and
alignment tab, setPath() is called several times in a row.
Currently, every request is full-field, which can end up being very
slow. However, we only care about the latest requested position.

=> Discard move requests which haven't started yet.

We could be even more clever, and immediately stop the current moves,
but that's quite a lot more complicated, espcially because that means
all the callers need to handle CancelledError.