### PR TITLE
acq stream: don't raise error if changing BC outliers before any data is available

### DIFF
--- a/src/odemis/acq/stream/_base.py
+++ b/src/odemis/acq/stream/_base.py
@@ -1124,6 +1124,9 @@ class Stream(object):
             self._recomputeIntensityRange()
 
     def _recomputeIntensityRange(self):
+        if len(self.histogram._full_hist) == 0:  # No histogram yet
+            return
+
         irange = img.findOptimalRange(self.histogram._full_hist,
                                       self.histogram._edges,
                                       self.auto_bc_outliers.value / 100)


### PR DESCRIPTION
If there is no data, recomputing the intensity range is not meaningful.
For now, it would try, and fail, leading to such error in the log:
  File "/home/piel/development/odemis/src/odemis/model/_vattributes.py", line 97, in notify
    l(v)
  File "/home/piel/development/odemis/src/odemis/util/weak.py", line 37, in __call__
    return self.f(ins, *arg, **kwargs)
  File "/home/piel/development/odemis/src/odemis/acq/stream/_base.py", line 1124, in _onOutliers
    self._recomputeIntensityRange()
  File "/home/piel/development/odemis/src/odemis/acq/stream/_base.py", line 1135, in _recomputeIntensityRange
    self.intensityRange.value = irange
  File "/home/piel/development/odemis/src/odemis/model/_vattributes.py", line 1175, in _set_value
    value = tuple(value)
TypeError: 'NoneType' object is not iterable

=> Detect there is no data, and skip the intensityRange update.