### PR TITLE
CryoSECOM lens aligner active position

### DIFF
--- a/src/odemis/gui/cont/actuators.py
+++ b/src/odemis/gui/cont/actuators.py
@@ -163,8 +163,11 @@ class ActuatorController(object):
         tab_data.main.is_acquiring.subscribe(self._on_acquisition)
 
     def _on_acquisition(self, acquiring):
+        self._enable_buttons(not acquiring)
+
+    def _enable_buttons(self, enable=True):
         for b in self._btns:
-            b.Enable(not acquiring)
+            b.Enable(enable)
 
     def bind_keyboard(self, tab_frame):
         """


### PR DESCRIPTION
The goal is to ensure that the optical lens is positioned as close as possible from the last known aligned position after a referencing (or a move to a safe position during 5DoF referencing).