### PR TITLE
install: change default interpreter to Python 3

### DIFF
--- a/install/linux/etc/odemis.conf
+++ b/install/linux/etc/odemis.conf
@@ -7,8 +7,8 @@ LOGLEVEL=2 # 0=Warning+, 1=Info+, 2=Debug+
 
 CONFIGPATH="/usr/share/odemis"
 
-PYTHON_INTERPRETER="/usr/bin/python2"
-#PYTHON_INTERPRETER="/usr/bin/python3"
+#PYTHON_INTERPRETER="/usr/bin/python2"
+PYTHON_INTERPRETER="/usr/bin/python3"
 
 # These values shouldn't be changed
 START=odemis.odemisd.start


### PR DESCRIPTION
When no interpreter is set, now Python 3 is used, so let's also update
the default configuration to use Python 3.