### PR TITLE
config: fix odemis-start using always system version

### DIFF
--- a/install/linux/usr/bin/odemis-start
+++ b/install/linux/usr/bin/odemis-start
@@ -2,4 +2,6 @@
 
 . /etc/odemis.conf
 
+export PYTHONPATH
+
 ${PYTHON_INTERPRETER:-/usr/bin/python} -m ${START:-odemis.odemisd.start} "$@"


### PR DESCRIPTION
Need to export PYTHONPATH, as for every other scripts.