### PR TITLE
util filename: improve date patterns

### DIFF
--- a/src/odemis/util/filename.py
+++ b/src/odemis/util/filename.py
@@ -54,17 +54,30 @@ def guess_pattern(fn):
     # Detect date
     # First check daterev, then datelng because sequence daterev + timelng might otherwise
     # be mistaken to be number + datelng + counter
-    date_ptn = '[0-3][0-9](0[1-9]|1[0-2])%s' % time.strftime('%Y')
+    date_ptn = time.strftime("%d%m%Y")
     fn_ptn = re.sub(date_ptn, "{daterev}", fn_ptn)
 
-    date_ptn = '%s(0[1-9]|1[0-2])[0-3][0-9]' % time.strftime('%Y')
+    date_ptn = time.strftime("%Y%m%d")
     fn_ptn = re.sub(date_ptn, "{datelng}", fn_ptn)
 
-    date_ptn = '[0-3][0-9]-(0[1-9]|1[0-2])-%s' % time.strftime('%Y')
+    date_ptn = time.strftime("%d-%m-%Y")
     fn_ptn = re.sub(date_ptn, "{daterev_hyphen}", fn_ptn)
 
-    date_ptn = '%s-(0[1-9]|1[0-2])-[0-3][0-9]' % time.strftime('%Y')
+    date_ptn = time.strftime("%Y-%m-%d")
     fn_ptn = re.sub(date_ptn, "{datelng_hyphen}", fn_ptn)
+
+    # Short dates second, only in case the long version had no match
+    date_ptn = time.strftime("%d%m%y")
+    fn_ptn = re.sub(date_ptn, "{dshrtrev}", fn_ptn)
+
+    date_ptn = time.strftime("%y%m%d")
+    fn_ptn = re.sub(date_ptn, "{dateshrt}", fn_ptn)
+
+    date_ptn = time.strftime("%d-%m-%y")
+    fn_ptn = re.sub(date_ptn, "{dshrtrev_hyphen}", fn_ptn)
+
+    date_ptn = time.strftime("%y-%m-%d")
+    fn_ptn = re.sub(date_ptn, "{dateshrt_hyphen}", fn_ptn)
 
     year_ptn = '%s' % time.strftime('%Y')
     fn_ptn = re.sub(year_ptn, "{year}", fn_ptn)
@@ -147,6 +160,10 @@ def create_filename(path, ptn, ext, count="001"):
                           daterev=time.strftime("%d%m%Y"),
                           datelng_hyphen=time.strftime("%Y-%m-%d"),
                           daterev_hyphen=time.strftime("%d-%m-%Y"),
+                          dateshrt=time.strftime("%y%m%d"),
+                          dshrtrev=time.strftime("%d%m%y"),
+                          dateshrt_hyphen=time.strftime("%y-%m-%d"),
+                          dshrtrev_hyphen=time.strftime("%d-%m-%y"),
                           year="%Y",
                           timelng=time.strftime("%H%M%S"),
                           timelng_colon=time.strftime("%H:%M:%S"),

--- a/src/odemis/util/test/filename_test.py
+++ b/src/odemis/util/test/filename_test.py
@@ -33,9 +33,11 @@ daterev = time.strftime("%d%m%Y")
 timeshrt = time.strftime("%H%M")
 timeshrt_colon = time.strftime("%H:%M")
 timelng = time.strftime("%H%M%S")
-date_sl = time.strftime("%Y/%m/%d")
-timelng_sl = time.strftime("%H/%M/%S")
+# date_sl = time.strftime("%Y/%m/%d")
+# timelng_sl = time.strftime("%H/%M/%S")
 current_year = time.strftime("%Y")
+dateshrt = time.strftime("%y%m%d")
+dshrtrev_hyphen = time.strftime("%d-%m-%y")
 
 EXTS = ('.tiff', '.ome.tiff', '.0.ome.tiff', '.h5', '.hdf5')
 PATH = get_home_folder()
@@ -55,8 +57,11 @@ class TestFilenameSuggestions(unittest.TestCase):
                    'test-123-%s' % timeshrt_colon: ('test-{cnt}-{timeshrt_colon}', '123'),
                    '%s%s-acquisition' % (date, timelng): ('{datelng}{timelng}-acquisition', '001'),
                    'test-0070': ('test-{cnt}', '0070'),  # test-0000 gives the wrong result at midnight
+                   '4580-test-%s' % dateshrt: ('{cnt}-test-{dateshrt}', '4580'),
+                   '4580-test:%s' % dshrtrev_hyphen: ('{cnt}-test:{dshrtrev_hyphen}', '4580'),
                    '%s%s' % (daterev, timelng): ('{daterev}{timelng}', '001'),
                    'test2-45': ('test2-{cnt}', '45'),
+                   'test 1980-08-23': ('test 1980-08-{cnt}', '23'),  # a date, but not *now*
                    'test': ('test-{cnt}', '001'),
                    'test%s' % timeshrt: ('test{timelng}', '001'),
                    '%s-cell5' % current_year: ('{year}-cell{cnt}', '5'),


### PR DESCRIPTION
Only detect date patterns corresponding to *today*. If for some reason
the file has some numbers that look like date, we shouldn't replace it
by the date of today.

Also now detects short dates, with only the last two digit of the year,
as requested by some users.