### PR TITLE
gui: fix support for time-correlator filters

### DIFF
--- a/src/odemis/gui/conf/data.py
+++ b/src/odemis/gui/conf/data.py
@@ -751,6 +751,15 @@ STREAM_SETTINGS_CONFIG = {
                 "choices": util.format_band_choices,
             }),
         )),
+    stream.ScannedTemporalSettingsStream:
+        OrderedDict((
+            ("density", {  # from tc-od-filter
+                "tooltip": u"Optical density",
+            }),
+            ("filter", {  # from tc-filter
+                "choices": util.format_band_choices,
+            }),
+        )),
     stream.MonochromatorSettingsStream:
         OrderedDict((
             ("wavelength", {
@@ -796,7 +805,10 @@ STREAM_SETTINGS_CONFIG = {
         )),
     stream.CLSettingsStream:
         OrderedDict((
-            ("filter", {  # from filter or cl-filter
+            ("density", {  # from tc-od-filter
+                "tooltip": u"Optical density",
+            }),
+            ("filter", {  # from filter, cl-filter, or tc-filter
                 "choices": util.format_band_choices,
             }),
         )),

--- a/src/odemis/gui/cont/streams.py
+++ b/src/odemis/gui/cont/streams.py
@@ -2728,14 +2728,15 @@ class SparcStreamsController(StreamBarController):
 
         main_data = self._main_data_model
 
+        axes = {"density": ("density", main_data.tc_od_filter)}
         # Need to pick the right filter wheel (if there is one)
-        axes = {}
-        for fw in (main_data.cl_filter, main_data.light_filter, main_data.tc_od_filter, main_data.tc_filter):
+        for fw in (main_data.cl_filter, main_data.light_filter, main_data.tc_filter):
             if fw is None:
                 continue
             if main_data.cld.name in fw.affects.value:
                 axes["filter"] = ("band", fw)
                 break
+        axes = self._filter_axes(axes)
 
         cli_stream = acqstream.CLSettingsStream(
             "CL intensity",


### PR DESCRIPTION
With the local axes changes, the tc-filter and tc-od-filter were not
anymore properly handled.
Especially, the CL intensity can also be affected by the tc-od-filter,
but it doesn't contain a band axis (it contains a "density" axis), so
this would prevent the stream from being created.