### PR TITLE
acq autofocus: earlier cancellation of the autofocus in some cases

### DIFF
--- a/src/odemis/acq/align/autofocus.py
+++ b/src/odemis/acq/align/autofocus.py
@@ -1281,6 +1281,9 @@ def _DoAutoFocusSpectrometer(future, spectrograph, focuser, detectors, selector,
                 except Exception:
                     logging.exception("Failed to move to 0th order for grating %s", g)
 
+                if future._autofocus_state == CANCELLED:
+                    raise CancelledError()
+
                 tstart = time.time()
                 # Note: we could try to reuse the focus position from the previous
                 # grating or detector, and pass it as good_focus, to save a bit


### PR DESCRIPTION
If the user cancels the autofocus when the grating changes, it will only
be cancelled after the end of the autofocusing, which can take up to a
minute.
=> check if the autofocus was cancelled before running the autofocus
again.