### PR TITLE
gui SPARC: leave the bottom legend enabled during acquisition

### DIFF
--- a/src/odemis/gui/comp/viewport.py
+++ b/src/odemis/gui/comp/viewport.py
@@ -233,15 +233,19 @@ class ViewPort(wx.Panel):
     def OnSize(self, evt):
         evt.Skip()  # processed also by the parent
 
-    def Disable(self, *args, **kwargs):
-        logging.debug("Disabling %s", self.canvas)
-        wx.Panel.Disable(self, *args, **kwargs)
-        self.canvas.Disable(*args, **kwargs)
+    def Disable(self):
+        return self.Enable(False)
 
-    def Enable(self, *args, **kwargs):
-        logging.debug("Enabling %s", self.canvas)
-        wx.Panel.Enable(self, *args, **kwargs)
-        self.canvas.Enable(*args, **kwargs)
+    def Enable(self, enable):
+        # Don't disable the entire panel, in order to allow the caller to re-enable
+        # the legend if needed (as done by the SPARC acquisition tab)
+
+        if self.bottom_legend:
+            self.bottom_legend.Enable(enable)
+        if self.left_legend:
+            self.left_legend.Enable(enable)
+
+        return self.canvas.Enable(enable)
 
 
 class CameraViewport(ViewPort):

--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -1158,6 +1158,13 @@ class SparcAcquisitionTab(Tab):
 
         self.tb.enable(not is_acquiring)
         self.panel.vp_sparc_tl.Enable(not is_acquiring)
+        # TODO: Leave the canvas accessible, but only forbid moving the stage and
+        # if the mpp changes, do not update the horizontalFoV of the e-beam.
+        # For now, as a hack, we re-enable the legend to allow changing the merge
+        # ratio between SEM and CL.
+        if is_acquiring:
+            self.panel.vp_sparc_tl.bottom_legend.Enable(True)
+
         self.panel.btn_sparc_change_file.Enable(not is_acquiring)
 
     def _copyDwellTimeToAnchor(self, dt):


### PR DESCRIPTION
With the new live view during acquisition, it's important to be able to
adjust the SEM/CL merge ratio. Ideally, we'd leave the entire viewport
enabled, with only restriction on the movement and zoom, but for now,
let's keep it simple, and just re-enable the bottom legend after
disabling the whole viewport.