### PR TITLE
model vattribute: don't fail on __del__ if __init__ failed

### DIFF
--- a/src/odemis/model/_vattributes.py
+++ b/src/odemis/model/_vattributes.py
@@ -274,15 +274,16 @@ class VigilantAttribute(VigilantAttributeBase):
         if daemon:
             daemon.unregister(self)
 
-        if self._remote_listeners:
-            logging.info("Unregistering %s while still %d remote listeners", self, len(self._remote_listeners))
-            self._remote_listeners.clear()
+        try:  # AttributeError can happen if exception during init
+            if self._remote_listeners:
+                logging.info("Unregistering %s while still %d remote listeners", self, len(self._remote_listeners))
+                self._remote_listeners.clear()
 
-        try:
             if self.pipe:
                 self.pipe.close()
                 self.pipe = None
-            if self._ctx: # no ._ctx if exception during init
+
+            if self._ctx:
                 self._ctx.term()
                 self._ctx = None
         except Exception:


### PR DESCRIPTION
__del__() is called even if __init__() didn't finish.
If it failed, for instance because the VA value is incorrect, then the
new code unregistering from the remote listeners would fail.
=> do the same as for the other attributes.