### PR TITLE
util driver: Never try to access the back-end if the file is not present

### DIFF
--- a/src/odemis/util/driver.py
+++ b/src/odemis/util/driver.py
@@ -222,7 +222,12 @@ BACKEND_STOPPED = "STOPPED"
 # TODO: support TERMINATING status?
 def get_backend_status():
     try:
-        model._core._microscope = None # force reset of the microscope
+        # Fast path: if no back-end file, for sure, it is stopped.
+        # The main goal is to avoid showing confusing error messages from Pyro.
+        if not os.path.exists(model.BACKEND_FILE):
+            return BACKEND_STOPPED
+
+        model._core._microscope = None  # force reset of the microscope
         microscope = model.getMicroscope()
         if not microscope.ghosts.value:
             return BACKEND_RUNNING


### PR DESCRIPTION
We used to just rely on Pyro to quickly find out it's not possible,
however, this leaves an ERROR log. In practice this meant that almost
every start of the backend started with:
ERROR   core:401:       cannot connect: [Errno 2] No such file or directory

It's a little confusing for the user. Especially in case there is really
an error, it's easy to be mislead and think this is the problem (as it's
the first error of the log).