### PR TITLE
gui xrc: re-center logo

### DIFF
--- a/src/odemis/gui/main.xrc
+++ b/src/odemis/gui/main.xrc
@@ -306,7 +306,7 @@
                   <assign_var>1</assign_var>
                 </XRCED>
               </object>
-              <flag>wxTOP|wxRIGHT</flag>
+              <flag>wxRIGHT|wxALIGN_CENTRE</flag>
               <border>10</border>
             </object>
           </object>

--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -936,7 +936,7 @@ def __init_resources():
                   <assign_var>1</assign_var>
                 </XRCED>
               </object>
-              <flag>wxTOP|wxRIGHT</flag>
+              <flag>wxRIGHT|wxALIGN_CENTRE</flag>
               <border>10</border>
             </object>
           </object>


### PR DESCRIPTION
The new logo is a little bit higher. This caused it to be shown lower.
=> Make it automatically centered.