### PR TITLE
acq stream ARRawProjection: use the tint

### DIFF
--- a/src/odemis/acq/stream/_projection.py
+++ b/src/odemis/acq/stream/_projection.py
@@ -444,7 +444,7 @@ class ARRawProjection(ARProjection):
                 self.stream._drange = None
                 self.stream._updateHistogram(polar_data)
 
-                self.image.value = self._project2RGB(polar_data)
+                self.image.value = self._project2RGB(polar_data, self.stream.tint.value)
         except Exception:
             logging.exception("Updating %s image", self.__class__.__name__)
 


### PR DESCRIPTION
In the update to use the tint, we added the support for it when
exporting the data, but not when displaying it in the GUI.
=> Also use the tint in the GUI display.