### PR TITLE
driver smaract: fix MCS2 always reporting axis is referenced

### DIFF
--- a/src/odemis/driver/smaract.py
+++ b/src/odemis/driver/smaract.py
@@ -2309,6 +2309,11 @@ class MCS2(model.Actuator):
         self._metadata[model.MD_HW_VERSION] = self._hwVersion
         logging.debug("Using SA_CTL library version %s to connect to %s", self._swVersion, self._hwVersion)
 
+        for name, channel in self._axis_map.items():
+            self._set_speed(channel, speed)
+            self._set_accel(channel, accel)
+            self._set_hold_time(channel, hold_time)
+
         self.position = model.VigilantAttribute({}, readonly=True)
 
         # will take care of executing axis move asynchronously
@@ -2329,11 +2334,6 @@ class MCS2(model.Actuator):
                 logging.warning("SA_CTL is not referenced. The device will not function until referencing occurs.")
 
         self._updatePosition()
-
-        for name, channel in self._axis_map.items():
-            self._set_speed(channel, speed)
-            self._set_accel(channel, accel)
-            self._set_hold_time(channel, hold_time)
 
         self._speed = {}
         self._updateSpeed()
@@ -2491,7 +2491,7 @@ class MCS2(model.Actuator):
         """
         Ask the controller if it is referenced.
         """
-        return bool(self.GetProperty_i32(SA_CTLDLL.SA_CTL_PKEY_CHANNEL_STATE, channel) | SA_CTLDLL.SA_CTL_CH_STATE_BIT_IS_REFERENCED)
+        return bool(self.GetProperty_i32(SA_CTLDLL.SA_CTL_PKEY_CHANNEL_STATE, channel) & SA_CTLDLL.SA_CTL_CH_STATE_BIT_IS_REFERENCED)
 
     def _is_channel_moving(self, channel):
         mask = SA_CTLDLL.SA_CTL_CH_STATE_BIT_ACTIVELY_MOVING

--- a/src/odemis/driver/test/smaract_test.py
+++ b/src/odemis/driver/test/smaract_test.py
@@ -438,6 +438,28 @@ class TestTMCS2(unittest.TestCase):
         new_pos = smaract.add_coord(smaract.add_coord(smaract.add_coord(old_pos, shift), shift), shift)
         test.assert_pos_almost_equal(self.dev.position.value, new_pos, **COMP_ARGS)
 
+    def test_reference_cancel(self):
+        """Test canceling referencing"""
+
+        if not TEST_NOHW:
+            # For now, the simulator reports an axis is referenced as soon as the
+            # procedure is started, so this doesn't work.
+            # TODO: extend the simulator to report axis is referenced only at the end of referencing.
+            f = self.dev.reference()
+            time.sleep(0.1)
+            f.cancel()
+
+            for a, i in self.dev.referenced.value.items():
+                self.assertFalse(i)
+
+        f = self.dev.reference()
+        f.result()
+
+        for a, i in self.dev.referenced.value.items():
+            self.assertTrue(i)
+
+        test.assert_pos_almost_equal(self.dev.position.value, {'x': 0, 'y': 0, 'z': 0}, **COMP_ARGS)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
A typo caused the reading of the referencing status to always be
reported as True.
This also caused the "ref_on_init" to never be executed.

=> Fix typo "|" => "&"