### PR TITLE
CryoSECOM position switching procedures

### DIFF
--- a/install/linux/usr/share/odemis/sim/cryosecom-sim.yaml
+++ b/install/linux/usr/share/odemis/sim/cryosecom-sim.yaml
@@ -1,0 +1,249 @@
+CryoSECOM: {
+    class: Microscope,
+    role: cryo-secom,
+    children: ["3DOF Stage",
+               "5DOF Stage", "Objective Stage", "Focus",
+               "Light Source", "Filter Wheel", "Camera", "Optical Objective",
+               "SEM E-beam", "SEM Detector",  "Linked Stage"
+    ],
+}
+
+# Quanta SEM driven via external X/Y connection, using a DAQ board
+"SEM Scan Interface": {
+    class: semcomedi.SEMComedi,
+    role: null,
+    init: {device: "/dev/comedi0"},
+    # more detectors can be added, if necessary
+    children: {
+       scanner: "SEM E-beam",
+       detector0: "SEM Detector",
+    }
+}
+
+# Connect:
+# X -> AO 0
+# Y -> AO 1
+# Ground -> AO GND
+"SEM E-beam": {
+    # Internal child of SEM ExtXY, so no class
+    creator: "SEM Scan Interface",
+    role: e-beam,
+    init: {
+        channels: [0, 1],
+        # On Delmic scanning box v2, the voltage is x2, so need to specify twice smaller values than needed.
+        #max_res: [4096, 4096], # px
+        limits: [[1.8, -1.8], [1.8, -1.8]],  # V
+        park: [-2, -2], # V
+        # Digital output port mapping on the Delmic scanning box v2:
+        # 0 = Relay
+        # 1 = Open drain output (Y0.0)
+        # 2 = Digital Out 1
+        # 3 = Digital Out 0
+        # 4 = Status led
+        scanning_ttl: {4: True}, # output ports -> True (indicate scanning) or False (indicate parked)
+        settle_time: 10.e-6, # s
+        hfw_nomag: 0.336644, # m
+    },
+    properties: {
+        scale: [8, 8], # (ratio) : start with a pretty fast scan
+        dwellTime: 10.e-6, # s
+        magnification: 4986, # (ratio)
+    },
+    affects: ["SEM Detector", "Camera"] # affects the CCD in case of cathodoluminescence
+}
+
+# Must be connected on AI1/AI9 (differential)
+"SEM Detector": { # aka ETD
+    # Internal child of SEM Scan Interface, so no class
+    role: se-detector,
+    init: {
+        channel: 1,
+        limits: [-3, 3], # V
+    },
+}
+
+"Light Source": {
+    class: lle.FakeLLE,
+    role: light,
+    init: {
+        port: "/dev/ttyUSB*",
+        # source name -> 99% low, 25% low, centre, 25% high, 99% high wavelength in m
+        # Values are from vendor: http://lumencor.com/products/filters-for-spectra-x-light-engines/
+        sources: {"UV": [379.e-9, 384.e-9, 390.e-9, 396.e-9, 401.e-9], # 390/22
+                  "cyan": [472.e-9, 479.e-9, 485.e-9, 491.e-9, 497.e-9], # 485/25
+                  "green": [544.e-9, 552.e-9, 560.e-9, 568.e-9, 576.e-9], # 560/32
+                  "red": [638.e-9, 643.e-9, 648.e-9, 653.e-9, 658.e-9], # 648/20
+                 }
+        },
+        # The light is reflected via a Semrock FF410/504/582/669-DI01-25X36
+    affects: ["Camera"],
+}
+
+"Optical Objective": {
+    class: static.OpticalLens,
+    role: lens,
+    init: {
+        # TODO: 100x mag?!
+        mag: 100.0, # ratio, (actually of the complete light path)
+        na: 0.85, # ratio, numerical aperture
+        ri: 1.0, # ratio, refractive index
+    },
+    affects: ["Camera"]
+}
+#TODO: add exposureTime: 0.3, # s
+"Camera": {
+    class: simcam.Camera,
+    role: ccd,
+    init: {image: "andorcam2-fake-clara.tiff",
+           #image: "andorcam2-fake-spots.h5", # 7x7 grid
+    },
+    dependencies: {focus: "Focus"}
+}
+
+# Controller for the filter-wheel
+# DIP must be configured with address 2 (= 0100000)
+"Optical Actuators": {
+    class: tmcm.TMCLController,
+    role: null,
+    init: {
+        port: "/dev/fake3",
+        address: null,
+        axes: ["fw"],
+        ustepsize: [1.227184e-6], # [rad/µstep]
+        rng: [[-7, 14]], # rad
+        unit: ["rad"],
+        refproc: "Standard",
+        refswitch: {"fw": 4},
+#        inverted: ["fw"],
+    },
+}
+
+"Filter Wheel": {
+    class: actuator.FixedPositionsActuator,
+    role: filter,
+    dependencies: {"band": "Optical Actuators"},
+    init: {
+        axis_name: "fw",
+        # TODO: a way to indicate the best filter to use during alignement?
+        # It supports 4 filters
+        positions: {
+            # pos (rad) -> m,m
+             3.857177647: [420.e-9, 460.e-9], # FF01-440/40-25
+             3.071779484: [510.e-9, 540.e-9], # FF01-525/30-25
+             2.286381320: [589.e-9, 625.e-9], # FF01-607/36-25
+             1.500983157: [672.e-9, 696.e-9], # FF02-684/24-25
+        },
+        cycle: 6.283185, # position of ref switch (0) after a full turn
+    },
+    affects: ["Camera"],
+}
+
+# Use 2 MultiplexActuators to separate the axes of the optical stage over different roles
+# TODO: If the X/Y axes are not aligned with the image axis, swap the axes in the
+# mapping here + use "inverted", if it's just a matter of 90° rotation. If the
+# angle is not such a multiple, use ConverterStage.
+"Objective Stage": {
+    class: actuator.MultiplexActuator,
+    role: align,
+    affects: ["Camera"],
+    dependencies: {"x": "3DOF Stage", "y": "3DOF Stage"},
+    init: {
+        axes_map: {"x": "x", "y": "y"},
+#        inverted: ["x"]
+    },
+    metadata: {
+        FAV_POS_ACTIVE: {'x':  0.0, 'y':  -0.002,},
+        FAV_POS_DEACTIVE:  {'x':  0.01, 'y':  0.00, },
+    },
+}
+# Axes should be synchronized with the camera
+# Stage axes are moving the sample, so they have opposite direction than convention
+# (so the stage "position" is the current position observed)
+"5DOF Stage": {
+  role:  s5,
+  class: tmcm.TMCLController,
+  init: {
+    port: "/dev/fake6",
+    ustepsize: [5.9e-9, 5.9e-9, 5.9e-9, 5.9e-9, 5.9e-9],
+    refproc: "Standard",
+    axes: {
+      'x': {
+        range: [-6e-3, 6e-3],
+        unit: 'm',
+      },
+      'y': {
+        range: [-6e-3, 6e-3],
+        unit: 'm',
+      },
+      'z': {
+        range: [-6e-3, 6e-3],
+        unit: 'm',
+      },
+      'rx': {
+        range: [-0.4293, 0.4293],
+        unit: 'rad',
+      },
+      'rz': {
+        range: [-0.5236, 0.5236],
+        unit: 'rad',
+      },
+    },
+  }
+}
+
+"3DOF Stage": {
+  role:  s3,
+  class: tmcm.TMCLController,
+  init: {
+    port: "/dev/fake3",
+    ustepsize: [5.9e-9, 5.9e-9, 5.9e-9],
+    refproc: "Standard",
+    axes: {
+      'x': {
+        range: [6e-3, 6e-3],
+        unit: 'm',
+      },
+      'y': {
+        range: [6e-3, 6e-3],
+        unit: 'm',
+      },
+      'z': {
+        range: [-6.e-3, 6.e-3],
+        unit: 'm',
+      },
+    },
+  },
+  metadata: {
+    FAV_POS_DEACTIVE: {'z': -6.e-3},
+  },
+}
+"Linked Stage": {
+  class: actuator.LinkedHeightActuator,
+  role: stage,
+  children: {
+    "focus": "Focus",
+  },
+  dependencies: {
+    "stage": "5DOF Stage",
+    "lensz": "3DOF Stage",
+  },
+  metadata: {
+    POS_ACTIVE_RANGE: {'x':  [0.00, 0.003], 'y':  [-0.003, -0.001], 'z':  [0.00, 0.003], } , # stage Z – lens Z, when the lens Z is the closest (highest) from the stage
+    FAV_POS_ACTIVE: {'rx': 0.00, 'rz': 0.0, 'x':  0.0, 'y':  -0.002, 'z':  0.002},
+    FAV_POS_DEACTIVE:  {'rx': 0.00, 'rz': 0.0, 'x':  0.01, 'y':  0.00, 'z':  -0.001},
+  },
+
+}
+
+# Note: Z goes up, so the bigger the value, the closer the lens is from the stage.
+"Focus": {
+  role: focus,
+  init: {
+    # at the maximum of the range, stage Z – lens Z == MD_POS_COR
+    rng: [0, 4.2e-3],  # min/max positions in m
+  },
+  metadata: {
+    POS_COR: {'z':  -0.0045} , # stage Z – lens Z, when the lens Z is the closest (highest) from the stage
+  },
+      affects: ["Camera"],
+}

