### PR TITLE
Made parameter `shape` optional in `to_physical_space` and `to_pixel_index`

### DIFF
--- a/src/odemis/util/test/transform_test.py
+++ b/src/odemis/util/test/transform_test.py
@@ -335,14 +335,21 @@ class PixelIndexCoordinateTransformBase(unittest.TestCase):
     def setUp(self):
         self._ji = [(0, 0), (0, 4), (7, 0), (7, 4), (0.5, 0.5)]
 
-        # (shape, pixel_size, xy)
+        # List of known values [(kwargs0, xy0), (kwargs1, xy1), ...] for which
+        # `xy == to_physical_space(self._ji, **kwargs)` is True.
         self._known_values = [
-            ((8, 5), None, [(-2, 3.5), (2, 3.5), (-2, -3.5), (2, -3.5), (-1.5, 3)]),
-            ((8, 5), 2, [(-4, 7), (4, 7), (-4, -7), (4, -7), (-3, 6)]),
-            ((8, 5), (2, 3), [(-4, 10.5), (4, 10.5), (-4, -10.5), (4, -10.5), (-3, 9)]),
-            (None, None, [(0, 0), (4, 0), (0, -7), (4, -7), (0.5, -0.5)]),
-            (None, 2, [(0, 0), (8, 0), (0, -14), (8, -14), (1, -1)]),
-            (None, (2, 3), [(0, 0), (8, 0), (0, -21), (8, -21), (1, -1.5)]),
+            ({'shape': (8, 5)},
+             [(-2, 3.5), (2, 3.5), (-2, -3.5), (2, -3.5), (-1.5, 3)]),
+            ({'shape': (8, 5), 'pixel_size': 2},
+             [(-4, 7), (4, 7), (-4, -7), (4, -7), (-3, 6)]),
+            ({'shape': (8, 5), 'pixel_size': (2, 3)},
+             [(-4, 10.5), (4, 10.5), (-4, -10.5), (4, -10.5), (-3, 9)]),
+            ({},
+             [(0, 0), (4, 0), (0, -7), (4, -7), (0.5, -0.5)]),
+            ({'pixel_size': 2},
+             [(0, 0), (8, 0), (0, -14), (8, -14), (1, -1)]),
+            ({'pixel_size': (2, 3)},
+             [(0, 0), (8, 0), (0, -21), (8, -21), (1, -1.5)]),
         ]
 
 
@@ -354,20 +361,20 @@ class ToPhysicalSpaceKnownValues(PixelIndexCoordinateTransformBase):
 
         """
         # tuple
-        for shape, pixel_size, _xy in self._known_values:
+        for kwargs, _xy in self._known_values:
             for ji, xy in zip(self._ji, _xy):
-                res = to_physical_space(ji, shape, pixel_size)
+                res = to_physical_space(ji, **kwargs)
                 numpy.testing.assert_array_almost_equal(xy, res)
 
         # list of tuples
-        for shape, pixel_size, xy in self._known_values:
-            res = to_physical_space(self._ji, shape, pixel_size)
+        for kwargs, xy in self._known_values:
+            res = to_physical_space(self._ji, **kwargs)
             numpy.testing.assert_array_almost_equal(xy, res)
 
         # ndarray
-        for shape, pixel_size, xy in self._known_values:
+        for kwargs, xy in self._known_values:
             ji = numpy.array(self._ji)
-            res = to_physical_space(ji, shape, pixel_size)
+            res = to_physical_space(ji, **kwargs)
             numpy.testing.assert_array_almost_equal(xy, res)
 
     def test_to_physical_space_zero_pixel_size(self):
@@ -385,10 +392,10 @@ class ToPhysicalSpaceKnownValues(PixelIndexCoordinateTransformBase):
         of indices, or on individual indices.
 
         """
-        for shape, pixel_size, _xy in self._known_values:
-            _xy = to_physical_space(self._ji, shape, pixel_size)
+        for kwargs, _xy in self._known_values:
+            _xy = to_physical_space(self._ji, **kwargs)
             for ji, xy in zip(self._ji, _xy):
-                res = to_physical_space(ji, shape, pixel_size)
+                res = to_physical_space(ji, **kwargs)
                 numpy.testing.assert_array_almost_equal(xy, res)
 
     def test_to_physical_space_raises_value_error(self):
