### PR TITLE
acq stream TemporalSpectrumSettingsStream: avoid errors when .raw is empty

### DIFF
--- a/src/odemis/acq/stream/_helper.py
+++ b/src/odemis/acq/stream/_helper.py
@@ -797,12 +797,12 @@ class TemporalSpectrumSettingsStream(CCDSettingsStream):
         Find the useful metadata for a 2D spatial projection from the metadata of a raw image.
         :returns: (dict) Metadata dictionary (MD_* -> value).
         """
-        md = super(TemporalSpectrumSettingsStream, self)._find_metadata(md)
-        if model.MD_TIME_LIST in self.raw[0].metadata:
-            md[model.MD_TIME_LIST] = self.raw[0].metadata[model.MD_TIME_LIST]
-        if model.MD_WL_LIST in self.raw[0].metadata:
-            md[model.MD_WL_LIST] = self.raw[0].metadata[model.MD_WL_LIST]
-        return md
+        simple_md = super(TemporalSpectrumSettingsStream, self)._find_metadata(md)
+        if model.MD_TIME_LIST in md:
+            simple_md[model.MD_TIME_LIST] = md[model.MD_TIME_LIST]
+        if model.MD_WL_LIST in md:
+            simple_md[model.MD_WL_LIST] = md[model.MD_WL_LIST]
+        return simple_md
 
     # Override Stream._is_active_setter() in RepetitionStream class and in _base.py
     def _is_active_setter(self, active):


### PR DESCRIPTION
During acquisition, the helper stream might update the "live" image in a
background thread while the acquisition thread has just reset the .raw
data, because a new e-beam position is used.

In such case, find_metadata() would fail. However, it's still updating
the projection based on the previous raw data, and the metadata is still
available. So use the metadata passed, instead of searching for it in
.raw again.