### PR TITLE
gui log: ensure the log shows the content of the variable when logged

### DIFF
--- a/src/odemis/gui/log.py
+++ b/src/odemis/gui/log.py
@@ -173,7 +173,9 @@ class TextFieldHandler(logging.Handler):
 
             # Do the actual writing in a rate-limited thread, so logging won't
             # interfere with the GUI drawing process.
-            self._to_print.append((record, text_style))
+            # Note: we need to do the formatting now, otherwise it could end-up
+            # showing the content of a variable delayed by 0.2s.
+            self._to_print.append((self.format(record), text_style))
             self.write_to_field()
 
     @wxlimit_invocation(0.2)
@@ -185,11 +187,11 @@ class TextFieldHandler(logging.Handler):
             try:
                 prev_style = None
                 while True:
-                    record, text_style = self._to_print.popleft()
+                    txt, text_style = self._to_print.popleft()
                     if prev_style != text_style:
                         self.textfield.SetDefaultStyle(text_style)
                         prev_style = text_style
-                    self.textfield.AppendText(self.format(record) + "\n")
+                    self.textfield.AppendText(txt + "\n")
             except IndexError:
                 pass  # end of the queue
 


### PR DESCRIPTION
We were delaying the formatting of the string to when it would be shown,
which can be delayed by up to 0.2s. For complex variables (eg, list,
VA), this could mean that if the variable has been changed in-between.
This is quite confusing.
In such case, the log in the GUI wouldn't be the same as in the
odemis-gui.log file.

=> Format the string immediately when logged.