@@ -410,20 +417,20 @@ class ToPixelIndexKnownValues(PixelIndexCoordinateTransformBase):
 
         """
         # tuple
-        for shape, pixel_size, _xy in self._known_values:
+        for kwargs, _xy in self._known_values:
             for ji, xy in zip(self._ji, _xy):
-                res = to_pixel_index(xy, shape, pixel_size)
+                res = to_pixel_index(xy, **kwargs)
                 numpy.testing.assert_array_almost_equal(ji, res)
 
         # list of tuples
-        for shape, pixel_size, xy in self._known_values:
-            res = to_pixel_index(xy, shape, pixel_size)
+        for kwargs, xy in self._known_values:
+            res = to_pixel_index(xy, **kwargs)
             numpy.testing.assert_array_almost_equal(self._ji, res)
 
         # ndarray
-        for shape, pixel_size, _xy in self._known_values:
+        for kwargs, _xy in self._known_values:
             xy = numpy.array(_xy)
-            res = to_pixel_index(xy, shape, pixel_size)
+            res = to_pixel_index(xy, **kwargs)
             numpy.testing.assert_array_almost_equal(self._ji, res)
 
     def test_to_pixel_index_multiple(self):
@@ -432,10 +439,10 @@ class ToPixelIndexKnownValues(PixelIndexCoordinateTransformBase):
         indices, or on individual indices.
 
         """
-        for shape, pixel_size, _xy in self._known_values:
-            _ji = to_pixel_index(_xy, shape, pixel_size)
+        for kwargs, _xy in self._known_values:
+            _ji = to_pixel_index(_xy, **kwargs)
             for ji, xy in zip(_ji, _xy):
-                res = to_pixel_index(xy, shape, pixel_size)
+                res = to_pixel_index(xy, **kwargs)
                 numpy.testing.assert_array_almost_equal(ji, res)
 
     def test_to_pixel_index_raises_value_error(self):

--- a/src/odemis/util/test/transform_test.py
+++ b/src/odemis/util/test/transform_test.py
@@ -333,23 +333,35 @@ def _angle_diff(x, y):
 class PixelIndexCoordinateTransformBase(unittest.TestCase):
 
     def setUp(self):
-        self._ji = [(0, 0), (0, 4), (7, 0), (7, 4), (0.5, 0.5)]
+        ji = [(0, 0), (0, 4), (7, 0), (7, 4), (0.5, 0.5)]
 
-        # List of known values [(kwargs0, xy0), (kwargs1, xy1), ...] for which
-        # `xy == to_physical_space(self._ji, **kwargs)` is True.
+        # List of tuples with known values `(ji, xy, kwargs)` for which
+        # both `xy == to_physical_space(ji, **kwargs)` as well as
+        # `ji == to_pixel_index(xy, **kwargs)` evaluate to True.
         self._known_values = [
-            ({'shape': (8, 5)},
-             [(-2, 3.5), (2, 3.5), (-2, -3.5), (2, -3.5), (-1.5, 3)]),
-            ({'shape': (8, 5), 'pixel_size': 2},
-             [(-4, 7), (4, 7), (-4, -7), (4, -7), (-3, 6)]),
-            ({'shape': (8, 5), 'pixel_size': (2, 3)},
-             [(-4, 10.5), (4, 10.5), (-4, -10.5), (4, -10.5), (-3, 9)]),
-            ({},
-             [(0, 0), (4, 0), (0, -7), (4, -7), (0.5, -0.5)]),
-            ({'pixel_size': 2},
-             [(0, 0), (8, 0), (0, -14), (8, -14), (1, -1)]),
-            ({'pixel_size': (2, 3)},
-             [(0, 0), (8, 0), (0, -21), (8, -21), (1, -1.5)]),
+            (ji,
+             [(0, 0), (4, 0), (0, -7), (4, -7), (0.5, -0.5)],
+             {}),  # empty dict means default function arguments are used
+
+            (ji,
+             [(0, 0), (8, 0), (0, -14), (8, -14), (1, -1)],
+             {'pixel_size': 2}),
+
+            (ji,
+             [(0, 0), (8, 0), (0, -21), (8, -21), (1, -1.5)],
+             {'pixel_size': (2, 3)}),
+
+            (ji,
+             [(-2, 3.5), (2, 3.5), (-2, -3.5), (2, -3.5), (-1.5, 3)],
+             {'shape': (8, 5)}),
+
+            (ji,
+             [(-4, 7), (4, 7), (-4, -7), (4, -7), (-3, 6)],
+             {'shape': (8, 5), 'pixel_size': 2}),
+
+            (ji,
+             [(-4, 10.5), (4, 10.5), (-4, -10.5), (4, -10.5), (-3, 9)],
+             {'shape': (8, 5), 'pixel_size': (2, 3)}),
         ]
 
 
