### PR TITLE
remove unused imports

### DIFF
--- a/src/odemis/acq/_futures.py
+++ b/src/odemis/acq/_futures.py
@@ -23,7 +23,6 @@ from concurrent.futures._base import CancelledError, FINISHED, CANCELLED, \
 import logging
 from odemis import model
 from odemis.util import executeAsyncTask
-import sys
 import threading
 import time
 

--- a/src/odemis/driver/picoquant.py
+++ b/src/odemis/driver/picoquant.py
@@ -17,7 +17,6 @@ You should have received a copy of the GNU General Public License along with Ode
 
 from __future__ import division
 
-from concurrent import futures
 from ctypes import *
 import ctypes
 from decorator import decorator

--- a/src/odemis/driver/semcomedi.py
+++ b/src/odemis/driver/semcomedi.py
@@ -37,7 +37,6 @@ import odemis
 from odemis.model import roattribute, oneway
 from odemis.util import driver, get_best_dtype_for_acc
 import os
-import re
 import threading
 import time
 import weakref

--- a/src/odemis/driver/simcam.py
+++ b/src/odemis/driver/simcam.py
@@ -28,7 +28,7 @@ import queue
 import logging
 import numpy
 from odemis import model, util, dataio
-from odemis.model import BASE_DIRECTORY, oneway
+from odemis.model import oneway
 import os
 from scipy import ndimage
 import time

--- a/src/odemis/driver/technolution.py
+++ b/src/odemis/driver/technolution.py
@@ -30,7 +30,6 @@ import json
 import logging
 import queue
 import re
-import signal
 import threading
 import time
 from PIL import Image

--- a/src/odemis/driver/tescan.py
+++ b/src/odemis/driver/tescan.py
@@ -38,7 +38,6 @@ from tescan import sem, CancelledError
 import threading
 import time
 import weakref
-from past.builtins import long
 
 ACQ_CMD_UPD = 1
 ACQ_CMD_TERM = 2

--- a/src/odemis/driver/tfsbc.py
+++ b/src/odemis/driver/tfsbc.py
@@ -24,7 +24,6 @@ from __future__ import division
 import logging
 
 import numpy
-import serial
 import serial.tools.list_ports
 from pymodbus.client.sync import ModbusSerialClient
 

--- a/src/odemis/gui/acqmng.py
+++ b/src/odemis/gui/acqmng.py
@@ -26,7 +26,6 @@ from __future__ import division
 from collections import OrderedDict
 import collections
 import logging
-from odemis import model
 
 EXTRA_STREAM_VAS = ("dwellTime", "pixelSize", "repetition")
 

--- a/src/odemis/gui/comp/canvas.py
+++ b/src/odemis/gui/comp/canvas.py
@@ -149,7 +149,6 @@ from odemis.gui.util.conversion import wxcol_to_frgb
 from odemis.gui.util.img import add_alpha_byte, apply_rotation, apply_shear, apply_flip, get_sub_img
 from odemis.util import intersect
 import os
-import sys
 import wx
 from wx.lib import wxcairo
 

--- a/src/odemis/gui/comp/combo.py
+++ b/src/odemis/gui/comp/combo.py
@@ -32,11 +32,8 @@ import logging
 from odemis.gui import img
 import odemis.gui
 from odemis.gui.comp.buttons import ImageButton, darken_image
-from odemis.gui.conf.data import COLORMAPS
 import wx
 import wx.adv
-from matplotlib import cm
-import matplotlib.colors as colors
 from odemis.util.img import getColorbar, tintToColormap
 
 

--- a/src/odemis/gui/comp/overlay/view.py
+++ b/src/odemis/gui/comp/overlay/view.py
@@ -24,7 +24,6 @@ This file is part of Odemis.
 from __future__ import division
 
 import cairo
-import itertools
 import logging
 import math
 import numbers

--- a/src/odemis/gui/comp/overlay/world.py
+++ b/src/odemis/gui/comp/overlay/world.py
@@ -30,7 +30,6 @@ import math
 from odemis import model, util
 from odemis.acq.stream import UNDEFINED_ROI
 from odemis.gui import img
-from odemis.gui.comp.buttons import ImageTextButton
 from odemis.gui.comp.overlay.base import Vec, WorldOverlay, Label, SelectionMixin, DragMixin, \
     PixelDataMixin, SEL_MODE_EDIT, SEL_MODE_CREATE, EDIT_MODE_BOX, EDIT_MODE_POINT, SpotModeBase
 from odemis.gui.model import TOOL_RULER, TOOL_LABEL, TOOL_NONE

--- a/src/odemis/gui/comp/stream.py
+++ b/src/odemis/gui/comp/stream.py
@@ -48,9 +48,7 @@ import wx
 import wx.lib.newevent
 from wx.lib.pubsub import pub
 from odemis.gui.conf.data import COLORMAPS
-from matplotlib import cm
 import matplotlib.colors as colors
-import numpy
 
 stream_remove_event, EVT_STREAM_REMOVE = wx.lib.newevent.NewEvent()
 stream_visible_event, EVT_STREAM_VISIBLE = wx.lib.newevent.NewEvent()

