### PR TITLE
gui comp: allow changing merge ratio between two Fluo or CL streams

### DIFF
--- a/src/odemis/gui/comp/canvas.py
+++ b/src/odemis/gui/comp/canvas.py
@@ -935,6 +935,12 @@ class BitmapCanvas(BufferedCanvas):
 
         if images:
             n = len(images)
+
+            im_last = images[-1]
+            if isinstance(im_last, tuple):
+                im_last = im_last[0][0]  # first tile
+            bm_last = im_last.metadata["blend_mode"]
+
             for i, im in enumerate(images):
                 if isinstance(im, tuple):
                     first_tile = im[0][0]
@@ -945,15 +951,39 @@ class BitmapCanvas(BufferedCanvas):
                 else:
                     md = im.metadata
 
-                if md['blend_mode'] == BLEND_SCREEN:
+                blend_mode = md['blend_mode']
+                if n == 1: # For single image, don't use merge ratio
                     merge_ratio = 1.0
-                elif i == n - 1: # last image
-                    if n == 1:
-                        merge_ratio = 1.0
-                    else:
-                        merge_ratio = self.merge_ratio
                 else:
-                    merge_ratio = 1 - i / n
+                    # If there are all "screen" (= last one is screen):
+                    # merge ratio   im0   im1
+                    #     0         1      0
+                    #    0.25       1      0.5
+                    #    0.5        1      1
+                    #    0.75       0.5    1
+                    #     1         0      1
+                    # TODO: for now, this only works correctly if the background
+                    # is black (otherwise, the background is also mixed in)
+                    if bm_last == BLEND_SCREEN:
+                        if ((self.merge_ratio < 0.5 and i < n - 1) or
+                            (self.merge_ratio >= 0.5 and i == n - 1)):
+                            merge_ratio = 1
+                        else:
+                            merge_ratio = (0.5 - abs(self.merge_ratio - 0.5)) * 2
+                    else:  # bm_last == BLEND_DEFAULT
+                        # Average all the first images
+                        if i < n - 1:
+                            if blend_mode == BLEND_SCREEN:
+                                merge_ratio = 1.0
+                            else:
+                                merge_ratio = 1 - i / n
+                        else:  # last image
+                            merge_ratio = self.merge_ratio
+
+                # Reset the first image to be drawn to the default blend operator to be
+                # drawn full opacity (only useful if the background is not full black)
+                if i == 0:
+                    blend_mode = BLEND_DEFAULT
 
                 if isinstance(im, tuple):
                     self._draw_tiles(
@@ -965,7 +995,7 @@ class BitmapCanvas(BufferedCanvas):
                         rotation=md['dc_rotation'],
                         shear=md['dc_shear'],
                         flip=md['dc_flip'],
-                        blend_mode=md['blend_mode'],
+                        blend_mode=blend_mode,
                         interpolate_data=interpolate_data
                     )
                 else:
@@ -978,7 +1008,7 @@ class BitmapCanvas(BufferedCanvas):
                         rotation=im.metadata['dc_rotation'],
                         shear=im.metadata['dc_shear'],
                         flip=im.metadata['dc_flip'],
-                        blend_mode=im.metadata['blend_mode'],
+                        blend_mode=blend_mode,
                         interpolate_data=interpolate_data
                     )
 

--- a/src/odemis/gui/comp/miccanvas.py
+++ b/src/odemis/gui/comp/miccanvas.py
@@ -482,11 +482,6 @@ class DblMicroscopeCanvas(canvas.DraggableCanvas):
         images_spc.sort(key=get_area, reverse=True)
         images_std.sort(key=get_area, reverse=True)
 
-        # Reset the first image to be drawn to the default blend operator to be
-        # drawn full opacity (only useful if the background is not full black)
-        if images_opt:
-            images_opt[0] = (images_opt[0][0], BLEND_DEFAULT, images_opt[0][2], images_opt[0][3])
-
         return images_opt + images_std + images_spc
 
     def _format_rgba_darray_cached(self, da):


### PR DESCRIPTION
For simplification, we had said that such image is always shown
all together (ie, merge ratio == 0.5). It might still be handy in some
cases to be able to change the display ratio finely between two images.

Note that if the ratio != 0.5 and the background is not black, the
background will be seen a little bit. As this only happens in some
internal debug mode, that shouldn't matter.