### PR TITLE
gui comp stream: fix colourmap not updated when custom tint is used

### DIFF
--- a/src/odemis/gui/comp/combo.py
+++ b/src/odemis/gui/comp/combo.py
@@ -202,10 +202,10 @@ class ColorMapComboBox(ComboBox):
         r = wx.Rect(*rect)  # make a copy
 
         # Draw a rectangle of the color
-        item_name = self.Strings[item]
         color_map = self.GetClientData(item)
 
         if not color_map:
+            logging.warning("Failed to find color map for combo item", item)
             return
 
         color_map = tintToColormap(color_map)
@@ -214,9 +214,6 @@ class ColorMapComboBox(ComboBox):
             # for painting the control itself
             w = r.width
             h = r.height
-
-            color_map = self.GetClientData(self.GetSelection())
-            color_map = tintToColormap(color_map)
 
             gradient = getColorbar(color_map, w, h)
             bmp = wx.Bitmap(*gradient.shape[1::-1])
@@ -232,5 +229,6 @@ class ColorMapComboBox(ComboBox):
             bmp.CopyFromBuffer(gradient, format=wx.BitmapBufferFormat_RGB)
             # image = wx.ImageFromBuffer(*gradient.shape[1::-1], gradient)
             dc.DrawBitmap(bmp, 0, item * r.height)
+            item_name = self.Strings[item]
             dc.DrawText(item_name.title(), colorbar_width + 5, item * r.height + 5)
 

--- a/src/odemis/gui/comp/stream.py
+++ b/src/odemis/gui/comp/stream.py
@@ -437,7 +437,6 @@ class StreamPanelHeader(wx.Control):
         name, tint = list(self.colormap_choices.items())[index]
 
         if name == TINT_CUSTOM_TEXT:
-
             # Set default colour to the current value
             cldata = wx.ColourData()
             cldata.SetColour(wx.Colour(*tint))


### PR DESCRIPTION
In case the .tint is changed, the combobox was updated, but not
the colour of the custom tint. So selecting a dye on a Fluorescence
Stream didn't update the colour.

=> Change the colour associated to the custom tint in such case.