--- a/src/odemis/acq/move.py
+++ b/src/odemis/acq/move.py
@@ -1,0 +1,317 @@
+# -*- coding: utf-8 -*-
+"""
+Created on 27 July 2020
+
+@author: Éric Piel, Bassim Lazem
+
+Copyright © 2020 Delmic
+
+This file is part of Odemis.
+
+Odemis is free software: you can redistribute it and/or modify it under the
+terms  of the GNU General Public License version 2 as published by the Free
+Software  Foundation.
+
+Odemis is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY;  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR  PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+Odemis. If not, see http://www.gnu.org/licenses/.
+"""
+
+from __future__ import division
+
+import logging
+import math
+import threading
+from asyncio import CancelledError
+from concurrent.futures._base import CANCELLED, RUNNING, FINISHED
+
+import numpy
+import scipy
+
+from odemis import model, util
+from odemis.util import executeAsyncTask
+
+MAX_SUBMOVE_DURATION = 60  # s
+LOADING, IMAGING = 0, 1
+ATOL_LINEAR_POS = 100e-6  # m
+ATOL_ROTATION_POS = 1e-3  # rad (~0.5°)
+RTOL_PROGRESS = 0.1
+
+
+def getLoadingProgress(current_pos, start_pos, end_pos):
+    """
+    Computes the position on the path between LOADING and IMAGING.
+    If it’s too far from the line between LOADING → IMAGING, then it’s considered out of the path.
+    :param current_pos: (dict str->float) Current position of the stage
+    :param start_pos: (dict str->float) Either LOADING or IMAGING position to start the movement from
+    :param end_pos: (dict str->float)Either LOADING or IMAGING position to end the movement to
+    :return:(0<=float<=1, or None) Ratio of the progress, None if it's far away from of the path
+    """
+
+    def get_distance(start, end):
+        # Calculate the euclidean distance between two 3D points
+        sp = numpy.array([start['x'], start['y'], start['z']])
+        ep = numpy.array([end['x'], end['y'], end['z']])
+        return scipy.spatial.distance.euclidean(ep, sp)
+
+    def check_axes(pos):
+        if not {'x', 'y', 'z'}.issubset(set(pos.keys())):
+            raise ValueError("Missing x,y,z axes in {} for correct distance measurement.".format(pos))
+
+    # Check we have the x,y,z axes in all points
+    check_axes(current_pos)
+    check_axes(start_pos)
+    check_axes(end_pos)
+    # Get distance for current point in respect to start and end
+    from_start = get_distance(start_pos, current_pos)
+    to_end = get_distance(current_pos, end_pos)
+    total_length = get_distance(start_pos, end_pos)
+    # Check if current position is on the line from start to end position
+    # That would happen if start_to_current +  current_to_start = total_distance from start to end
+    if util.almost_equal((from_start + to_end), total_length, rtol=RTOL_PROGRESS):
+        return min(from_start / total_length, 1.0)  # Clip in case from_start slightly > total_length
+    else:
+        return None
+
+
+def _isInRange(stage, axis):
+    """
+    Check if current position is within active range
+    :return: True if position in active range, False otherwise
+    """
+    if axis not in stage.axes.keys():
+        raise ValueError("Axis %s is not found in stage axes", axis)
+    pos = stage.position.value[axis]
+    active_range = [r for r in stage.getMetadata()[model.MD_POS_ACTIVE_RANGE][axis]]
+    # Add 1% margin for hardware slight errors
+    margin = (active_range[1] - active_range[0]) * 0.01
+    return (active_range[0] - margin) <= pos <= (active_range[1] + margin)
+
+
+def _isNearDeactive(current_pos, stage_deactive, axis):
+    """
+    Check whether given axis is near stage's FAV_POS_DEACTIVE position
+    :return: True if the axis is near (within 1 mm or 0.1 rad) FAV_POS_DEACTIVE, False otherwise
+    :raises ValueError if axis is unknown
+    """
+    current_value = current_pos[axis]
+    deactive_value = stage_deactive[axis]
+    if axis in {'x', 'y', 'z'}:
+        return abs(deactive_value - current_value) < ATOL_LINEAR_POS
+    elif axis in {'rx', 'rz'}:
+        return util.rot_almost_equal(current_value, deactive_value, atol=ATOL_ROTATION_POS)
+    else:
+        raise ValueError("Unknown axis value %s.", axis)
+
+
+def cryoLoadSample(target):
+    """
+    Provide the ability to switch between loading position and imaging position, without bumping into anything.
+    :param target: (int) target position either one of the constants LOADING or IMAGING
+    :return (CancellableFuture -> None): cancellable future of the move to observe the progress, and control the
+   raise ValueError exception
+    """
+    # Get the stage and focus components from the backend components
+    stage = model.getComponent(role='stage')
+    focus = model.getComponent(role='focus')
+
+    f = model.CancellableFuture()
+    f.task_canceller = _cancelCryoMoveSample
+    f._task_state = RUNNING
+    f._task_lock = threading.Lock()
+    f._running_subf = model.InstantaneousFuture()
+    # Run in separate thread
+    executeAsyncTask(f, _doCryoLoadSample, args=(f, stage, focus, target))
+    return f
+
+
+def _doCryoLoadSample(future, stage, focus, target):
+    """
+    Do the actual switching procedure for the Cryo sample stage between loading and imaging
+    :param future: cancellable future of the move
+    :param stage: sample stage that's being controlled
+    :param focus: focus for optical lens
+    :param target: target position either one of the constants LOADING or IMAGING
+    """
+    try:
+        stage_md = stage.getMetadata()
+        focus_md = focus.getMetadata()
+        stage_active = stage_md[model.MD_FAV_POS_ACTIVE]
+        stage_deactive = stage_md[model.MD_FAV_POS_DEACTIVE]
+        focus_deactive = focus_md[model.MD_FAV_POS_DEACTIVE]
+        # Create axis->pos dict from target position given smaller number of axes
+        filter_dict = lambda keys, d: {key: d[key] for key in keys}
+
+        if target == LOADING:
+            # Check that the stage X,Y,Z are within the limits
+            for axis in {'x', 'y', 'z'}:
+                if not _isInRange(stage, axis):
+                    logging.warning("Axis %s position is out of active range.", axis)
+            # Check that current position is near the ACTIVE to DEACTIVE line
+            # (ie, in case it was previously stopped half-way through loading/unloading)
+            if getLoadingProgress(stage.position.value, stage_active, stage_deactive) is None:
+                logging.warning("Stage position is not near the ACTIVE to DEACTIVE line.")
+
+            if abs(stage_deactive['rx']) > ATOL_ROTATION_POS:
+                raise ValueError(
+                    "Absolute value of rx for FAV_POS_DEACTIVE is greater than {}".format(ATOL_ROTATION_POS))
+
+            # Create an ordered sub moves list to perform the loading move
+            sub_moves = [
+                (focus, focus_deactive),
+                (stage, filter_dict({'rx', 'rz'}, stage_deactive)),
+                (stage, filter_dict({'x', 'y'}, stage_deactive)),
+                (stage, filter_dict({'z'}, stage_deactive)),
+            ]
+        elif target == IMAGING:
+            current_pos = stage.position.value
+            for axis in stage.axes:
+                # Check if the current position is near DEACTIVE position (within 1 mm or 0.1 rad)
+                if not _isNearDeactive(current_pos, stage_deactive, axis):
+                    raise ValueError("Axis %s position is not near FAV_POS_DEACTIVE position.", axis)
+
+            focus_active = focus_md[model.MD_FAV_POS_ACTIVE]
+            # Create an ordered sub moves list to perform the imaging move
+            sub_moves = [
+                (focus, focus_deactive),
+                (stage, filter_dict({'z'}, stage_active)),
+                (stage, filter_dict({'x', 'y'}, stage_active)),
+                (stage, filter_dict({'rx', 'rz'}, stage_active)),
+                # TODO: check if the following movement is necessary
+                (focus, focus_active),
+            ]
+        else:
+            raise ValueError("Unknown target value %s.", target)
+
+        for component, sub_move in sub_moves:
+            run_sub_move(future, component, sub_move)
+    except CancelledError:
+        logging.info("_doCryoLoadSample cancelled.")
+    except Exception as exp:
+        target_str = {LOADING: "loading", IMAGING: "imaging"}
+        logging.exception("Failure to move to {} position.".format(target_str.get(target, lambda: "invalid")))
+        raise
+    finally:
+        with future._task_lock:
+            if future._task_state == CANCELLED:
+                raise CancelledError()
+            future._task_state = FINISHED
+
+
+def cryoTiltSample(rx, rz=None):
+    """
+    Provide the ability to switch between imaging and tilted position, withing bumping into anything.
+    Imaging position is considered when rx and rz are equal 0, otherwise it's considered tilting
+    :param rx: (float) rotation movement in x axis
+    :param rz: (float) rotation movement in z axis
+    :return (CancellableFuture -> None): cancellable future of the move to observe the progress, and control the
+   raise ValueError exception
+    """
+    # Get the stage and focus components from the backend components
+    stage = model.getComponent(role='stage')
+    focus = model.getComponent(role='focus')
+
+    f = model.CancellableFuture()
+    f.task_canceller = _cancelCryoMoveSample
+    f._task_state = RUNNING
+    f._task_lock = threading.Lock()
+    f._running_subf = model.InstantaneousFuture()
+    # Run in separate thread
+    executeAsyncTask(f, _doCryoTiltSample, args=(f, stage, focus, rx, rz,))
+    return f
+
+
+def _doCryoTiltSample(future, stage, focus, rx, rz):
+    """
+    Do the actual switching procedure for the Cryo sample stage between imaging and tilting
+    :param future: cancellable future of the move
+    :param stage: sample stage that's being controlled
+    :param focus: focus for optical lens
+    :param rx: (float) rotation movement in x axis
+    :param rz: (float) rotation movement in z axis
+    """
+    try:
+        # Check that the stage X,Y,Z are within the limits
+        for axis in {'x', 'y', 'z'}:
+            if not _isInRange(stage, axis):
+                raise ValueError("Axis %s position is out of active range.", axis)
+        # To hold the ordered sub moves list to perform the tilting/imaging move
+        sub_moves = []
+        # Move focus to FAV_POS_DEACTIVE only if stage rx and rz are equal to 0
+        # Otherwise stop if focus is's not already near FAV_POS_DEACTIVE
+        if (util.almost_equal(stage.position.value['rx'], 0, atol=ATOL_ROTATION_POS) and
+                util.almost_equal(stage.position.value['rz'], 0, atol=ATOL_ROTATION_POS)):
+            sub_moves.append((focus, focus.getMetadata()[model.MD_FAV_POS_DEACTIVE]))
+        elif not util.almost_equal(focus.position.value, focus.getMetadata()[model.MD_FAV_POS_DEACTIVE],
+                                   atol=ATOL_LINEAR_POS):
+            raise ValueError("Cannot proceed while focus is not near FAV_POS_DEACTIVE position.")
+
+        if rx == 0 and rz == 0:  # Imaging
+            # Get the actual Imaging position (which should be ~ 0 as well)
+            stage_active = stage.getMetadata()[model.MD_FAV_POS_ACTIVE]
+            rx = stage_active['rx']
+            rz = stage_active['rz']
+            sub_moves.append((stage, {'rz': rz}))
+            sub_moves.append((stage, {'rx': rx}))
+        else:
+            sub_moves.append((stage, {'rx': rx}))
+            if rz is not None:
+                sub_moves.append((stage, {'rz': rz}))
+
+        for component, sub_move in sub_moves:
+            run_sub_move(future, component, sub_move)
+    except CancelledError:
+        logging.info("_doCryoTiltSample cancelled.")
+    except Exception as exp:
+        logging.exception("Failure to move to position rx={}, rz={}.".format(rx, rz))
+        raise
+    finally:
+        with future._task_lock:
+            if future._task_state == CANCELLED:
+                raise CancelledError()
+            future._task_state = FINISHED
+
+
+def _cancelCryoMoveSample(future):
+    """
+    Canceller of _doCryoTiltSample and _doCryoLoadSample tasks
+    """
+    logging.debug("Cancelling CryoMoveSample...")
+
+    with future._task_lock:
+        if future._task_state == FINISHED:
+            return False
+        future._task_state = CANCELLED
+        future._running_subf.cancel()
+        logging.debug("CryoMoveSample cancellation requested.")
+
+    return True
+
+
+def run_sub_move(future, component, sub_move):
+    """
+    Perform the sub moveAbs using the given component and axis->pos dict
+    :param future: cancellable future of the whole move
+    :param component: Either the stage of the focus component
+    :param sub_move: the sub_move axis->pos dict
+    :raises TimeoutError: if the sub move timed out
+    :raises CancelledError: if the sub move is cancelled
+    """
+    try:
+        with future._task_lock:
+            if future._task_state == CANCELLED:
+                logging.info("Move procedure is cancelled before moving {} -> {}.".format(component.name, sub_move))
+                raise CancelledError()
+            logging.debug("Performing sub move {} -> {}".format(component.name, sub_move))
+            future._running_subf = component.moveAbs(sub_move)
+        future._running_subf.result(timeout=MAX_SUBMOVE_DURATION)
+    except TimeoutError:
+        future._running_subf.cancel()
+        logging.exception("Timed out during moving {} -> {}.".format(component.name, sub_move))
+        raise
+    if future._task_state == CANCELLED:
+        logging.info("Move procedure is cancelled after moving {} -> {}.".format(component.name, sub_move))
+        raise CancelledError()

