### PR TITLE
acq align test: move clspots autofocus test to the right place

### DIFF
--- a/src/odemis/acq/align/test/clspots_optical_autofocus_test.py
+++ b/src/odemis/acq/align/test/clspots_optical_autofocus_test.py
@@ -235,3 +235,7 @@ class TestAutofocusHW(unittest.TestCase):
         # Test that the correct focus has been found.
         logging.debug("found focus at {} good focus at {}".format(foc_pos, self._optimal_focus))
         numpy.testing.assert_allclose(foc_pos, self._optimal_focus, atol=0.5e-6)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
It should be in the "test/" subfolder of the code it checks.

Also it should run the test cases when run from the command line.