### PR TITLE
acq align delphi: fix stages not found

### DIFF
--- a/src/odemis/acq/align/delphi.py
+++ b/src/odemis/acq/align/delphi.py
@@ -217,21 +217,9 @@ def _DoDelphiCalibration(future, main_data):
         raise CancelledError()
 
     try:
-        # We need access to the separate sem and optical stages, which form
-        # the "stage". They are not found in the model, but we can find them
-        # as children of stage (on the DELPHI), and distinguish them by
-        # their role.
-        sem_stage = None
-        opt_stage = None
-        logger.debug("Find SEM and optical stages...")
-        for c in main_data.stage.children.value:
-            if c.role == "sem-stage":
-                sem_stage = c
-            elif c.role == "align":
-                opt_stage = c
-
-        if not sem_stage or not opt_stage:
-            raise KeyError("Failed to find SEM and optical stages")
+        logger.debug("Looking for SEM and optical stages...")
+        sem_stage = model.getComponent(role="sem-stage")
+        opt_stage = model.getComponent(role="align")
 
         # Move to the overview position first
         f = main_data.chamber.moveAbs({"pressure": overview_pressure})


### PR DESCRIPTION
The change from children to dependencies broke that part of the code.
A long long time ago, the stages where not directly available in the
model. So we had to rely on a hack, which consisted in looking on the
children of the main stage. The recent change to use depedencies broke
this part of the code.
=> Don't rely on this hack at all, and instead use the standard way to
search for components. That's what the manual calibration has been
doing, so it works on all systems, for sure.