### PR TITLE
acq stream test: test_arpolarimetry warn if arpolarimetry module is missing

### DIFF
--- a/src/odemis/acq/test/stream_test.py
+++ b/src/odemis/acq/test/stream_test.py
@@ -4261,6 +4261,12 @@ class StaticStreamsTestCase(unittest.TestCase):
     def test_arpolarimetry(self):
         """Test StaticARStream with ARPolarimetryProjection projection."""
 
+        # Check whether the arpolarimetry package is available
+        try:
+            import arpolarimetry
+        except ImportError:
+            self.skipTest("arpolarimetry package not available, type in a terminal: sudo apt install python-arpolarimetry python3-arpolarimetry")
+
         data_raw = []
         bg_data = []  # list of background images
         for i, pol in enumerate(POL_POSITIONS):


### PR DESCRIPTION
Without this module, the projection cannot be computed, so it'll
obviously fail. However, in such case it fails with such generic error:
Traceback (most recent call last):
  File "/home/philip/development/odemis/src/odemis/acq/test/stream_test.py", line 4287, in test_arpolarimetry
    assert e.is_set()
AssertionError

=> Detect the module is missing and indicate how to install it.