### PR TITLE
Added DeprecationWarning to transform.__call__ method

### DIFF
--- a/src/odemis/util/test/transform_test.py
+++ b/src/odemis/util/test/transform_test.py
@@ -549,7 +549,7 @@ class RigidTransformKnownValues(unittest.TestCase):
         src = RIGID_KNOWN_VALUES[0][-1]
         for rotation, _, _, translation, dst in RIGID_KNOWN_VALUES:
             tform = RigidTransform(rotation=rotation, translation=translation)
-            numpy.testing.assert_array_almost_equal(dst, tform(src))
+            numpy.testing.assert_array_almost_equal(dst, tform.apply(src))
 
     def test_rigid_transform_inverse_known_values(self):
         """
@@ -560,7 +560,7 @@ class RigidTransformKnownValues(unittest.TestCase):
         for rotation, _, _, translation, dst in RIGID_KNOWN_VALUES:
             tform = RigidTransform(rotation=rotation,
                                    translation=translation).inverse()
-            numpy.testing.assert_array_almost_equal(src, tform(dst))
+            numpy.testing.assert_array_almost_equal(src, tform.apply(dst))
 
 
 class SimilarityTransformKnownValues(unittest.TestCase):
@@ -609,9 +609,9 @@ class SimilarityTransformKnownValues(unittest.TestCase):
         for rotation, (scale, _), _, translation, dst in SIMILARITY_KNOWN_VALUES:
             tform = SimilarityTransform(rotation=rotation, scale=scale,
                                         translation=translation)
-            numpy.testing.assert_array_almost_equal(dst, tform(src))
+            numpy.testing.assert_array_almost_equal(dst, tform.apply(src))
             ti = tform.inverse()
-            numpy.testing.assert_array_almost_equal(ti(tform(src)), src)
+            numpy.testing.assert_array_almost_equal(ti.apply(tform.apply(src)), src)
 
     def test_similarity_transform_inverse_known_values(self):
         """
@@ -622,7 +622,7 @@ class SimilarityTransformKnownValues(unittest.TestCase):
         for rotation, (scale, _), _, translation, dst in SIMILARITY_KNOWN_VALUES:
             tform = SimilarityTransform(rotation=rotation, scale=scale,
                                         translation=translation).inverse()
-            numpy.testing.assert_array_almost_equal(src, tform(dst))
+            numpy.testing.assert_array_almost_equal(src, tform.apply(dst))
 
 
 class ScalingTransformKnownValues(unittest.TestCase):
@@ -667,7 +667,7 @@ class ScalingTransformKnownValues(unittest.TestCase):
         for rotation, scale, _, translation, dst in SCALING_KNOWN_VALUES:
             tform = ScalingTransform(rotation=rotation, scale=scale,
                                      translation=translation)
-            numpy.testing.assert_array_almost_equal(dst, tform(src))
+            numpy.testing.assert_array_almost_equal(dst, tform.apply(src))
 
     def test_scaling_transform_inverse_known_values(self):
         """
@@ -678,7 +678,7 @@ class ScalingTransformKnownValues(unittest.TestCase):
         for rotation, scale, _, translation, dst in SCALING_KNOWN_VALUES:
             tform = ScalingTransform(rotation=rotation, scale=scale,
                                      translation=translation).inverse()
-            numpy.testing.assert_array_almost_equal(src, tform(dst))
+            numpy.testing.assert_array_almost_equal(src, tform.apply(dst))
 
 
 class AffineTransformKnownValues(unittest.TestCase):
@@ -726,7 +726,7 @@ class AffineTransformKnownValues(unittest.TestCase):
         for rotation, scale, shear, translation, dst in AFFINE_KNOWN_VALUES:
             tform = AffineTransform(rotation=rotation, scale=scale,
                                     shear=shear, translation=translation)
-            numpy.testing.assert_array_almost_equal(dst, tform(src))
+            numpy.testing.assert_array_almost_equal(dst, tform.apply(src))
 
     def test_affine_transform_inverse_known_values(self):
         """
