### PR TITLE
acq stream AlignedSEMStream: fix preparation with MTD_MD_UPD

### DIFF
--- a/src/odemis/acq/stream/_live.py
+++ b/src/odemis/acq/stream/_live.py
@@ -404,7 +404,7 @@ class AlignedSEMStream(SEMStream):
         stage.position.subscribe(self._onMove)
         focus.position.subscribe(self._onMove)
         self._executor = ThreadPoolExecutor(max_workers=1)
-        self._beamshift = None
+        self._beamshift = (0, 0)
 
     def _onMove(self, pos):
         """
@@ -433,8 +433,7 @@ class AlignedSEMStream(SEMStream):
         # always in this order: resolution, then shift
         self._emitter.resolution.value = res
         if self._shiftebeam == MTD_EBEAM_SHIFT:
-            if self._beamshift is not None:
-                shift = tuple(s + c for s, c in zip(shift, self._beamshift))
+            shift = (shift[0] + self._beamshift[0], shift[1] + self._beamshift[1])
             self._emitter.shift.value = shift
 
     def _prepare(self):
@@ -467,7 +466,7 @@ class AlignedSEMStream(SEMStream):
             self._getEmitterVA("resolution").unsubscribe(self._onResolution)
 
             shift = (0, 0)
-            self._beamshift = None
+            self._beamshift = (0, 0)
             try:
                 logging.info("Determining the Ebeam center position")
                 if self._shiftebeam == MTD_EBEAM_SHIFT:


### PR DESCRIPTION
Commit 5c839bba4f31 (don't try to shift more than the hardware supports)
put extra checks for MTD_EBEAM_SHIFT. However, it requires having .shift
VA.

For some bad reason, related to Pyro and proxies, the code previously
didn't break even if the emitter didn't have a .shift VA. It now got
officially broken.
=> Don't access .shift if not using MTD_EBEAM_SHIFT.