### PR TITLE
update doc:

### DIFF
--- a/doc/develop/documentation.rst
+++ b/doc/develop/documentation.rst
@@ -23,7 +23,7 @@ For more information on using Sphinx, refer to:
 Note, in case you don't have it yet, install sphinx (and other needed software)
 with::
 
-    sudo apt-get install python-sphinx inkscape dia-gnome texlive
+    sudo apt-get install python-sphinx inkscape texlive latexmk
 
 To build a manual, go to its root directory (e.g., ``doc/develop/``) and depending
 on the format you want to obtain either run ``make html`` (for HTML) or 

--- a/doc/develop/extending.rst
+++ b/doc/develop/extending.rst
@@ -99,7 +99,7 @@ and type the following::
     comedi_config /dev/comedi1 comedi_test 100000,100000
 
 Finally, make it executable with ``sudo chmod a+x /etc/rc.local``. You can run
-it immediately by typing ``/etc/rc.local``.
+it immediately by typing ``sudo /etc/rc.local``.
 
 Install PyCharm
 """""""""""""""


### PR DESCRIPTION
* add sudo in order to be able to directly use the comedi drivers when starting a simulator with Odemis
* add latexmk package as it is required to build the developer manual
* remove dia-gnome package -> was not found and seemed not to be needed to successfully compile the manual