### PR TITLE
driver-piezomotor: bugfix and yaml file

### DIFF
--- a/install/linux/usr/share/odemis/hwtest/piezomotor.odm.yaml
+++ b/install/linux/usr/share/odemis/hwtest/piezomotor.odm.yaml
@@ -1,6 +1,6 @@
 MultiBeamSEM: {
   class: Microscope,
-  role: mbsem,
+  role: brightfield,
   children: ["Piezomotor"],
 }
 

--- a/install/linux/usr/share/odemis/hwtest/piezomotor.odm.yaml
+++ b/install/linux/usr/share/odemis/hwtest/piezomotor.odm.yaml
@@ -1,0 +1,30 @@
+MultiBeamSEM: {
+  class: Microscope,
+  role: mbsem,
+  children: ["Piezomotor"],
+}
+
+Piezomotor: {
+    class: piezomotor.PMD401Bus,
+    role: stage,
+    init: {
+        port: "/dev/ttyUSB*", #"/dev/fake",
+        axes: {
+            'x': {
+                axis_number: 1,
+                speed: 0.001, # m/s
+                closed_loop: True,
+                },
+            'y': {
+                axis_number: 2,
+                speed: 0.001, # m/s
+                closed_loop: True,
+                },
+            'z': {
+                axis_number: 3,
+                speed: 0.001, # m/s
+                closed_loop: True,
+                },
+        },
+    },
+}

--- a/src/odemis/driver/piezomotor.py
+++ b/src/odemis/driver/piezomotor.py
@@ -232,7 +232,7 @@ class PMD401Bus(Actuator):
                     logging.info("Axis %s is using spc value from flash: %s" % (axis, val))
                 self._steps_per_count[axname] = val
             self._steps_per_meter[axname] = self._steps_per_count[axname] * self._counts_per_meter[axname]
-            self._speed_steps[axis_name] = round(self._speed * self._steps_per_meter[axis_name])
+            self._speed_steps[axname] = round(self._speed * self._steps_per_meter[axname])
 
         # Limit switch
         for axis in self._axis_map.values():

--- a/src/odemis/driver/test/piezomotor_test.py
+++ b/src/odemis/driver/test/piezomotor_test.py
@@ -37,9 +37,20 @@ logging.getLogger().setLevel(logging.DEBUG)
 TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
 MULTIPLE_AXES = (os.environ.get("MULTIPLE_AXES", 0) != 0)  # if available, test 2 axes
 
-TEST_SPEED = 0.001  # m / s
-AXIS_NUM = 1
-AXIS_NUM2 = 2
+if TEST_NOHW:
+    PORT = "/dev/fake"
+else:
+    PORT = "/dev/ttyUSB*"
+
+KWARGS_OPEN = dict(name="test", role="test", port=PORT,
+              axes={'x': {'axis_number': 1, 'speed': 0.001, 'closed_loop': False},
+                    'y': {'axis_number': 2, 'speed': 0.001, 'closed_loop': False}}
+              )
+
+KWARGS_CLOSED = dict(name="test", role="test", port=PORT,
+              axes={'x': {'axis_number': 1, 'speed': 0.001, 'closed_loop': True},
+                    'y': {'axis_number': 2, 'speed': 0.001, 'closed_loop': True}}
+              )
 
 
 class TestPMD401OpenLoop(unittest.TestCase):
@@ -48,17 +59,7 @@ class TestPMD401OpenLoop(unittest.TestCase):
     """
 
     def setUp(self):
-        if TEST_NOHW:
-            port = "/dev/fake"
-        else:
-            port = "/dev/ttyUSB*"
-
-        if TEST_NOHW or MULTIPLE_AXES:
-            axes = {'x': {'axis_number': AXIS_NUM, 'speed': TEST_SPEED, 'closed_loop': True},
-                    'y': {'axis_number': AXIS_NUM2, 'speed': TEST_SPEED, 'closed_loop': True}}
-        else:
-            axes = {'x': {'axis_number': AXIS_NUM, 'speed': TEST_SPEED, 'closed_loop': True}}
-        self.stage = PMD401Bus('test', 'test', port, axes)
+        self.stage = PMD401Bus(**KWARGS_OPEN)
 
     def test_simple(self):
         """
@@ -121,19 +122,13 @@ class TestPMD401OpenLoop(unittest.TestCase):
         self.assertEqual(self.stage._executor._queue, deque([]))
 
 
-class TestPMD401ClosedLoop(unittest.TestCase):
+class TestPMD401ClosedLoop(TestPMD401OpenLoop):
     """
     Test the PMD401 class with closed loop functionality.
     """
 
     def setUp(self):
-        if TEST_NOHW:
-            port = "/dev/fake"
-        else:
-            port = "/dev/ttyUSB*"
-
-        axes = {'x': {'axis_number': AXIS_NUM, 'speed': TEST_SPEED, 'closed_loop': True}}
-        self.stage = PMD401Bus('test', 'test', port, axes)
+        self.stage = PMD401Bus(**KWARGS_CLOSED)
 
 
 if __name__ == '__main__':

--- a/src/odemis/driver/test/piezomotor_test.py
+++ b/src/odemis/driver/test/piezomotor_test.py
@@ -35,9 +35,11 @@ logging.getLogger().setLevel(logging.DEBUG)
 # Export TEST_NOHW=1 to force using only the simulator and skipping test cases
 # needing real hardware
 TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
+MULTIPLE_AXES = (os.environ.get("MULTIPLE_AXES", 0) != 0)  # if available, test 2 axes
 
 TEST_SPEED = 0.001  # m / s
 AXIS_NUM = 1
+AXIS_NUM2 = 2
 
 
 class TestPMD401OpenLoop(unittest.TestCase):
@@ -51,7 +53,11 @@ class TestPMD401OpenLoop(unittest.TestCase):
         else:
             port = "/dev/ttyUSB*"
 
-        axes = {'x': {'axis_number': AXIS_NUM, 'speed': TEST_SPEED, 'closed_loop': True}}
+        if TEST_NOHW or MULTIPLE_AXES:
+            axes = {'x': {'axis_number': AXIS_NUM, 'speed': TEST_SPEED, 'closed_loop': True},
+                    'y': {'axis_number': AXIS_NUM2, 'speed': TEST_SPEED, 'closed_loop': True}}
+        else:
+            axes = {'x': {'axis_number': AXIS_NUM, 'speed': TEST_SPEED, 'closed_loop': True}}
         self.stage = PMD401Bus('test', 'test', port, axes)
 
     def test_simple(self):


### PR DESCRIPTION
* fixed bug in init (probably introduced during review process)
* added testcase for bug (was not caught when testing with single axis, so test with 2 axes, at least in simulator)
* added yaml file to hwtest because the driver parameters are sufficiently complicated