--- a/src/odemis/gui/comp/text.py
+++ b/src/odemis/gui/comp/text.py
@@ -31,7 +31,6 @@ from builtins import str, chr # For Python 2 & 3
 import locale
 import logging
 import math
-import numpy
 import os
 import re
 import string

--- a/src/odemis/gui/cont/streams.py
+++ b/src/odemis/gui/cont/streams.py
@@ -35,7 +35,7 @@ import numpy
 from odemis import model, util
 from odemis.acq.stream import MeanSpectrumProjection
 from odemis.gui import FG_COLOUR_DIS, FG_COLOUR_WARNING, FG_COLOUR_ERROR, \
-    CONTROL_COMBO, CONTROL_FLT, FG_COLOUR_MAIN, BG_COLOUR_MAIN
+    CONTROL_COMBO, CONTROL_FLT
 from odemis.gui.comp.overlay.world import RepetitionSelectOverlay
 from odemis.gui.comp.stream import StreamPanel, EVT_STREAM_VISIBLE, \
     EVT_STREAM_PEAK, OPT_BTN_REMOVE, OPT_BTN_SHOW, OPT_BTN_UPDATE, OPT_BTN_TINT, \

--- a/src/odemis/gui/log.py
+++ b/src/odemis/gui/log.py
@@ -21,7 +21,6 @@ from __future__ import division, print_function
 
 import collections
 import logging
-import time
 from logging.handlers import RotatingFileHandler
 from odemis.gui import FG_COLOUR_ERROR, FG_COLOUR_WARNING, FG_COLOUR_DIS, FG_COLOUR_MAIN
 from odemis.gui.util import wxlimit_invocation, get_home_folder

--- a/src/odemis/gui/main.py
+++ b/src/odemis/gui/main.py
@@ -22,7 +22,6 @@ see http://www.gnu.org/licenses/.
 from __future__ import division, print_function
 
 from odemis.gui.util import wx_adapter
-import Pyro4
 import Pyro4.errors
 import argparse
 import logging

--- a/src/odemis/gui/util/img.py
+++ b/src/odemis/gui/util/img.py
@@ -25,7 +25,6 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 from __future__ import division
 
 from past.builtins import basestring
-from odemis.gui.util import wx_adapter
 import threading
 import cairo
 import logging
@@ -34,7 +33,7 @@ import numpy
 from odemis import model
 from odemis.gui import BLEND_SCREEN, BLEND_DEFAULT
 from odemis.gui.comp.overlay.base import Label
-from odemis.util import intersect, fluo, conversion, img, units
+from odemis.util import intersect, fluo, img, units
 import time
 import wx
 import odemis.acq.stream as acqstream
@@ -44,7 +43,6 @@ from odemis.acq.stream import RGBProjection, RGBSpatialProjection,\
     SinglePointTemporalProjection, DataProjection
 from odemis.model import TINT_FIT_TO_RGB, TINT_RGB_AS_IS
 from odemis.model import DataArrayShadow
-import matplotlib.colors as colors
 
 BAR_PLOT_COLOUR = (0.5, 0.5, 0.5)
 CROP_RES_LIMIT = 1024

--- a/src/odemis/gui/win/acquisition.py
+++ b/src/odemis/gui/win/acquisition.py
@@ -31,7 +31,7 @@ import math
 from odemis import model, dataio
 from odemis.acq import stream, path, acqmng, stitching
 from odemis.util.comp import compute_camera_fov
-from odemis.acq.stream import NON_SPATIAL_STREAMS, EMStream, StaticStream, OpticalStream, ScannedFluoStream, LiveStream
+from odemis.acq.stream import NON_SPATIAL_STREAMS, EMStream, OpticalStream, ScannedFluoStream, LiveStream
 from odemis.gui.acqmng import presets, preset_as_is, apply_preset, \
     get_global_settings_entries, get_local_settings_entries
 from odemis.gui.comp.overlay.world import RepetitionSelectOverlay
@@ -46,7 +46,6 @@ from odemis.gui.util.widgets import ProgressiveFutureConnector
 from odemis.util import units
 from odemis.util.filename import guess_pattern, create_filename, update_counter
 import os.path
-import time
 import wx
 
 import odemis.gui.model as guimodel

--- a/src/odemis/util/img.py
+++ b/src/odemis/util/img.py
@@ -32,7 +32,6 @@ import scipy.ndimage
 import cv2
 
 from odemis.model import MD_DWELL_TIME, MD_EXP_TIME, TINT_FIT_TO_RGB, TINT_RGB_AS_IS
-from odemis.util.conversion import get_img_transformation_matrix
 from odemis.util import get_best_dtype_for_acc
 from odemis.util.conversion import get_img_transformation_matrix, rgb_to_frgb
 import matplotlib.colors as colors


### PR DESCRIPTION
All of the unused imports are actually used by other modules, which
typically are used at the same time, so it wouldn't change much.

Still, it cleans up the code.