### PR TITLE
Remove emissions from manual focus

### DIFF
--- a/src/odemis/acq/align/autofocus.py
+++ b/src/odemis/acq/align/autofocus.py
@@ -805,7 +805,6 @@ def _DoSparc2ManualFocus(opm, bl, align_mode, toggled=True):
     # Go to the special focus mode (=> close the slit)
     f = opm.setPath(align_mode)
     bl.power.value = bl.power.range[(1 * toggled)]  # When mf_toggled = False 1 will be 0
-    bl.emissions.value = [(1 * toggled)] * len(bl.emissions.value)
     f.result()
 
 


### PR DESCRIPTION
As power api refactoring task was directly after manual focus task, this emissions usage went unnoticed (also as there's no unit test for it). This gotta be the last usage of emissions in odemis, ironically it's by me! :-) 