### PR TITLE
driver-tmcm: bugfix canopen simulator

### DIFF
--- a/src/odemis/driver/tmcm.py
+++ b/src/odemis/driver/tmcm.py
@@ -3454,7 +3454,7 @@ class CANNodeSimulator(object):
     def op_mode(self, val):
         if self._op_mode == val:
             # canopen library raises error if new opmode is the same as previous opmode
-            raise ValueError("Opmode already %s." % val)
+            raise SdoAbortedError("Opmode already %s." % val)
         self._op_mode = val
 
     @property


### PR DESCRIPTION
The last change to the canopen simulator introduced a bug. In case of a duplicated mode, the canopen library raises an SdoAbortedError, which is caught in the __init__ of the driver. The simulator raised a ValueError which was not caught and therefore the testcases didn't run.