### PR TITLE
gui plugin: .pauseSettings() and .resumeSettings() should be run in GUI main thread

### DIFF
--- a/src/odemis/gui/plugin/__init__.py
+++ b/src/odemis/gui/plugin/__init__.py
@@ -533,20 +533,16 @@ class AcquisitionDialog(xrcfr_plugin):
 
         self.Layout()
 
+    @call_in_wx_main
     def pauseSettings(self):
         """ Pause the settings widgets. They will be disabled and the value frozen even when the VAs are changed """
         self.setting_controller.pause()
-        self.setting_controller.enable(False)
-
         self.streambar_controller.pause()
-        self.streambar_controller.enable(False)
 
+    @call_in_wx_main
     def resumeSettings(self):
         """ unpause the settings widgets. They will be re-enabled and the value unfrozen """
-        self.setting_controller.enable(True)
         self.setting_controller.resume()
-
-        self.streambar_controller.enable(True)
         self.streambar_controller.resume()
 
     @call_in_wx_main


### PR DESCRIPTION
The functions that they call directly manipulate the GUI, so the
simplest is to run the entire function in the main thread.

Also remove the calls to .enable() as actuall the .pause() and .resume()
already take care of doing this, and do it better.