### PR TITLE
CryoSECOM position switching missing functions 

### DIFF
--- a/install/linux/usr/share/odemis/sim/cryosecom-sim.yaml
+++ b/install/linux/usr/share/odemis/sim/cryosecom-sim.yaml
@@ -165,7 +165,7 @@ CryoSECOM: {
   class: tmcm.TMCLController,
   init: {
     port: "/dev/fake6",
-    ustepsize: [5.9e-9, 5.9e-9, 5.9e-9, 5.9e-9, 5.9e-9],
+    ustepsize: [5.9e-9, 5.9e-9, 5.9e-9, 5.9e-6, 5.9e-6],
     refproc: "Standard",
     axes: {
       'x': {
@@ -181,7 +181,7 @@ CryoSECOM: {
         unit: 'm',
       },
       'rx': {
-        range: [-0.4293, 0.4293],
+        range: [-0.49, 0.49], # ~28°
         unit: 'rad',
       },
       'rz': {
@@ -233,6 +233,7 @@ CryoSECOM: {
     FAV_POS_ACTIVE: {'rx': 0.00, 'rz': 0.0, 'x':  0.0, 'y':  -0.002, 'z':  0.002},
     FAV_POS_DEACTIVE:  {'rx': 0.00, 'rz': 0.0, 'x':  0.01, 'y':  0.00, 'z':  -0.001},
     FAV_AREA:  [-0.001, -0.001, 0.001, 0.001]  # left, top, right, bottom
+    FAV_POS_COATING: {'rx': 0.4363, 'rz': 0.0, 'x':  0.0, 'y':  -0.001, 'z':  -0.001},
   },
    affects: ["Camera"],
 }

--- a/install/linux/usr/share/odemis/sim/cryosecom-sim.yaml
+++ b/install/linux/usr/share/odemis/sim/cryosecom-sim.yaml
@@ -165,30 +165,11 @@ CryoSECOM: {
   class: tmcm.TMCLController,
   init: {
     port: "/dev/fake6",
-    ustepsize: [5.9e-9, 5.9e-9, 5.9e-9, 5.9e-6, 5.9e-6],
     refproc: "Standard",
-    axes: {
-      'x': {
-        range: [-6e-3, 6e-3],
-        unit: 'm',
-      },
-      'y': {
-        range: [-6e-3, 6e-3],
-        unit: 'm',
-      },
-      'z': {
-        range: [-6e-3, 6e-3],
-        unit: 'm',
-      },
-      'rx': {
-        range: [-0.49, 0.49], # ~28°
-        unit: 'rad',
-      },
-      'rz': {
-        range: [-0.5236, 0.5236],
-        unit: 'rad',
-      },
-    },
+    axes: ["x", "y", "z", "rx", "rz"],
+    unit: ["m", "m", "m", "rad", "rad"],
+    rng: [[-6.0e-3, 6.0e-3], [-6.0e-3, 6.0e-3], [-6.0e-3, 6.0e-3], [-0.49, 0.49], [-0.5236, 5236]],
+    ustepsize: [5.9e-8, 5.9e-8, 5.9e-8, 5.9e-6, 5.9e-6],
   }
 }
 
@@ -197,22 +178,11 @@ CryoSECOM: {
   class: tmcm.TMCLController,
   init: {
     port: "/dev/fake3",
-    ustepsize: [5.9e-9, 5.9e-9, 5.9e-9],
+    axes: ["x", "y", "z"],
+    unit: ["m", "m", "m"],
+    rng: [[-6.0e-3, 6.0e-3], [-6.0e-3, 6.0e-3], [-6.0e-3, 6.0e-3]],
+    ustepsize: [5.9e-8, 5.9e-8, 5.9e-8],
     refproc: "Standard",
-    axes: {
-      'x': {
-        range: [6e-3, 6e-3],
-        unit: 'm',
-      },
-      'y': {
-        range: [6e-3, 6e-3],
-        unit: 'm',
-      },
-      'z': {
-        range: [-6.e-3, 6.e-3],
-        unit: 'm',
-      },
-    },
   },
   metadata: {
     FAV_POS_DEACTIVE: {'z': -6.e-3},
@@ -231,9 +201,9 @@ CryoSECOM: {
   metadata: {
     POS_ACTIVE_RANGE: {'x':  [0.00, 0.003], 'y':  [-0.003, -0.001], 'z':  [0.00, 0.003], } , # stage Z – lens Z, when the lens Z is the closest (highest) from the stage
     FAV_POS_ACTIVE: {'rx': 0.00, 'rz': 0.0, 'x':  0.0, 'y':  -0.002, 'z':  0.002},
-    FAV_POS_DEACTIVE:  {'rx': 0.00, 'rz': 0.0, 'x':  0.01, 'y':  0.00, 'z':  -0.001},
-    FAV_AREA:  [-0.001, -0.001, 0.001, 0.001]  # left, top, right, bottom
-    FAV_POS_COATING: {'rx': 0.4363, 'rz': 0.0, 'x':  0.0, 'y':  -0.001, 'z':  -0.001},
+    FAV_POS_DEACTIVE:  {'rx': 0.00, 'rz': 0.0, 'x':  0.002, 'y':  0.00, 'z':  -0.001},
+    FAV_AREA:  [-0.001, -0.001, 0.001, 0.001],  # left, top, right, bottom
+    FAV_POS_COATING: {'rx': 0.4363, 'rz': 0.0, 'x':  0.0, 'y':  -0.003, 'z':  0.001},
   },
    affects: ["Camera"],
 }

--- a/src/odemis/acq/move.py
+++ b/src/odemis/acq/move.py
@@ -68,7 +68,7 @@ def getCurrentPositionLabel(current_pos, stage):
         return LOADING
 
     # Check the current position is near the line between ACTIVE and DEACTIVE
-    loading_progress = getLoadingProgress(current_pos, stage_active, stage_deactive)
+    loading_progress = getMovementProgress(current_pos, stage_active, stage_deactive)
     if loading_progress is not None:
         return LOADING_PATH
 
@@ -76,13 +76,13 @@ def getCurrentPositionLabel(current_pos, stage):
     return UNKNOWN
 
 
-def getLoadingProgress(current_pos, start_pos, end_pos):
+def getMovementProgress(current_pos, start_pos, end_pos):
     """
-    Computes the position on the path between LOADING and IMAGING.
-    If it’s too far from the line between LOADING → IMAGING, then it’s considered out of the path.
+    Compute the position on the path between start and end positions of a stage movement (such as LOADING to IMAGING)
+    If it’s too far from the line between the start and end positions, then it’s considered out of the path.
     :param current_pos: (dict str->float) Current position of the stage
-    :param start_pos: (dict str->float) Either LOADING or IMAGING position to start the movement from
-    :param end_pos: (dict str->float)Either LOADING or IMAGING position to end the movement to
+    :param start_pos: (dict str->float) A position to start the movement from
+    :param end_pos: (dict str->float) A position to end the movement to
     :return:(0<=float<=1, or None) Ratio of the progress, None if it's far away from of the path
     """
 
@@ -187,7 +187,7 @@ def _doCryoLoadSample(future, stage, focus, target):
                     logging.warning("Axis %s position is out of active range.", axis)
             # Check that current position is near the ACTIVE to DEACTIVE line
             # (ie, in case it was previously stopped half-way through loading/unloading)
-            if getLoadingProgress(stage.position.value, stage_active, stage_deactive) is None:
+            if getMovementProgress(stage.position.value, stage_active, stage_deactive) is None:
                 logging.warning("Stage position is not near the ACTIVE to DEACTIVE line.")
 
             if abs(stage_deactive['rx']) > ATOL_ROTATION_POS:

--- a/src/odemis/acq/test/move_test.py
+++ b/src/odemis/acq/test/move_test.py
@@ -24,7 +24,7 @@ import odemis
 from odemis import model
 from odemis import util
 from odemis.acq.move import LOADING, IMAGING, TILTED, LOADING_PATH, RTOL_PROGRESS
-from odemis.acq.move import cryoTiltSample, cryoLoadSample, getLoadingProgress, getCurrentPositionLabel
+from odemis.acq.move import cryoTiltSample, cryoLoadSample, getMovementProgress, getCurrentPositionLabel
 from odemis.util import test
 
 logging.getLogger().setLevel(logging.DEBUG)
@@ -179,24 +179,24 @@ class TestCryoMove(unittest.TestCase):
 
     def test_get_progress(self):
         """
-        Test getLoadingProgress function behaves as expected
+        Test getMovementProgress function behaves as expected
         """
         start_point = {'x': 0, 'y': 0, 'z': 0}
         end_point = {'x': 2, 'y': 2, 'z': 2}
         current_point = {'x': 1, 'y': 1, 'z': 1}
-        progress = getLoadingProgress(current_point, start_point, end_point)
+        progress = getMovementProgress(current_point, start_point, end_point)
         self.assertTrue(util.almost_equal(progress, 0.5, rtol=RTOL_PROGRESS))
         current_point = {'x': .998, 'y': .999, 'z': .999}  # slightly off the line
-        progress = getLoadingProgress(current_point, start_point, end_point)
+        progress = getMovementProgress(current_point, start_point, end_point)
         self.assertTrue(util.almost_equal(progress, 0.5, rtol=RTOL_PROGRESS))
         current_point = {'x': 3, 'y': 3, 'z': 3}  # away from the line
-        progress = getLoadingProgress(current_point, start_point, end_point)
+        progress = getMovementProgress(current_point, start_point, end_point)
         self.assertIsNone(progress)
         current_point = {'x': 1, 'y': 1, 'z': 3}  # away from the line
-        progress = getLoadingProgress(current_point, start_point, end_point)
+        progress = getMovementProgress(current_point, start_point, end_point)
         self.assertIsNone(progress)
         current_point = {'x': -1, 'y': 0, 'z': 0}  # away from the line
-        progress = getLoadingProgress(current_point, start_point, end_point)
+        progress = getMovementProgress(current_point, start_point, end_point)
         self.assertIsNone(progress)
 
     def test_get_current_position(self):

--- a/src/odemis/model/_metadata.py
+++ b/src/odemis/model/_metadata.py
@@ -183,6 +183,7 @@ MD_SHIFT_LOOKUP = "Pixel shift compensation table"
 MD_FAV_POS_ACTIVE = "Favourite position active"  # dict of str -> float representing a good position for being "active" (eg, mirror engaged, lens in use)
 MD_FAV_POS_DEACTIVE = "Favourite position deactive"  # dict of str -> float representing a good position for being "deactive" (eg, mirror parked, lens not in use)
 MD_POS_ACTIVE_RANGE = "Range for active position"  # dict str → (float, float): axis name → (min,max): the range of the axes within which can be used imaging.
+MD_FAV_POS_COATING = "Favourite position coating"  # dict of str -> float representing a good position for GIS coating
 MD_FAV_AREA = "Favourite acquisition area"  # (float, float, float, float) minX, minY, maxX, maxY of the acquisition area
 # The following metadata is used to store the destination components of the
 # specific known positions for the actuators.

--- a/src/odemis/model/_metadata.py
+++ b/src/odemis/model/_metadata.py
@@ -182,9 +182,9 @@ MD_SHIFT_LOOKUP = "Pixel shift compensation table"
 # actuators.
 MD_FAV_POS_ACTIVE = "Favourite position active"  # dict of str -> float representing a good position for being "active" (eg, mirror engaged, lens in use)
 MD_FAV_POS_DEACTIVE = "Favourite position deactive"  # dict of str -> float representing a good position for being "deactive" (eg, mirror parked, lens not in use)
-MD_POS_ACTIVE_RANGE = "Range for active position"  # dict str → (float, float): axis name → (min,max): the range of the axes within which can be used imaging.
 MD_FAV_POS_COATING = "Favourite position coating"  # dict of str -> float representing a good position for GIS coating
 MD_FAV_AREA = "Favourite acquisition area"  # (float, float, float, float) minX, minY, maxX, maxY of the acquisition area
+MD_POS_ACTIVE_RANGE = "Range for active position"  # dict str → (float, float): axis name → (min,max): the range of the axes within which can be used imaging.
 # The following metadata is used to store the destination components of the
 # specific known positions for the actuators.
 MD_FAV_POS_ACTIVE_DEST = "Favourite position active destination"  # list or set of str


### PR DESCRIPTION
Some further missing features in the `move` module for the CryoSECOM position switching procedures: 

- Add support for safe movement to coating position
- Add function returning current position label 
- Rename `getLoadingProgress` to `getMovementProgress`
- Refine `move_test` test cases