--- a/src/odemis/acq/test/move_test.py
+++ b/src/odemis/acq/test/move_test.py
@@ -1,0 +1,198 @@
+# -*- coding: utf-8 -*-
+"""
+Copyright © 2020 Delmic
+
+This file is part of Odemis.
+
+Odemis is free software: you can redistribute it and/or modify it under the terms
+of the GNU General Public License version 2 as published by the Free Software
+Foundation.
+
+Odemis is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+Odemis. If not, see http://www.gnu.org/licenses/.
+"""
+import logging
+import os
+import time
+import unittest
+
+import odemis
+from odemis import model
+from odemis.acq.move import LOADING, IMAGING, getLoadingProgress, RTOL_PROGRESS
+from odemis.acq.move import cryoTiltSample, cryoLoadSample
+from odemis import util
+from odemis.util import test
+
+logging.getLogger().setLevel(logging.DEBUG)
+
+CONFIG_PATH = os.path.dirname(odemis.__file__) + "/../../install/linux/usr/share/odemis/"
+CRYO_SECOM_CONFIG = CONFIG_PATH + "sim/cryosecom-sim.yaml"
+
+ATOL_STAGE = 1e-7
+
+
+class TestCryoMove(unittest.TestCase):
+    """
+    Test cryoLoadSample and cryoTiltSample functions
+    """
+    backend_was_running = False
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            test.start_backend(CRYO_SECOM_CONFIG)
+        except LookupError:
+            logging.info("A running backend is already found, skipping tests")
+            cls.backend_was_running = True
+            return
+        except IOError as exp:
+            logging.error(str(exp))
+            raise
+
+        # find components by their role
+        cls.stage = model.getComponent(role="stage")
+        cls.focus = model.getComponent(role="focus")
+
+        cls.stage_active = cls.stage.getMetadata()[model.MD_FAV_POS_ACTIVE]
+        cls.stage_deactive = cls.stage.getMetadata()[model.MD_FAV_POS_DEACTIVE]
+        cls.focus_deactive = cls.focus.getMetadata()[model.MD_FAV_POS_DEACTIVE]
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.backend_was_running:
+            return
+        test.stop_backend()
+
+    def setUp(self):
+        if self.backend_was_running:
+            self.skipTest("Running backend found")
+
+    def test_loading_and_imaging(self):
+        """
+        Test moving the sample stage to imaging position while it's in loading position and vice versa
+        """
+        stage = self.stage
+        focus = self.focus
+        # Get the stage to loading position
+        f = cryoLoadSample(LOADING)
+        f.result()
+        test.assert_pos_almost_equal(stage.position.value, self.stage_deactive,
+                                     atol=ATOL_STAGE)
+        # Get the stage to imaging position
+        f = cryoLoadSample(IMAGING)
+        f.result()
+        test.assert_pos_almost_equal(stage.position.value, self.stage_active, atol=ATOL_STAGE)
+        # Switch back to loading position
+        f = cryoLoadSample(LOADING)
+        f.result()
+        test.assert_pos_almost_equal(stage.position.value, self.stage_deactive, atol=ATOL_STAGE)
+        test.assert_pos_almost_equal(focus.position.value, self.focus_deactive, atol=ATOL_STAGE)
+
+    def test_imaging_from_tilting(self):
+        """
+        Test moving the sample stage to imaging position while it's in tilting position
+        """
+        stage = self.stage
+        focus = self.focus
+        # Get the stage to tilting position and park focus
+        f = cryoLoadSample(LOADING)  # Loading first, then Imaging
+        f.result()
+        f = cryoLoadSample(IMAGING)
+        f.result()
+        f = focus.moveAbs(self.focus_deactive)
+        f.result()
+        f = stage.moveAbs({'rx': 0.003, 'rz': 0.003})
+        f.result()
+        f = cryoTiltSample(rx=0, rz=0)
+        f.result()
+        test.assert_pos_almost_equal(stage.position.value, {'rx': 0, 'rz': 0}, match_all=False,
+                                     atol=ATOL_STAGE)
+
+    def test_tilting_from_imaging(self):
+        """
+        Test tilting the sample stage while the stage is in Imaging position
+        """
+        stage = self.stage
+        focus = self.focus
+        # Get the stage to imaging position and park focus
+        f = cryoLoadSample(LOADING)
+        f.result()
+        f = cryoLoadSample(IMAGING)
+        f.result()
+        f = focus.moveAbs(self.focus_deactive)
+        f.result()
+        # Tilt the stage
+        f = cryoTiltSample(rx=0.003, rz=0.003)
+        f.result()
+        test.assert_pos_almost_equal(stage.position.value, {'rx': 0.003, 'rz': 0.003}, match_all=False,
+                                     atol=ATOL_STAGE)
+
+    def test_tilting_from_loading(self):
+        """
+        Test it's not possible to do tilting movement while the stage is in Loading position
+        """
+        stage = self.stage
+        f = cryoLoadSample(LOADING)
+        f.result()
+        with self.assertRaises(ValueError):
+            f = cryoTiltSample(rx=0.003, rz=0.003)
+            f.result()
+
+    def test_cancel_loading(self):
+        """
+        Test cryoLoadSample movement cancellation is handled correctly
+        """
+        stage = self.stage
+        f = cryoLoadSample(LOADING)
+        f.result()
+        f = cryoLoadSample(IMAGING)
+        time.sleep(2)
+        cancelled = f.cancel()
+        self.assertTrue(cancelled)
+        test.assert_pos_not_almost_equal(stage.position.value, self.stage_deactive,
+                                         atol=ATOL_STAGE)
+
+    def test_cancel_tilting(self):
+        """
+        Test cryoTiltSample movement cancellation is handled correctly
+        """
+        stage = self.stage
+        focus = self.focus
+        f = cryoLoadSample(LOADING)  # (Loading first, then Imaging)
+        f.result()
+        f = cryoLoadSample(IMAGING)
+        f.result()
+        f = focus.moveAbs(self.focus_deactive)
+        f.result()
+        f = cryoTiltSample(rx=0.003, rz=0.003)
+        time.sleep(2)
+        cancelled = f.cancel()
+        self.assertTrue(cancelled)
+        test.assert_pos_not_almost_equal(stage.position.value, {'rx': 0.003, 'rz': 0.003}, match_all=False,
+                                         atol=ATOL_STAGE)
+
+    def test_get_progress(self):
+        """
+        Test getLoadingProgress function behaves as expected
+        """
+        start_point = {'x': 0, 'y': 0, 'z': 0}
+        end_point = {'x': 2, 'y': 2, 'z': 2}
+        current_point = {'x': 1, 'y': 1, 'z': 1}
+        progress = getLoadingProgress(current_point, start_point, end_point)
+        self.assertTrue(util.almost_equal(progress, 0.5, rtol=RTOL_PROGRESS))
+        current_point = {'x': .998, 'y': .999, 'z': .999}  # slightly off the line
+        progress = getLoadingProgress(current_point, start_point, end_point)
+        self.assertTrue(util.almost_equal(progress, 0.5, rtol=RTOL_PROGRESS))
+        current_point = {'x': 3, 'y': 3, 'z': 3}  # away from the line
+        progress = getLoadingProgress(current_point, start_point, end_point)
+        self.assertIsNone(progress)
+        current_point = {'x': 1, 'y': 1, 'z': 3}  # away from the line
+        progress = getLoadingProgress(current_point, start_point, end_point)
+        self.assertIsNone(progress)
+        current_point = {'x': -1, 'y': 0, 'z': 0}  # away from the line
+        progress = getLoadingProgress(current_point, start_point, end_point)
+        self.assertIsNone(progress)

