### PR TITLE
config: Ensure the script shebang is Python 3

### DIFF
--- a/debian/odemis.dirs
+++ b/debian/odemis.dirs
@@ -2,4 +2,4 @@ etc/sudoers.d
 etc/logrotate.d
 etc/bash_completion.d
 usr/lib/odemis/plugins
-usr/lib/odemis/python3
+usr/lib/odemis/python2

--- a/debian/rules
+++ b/debian/rules
@@ -6,9 +6,9 @@ VER := $(shell dpkg-parsechangelog | sed -n 's/^Version: *\([^-]\+\)-.\+/\1/p')
 	dh $@ --with python2,python3 --with sphinxdoc
 
 override_dh_auto_install:
-	python setup.py install --root debian/odemis --install-layout=deb
-	# Don't override Python 2 scripts, so copy them in some non-standard directory
-	python3 setup.py install --root debian/odemis --install-layout=deb --install-scripts usr/lib/odemis/python3/
+	# Don't use Python 2 scripts, so copy them in some non-standard directory
+	python setup.py install --root debian/odemis --install-layout=deb --install-scripts usr/lib/odemis/python2/
+	python3 setup.py install --root debian/odemis --install-layout=deb
 
 override_dh_installdocs:
 	# Just be sure there is no left over from previous builds


### PR DESCRIPTION
Commit eec959b85 (switch to Python 3 by default) should have made
sure that the shebang was not changed... but it wasn't properly tested.
It turns out that there are two places which tries to rewrite the
shebang, and we had only disabled one. For now, use the scripts
installed when installed via Python 3, so we get the right shebang.