### PR TITLE
gui comp: Also show CLStreams using "screen" operator

### DIFF
--- a/src/odemis/gui/comp/miccanvas.py
+++ b/src/odemis/gui/comp/miccanvas.py
@@ -456,9 +456,9 @@ class DblMicroscopeCanvas(canvas.DraggableCanvas):
             # FluoStreams are merged using the "Screen" method that handles colour
             # merging without decreasing the intensity.
             ostream = s.stream if isinstance(s, DataProjection) else s
-            if isinstance(ostream, (stream.FluoStream, stream.StaticFluoStream)):
+            if isinstance(ostream, (stream.FluoStream, stream.StaticFluoStream, stream.CLStream)):
                 images_opt.append((image, BLEND_SCREEN, s.name.value, s))
-            elif isinstance(ostream, (stream.SpectrumStream, stream.CLStream)):
+            elif isinstance(ostream, stream.SpectrumStream):
                 images_spc.append((image, BLEND_DEFAULT, s.name.value, s))
             else:
                 images_std.append((image, BLEND_DEFAULT, s.name.value, s))

--- a/src/odemis/gui/comp/viewport.py
+++ b/src/odemis/gui/comp/viewport.py
@@ -442,45 +442,29 @@ class MicroscopeViewport(ViewPort):
                 len(self._view.stream_tree) >= 2
         ):
             streams = self._view.getStreams()
-            all_opt = all(isinstance(s, (FluoStream, StaticFluoStream)) for s in streams)
+            all_opt = all(isinstance(s, (FluoStream, StaticFluoStream, CLStream)) for s in streams)
 
             # If all images are optical, assume they are merged using screen blending and no
             # merge ratio is required
             if all_opt:
                 self.ShowMergeSlider(False)
             else:
-                # TODO: How is the order guaranteed? (Left vs Right)
-                # => it should be done in the MicroscopeView when adding a stream
-                # For now, special hack for the MicroscopeCanvas which always sets
-                # the EM image as "right" (ie, it's drawn last).
-                # If there is EM and Spectrum or CL, the spectrum/CL image is always
-                # set as "right" (ie, it's drawn last).
+                # TODO: For now the order is set in the MicroscopeCanvas, but it
+                # should be done in the MicroscopeView when adding a stream.
+                # The order is: (left) CL/Fluo < EM/anything else < Spectrum (right)
                 # Note: in practice, there is no AR spatial stream, so it's
                 # never mixed with any other stream.
-                if (
-                        any(isinstance(s, EMStream) for s in streams) and
-                        any(isinstance(s, (FluoStream, StaticFluoStream)) for s in streams)
-                ):
-                    # TODO: don't hard-code MD_AT_FLUO and MD_AT_EM but use the
-                    # acquisitionType of the corresponding streams.
-                    self.bottom_legend.set_stream_type(wx.LEFT, model.MD_AT_FLUO)
-                    self.bottom_legend.set_stream_type(wx.RIGHT, model.MD_AT_EM)
-                elif (
-                        any(isinstance(s, EMStream) for s in streams) and
-                        any(isinstance(s, SpectrumStream) for s in streams)
-                ):
-                    self.bottom_legend.set_stream_type(wx.LEFT, model.MD_AT_EM)
-                    self.bottom_legend.set_stream_type(wx.RIGHT, model.MD_AT_SPECTRUM)
-                elif (
-                        any(isinstance(s, EMStream) for s in streams) and
-                        any(isinstance(s, CLStream) for s in streams)
-                ):
-                    self.bottom_legend.set_stream_type(wx.LEFT, model.MD_AT_EM)
-                    self.bottom_legend.set_stream_type(wx.RIGHT, model.MD_AT_CL)
-                else:
-                    self.bottom_legend.set_stream_type(wx.LEFT, streams[0].acquisitionType.value)
-                    self.bottom_legend.set_stream_type(wx.RIGHT, streams[1].acquisitionType.value)
+                def get_stream_prio(s):
+                    if isinstance(s, (FluoStream, StaticFluoStream, CLStream)):
+                        return 0
+                    elif isinstance(s, SpectrumStream):
+                        return 2
+                    else:
+                        return 1
 
+                streams_ordered = sorted(streams, key=get_stream_prio)
+                self.bottom_legend.set_stream_type(wx.LEFT, streams_ordered[0].acquisitionType.value)
+                self.bottom_legend.set_stream_type(wx.RIGHT, streams_ordered[-1].acquisitionType.value)
                 self.ShowMergeSlider(True)
         else:
             self.ShowMergeSlider(False)

--- a/src/odemis/gui/util/img.py
+++ b/src/odemis/gui/util/img.py
@@ -1994,9 +1994,9 @@ def get_ordered_images(streams, raw=False):
 
         # FluoStreams are merged using the "Screen" method that handles colour
         # merging without decreasing the intensity.
-        if isinstance(ostream, acqstream.OpticalStream):
+        if isinstance(ostream, (acqstream.FluoStream, acqstream.StaticFluoStream, acqstream.CLStream)):
             images_opt.append((data, BLEND_SCREEN, ostream, md))
-        elif isinstance(ostream, (acqstream.SpectrumStream, acqstream.CLStream)):
+        elif isinstance(ostream, acqstream.SpectrumStream):
             images_spc.append((data, BLEND_DEFAULT, ostream, md))
         else:
             images_std.append((data, BLEND_DEFAULT, ostream, md))


### PR DESCRIPTION
They are also typically shown using tint, several of them together (eg,
using some RGB filters), and so it makes more sense to add the pixel
values, like for the FluoStreams, instead of averaging.

Note that in case there is only one CLStream, it's always shown first,
so it doesn't affect the behaviour in this case.