### PR TITLE
driver simcam: remove blur_factor argument

### DIFF
--- a/install/linux/usr/share/odemis/sim/clspots-optical-autofocus-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/clspots-optical-autofocus-sim.odm.yaml
@@ -9,11 +9,16 @@ MultiBeamSEM: {
 "DiagnosticCam": {
     class: simcam.Camera,
     role: diagnostic-ccd,
+    dependencies: {focus: "DiagnosticCam Focus"},
     init: {
         image: "../acq/align/test/multiprobe01.tiff",
-        blur_factor: 100.e4,
     },
-    children: {focus: "DiagnosticCam Focus"}
+    metadata: {
+        # Adjust the metadata to have a small depthOfField, which makes the focus blur stronger
+        LENS_MAG: 60,
+        LENS_NA: 0.95,
+        LENS_RI: 0.13,
+    },
 }
 
 "DiagnosticCam Focus": {

--- a/src/odemis/driver/simcam.py
+++ b/src/odemis/driver/simcam.py
@@ -42,7 +42,7 @@ class Camera(model.DigitalCamera):
     given at initialisation.
     '''
 
-    def __init__(self, name, role, image, dependencies=None, daemon=None, blur_factor=1e4, max_res=None, **kwargs):
+    def __init__(self, name, role, image, dependencies=None, daemon=None, max_res=None, **kwargs):
         """
         dependencies (dict string->Component): If "focus" is passed, and it's an
             actuator with a z axis, the image will be blurred based on the
@@ -128,9 +128,6 @@ class Camera(model.DigitalCamera):
         self._metadata = {model.MD_HW_NAME: "FakeCam",
                           model.MD_SENSOR_PIXEL_SIZE: spxs,
                           model.MD_DET_TYPE: model.MD_DT_INTEGRATING}
-
-        # Set the amount of blurring during defocusing.
-        self._blur_factor = float(blur_factor)
 
         try:
             focuser = dependencies["focus"]
@@ -266,8 +263,8 @@ class Camera(model.DigitalCamera):
         if self._focus:
             # apply the defocus
             pos = self._focus.position.value['z']
-            dist = abs(pos - self._metadata[model.MD_FAV_POS_ACTIVE]["z"]) * self._blur_factor
-            logging.debug("Focus dist = %g", dist)
+            dist = abs(pos - self._metadata[model.MD_FAV_POS_ACTIVE]["z"]) / (self.depthOfField.value * 10)
+            logging.debug("Focus blur = %g", dist)
             img = ndimage.gaussian_filter(gen_img, sigma=dist)
         else:
             img = gen_img


### PR DESCRIPTION
This was used by a single simulator, to make the blur "stronger" when
moving the focus.
In addition, every DigitalCamera has a .depthOfField VA, which is automatically
computed based on the LENS metadata. This VA has a similar meaning. So
it makes sense that the simulated camera follows this VA to adjust the
blur factor.

=> Use depthOfField, and update the simulator with metadata which makes
the blur equivalent.