### PR TITLE
bugreporter: odemis-model-selector.log is another name for odemis-mic-selector.log

### DIFF
--- a/src/bugreporter/odemis_bugreporter.py
+++ b/src/bugreporter/odemis_bugreporter.py
@@ -252,6 +252,7 @@ class OdemisBugreporter(object):
         files = [LOGFILE_BACKEND, os.path.join(home_dir, 'odemis-gui.log'),
                  os.path.join(home_dir, 'odemis-gui.log.1'), '/etc/odemis.conf', '/var/log/syslog',
                  os.path.join(home_dir, 'odemis-mic-selector.log'), '/tmp/odemis-bug-screenshot.png',
+                 os.path.join(home_dir, 'odemis-model-selector.log'),  # another name for odemis-mic-selector.log
                  '/etc/odemis-settings.yaml']
 
         # If odemis.log is < 2M, it might not have enough info, so also get odemis.log.1


### PR DESCRIPTION
A lot of systems use odemis-model-selector.log as name for the log of
the odemis-mic-selector, so let's handle it.
It's just too late to fix all these systems now.