### PR TITLE
gui plugin: add log when pressing a button

### DIFF
--- a/src/odemis/gui/plugin/__init__.py
+++ b/src/odemis/gui/plugin/__init__.py
@@ -420,6 +420,7 @@ class AcquisitionDialog(xrcfr_plugin):
                 # allowing that).
                 try:
                     self.SetReturnCode(btnid)
+                    logging.info("Button '%s' handled by %s, %s", label, self.plugin.__class__.__name__, callback)
                     t = threading.Thread(target=callback, args=(self,),
                                          name="Callback for button %s" % (label,))
                     t.start()


### PR DESCRIPTION
As the button callbacks run in a separate thread, it can easily crash
the GUI if it ever calls a wxPython function. So it's handy to know if
a callback has started if a crash is followed.