### PR TITLE
correct xt_client test_apply_auto_contrast_brightness

### DIFF
--- a/src/odemis/driver/test/xt_client_test.py
+++ b/src/odemis/driver/test/xt_client_test.py
@@ -630,8 +630,8 @@ class TestMicroscopeInternal(unittest.TestCase):
         with self.assertRaises(KeyError):
             self.scanner.applyAutoContrastBrightness("error_expected")
         time.sleep(2.5)  # Give microscope/simulator the time to update the state
-        autofocus_state = self.microscope.is_autofocusing(channel)
-        self.assertEqual(autofocus_state, False)
+        auto_contrast_brightness_state = self.microscope.is_running_auto_contrast_brightness(channel)
+        self.assertEqual(auto_contrast_brightness_state, False)
 
     def test_apply_autofocus(self):
         """


### PR DESCRIPTION
small change in the test case to test if the correct autofuncionality is not running. [tested on EA]