@@ -361,19 +373,19 @@ class ToPhysicalSpaceKnownValues(PixelIndexCoordinateTransformBase):
 
         """
         # tuple
-        for kwargs, _xy in self._known_values:
-            for ji, xy in zip(self._ji, _xy):
+        for _ji, _xy, kwargs in self._known_values:
+            for ji, xy in zip(_ji, _xy):
                 res = to_physical_space(ji, **kwargs)
                 numpy.testing.assert_array_almost_equal(xy, res)
 
         # list of tuples
-        for kwargs, xy in self._known_values:
-            res = to_physical_space(self._ji, **kwargs)
+        for ji, xy, kwargs in self._known_values:
+            res = to_physical_space(ji, **kwargs)
             numpy.testing.assert_array_almost_equal(xy, res)
 
         # ndarray
-        for kwargs, xy in self._known_values:
-            ji = numpy.array(self._ji)
+        for ji, xy, kwargs in self._known_values:
+            ji = numpy.asarray(ji)
             res = to_physical_space(ji, **kwargs)
             numpy.testing.assert_array_almost_equal(xy, res)
 
@@ -382,9 +394,9 @@ class ToPhysicalSpaceKnownValues(PixelIndexCoordinateTransformBase):
         to_physical space should return zero when given zero pixel size.
 
         """
-        for ji in self._ji:
+        for ji, _, _ in self._known_values:
             res = to_physical_space(ji, pixel_size=0)
-            numpy.testing.assert_array_almost_equal((0, 0), res)
+            numpy.testing.assert_allclose(0, res)
 
     def test_to_physical_space_multiple(self):
         """
@@ -392,9 +404,9 @@ class ToPhysicalSpaceKnownValues(PixelIndexCoordinateTransformBase):
         of indices, or on individual indices.
 
         """
-        for kwargs, _xy in self._known_values:
-            _xy = to_physical_space(self._ji, **kwargs)
-            for ji, xy in zip(self._ji, _xy):
+        for _ji, _, kwargs in self._known_values:
+            _xy = to_physical_space(_ji, **kwargs)
+            for ji, xy in zip(_ji, _xy):
                 res = to_physical_space(ji, **kwargs)
                 numpy.testing.assert_array_almost_equal(xy, res)
 
@@ -417,21 +429,21 @@ class ToPixelIndexKnownValues(PixelIndexCoordinateTransformBase):
 
         """
         # tuple
-        for kwargs, _xy in self._known_values:
-            for ji, xy in zip(self._ji, _xy):
+        for _ji, _xy, kwargs in self._known_values:
+            for ji, xy in zip(_ji, _xy):
                 res = to_pixel_index(xy, **kwargs)
                 numpy.testing.assert_array_almost_equal(ji, res)
 
         # list of tuples
-        for kwargs, xy in self._known_values:
+        for ji, xy, kwargs in self._known_values:
             res = to_pixel_index(xy, **kwargs)
-            numpy.testing.assert_array_almost_equal(self._ji, res)
+            numpy.testing.assert_array_almost_equal(ji, res)
 
         # ndarray
-        for kwargs, _xy in self._known_values:
-            xy = numpy.array(_xy)
+        for ji, xy, kwargs in self._known_values:
+            xy = numpy.asarray(xy)
             res = to_pixel_index(xy, **kwargs)
-            numpy.testing.assert_array_almost_equal(self._ji, res)
+            numpy.testing.assert_array_almost_equal(ji, res)
 
     def test_to_pixel_index_multiple(self):
         """
