### PR TITLE
driver simsem: don't fail to generate an image if the shift is large

### DIFF
--- a/src/odemis/driver/simsem.py
+++ b/src/odemis/driver/simsem.py
@@ -456,12 +456,25 @@ class Detector(model.Detector):
             center = (shape[1] / 2 - shi[0] / pxs[0] - self.current_drift,
                       shape[0] / 2 - shi[1] / pxs[1] + self.current_drift)
 
-            lt = (center[0] + pxs_pos[0] - (res[0] / 2) * scale[0],
-                  center[1] + pxs_pos[1] - (res[1] / 2) * scale[1])
-            assert(lt[0] >= 0 and lt[1] >= 0)
+            ltrb = [center[0] + pxs_pos[0] - (res[0] / 2) * scale[0],
+                    center[1] + pxs_pos[1] - (res[1] / 2) * scale[1],
+                    center[0] + pxs_pos[0] + (res[0] / 2) * scale[0],
+                    center[1] + pxs_pos[1] + (res[1] / 2) * scale[1]
+                    ]
+            # If the shift caused the image to go out of bounds, limit it
+            if ltrb[0] < 0:
+                ltrb[0] = 0
+            elif ltrb[2] > shape[1] - 1:
+                ltrb[0] -= ltrb[2] - (shape[1] - 1)
+            if ltrb[1] < 0:
+                ltrb[1] = 0
+            elif ltrb[3] >= shape[0] - 1:
+                ltrb[1] -= ltrb[3] - (shape[0] - 1)
+            assert(ltrb[0] >= 0 and ltrb[1] >= 0)
+
             # compute each row and column that will be included
-            coord = ([int(round(lt[0] + i * scale[0])) for i in range(res[0])],
-                     [int(round(lt[1] + i * scale[1])) for i in range(res[1])])
+            coord = ([int(round(ltrb[0] + i * scale[0])) for i in range(res[0])],
+                     [int(round(ltrb[1] + i * scale[1])) for i in range(res[1])])
             sim_img = self.fake_img[numpy.ix_(coord[1], coord[0])] # copy
 
             # reduce image depth if requested


### PR DESCRIPTION
The shift is also taken into account to move the generated image within the whole raw image.
While the translation VA can never be set to go out of bound, the shift
VA can. In such case, we shouldn't fail to simulate, but just clip the
image.