### PR TITLE
driver ueye: don't worry if the shutter mode cannot be changed

### DIFF
--- a/src/odemis/driver/test/ueye_test.py
+++ b/src/odemis/driver/test/ueye_test.py
@@ -58,13 +58,16 @@ class TestUEye(VirtualTestCam, unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        if not TEST_NOHW:
-            VirtualTestCam.setUpClass()
+        if TEST_NOHW:
+            raise unittest.SkipTest('No camera HW present. Skipping tests.')
+
+        super(TestUEye, cls).setUpClass()
 
     @classmethod
-    def tearDownClass(self):
-        if not TEST_NOHW:
-            VirtualTestCam.tearDown(self)
+    def tearDownClass(cls):
+        if TEST_NOHW:
+            return
+        super(TestUEye, cls).tearDownClass()
 
     def setUp(self):
         if TEST_NOHW:


### PR DESCRIPTION
On some camera (or version of libueye ?), the device capabilities
indicate that it's possible to change the shutter mode, and whenever
reading or writing it, it fails with a "NOT SUPPORTED" error.

=> Don't worry about this, and just conclude that finally it's not
supported.

Also log the hardware version at startup (handy for debugging).

Also fix the test cases which only worked when there was no hardware!