@@ -439,7 +451,7 @@ class ToPixelIndexKnownValues(PixelIndexCoordinateTransformBase):
         indices, or on individual indices.
 
         """
-        for kwargs, _xy in self._known_values:
+        for _, _xy, kwargs in self._known_values:
             _ji = to_pixel_index(_xy, **kwargs)
             for ji, xy in zip(_ji, _xy):
                 res = to_pixel_index(xy, **kwargs)

--- a/src/odemis/util/test/transform_test.py
+++ b/src/odemis/util/test/transform_test.py
@@ -334,10 +334,16 @@ class PixelIndexCoordinateTransformBase(unittest.TestCase):
 
     def setUp(self):
         self._ji = [(0, 0), (0, 4), (7, 0), (7, 4), (0.5, 0.5)]
-        self._xy = [(-2, 3.5), (2, 3.5), (-2, -3.5), (2, -3.5), (-1.5, 3)]
-        self._xy2 = [(-4, 7), (4, 7), (-4, -7), (4, -7), (-3, 6)]
-        self._xy23 = [(-4, 10.5), (4, 10.5), (-4, -10.5), (4, -10.5), (-3, 9)]
-        self._shape = (8, 5)
+
+        # (shape, pixel_size, xy)
+        self._known_values = [
+            ((8, 5), None, [(-2, 3.5), (2, 3.5), (-2, -3.5), (2, -3.5), (-1.5, 3)]),
+            ((8, 5), 2, [(-4, 7), (4, 7), (-4, -7), (4, -7), (-3, 6)]),
+            ((8, 5), (2, 3), [(-4, 10.5), (4, 10.5), (-4, -10.5), (4, -10.5), (-3, 9)]),
+            (None, None, [(0, 0), (4, 0), (0, -7), (4, -7), (0.5, -0.5)]),
+            (None, 2, [(0, 0), (8, 0), (0, -14), (8, -14), (1, -1)]),
+            (None, (2, 3), [(0, 0), (8, 0), (0, -21), (8, -21), (1, -1.5)]),
+        ]
 
 
 class ToPhysicalSpaceKnownValues(PixelIndexCoordinateTransformBase):
@@ -348,31 +354,21 @@ class ToPhysicalSpaceKnownValues(PixelIndexCoordinateTransformBase):
 
         """
         # tuple
-        for ji, xy, xy2, xy23 in zip(self._ji, self._xy, self._xy2, self._xy23):
-            res = to_physical_space(ji, self._shape)
-            res2 = to_physical_space(ji, self._shape, pixel_size=2)
-            res23 = to_physical_space(ji, self._shape, pixel_size=(2, 3))
-
-            numpy.testing.assert_array_almost_equal(xy, res)
-            numpy.testing.assert_array_almost_equal(xy2, res2)
-            numpy.testing.assert_array_almost_equal(xy23, res23)
+        for shape, pixel_size, _xy in self._known_values:
+            for ji, xy in zip(self._ji, _xy):
+                res = to_physical_space(ji, shape, pixel_size)
+                numpy.testing.assert_array_almost_equal(xy, res)
 
         # list of tuples
-        res = to_physical_space(self._ji, self._shape)
-        res2 = to_physical_space(self._ji, self._shape, pixel_size=2)
-        res23 = to_physical_space(self._ji, self._shape, pixel_size=(2, 3))
-        numpy.testing.assert_array_almost_equal(self._xy, res)
-        numpy.testing.assert_array_almost_equal(self._xy2, res2)
-        numpy.testing.assert_array_almost_equal(self._xy23, res23)
+        for shape, pixel_size, xy in self._known_values:
+            res = to_physical_space(self._ji, shape, pixel_size)
+            numpy.testing.assert_array_almost_equal(xy, res)
 
         # ndarray
-        ji = numpy.array(self._ji)
-        res = to_physical_space(ji, self._shape)
-        res2 = to_physical_space(ji, self._shape, pixel_size=2)
-        res23 = to_physical_space(ji, self._shape, pixel_size=(2, 3))
-        numpy.testing.assert_array_almost_equal(self._xy, res)
-        numpy.testing.assert_array_almost_equal(self._xy2, res2)
-        numpy.testing.assert_array_almost_equal(self._xy23, res23)
+        for shape, pixel_size, xy in self._known_values:
+            ji = numpy.array(self._ji)
+            res = to_physical_space(ji, shape, pixel_size)
+            numpy.testing.assert_array_almost_equal(xy, res)
 
     def test_to_physical_space_zero_pixel_size(self):
         """
@@ -380,7 +376,7 @@ class ToPhysicalSpaceKnownValues(PixelIndexCoordinateTransformBase):
 
         """
         for ji in self._ji:
-            res = to_physical_space(ji, self._shape, pixel_size=0)
+            res = to_physical_space(ji, pixel_size=0)
             numpy.testing.assert_array_almost_equal((0, 0), res)
 
     def test_to_physical_space_multiple(self):
