### PR TITLE
gui cont microscope: DELPHI first calibration dialog automatically closed when sample is ejected

### DIFF
--- a/src/odemis/gui/cont/microscope.py
+++ b/src/odemis/gui/cont/microscope.py
@@ -648,6 +648,8 @@ class DelphiStateController(SecomStateController):
         self._in_overview = threading.Event()
         self._phenom_load_done = True
 
+        self._first_calib_dlg = None
+
         super(DelphiStateController, self).__init__(tab_data, tab_panel, *args, **kwargs)
 
         # Display the panel with the loading progress indicators
@@ -886,6 +888,9 @@ class DelphiStateController(SecomStateController):
                 logging.info("Door closed (again?) while the chamber was not vented")
         else:
             self._tab_panel.btn_press.SetToolTip(u"Please insert a sample first")
+            # In case we asked to eject/calibrate the sample, stop asking
+            if self._first_calib_dlg:
+                self._first_calib_dlg.Close()
 
     def _start_chamber_pumping(self):
         """
@@ -1174,6 +1179,7 @@ class DelphiStateController(SecomStateController):
             need_register = False
 
         dlg = windelphi.FirstCalibrationDialog(self._main_frame, shid, need_register)
+        self._first_calib_dlg = dlg  # To close it when the sample is ejected by other means
         val = dlg.ShowModal()  # blocks
         regcode = dlg.registrationCode
         dlg.Destroy()


### PR DESCRIPTION
When inserting a sample holder which is not calibrated, a dialog box
appear to either eject the sample or calibrate it.
This happens on the first time the CLEM sample holder is inserted.
However, if the user also use a standard SEM sample holder, with the
standard Phenom GUI, while Odemis is running, this also happens.
Then, the dialog appear *every* time the sample holder is inserted.
This can cause many time the same dialog box to be shown. None of them
useful.

=> Automatically close the dialog window when the sample is ejected by
an other mean than the Odemis GUI. This way, it never shows more than
one dialog.

Can be tested on the simulator by removing the calibration file, and
then doing:
odemis-cli --set-attr chamber opened True
odemis-cli --set-attr chamber opened False