--- a/src/odemis/model/_metadata.py
+++ b/src/odemis/model/_metadata.py
@@ -182,7 +182,7 @@ MD_SHIFT_LOOKUP = "Pixel shift compensation table"
 # actuators.
 MD_FAV_POS_ACTIVE = "Favourite position active"  # dict of str -> float representing a good position for being "active" (eg, mirror engaged, lens in use)
 MD_FAV_POS_DEACTIVE = "Favourite position deactive"  # dict of str -> float representing a good position for being "deactive" (eg, mirror parked, lens not in use)
-
+MD_POS_ACTIVE_RANGE = "Range for active position"  # dict str → (float, float): axis name → (min,max): the range of the axes within which can be used imaging.
 # The following metadata is used to store the destination components of the
 # specific known positions for the actuators.
 MD_FAV_POS_ACTIVE_DEST = "Favourite position active destination"  # list or set of str

--- a/src/odemis/util/__init__.py
+++ b/src/odemis/util/__init__.py
@@ -102,6 +102,26 @@ def almost_equal(a, b, atol=1e-18, rtol=1e-7):
     return False
 
 
+def rot_almost_equal(a, b, atol=1e-18, rtol=1e-7):
+    """
+    Check the rotation difference between two radian angles is within a margin
+    a (float) an angle, in radians
+    b (float) an angle, in radians
+    atol (float): absolute tolerance
+    rtol (float): relative tolerance
+    returns (bool): True if a and b rotation is within a margin
+    """
+    if a == b:
+        return True
+
+    tau = 2 * math.pi
+    tol = max(atol, max(abs(a % tau), abs(b % tau)) * rtol)
+    if abs(((a - b) + math.pi) % tau - math.pi) <= tol:
+        return True
+
+    return False
+
+
 if sys.version_info[0] < 3:
     def to_str_escape(s):
         """

--- a/src/odemis/util/test.py
+++ b/src/odemis/util/test.py
@@ -111,7 +111,7 @@ def stop_backend():
 def assert_pos_almost_equal(actual, expected, match_all=True, *args, **kwargs):
     """
     Asserts that two stage positions have almost equal coordinates.
