### PR TITLE
driver andorshrk: option to workaround slit reference issue

### DIFF
--- a/src/odemis/driver/test/andorshrk_test.py
+++ b/src/odemis/driver/test/andorshrk_test.py
@@ -50,7 +50,7 @@ KWARGS = dict(name="spectrometer", role="spectrometer",
 CLASS_SHRK = andorshrk.Shamrock
 KWARGS_SHRK = dict(name="sr193", role="spectrograph", device=0)
 KWARGS_SHRK_SIM = dict(name="sr193", role="spectrograph", device="fake",
-                       slits={1: "slit-in", 3: "slit-monochromator"},
+                       slits={1: ["slit-in", "force_max"], 3: "slit-monochromator"},
                        bands={1: (230e-9, 500e-9), 3: (600e-9, 1253e-9), 5: "pass-through"},
                        drives_shutter=[1.57],
                        accessory="slitleds")


### PR DESCRIPTION
One spectrograph's slit had the reference switch not working.
As we don't need a very precise slit opening (because the user can
visually check), we can work around it by forcing the slit to go to the
maximum opening before every move. This has a similar effect as the
referencing as it allows to know where is the slit.