### PR TITLE
driver-tfsbc: log requested shift

### DIFF
--- a/src/odemis/driver/tfsbc.py
+++ b/src/odemis/driver/tfsbc.py
@@ -237,6 +237,7 @@ class BeamShiftController(model.HwComponent):
         """
         :param value (float, float): x, y shift from the center (in m)
         """
+        logging.debug("Requesting shift of %s m." % value)
         try:
             xlower, ylower, xupper, yupper = self._metadata[model.MD_CALIB]
         except KeyError:


### PR DESCRIPTION
It is quite useful for debugging purposes to also log the requested shift in the scan coordinate system (and not only the register values).