### PR TITLE
driver pvcam: String parameters need to be converted to Python string

### DIFF
--- a/src/odemis/driver/pvcam.py
+++ b/src/odemis/driver/pvcam.py
@@ -533,6 +533,10 @@ class PVCam(model.DigitalCamera):
 
         # read the parameter
         self.pvcam.pl_get_param(self._handle, param, value, byref(content))
+
+        if tp.value == pv.TYPE_CHAR_PTR:
+            # Convert to a Python string (aka unicode)
+            return content.value.decode("latin1")
         return content.value
 
     def get_param_access(self, param):


### PR DESCRIPTION
That should help the driver on Python 3. Untested, and as the device
actually only works on Ubuntu 12.04 (for now?), this might stay like
this for a long time...