### PR TITLE
driver tmcm: adjust simulator to not fail on 1-axis hardware

### DIFF
--- a/src/odemis/driver/tmcm.py
+++ b/src/odemis/driver/tmcm.py
@@ -2302,8 +2302,7 @@ class TMCMSimulator(object):
         # 4 * dict(int -> int: param number -> value)
         self._gstate = [{}, {},
                         # Bank 2: example user config v1
-                        {0: 353304838, 1: 50462723, 2: 17104896, 3: 33555201,
-                         4: 83886082, 5: 196869, 6: 0},
+                        {0: 168034562, 1: 50462723, 2: 17104896},
                         {}]
 
         # internal axis param values


### PR DESCRIPTION
The user config contained 3 axes, so on 1-axis simulated hardware, it
would fail.
=> Make a new user config with only 1 axis. It ought to work on any
simulated hardware!