### PR TITLE
acq path: Drop extra argument from OneTaskExecutor

### DIFF
--- a/src/odemis/acq/path.py
+++ b/src/odemis/acq/path.py
@@ -266,8 +266,8 @@ class OneTaskExecutor(ThreadPoolExecutor):
     last one is executed.
     """
 
-    def __init__(self, thread_name_prefix=''):
-        super(OneTaskExecutor, self).__init__(max_workers=1, thread_name_prefix=thread_name_prefix)
+    def __init__(self):
+        super(OneTaskExecutor, self).__init__(max_workers=1)
 
     # Override ThreadPoolExecutor.submit()
     def submit(self, fn, *args, **kwargs):


### PR DESCRIPTION
The old version of the ThreadPoolExecutor (which is on Ubuntu 16.04)
doesn't have this argument. So drop it here. Noone actually uses it (in
Odemis).