### PR TITLE
gui cont tabs Sparc2AlignTab: ensure the last autofocus stream has the ccd

### DIFF
--- a/src/odemis/acq/align/autofocus.py
+++ b/src/odemis/acq/align/autofocus.py
@@ -677,7 +677,8 @@ def Sparc2AutoFocus(align_mode, opm, streams=None, start_autofocus=True):
         Turn off the light
     align_mode (str): OPM mode, spec-focus or spec-fiber-focus, streak-focus
     opm: OpticalPathManager
-    streams: list of streams
+    streams: list of streams. The first stream is used for displaying the last
+       image with the slit closed.
     return (ProgressiveFuture -> dict((grating, detector)->focus position)): a progressive future
           which will eventually return a map of grating/detector -> focus position, the same as AutoFocusSpectrometer
     raises:
@@ -820,10 +821,12 @@ def GetSpectrometerFocusingDetectors(focuser):
         try:
             d = model.getComponent(name=n)
         except LookupError:
+            logging.info("Focuser affects non-existing component %s", n)
             continue
         if d.role.startswith("ccd") or d.role.startswith("sp-ccd"):  # catches ccd*, sp-ccd*
             dets.append(d)
     return dets
+
 
 def _getSpectrometerFocusingComponents(focuser):
     """

--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -4018,6 +4018,14 @@ class Sparc2AlignTab(Tab):
         """
         focus_streams = []
         dets = GetSpectrometerFocusingDetectors(focuser)
+
+        # Sort to have the first stream corresponding to the same detector as the
+        # stream in the alignment view. As this stream will be used for showing
+        # the slit line after the autofocus.
+        if self._ccd_stream:
+            ccd = self._ccd_stream.detector
+            dets = sorted(dets, key=lambda d: d.name == ccd.name, reverse=True)
+
         # One "line" stream per detector
         # Add a stream to see the focus, and the slit for lens alignment.
         # As it is a BrightfieldStream, it will turn on the emitter when


### PR DESCRIPTION
Now that we have several focus steams, the order matters.
Otherwise, we have 50% chance of ending with the stream corresponding to
the "other" detector, which also shows the slit, but not in the same way
as the standard image. Therefore the slit line doesn't match perfectly.

=> Always place the stream with the ccd as the first stream.