### PR TITLE
Add the shear of the grid to the spot grid live visualization.

### DIFF
--- a/scripts/spot-grid.py
+++ b/scripts/spot-grid.py
@@ -51,10 +51,11 @@ class VideoDisplayerGrid(VideoDisplayer):
         at ratio 1:1)
         data (numpy.ndarray): an 2D array containing the image (can be 3D if in RGB)
         """
-        self.app.spots, trans, scale, rot = FindGridSpots(data, self.gridsize)
+        self.app.spots, trans, scale, rot, shear = FindGridSpots(data, self.gridsize)
         self.app.translation = trans[0], data.shape[0] - trans[1]
         self.app.scale = scale
         self.app.rotation = -rot
+        self.app.shear = shear
 
         super(VideoDisplayerGrid, self).new_image(data)
 
@@ -115,6 +116,7 @@ class ImageWindowApp(wx.App):
             "pitch-y: {:.2f} um".format(PIXEL_SIZE_UM * self.scale[1]),
             "translation-x: {:.1f} um".format(PIXEL_SIZE_UM * self.translation[0]),
             "translation-y: {:.1f} um".format(PIXEL_SIZE_UM * self.translation[1]),
+            "shear: {:.5f} ".format(self.shear),
         ]
         ctx2 = cairo.Context(text_surface)
         ctx2.set_source_rgb(1.00, 0.83, 0.00)

--- a/src/odemis/acq/align/spot.py
+++ b/src/odemis/acq/align/spot.py
@@ -349,6 +349,7 @@ def FindGridSpots(image, repetition):
     translation : tuple of two floats
     scaling : tuple of two floats
     rotation : float
+    shear : float
 
     """
     spot_positions = MaximaFind(image, repetition[0] * repetition[1])
@@ -371,8 +372,7 @@ def FindGridSpots(image, repetition):
     pos_sorted = spot_positions[ii.ravel(), :]
     transformation = AffineTransform.from_pointset(grid, pos_sorted)
     spot_coordinates = transformation(grid)
-
-    return spot_coordinates, translation, transformation.scale, transformation.rotation
+    return spot_coordinates, translation, transformation.scale, transformation.rotation, transformation.shear
 
 
 def CropFoV(ccd, dfbkg=None):

--- a/src/odemis/acq/align/test/spot_test.py
+++ b/src/odemis/acq/align/test/spot_test.py
@@ -173,7 +173,7 @@ class TestFindGridSpots(unittest.TestCase):
         # # set a grid of 8 by 8 points to 1 at the top left of the image
         image = numpy.zeros((256, 256))
         image[4:100:12, 4:100:12] = 1
-        spot_coordinates, translation, scaling, rotation = spot.FindGridSpots(image, (8, 8))
+        spot_coordinates, translation, scaling, rotation, shear = spot.FindGridSpots(image, (8, 8))
         # create a grid that contains the coordinates of the spots
         xv = numpy.arange(4, 100, 12)
         xx, yy = numpy.meshgrid(xv, xv)
@@ -183,7 +183,7 @@ class TestFindGridSpots(unittest.TestCase):
         # set a grid of 8 by 8 points to 1 at the bottom right of the image
         image = numpy.zeros((256, 300))
         image[168:253:12, 212:297:12] = 1
-        spot_coordinates, translation, scaling, rotation = spot.FindGridSpots(image, (8, 8))
+        spot_coordinates, translation, scaling, rotation, shear = spot.FindGridSpots(image, (8, 8))
         # create a grid that contains the coordinates of the spots
         xv = numpy.arange(168, 253, 12)
         yv = numpy.arange(212, 297, 12)
@@ -200,8 +200,9 @@ class TestFindGridSpots(unittest.TestCase):
         image = numpy.zeros((256, 256))
         # set a grid of 8 by 8 points to 1
         image[54:150:12, 54:150:12] = 1
-        spot_coordinates, translation, scaling, rotation = spot.FindGridSpots(image, (8, 8))
+        spot_coordinates, translation, scaling, rotation, shear = spot.FindGridSpots(image, (8, 8))
         self.assertAlmostEqual(rotation, 0, places=4)
+        self.assertEqual(shear, 0)
         # create a grid that contains the coordinates of the spots
         xv = numpy.arange(54, 150, 12)
         xx, yy = numpy.meshgrid(xv, xv)
@@ -218,7 +219,7 @@ class TestFindGridSpots(unittest.TestCase):
         grid_spots = numpy.load(os.path.join(TEST_IMAGE_PATH, "multiprobe01_grid_spots.npz"))
         filename = os.path.join(TEST_IMAGE_PATH, "multiprobe01.tiff")
         img = tiff.open_data(filename).content[0].getData()
-        spot_coordinates, translation, scaling, rotation = spot.FindGridSpots(img, (14, 14))
+        spot_coordinates, translation, scaling, rotation, shear = spot.FindGridSpots(img, (14, 14))
         numpy.testing.assert_array_almost_equal(spot_coordinates, grid_spots['spot_coordinates'])
         numpy.testing.assert_array_almost_equal(translation, grid_spots['translation'], decimal=3)
         numpy.testing.assert_array_almost_equal(scaling, grid_spots['scaling'], decimal=3)


### PR DESCRIPTION
To see if the shape of the grid is perfectly square it is important to see the shear.
To keep the FindGridSpots function compatible with scripts outside odemis I decided to only return the shear if specifically requested.