### PR TITLE
util conversion: new JsonExtraEncoder to export numpy types as JSON

### DIFF
--- a/src/odemis/dataio/hdf5.py
+++ b/src/odemis/dataio/hdf5.py
@@ -4,7 +4,7 @@ Created on 14 Jan 2013
 
 @author: Éric Piel
 
-Copyright © 2013 Éric Piel, Delmic
+Copyright © 2013-2020 Éric Piel, Delmic
 
 This file is part of Odemis.
 
@@ -24,14 +24,15 @@ from past.builtins import basestring, unicode
 
 import collections
 import h5py
+import json
 import logging
 import numpy
-import odemis
 from odemis import model
+import odemis
 from odemis.util import spectrum, img, fluo
+from odemis.util.conversion import JsonExtraEncoder
 import os
 import time
-import json
 
 
 # User-friendly name
@@ -1012,7 +1013,7 @@ def _add_image_metadata(group, image, mds):
     sett = [md.get(model.MD_EXTRA_SETTINGS) for md in mds]
     if any(sett):
         try:
-            value = [json.dumps(s) for s in sett]
+            value = [json.dumps(s, cls=JsonExtraEncoder) for s in sett]
             state = [ST_INVALID if s is None else ST_REPORTED for s in sett]
             set_metadata(gp, "ExtraSettings", state, value)
         except Exception as ex:

--- a/src/odemis/dataio/tiff.py
+++ b/src/odemis/dataio/tiff.py
@@ -4,7 +4,7 @@ Created on 17 Jul 2012
 
 @author: Éric Piel
 
-Copyright © 2012 Éric Piel, Delmic
+Copyright © 2012-2020 Éric Piel, Delmic
 
 This file is part of Odemis.
 
@@ -21,31 +21,31 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 '''
 # Don't import unicode_literals to avoid issues with external functions. Code works on python2 and python3.
 from __future__ import division
-
 from past.builtins import basestring
+from builtins import range
+
 import calendar
+from datetime import datetime
+import json
 from libtiff import TIFF
 import logging
 import math
 import numpy
 from odemis import model, util
 import odemis
+from odemis.model import DataArrayShadow, AcquisitionData
 from odemis.util import spectrum, img, fluo
+from odemis.util.conversion import get_tile_md_pos, JsonExtraEncoder
 import operator
 import os
 import re
 import sys
-import time
-import json
-import uuid
 import threading
-from odemis.model import DataArrayShadow, AcquisitionData
+import time
+import uuid
 
 import libtiff.libtiff_ctypes as T  # for the constant names
 import xml.etree.ElementTree as ET
-from odemis.util.conversion import get_tile_md_pos
-from datetime import datetime
-from builtins import range
 
 #pylint: disable=E1101
 # Note about libtiff: it's a pretty ugly library, with 2 different wrappers.
@@ -1266,7 +1266,7 @@ def _addImageElement(root, das, ifd, rois, fname=None, fuuid=None):
         sett = globalMD[model.MD_EXTRA_SETTINGS]
         extrase = ET.SubElement(ime, "ExtraSettings")
         try:
-            extrase.text = json.dumps(sett)  # serialize hw settings
+            extrase.text = json.dumps(sett, cls=JsonExtraEncoder)  # serialize hw settings
         except Exception as ex:
             logging.error("Failed to save ExtraSettings metadata, exception %s" % ex)
             extrase.text = ''

--- a/src/odemis/util/conversion.py
+++ b/src/odemis/util/conversion.py
@@ -2,7 +2,7 @@
 """
 @author: Rinze de Laat
 
-Copyright © 2012-2017 Rinze de Laat, Éric Piel, Delmic
+Copyright © 2012-2020 Rinze de Laat, Éric Piel, Delmic
 
 This file is part of Odemis.
 
@@ -19,16 +19,17 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 """
 
 from __future__ import division
-
 from past.builtins import basestring, long
+
 import collections
+import cv2
+import json
 import logging
+import math
+import numpy
+from odemis import model
 import re
 import yaml
-from odemis import model
-import numpy
-import cv2
-import math
 
 
 # Inspired by code from:
@@ -458,3 +459,30 @@ def get_img_transformation_md(mat, timage, src_img):
     }
 
     return metadata
+
+
+class JsonExtraEncoder(json.JSONEncoder):
+    """Support for data types that JSON default encoder
+    does not do.
+    This includes:
+        * Numpy array or number
+        * Complex number
+        * Set
+        * Bytes
+
+    Based on astropy.utils.misc.JsonCustomEncoder.
+    Use as: json.dumps(obj, cls=JsonExtraEncoder)
+    """
+
+    def default(self, obj):
+        if isinstance(obj, (numpy.number, numpy.ndarray)):
+            return obj.tolist()
+        elif isinstance(obj, complex):
+            return [obj.real, obj.imag]
+        elif isinstance(obj, set):
+            return list(obj)
+        elif isinstance(obj, bytes):
+            return obj.decode()
+
+        return json.JSONEncoder.default(self, obj)
+


### PR DESCRIPTION
When exporting some Metadata ExtraSettings, if it contains a numpy
value, the whole data fails to be exported.
Example:
Failed to save ExtraSettings metadata, exception: Object of type 'int64' is not JSON serializable

=> Properly convert the numpy scalar/array into the right JSON
representation.