### PR TITLE
driver zeiss: Fix finding device on Python 3

### DIFF
--- a/src/odemis/driver/zeiss.py
+++ b/src/odemis/driver/zeiss.py
@@ -205,7 +205,7 @@ class SEM(model.HwComponent):
         """
         Send query/order to device
         cmd: valid query command for Remcon SEM
-        returns str if successful, otherwise raises error
+        returns bytes if successful, otherwise raises error
         """
         cmd = cmd + self.eol
         with self._ser_access:
@@ -260,7 +260,7 @@ class SEM(model.HwComponent):
         """
         return (String): version number
         """
-        return self._SendCmd(b'VER?')
+        return self._SendCmd(b'VER?').decode("latin1")
 
     def GetStagePosition(self):
         """


### PR DESCRIPTION
GetVersion() returned bytes (on Python 3), which caused error when
comparing the string searched. It also caused a tiny bit wrong hwVersion
attribute.

This caused such error at startup:
  File "/usr/lib/python3/dist-packages/odemis/driver/zeiss.py", line 84, in __init__
    self._port, self._idn = self._findDevice(port)  # sets ._serial and ._file
  File "/usr/lib/python3/dist-packages/odemis/driver/zeiss.py", line 187, in _findDevice
    if not "smartsem" in idn.lower():
TypeError: a bytes-like object is required, not 'str'