@@ -389,23 +385,11 @@ class ToPhysicalSpaceKnownValues(PixelIndexCoordinateTransformBase):
         of indices, or on individual indices.
 
         """
-        _xy = to_physical_space(self._ji, self._shape)
-        for ji, xy in zip(self._ji, _xy):
-            res = to_physical_space(ji, self._shape)
-            numpy.testing.assert_array_almost_equal(xy, res)
-
-    def test_to_physical_space_raises_index_error(self):
-        """
-        to_physical_space should raise an IndexError when the provided index is
-        negative or out-of-bounds.
-
-        """
-        self.assertRaises(IndexError, to_physical_space, (-1, 0), self._shape)
-        self.assertRaises(IndexError, to_physical_space, (0, -1), self._shape)
-        self.assertRaises(IndexError, to_physical_space, (-1, -1), self._shape)
-        self.assertRaises(IndexError, to_physical_space, (8, 0), self._shape)
-        self.assertRaises(IndexError, to_physical_space, (0, 5), self._shape)
-        self.assertRaises(IndexError, to_physical_space, (8, 5), self._shape)
+        for shape, pixel_size, _xy in self._known_values:
+            _xy = to_physical_space(self._ji, shape, pixel_size)
+            for ji, xy in zip(self._ji, _xy):
+                res = to_physical_space(ji, shape, pixel_size)
+                numpy.testing.assert_array_almost_equal(xy, res)
 
     def test_to_physical_space_raises_value_error(self):
         """
@@ -413,9 +397,9 @@ class ToPhysicalSpaceKnownValues(PixelIndexCoordinateTransformBase):
         not 2-dimensional.
 
         """
-        self.assertRaises(ValueError, to_physical_space, (), self._shape)
-        self.assertRaises(ValueError, to_physical_space, (1, ), self._shape)
-        self.assertRaises(ValueError, to_physical_space, (1, 2, 3), self._shape)
+        self.assertRaises(ValueError, to_physical_space, ())
+        self.assertRaises(ValueError, to_physical_space, (1, ))
+        self.assertRaises(ValueError, to_physical_space, (1, 2, 3))
 
 
 class ToPixelIndexKnownValues(PixelIndexCoordinateTransformBase):
@@ -426,33 +410,21 @@ class ToPixelIndexKnownValues(PixelIndexCoordinateTransformBase):
 
         """
         # tuple
-        for ji, xy, xy2, xy23 in zip(self._ji, self._xy, self._xy2, self._xy23):
-            res = to_pixel_index(xy, self._shape)
-            res2 = to_pixel_index(xy2, self._shape, pixel_size=2)
-            res23 = to_pixel_index(xy23, self._shape, pixel_size=(2, 3))
-
-            numpy.testing.assert_array_almost_equal(ji, res)
-            numpy.testing.assert_array_almost_equal(ji, res2)
-            numpy.testing.assert_array_almost_equal(ji, res23)
+        for shape, pixel_size, _xy in self._known_values:
+            for ji, xy in zip(self._ji, _xy):
+                res = to_pixel_index(xy, shape, pixel_size)
+                numpy.testing.assert_array_almost_equal(ji, res)
 
         # list of tuples
-        res = to_pixel_index(self._xy, self._shape)
-        res2 = to_pixel_index(self._xy2, self._shape, pixel_size=2)
-        res23 = to_pixel_index(self._xy23, self._shape, pixel_size=(2, 3))
-        numpy.testing.assert_array_almost_equal(self._ji, res)
-        numpy.testing.assert_array_almost_equal(self._ji, res2)
-        numpy.testing.assert_array_almost_equal(self._ji, res23)
+        for shape, pixel_size, xy in self._known_values:
+            res = to_pixel_index(xy, shape, pixel_size)
+            numpy.testing.assert_array_almost_equal(self._ji, res)
 
         # ndarray
-        xy = numpy.array(self._xy)
-        xy2 = numpy.array(self._xy2)
-        xy23 = numpy.array(self._xy23)
-        res = to_pixel_index(xy, self._shape)
-        res2 = to_pixel_index(xy2, self._shape, pixel_size=2)
-        res23 = to_pixel_index(xy23, self._shape, pixel_size=(2, 3))
-        numpy.testing.assert_array_almost_equal(self._ji, res)
-        numpy.testing.assert_array_almost_equal(self._ji, res2)
-        numpy.testing.assert_array_almost_equal(self._ji, res23)
+        for shape, pixel_size, _xy in self._known_values:
+            xy = numpy.array(_xy)
+            res = to_pixel_index(xy, shape, pixel_size)
+            numpy.testing.assert_array_almost_equal(self._ji, res)
 
     def test_to_pixel_index_multiple(self):
         """
@@ -460,10 +432,11 @@ class ToPixelIndexKnownValues(PixelIndexCoordinateTransformBase):
         indices, or on individual indices.
 
         """
