### PR TITLE
acq align autofocus: Measure1D shouldn't fail on noise

### DIFF
--- a/src/odemis/acq/align/autofocus.py
+++ b/src/odemis/acq/align/autofocus.py
@@ -141,7 +141,13 @@ def Measure1d(image):
     # give an initial estimate for the parameters of the gaussian fit: [amplitude, expected position, width, base]
     p_initial = [numpy.median(max_sig) - med_sig, numpy.median(max_ids), width, med_sig]
     # Use curve_fit to fit the gauss function to the data. Use p_initial as our initial guess.
-    popt, pcov = curve_fit(gauss, x, signal, p0=p_initial)
+    try:
+        popt, pcov = curve_fit(gauss, x, signal, p0=p_initial)
+    except RuntimeError as ex:
+        # No fitting can be found => the focus is really bad
+        logging.debug("Failed to estimate focus level, assuming a very bad level: %s", ex)
+        return 0
+
     # The focus metric is the inverse of width of the gaussian fit (a smaller width is a higher focus level).
     return 1 / abs(popt[2])
 


### PR DESCRIPTION
Sometimes the image has so little feature that the gaussian fitting
fails to find any fitting. In such case curve_fit raises a RuntimeError.

=> Catch it and return a really low score.

This avoids randomly failing to autofocus with exceptions like this:

ERROR   log:44: Autofocus failed
  File "/home/sparc/development/odemis/src/odemis/acq/align/autofocus.py", line 1296, in _DoAutoFocusSpectrometer
    fp, flvl = future._subfuture.result()
  File "/usr/lib/python3.6/concurrent/futures/_base.py", line 432, in result
    return self.__get_result()
  File "/usr/lib/python3.6/concurrent/futures/_base.py", line 384, in __get_result
    raise self._exception
  File "/home/sparc/development/odemis/src/odemis/util/__init__.py", line 699, in bindFuture
    result = fn(*args, **kwargs)
  File "/home/sparc/development/odemis/src/odemis/acq/align/autofocus.py", line 382, in _DoBinaryFocus
    fm_center = Measure(image)
  File "/home/sparc/development/odemis/src/odemis/acq/align/autofocus.py", line 144, in Measure1d
    popt, pcov = curve_fit(gauss, x, signal, p0=p_initial)
  File "/usr/lib/python3/dist-packages/scipy/optimize/minpack.py", line 740, in curve_fit
    raise RuntimeError("Optimal parameters not found: " + errmsg)
RuntimeError: Optimal parameters not found: Number of calls to function has reached maxfev = 1000.