@@ -738,7 +738,7 @@ class AffineTransformKnownValues(unittest.TestCase):
             tform = AffineTransform(rotation=rotation, scale=scale,
                                     shear=shear,
                                     translation=translation).inverse()
-            numpy.testing.assert_array_almost_equal(src, tform(dst))
+            numpy.testing.assert_array_almost_equal(src, tform.apply(dst))
 
 
 class AnamorphosisTransformKnownValues(unittest.TestCase):
@@ -762,7 +762,7 @@ class AnamorphosisTransformKnownValues(unittest.TestCase):
         for rotation, scale, shear, translation, dst in AFFINE_KNOWN_VALUES:
             tform = AnamorphosisTransform(rotation=rotation, scale=scale,
                                           shear=shear, translation=translation)
-            numpy.testing.assert_array_almost_equal(dst, tform(src))
+            numpy.testing.assert_array_almost_equal(dst, tform.apply(src))
 
     def test_anamorphosis_transform_comparison_known_values(self):
         """
@@ -779,7 +779,7 @@ class AnamorphosisTransformKnownValues(unittest.TestCase):
         for rotation, scale, shear, translation in iterator:
             affine = AffineTransform(rotation=rotation, scale=scale,
                                      shear=shear, translation=translation)
-            dst = affine(src)
+            dst = affine.apply(src)
             tform = AnamorphosisTransform.from_pointset(src, dst)
             self.assertAlmostEqual(0., _angle_diff(rotation, tform.rotation))
             numpy.testing.assert_array_almost_equal(scale, tform.scale)

--- a/src/odemis/util/transform.py
+++ b/src/odemis/util/transform.py
@@ -60,6 +60,7 @@ from future.utils import with_metaclass
 import numbers
 import numpy
 import scipy.optimize
+import warnings
 from numpy.linalg import LinAlgError
 from odemis.util.linalg import qrp, tri_inv
 
@@ -345,7 +346,7 @@ class GeometricTransform(with_metaclass(ABCMeta, object)):
             if len(self.translation) != 2 or not all(isinstance(a, numbers.Real) for a in self.translation):
                 raise ValueError("Translation should be 2 floats, but got %s" % (self.translation,))
 
-    def __call__(self, x):
+    def apply(self, x):
         """
         Apply the forward transformation to a (set of) input coordinates.
 
@@ -362,6 +363,12 @@ class GeometricTransform(with_metaclass(ABCMeta, object)):
         """
         x = numpy.asarray(x)
         return numpy.einsum('ik,...k->...i', self.transformation_matrix, x) + self.translation
+
+    def __call__(self, x):
+        warnings.warn("__call__ is deprecated, use apply instead",
+                      DeprecationWarning)
+        return self.apply(x)
+    __call__.__doc__ = apply.__doc__
 
     @abstractmethod
     def inverse(self):
@@ -1023,7 +1030,7 @@ class AnamorphosisTransform(AffineTransform):
                                 w3wcc2, w2wcc3))  # fifth order
         return M
 
-    def __call__(self, x):
+    def apply(self, x):
         x = numpy.asarray(x)
         w = x[..., 0] + 1.0j * x[..., 1]
 
@@ -1033,6 +1040,12 @@ class AnamorphosisTransform(AffineTransform):
         if x.ndim == 1:
             return numpy.array((v.real, v.imag))
         return numpy.column_stack((v.real, v.imag))
+
+    def __call__(self, x):
+        warnings.warn("__call__ is deprecated, use apply instead",
+                      DeprecationWarning)
+        return self.apply(x)
+    __call__.__doc__ = apply.__doc__
 
     @classmethod
     def from_pointset(cls, x, y):


### PR DESCRIPTION
Usage of transform.apply() is now preferred.