### PR TITLE
driver npmc: fix the Python 3 fix not working on Python 3

### DIFF
--- a/src/odemis/driver/npmc.py
+++ b/src/odemis/driver/npmc.py
@@ -176,7 +176,7 @@ class ESP(model.Actuator):
         self.referenced = model.VigilantAttribute({a: False for a in axes}, readonly=True)
 
         self._hwVersion = str(self._id)
-        self._swVersion = self._version.decode('latin1')
+        self._swVersion = self._version
 
         # Get the position in object coord with the offset applied.
 


### PR DESCRIPTION
commit 59ed1a8f45 (fix instantiation on Python 3) tried to
fix the code for Python 3, but it didn't even work at init.
I guess I mistakenly only tested on Python 2...
Anyway, now it should be properly working.