-        _ji = to_pixel_index(self._xy, self._shape)
-        for xy, ji in zip(self._xy, _ji):
-            res = to_pixel_index(xy, self._shape)
-            numpy.testing.assert_array_almost_equal(ji, res)
+        for shape, pixel_size, _xy in self._known_values:
+            _ji = to_pixel_index(_xy, shape, pixel_size)
+            for ji, xy in zip(_ji, _xy):
+                res = to_pixel_index(xy, shape, pixel_size)
+                numpy.testing.assert_array_almost_equal(ji, res)
 
     def test_to_pixel_index_raises_value_error(self):
         """
@@ -471,9 +444,9 @@ class ToPixelIndexKnownValues(PixelIndexCoordinateTransformBase):
         is not 2-dimensional.
 
         """
-        self.assertRaises(ValueError, to_pixel_index, (), self._shape)
-        self.assertRaises(ValueError, to_pixel_index, (1, ), self._shape)
-        self.assertRaises(ValueError, to_pixel_index, (1, 2, 3), self._shape)
+        self.assertRaises(ValueError, to_pixel_index, ())
+        self.assertRaises(ValueError, to_pixel_index, (1, ))
+        self.assertRaises(ValueError, to_pixel_index, (1, 2, 3))
 
 
 class RotationMatrixKnownValues(unittest.TestCase):

--- a/src/odemis/util/transform.py
+++ b/src/odemis/util/transform.py
@@ -194,27 +194,29 @@ def _optimal_rotation(x, y):
     return numpy.dot(V.T, U.T)
 
 
-def to_physical_space(ji, shape, pixel_size=None):
+def to_physical_space(ji, shape=None, pixel_size=None):
     """
     Converts an image pixel index into a coordinate in physical space.
 
     Images are displayed on a computer screen with the origin in the top-left
-    corner. The column-index `i` is used as the primary axis and the row-index
-    `j` is used as the secondary axis. This represents a left-handed coordinate
-    system. Physical coordinates are typically described in a right-handed
-    coordinate system.
+    corner. The position of a pixel is described by a pixel index `(j, i)`,
+    where `j` is the row-index and `i` is the column-index. The index `(0, 0)`
+    is located at the center of the top-left pixel. Note that the index does
+    not need to be integer, i.e. the pixel index `(-0.5, -0.5)` is at the
+    top-left corner of the image.
 
-    Calculations should be done preferably in the right-handed physical
-    coordinate system. Calculations using mixed left-handed and right-handed
-    coordinates should be avoided.
+    A position in physical space is typically given in coordinates `(x, y)`.
+    The x-axis is aligned with the columns of the image, and the y-axis with
+    the rows. The direction of the y-axis is opposite to the row-index, such
+    that it is increasing in the upward direction.
 
     `to_physical_space` converts an image pixel index into a coordinate in
-    physical space. The x-axis is aligned with the columns of the image, and
-    the y-axis with the rows. The direction of the y-axis is opposite to the
-    row-index, such that it is increasing in the upward direction. The origin
-    is placed at the center of the image. If the image has an even amount of
-    rows and/or columns, the origin will be at the boundary between two pixels
-    and the physical coordinates will be non-integer.
+    physical space. The origin is moved to the center of the image when
+    provided with the shape of the image. Note that if the image has an even
+    amount of rows and/or columns, the origin will be at the boundary between
+    two pixels and the physical coordinates will be non-integer. If the shape
+    of the image is not provided the origin is not altered. This is useful when
+    converting a relative displacement (shift) in pixels.
 
 
               Image Pixel Indices                   Physical Coordinates
@@ -241,9 +243,10 @@ def to_physical_space(ji, shape, pixel_size=None):
         Pixel index, list of indices, or array of indices. For each index the
         first entry is the row-index `j` and the second entry is the
         column-index `i`.
-    shape : tuple of ints
+    shape : tuple of ints (optional)
         Shape of the image. The first entry is the number of rows, the second
-        entry is the number of columns in the image.
+        entry is the number of columns in the image. Used to move the origin to
+        the center of the image. If not provided the origin is not altered.
     pixel_size : tuple of 2 floats, float (optional)
         Pixel size in (x, y). For square pixels, a single float can be
         provided.
@@ -270,18 +273,19 @@ def to_physical_space(ji, shape, pixel_size=None):
 
     """
     ji = numpy.asarray(ji)
