### PR TITLE
driver tmcm: _instr_to_str() should return a string

### DIFF
--- a/src/odemis/driver/tmcm.py
+++ b/src/odemis/driver/tmcm.py
@@ -635,7 +635,8 @@ class TMCLController(model.Actuator):
         instr (buffer of 9 bytes)
         """
         target, n, typ, mot, val, chk = struct.unpack('>BBBBiB', instr)
-        s = b"%d, %d, %d, %d, %d (%d)" % (target, n, typ, mot, val, chk)
+        s = "%d, %d, %d, %d, %d (%d)" % (target, n, typ, mot, val, chk)
+        # FIXME: return a string
         return s
 
     @staticmethod


### PR DESCRIPTION
As the name of the function implies it should return a string, not
bytes. That is different in Python 3.
It didn't cause much problem as it's only use for debugging, but the log
output was weird looking.