### PR TITLE
Reduce the dwell time during check megafield to increase the testing speed

### DIFF
--- a/src/odemis/driver/test/technolution_test.py
+++ b/src/odemis/driver/test/technolution_test.py
@@ -326,6 +326,8 @@ class TestAcquisitionServer(unittest.TestCase):
         Testing basics of checkMegaFieldExists functionality.
         """
         ASM = self.ASM_manager
+        # Set dwell time to minimum so scanning of an image is as fast.
+        self.EBeamScanner.dwellTime.value = self.EBeamScanner.dwellTime.range[0]
         # In the "setUp" method the megafield id is (re)set everytime when te test is stared to a string which contains
         # the current time i.e. time.strftime("testing_megafield_id-%Y-%m-%d-%H-%M-%S").
         mega_field_id = self.MPPC.filename.value


### PR DESCRIPTION
Currently there is an error at the ASM side for long dwell times.
This was found because the check megafield (accidentally uses a long dwell time) however this test should not test a long scan but only check if the functionality of check_mega_field exists.
Therefore the dwell time for this test is set to the minimal allowed value.