### PR TITLE
driver lakeshore: fix instantiation in the backend

### DIFF
--- a/src/odemis/driver/lakeshore.py
+++ b/src/odemis/driver/lakeshore.py
@@ -77,9 +77,10 @@ class Lakeshore(model.HwComponent):
         port: (str) port name. Can be a pattern, in which case all the ports
           fitting the pattern will be tried.
           Use /dev/fake for a simulator
-        sensor_input (str): The sensor input to use, typically 'a' or 'b'
+        sensor_input (str): The sensor input to use, typically 'A' or 'B'
         output_channel: (int): The channel output to control, typically 1 or 2
         """
+        super(Lakeshore, self).__init__(name, role, **kwargs)
 
         # Connect to serial port
         self._ser_access = threading.Lock()

--- a/src/odemis/driver/test/lakeshore_test.py
+++ b/src/odemis/driver/test/lakeshore_test.py
@@ -25,8 +25,6 @@ from __future__ import division
 
 import logging
 from odemis.driver import lakeshore
-import odemis.model as model
-from odemis.util import test
 import os
 import time
 import unittest
@@ -42,7 +40,7 @@ TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
 CONFIG = {"name": "Lakeshore Test",
           "role": "temperature-controller",
           "port": "/dev/ttyUSB0",
-          "sensor_input": 'b',
+          "sensor_input": "B",
           "output_channel": 2,
 }
 


### PR DESCRIPTION
The class needs to call the super() with **kwargs, in order to have the
component registered as a Pyro4 object, so that it's not directly
passed, but instead a proxy is passed.