### PR TITLE
odemis-mic-selector: dedicated error message if no EEPROM IDs found

### DIFF
--- a/install/linux/usr/bin/odemis-mic-selector
+++ b/install/linux/usr/bin/odemis-mic-selector
@@ -126,6 +126,11 @@ def guess_hw(config):
             else:
                 logging.warning("Failed to read EEPROM IDs, will pretend no ID is connected", exc_info=True)
 
+        if not eids and all(c.eeprom for c in config):
+            # No IDs found is a sign that something fishy is going on, let's warn
+            # the user in a clear way.
+            raise IOError("Power control unit failed to find any EEPROM ID")
+
     for c in config:
         if not c.eeprom <= eids:
             logging.debug("Skipping config %s due to missing EEPROM ID", c.file)


### PR DESCRIPTION
There is typically always at least one optical module, so one EEPROM ID on a SPARC.
If no ID is found, it's a sign of something fishy, so it's best to
distinguish this case explicitly from the standard message "no matching
hardware found".