### PR TITLE
model core: prepare_to_listen_to_more_vas() increases the file limit by a larger amount

### DIFF
--- a/src/odemis/model/_core.py
+++ b/src/odemis/model/_core.py
@@ -236,7 +236,7 @@ def prepare_to_listen_to_more_vas(inc):
         resource.setrlimit(resource.RLIMIT_NOFILE, (cur_limit[0] + inc * FILES_PER_VA, cur_limit[1]))
     except ValueError:
         # this happens when starting odemis from eclipse
-        logging.warning("Maximum number of open files is already at its limit %s." % cur_limit[0])
+        logging.info("Maximum number of open files is already at its limit %s.", cur_limit[0])
 
 # Container management functions and class
 

--- a/src/odemis/model/_core.py
+++ b/src/odemis/model/_core.py
@@ -219,6 +219,8 @@ def load_roattributes(self, roattributes):
     # save the list in case we need to pickle the object again
     self._odemis_roattributes = list(roattributes.keys())
 
+
+FILES_PER_VA = 6
 def prepare_to_listen_to_more_vas(inc):
     """
     There's a limit on the number of VA subscribers we can create (the number of open
@@ -227,11 +229,11 @@ def prepare_to_listen_to_more_vas(inc):
     the SettingsObserver (cf odemis.acq).
     This function allows us to use an additional amount of inc VA subscribers. It corresponds
     to the system call ulimit -n.
-    inc (int): how many files to open additionally
+    inc (int): how many VAs to open additionally
     """
     cur_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
     try:
-        resource.setrlimit(resource.RLIMIT_NOFILE, (cur_limit[0] + inc, cur_limit[1]))
+        resource.setrlimit(resource.RLIMIT_NOFILE, (cur_limit[0] + inc * FILES_PER_VA, cur_limit[1]))
     except ValueError:
         # this happens when starting odemis from eclipse
         logging.warning("Maximum number of open files is already at its limit %s." % cur_limit[0])


### PR DESCRIPTION
The function was very optimistic, expecting that each VA needs only one
file opening. With a large back-end, the GUI end-up still reaching the
file limit.

In practice, all included, it seems that subscribing to a
VA (which was not proxy'd before) causes about 6 new files to be opened.
This is measured by using this command which reports the amound of files
currently opened by the GUI:
lsof -p $(pgrep -f odemis.gui.main) | wc -l

Comparing between the SettingsObserver activated or not, this showed
that for 102 VAs we need 686 more files.

=> Bump the file limit by 6 for each VA to be opened.