### PR TITLE
gui util img: fix merge_screen() only returning original im

### DIFF
--- a/src/odemis/gui/util/img.py
+++ b/src/odemis/gui/util/img.py
@@ -2609,16 +2609,15 @@ def merge_screen(im, background):
     Merges two images (im and background) into one using the "screen" operator:
     f(xA,xB) = xA + xB − xA·xB (with values between 0 and 1, with each channel independent)
     im, background: DataArray with im.shape = background.shape (either RGB or RGBA)
-    returns RGB DataArray (of the same shape as im)
+    returns RGBA DataArray (of the same YX as im, but with always depth=4)
     """
     assert im.shape == background.shape, "Images have different shapes."
     if im.shape[-1] != 3 and im.shape[-1] != 4:
         raise ValueError("Ovv images have an invalid number of channels: %d" % (im.shape[-1]))
 
-    md = im.metadata.copy()
-    md["dc_keepalpha"] = True
+    md = background.metadata.copy()
     im = format_rgba_darray(im, 255)  # convert to BGRA
-    im = model.DataArray(im, md)
+    im.metadata["dc_keepalpha"] = True
     background = format_rgba_darray(background, 255)
 
     height, width, _ = im.shape
@@ -2635,6 +2634,7 @@ def merge_screen(im, background):
                buffer_size, 1, blend_mode=BLEND_SCREEN)
 
     # Convert back to RGB
-    format_bgra_to_rgb(im, inplace=True)
-    return im
+    format_bgra_to_rgb(background, inplace=True)
+    background.metadata = md
+    return background
 

--- a/src/odemis/gui/util/test/img_test.py
+++ b/src/odemis/gui/util/test/img_test.py
@@ -1403,19 +1403,20 @@ class TestOverviewFunctions(unittest.TestCase):
         opt = model.DataArray(200 * numpy.ones((10, 10, 3), dtype=numpy.uint8), md)
         sem = model.DataArray(10 * numpy.ones((10, 10, 3), dtype=numpy.uint8), md)
         merged = merge_screen(opt, sem)
+        self.assertEqual(merged.shape, (10, 10, 4))
         # Test if at least one element of ovv image is different from original images
-        # self.assertEqual(merged.shape, (10, 10, 3))
-        self.assertTrue(numpy.all(merged >= opt))
-        self.assertTrue(numpy.any(merged != opt))
-        self.assertTrue(numpy.all(merged >= sem))
-        self.assertTrue(numpy.any(merged != sem))
+        merged_rgb = merged[:,:,:3]
+        self.assertTrue(numpy.all(merged_rgb >= opt))
+        self.assertTrue(numpy.any(merged_rgb != opt))
+        self.assertTrue(numpy.all(merged_rgb >= sem))
+        self.assertTrue(numpy.any(merged_rgb != sem))
 
         # Two very bright images should give a complete white
-        opt = model.DataArray(250 * numpy.ones((10, 10, 3), dtype=numpy.uint8), md)
-        sem = model.DataArray(250 * numpy.ones((10, 10, 3), dtype=numpy.uint8), md)
+        opt = model.DataArray(250 * numpy.ones((10, 12, 3), dtype=numpy.uint8), md)
+        sem = model.DataArray(250 * numpy.ones((10, 12, 3), dtype=numpy.uint8), md)
         merged = merge_screen(opt, sem)
-        # Test if at least one element of ovv image is different from original images
-        # self.assertEqual(merged.shape, (10, 10, 3))
+        self.assertEqual(merged.shape, (10, 12, 4))
+        # all pixels are white, without any transparency
         self.assertTrue(numpy.all(merged == 255))
 
 


### PR DESCRIPTION
In commit e7789884b3 (add format_bgra_to_rgb() function), merge_screen()
was updated to make use of the new function, but that was incorrectly
done, as the original code was a little confusing.

It needs to return the update *background*, not the input im.

Also update the docstring and test cases to indicate now it returns a
RGBA (instead of RGB or RGBA). The actual calling code in Odemis doesn't
care.