-    n, m = shape
 
-    if numpy.any(ji < 0):
-        raise IndexError("Negative indices (wrap-around) are not supported.")
-    if numpy.any(ji >= shape):
-        raise IndexError("Index out of range.")
     if ji.shape[-1] != 2:
         raise ValueError("Indices must be 2-dimensional.")
 
     xy = numpy.empty(ji.shape, dtype=float)
-    xy[..., 0] = ji[..., 1] - 0.5 * (m - 1)  # map column-index `i` to x-axis
-    xy[..., 1] = 0.5 * (n - 1) - ji[..., 0]  # map row-index `j` to y-axis
+    xy[..., 0] = ji[..., 1]   # map column-index `i` to x-axis
+    xy[..., 1] = -ji[..., 0]  # map row-index `j` to y-axis
+
+    if shape:
+        # Move the origin to the center of the image.
+        n, m = shape
+        xy[..., 0] -= 0.5 * (m - 1)
+        xy[..., 1] += 0.5 * (n - 1)
 
     if pixel_size is not None:
         xy *= pixel_size
@@ -289,7 +293,7 @@ def to_physical_space(ji, shape, pixel_size=None):
     return xy
 
 
-def to_pixel_index(xy, shape, pixel_size=None):
+def to_pixel_index(xy, shape=None, pixel_size=None):
     """
     Converts a coordinate in physical space into an image pixel index.
 
@@ -297,7 +301,10 @@ def to_pixel_index(xy, shape, pixel_size=None):
     coordinate in physical space into an image pixel index. The columns of the
     image are aligned with the x-axis, and the rows with the y-axis. The
     direction of the y-axis is opposite to the row-index. The origin of the
-    image pixel index is placed at the center of the top-left pixel.
+    image pixel index is moved to the center of the top-left pixel when
+    provided with the shape of the image. If the shape of the image is not
+    provided the origin is not altered. This is useful when converting a
+    relative displacement (shift).
 
     Parameters
     ----------
@@ -305,7 +312,7 @@ def to_pixel_index(xy, shape, pixel_size=None):
         Physical coordinates, list of coordinates, or array of coordinates. For
         each coordinate the first entry is the `x`-coordinate and the second
         entry is the `y`-coordinate.
-    shape : tuple of ints
+    shape : tuple of ints (optional)
         Shape of the image. The first entry is the number of rows, the second
         entry is the number of columns in the image.
     pixel_size : tuple of 2 floats, float (optional)
@@ -342,10 +349,14 @@ def to_pixel_index(xy, shape, pixel_size=None):
     if xy.shape[-1] != 2:
         raise ValueError("Coordinates must be 2-dimensional.")
 
-    n, m = shape
     ji = numpy.empty(xy.shape, dtype=float)
-    ji[..., 0] = 0.5 * (n - 1) - xy[..., 1]  # map y-axis to row-index `j`
-    ji[..., 1] = xy[..., 0] + 0.5 * (m - 1)  # map x-axis to column-index `i`
+    ji[..., 0] = -xy[..., 1]  # map y-axis to row-index `j`
+    ji[..., 1] = xy[..., 0]   # map x-axis to column-index `i`
+
+    if shape:
+        n, m = shape
+        ji[..., 0] += 0.5 * (n - 1)
+        ji[..., 1] += 0.5 * (m - 1)
 
     return ji
 

--- a/src/odemis/util/transform.py
+++ b/src/odemis/util/transform.py
@@ -314,7 +314,8 @@ def to_pixel_index(xy, shape=None, pixel_size=None):
         entry is the `y`-coordinate.
     shape : tuple of ints (optional)
         Shape of the image. The first entry is the number of rows, the second
-        entry is the number of columns in the image.
+        entry is the number of columns in the image. If not provided the origin
+        is not altered.
     pixel_size : tuple of 2 floats, float (optional)
         Pixel size in (x, y). For square pixels, a single float can be
         provided. If not specified, a pixel size of 1 is used.


### PR DESCRIPTION
Useful when converting a relative displacement (shift).