### PR TITLE
driver zeiss: fix move functions immediately returning on Python 3

### DIFF
--- a/src/odemis/driver/test/zeiss_test.py
+++ b/src/odemis/driver/test/zeiss_test.py
@@ -205,6 +205,19 @@ class TestSEM(unittest.TestCase):
         time.sleep(6)
         test.assert_pos_almost_equal(self.stage.position.value, p)
 
+        # Check that a long move takes time (ie, that it waits until the end of the move)
+        # It's tricky, because it always waits at least 1s.
+        prev_pos = self.stage.position.value.copy()
+        tstart = time.time()
+        self.stage.moveRelSync({"x": 1e-3})
+        dur = time.time() - tstart
+        self.assertGreaterEqual(dur, 1.1, "1 mm move took only %g s" % dur)
+
+        tstart = time.time()
+        self.stage.moveAbsSync(prev_pos)
+        dur = time.time() - tstart
+        self.assertGreaterEqual(dur, 1.1, "1 mm move took only %g s" % dur)
+
     def test_stop(self):
         """
         Check it's possible to move the stage

--- a/src/odemis/driver/zeiss.py
+++ b/src/odemis/driver/zeiss.py
@@ -272,7 +272,7 @@ class SEM(model.HwComponent):
         # stage moving is either 0.0 or 1.0
         s = self._SendCmd(b'STG?')
         vals = s.split(b' ')
-        return tuple(float(i) for i in vals[0:3]) + (vals[3] == "1.0",)
+        return tuple(float(i) for i in vals[0:3]) + (vals[3] == b"1.0",)
 
     def GetBlankBeam(self):
         """


### PR DESCRIPTION
One more issue of bytes vs string.
Actually, a move would always at least wait 1s, so for small moves, this
wouldn't be noticeable.