### PR TITLE
model component: forbid overriding VAs on a Proxy

### DIFF
--- a/src/odemis/model/_components.py
+++ b/src/odemis/model/_components.py
@@ -247,6 +247,15 @@ class ComponentProxy(ComponentBase, Pyro4.Proxy):
         _vattributes.load_vigilant_attributes(self, vas)
         _dataflow.load_events(self, events)
 
+    def __setattr__(self, name, value):
+        # Detect that the user is trying to replace a VigilantAttribute, which is
+        # most likely a typo of forgetting VA.value .
+        # On a Component, it's fishy, but on a Proxy, there is just no reason to
+        # do that.
+        if hasVA(self, name):
+            raise AttributeError("Cannot override existing VigilantAttribute %s" % (name,))
+        super(ComponentProxy, self).__setattr__(name, value)
+
     def __str__(self):
         try:
             return "Proxy of Component '%s'" % (self.name,)

--- a/src/odemis/model/test/remote_test.py
+++ b/src/odemis/model/test/remote_test.py
@@ -718,6 +718,12 @@ class RemoteTest(unittest.TestCase):
         self.last_value = value
         self.assertIsInstance(value, (int, float))
 
+    def test_va_override(self):
+        self.comp.prop.value = 42
+        with self.assertRaises(AttributeError):
+            # Simulate typo of "self.comp.prop.value = 42"
+            self.comp.prop = 42
+
 #    @unittest.skip("simple")
     def test_enumerated_va(self):
         # enumerated


### PR DESCRIPTION
When writing Python code, due to the weird syntax of VAs, it's easy to
override a VA instead of actually setting a value. This should hopefully
catch a few bugs a bit earlier.

We could also do a similar behaviour on a Component, but there might be
some specific cases where this is acceptable. Maybe we could acccept
overriding a VA only with another VA... but for now I don't dare trying.