-    :param match_all: if False, only the expected keys are checked, and actual can have more keys
+    :param match_all: (bool) if False, only the expected keys are checked, and actual can have more keys
     """
     if match_all and set(expected.keys()) != set(actual.keys()):
         raise AssertionError("Dimensions of position do not match: %s != %s" %
@@ -120,6 +120,24 @@ def assert_pos_almost_equal(actual, expected, match_all=True, *args, **kwargs):
     for k in expected.keys():
         if not util.almost_equal(actual[k], expected[k], *args, **kwargs):
             raise AssertionError("Position %s != %s" % (actual, expected))
+
+
+def assert_pos_not_almost_equal(actual, expected, match_all=True, *args, **kwargs):
+    """
+    Asserts that two stage positions do not have almost equal coordinates. This means at least one of the axes has a
+    different value.
+    :param match_all: (bool) if False, only the expected keys are checked, and actual can have more keys
+    """
+    if match_all and set(expected.keys()) != set(actual.keys()):
+        raise AssertionError("Dimensions of position do not match: %s != %s" %
+                             (list(actual.keys()), list(expected.keys())))
+
+    # Check that at least one of the axes not equal
+    for k in expected.keys():
+        if not util.almost_equal(actual[k], expected[k], *args, **kwargs):
+            return
+    # Otherwise coordinates are almost equal
+    raise AssertionError("Position %s == %s" % (actual, expected))
 
 
 def assert_array_not_equal(a, b, msg="Arrays are equal"):


### PR DESCRIPTION

The following is an implementation for the procedures to switch between loading/imaging/tilting position for the CryoSECOM stage. 
Two functions in `odemis.acq.move module`:
**cryoTiltSample**: Allows to switch between imaging ↔ tilted. 
**cryoLoadSample**: Allows to switch between imaging ↔ loading.
 