### PR TITLE
driver andorshrk: fix relative move of slit axes

### DIFF
--- a/src/odemis/driver/andorshrk.py
+++ b/src/odemis/driver/andorshrk.py
@@ -1557,9 +1557,11 @@ class Shamrock(model.Actuator):
                 actions.append((axis, self._doSetWavelengthRel, s))
             elif axis == "focus":
                 actions.append((axis, self._doSetFocusRel, s))
-            elif axis == self._slit_names.values():
+            elif axis in self._slit_names.values():
                 sid = [k for k, v in self._slit_names.items() if v == axis][0]
                 actions.append((axis, self._doSetSlitRel, sid, s))
+            else:
+                raise NotImplementedError("Relative move of axis %s not supported" % (axis,))
 
         f = self._executor.submit(self._doMultipleActions, actions)
         return f


### PR DESCRIPTION
A typo caused the relative moves of slit axes to silently discarded.
=> Fix the typo

Also raise an error if trying to move an axis which doesn't support
relative move.