### PR TITLE
gui: define an explicit CURSOR_DRAG

### DIFF
--- a/src/odemis/gui/__init__.py
+++ b/src/odemis/gui/__init__.py
@@ -20,10 +20,10 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 
 from __future__ import division
 
+import sys
 import wx.lib.newevent
 
 # Colour definitions
-
 # Background colours
 BG_COLOUR_MAIN = "#333333"      # Default dark background
 BG_COLOUR_STREAM = "#4D4D4D"    # Stream panel background
@@ -62,6 +62,12 @@ FOCUS_STREAM_COLOR = (0, 64, 255)  # colour it blue
 
 # END Colour definitions
 
+# This is ugly, but there is no official "drag" cursor, and the best fitting
+# one depends on the OS. Ideally, we want a "closed hand".
+if sys.platform.startswith("linux"):
+    DRAG_CURSOR = wx.CURSOR_SIZENESW
+else:  # Windows
+    DRAG_CURSOR = wx.CURSOR_SIZING
 
 # Control types
 

--- a/src/odemis/gui/comp/canvas.py
+++ b/src/odemis/gui/comp/canvas.py
@@ -138,7 +138,7 @@ from abc import abstractmethod
 import cairo
 from decorator import decorator
 import logging
-from odemis import util
+from odemis import util, gui
 from odemis.gui import BLEND_DEFAULT, BLEND_SCREEN, BufferSizeEvent
 from odemis.gui import img
 from odemis.gui.comp.overlay.base import WorldOverlay, ViewOverlay
@@ -212,12 +212,7 @@ class BufferedCanvas(wx.Panel):
         # The main cursor is the default cursor when the mouse hovers over the canvas
         self.default_cursor = wx.STANDARD_CURSOR
         self.dynamic_cursor = None
-        # This is ugly, but there is no official "drag" cursor, and the best fitting
-        # one depends on the OS.
-        if sys.platform.startswith("linux"):
-            self._drag_cursor = wx.Cursor(wx.CURSOR_SIZENESW)
-        else:
-            self._drag_cursor = wx.Cursor(wx.CURSOR_SIZING)
+        self._drag_cursor = wx.Cursor(gui.DRAG_CURSOR)
 
         # Event Biding
 

--- a/src/odemis/gui/comp/overlay/world.py
+++ b/src/odemis/gui/comp/overlay/world.py
@@ -228,7 +228,7 @@ class WorldSelectOverlay(WorldOverlay, SelectionMixin):
 
             if not self.dragging:
                 if self.hover == gui.HOVER_SELECTION:
-                    self.cnvs.set_dynamic_cursor(wx.CURSOR_SIZENESW)  # = closed hand
+                    self.cnvs.set_dynamic_cursor(gui.DRAG_CURSOR)
                 elif self.hover in (gui.HOVER_LEFT_EDGE, gui.HOVER_RIGHT_EDGE):
                     self.cnvs.set_dynamic_cursor(wx.CURSOR_SIZEWE)
                 elif self.hover in (gui.HOVER_TOP_EDGE, gui.HOVER_BOTTOM_EDGE):
@@ -1542,7 +1542,7 @@ class LineSelectOverlay(WorldSelectOverlay):
 
             if not self.dragging:
                 if self.hover in (gui.HOVER_START, gui.HOVER_END, gui.HOVER_LINE):
-                    self.cnvs.set_dynamic_cursor(wx.CURSOR_HAND)
+                    self.cnvs.set_dynamic_cursor(gui.DRAG_CURSOR)
                 else:
                     self.cnvs.set_dynamic_cursor(wx.CURSOR_PENCIL)
             else:
@@ -2158,7 +2158,7 @@ class MirrorArcOverlay(WorldOverlay, DragMixin):
     def on_left_down(self, evt):
         if self.active:
             DragMixin._on_left_down(self, evt)
-            self.cnvs.set_dynamic_cursor(wx.CURSOR_SIZENESW)  # = closed hand
+            self.cnvs.set_dynamic_cursor(gui.DRAG_CURSOR)
         else:
             WorldOverlay.on_left_down(self, evt)
 

--- a/src/odemis/gui/comp/slider.py
+++ b/src/odemis/gui/comp/slider.py
@@ -930,7 +930,7 @@ class VisualRangeSlider(BaseSlider):
             if hover in (gui.HOVER_LEFT_EDGE, gui.HOVER_RIGHT_EDGE):
                 self.SetCursor(wx.Cursor(wx.CURSOR_SIZEWE))
             elif hover == gui.HOVER_SELECTION:
-                self.SetCursor(wx.Cursor(wx.CURSOR_SIZENESW)) # A closed hand!
+                self.SetCursor(wx.Cursor(gui.DRAG_CURSOR))
             else:
                 self.SetCursor(wx.STANDARD_CURSOR)
 


### PR DESCRIPTION
We used CURSOR_SIZNESW, because that's a closed hand on GTK (Linux).
For Windows, a different value is needed. So we used to have a if in
some places (eg, canvas), while some other places (eg, histogram) just
showed the wrong cursor.

=> Have a single place with the right cursor.