### PR TITLE
driver pigcs: fix Python 3 issue for hardware with weird multi-line

### DIFF
--- a/src/odemis/driver/pigcs.py
+++ b/src/odemis/driver/pigcs.py
@@ -3648,7 +3648,7 @@ class SerialBusAccesser(object):
                             l = l[len(prefix):]
                         else:
                             # Maybe the previous line was actually continuing (but the hardware is strange)?
-                            if ret and ret[-1] == b"":
+                            if ret and ret[-1] == "":
                                 logging.debug("Reconsidering previous line as beginning of multi-line")
                                 ret = ret[:-1]
                             else:
@@ -3823,7 +3823,7 @@ class IPBusAccesser(object):
                             l = l[len(prefix):]
                         else:
                             # Maybe the previous line was actually continuing (but the hardware is strange)?
-                            if ret and ret[-1] == b"":
+                            if ret and ret[-1] == "":
                                 logging.debug("Reconsidering previous line as beginning of multi-line")
                                 ret = ret[:-1]
                             else:


### PR DESCRIPTION
The code to backtrack and reconsider a previous line as a begining of a
multi-line uses the already decoded text, so it's a string, not bytes.
On Python 3, this matters.

This was not detected in the test cases, with the simulator and
other hardwares, as it only happens for very few old version of the PI
controllers.