### PR TITLE
ASM wrapper: update MD every time a new field image is acquired

### DIFF
--- a/src/odemis/driver/technolution.py
+++ b/src/odemis/driver/technolution.py
@@ -1135,7 +1135,6 @@ class MPPC(model.Detector):
 
                     acquisition_in_progress = True
                     megafield_metadata = args[0]
-                    self._metadata = self._mergeMetadata()
                     self.parent.asmApiPostCall("/scan/start_mega_field", 204, megafield_metadata.to_dict())
 
                 elif command == "next":
@@ -1143,6 +1142,7 @@ class MPPC(model.Detector):
                         logging.warning("Start ASM acquisition before request to acquire field images.")
                         continue
 
+                    self._metadata = self._mergeMetadata()
                     field_data = args[0]  # Field metadata for the specific position of the field to scan
                     dataContent = args[1]  # Specifies the type of image to return (empty, thumbnail or full)
                     notifier_func = args[2]  # Return function (usually, dataflow.notify or acquire_single_field queue)


### PR DESCRIPTION
If we update the MD only in the start of a megafield, each dataarray (field) returned would have the same stage position. Update the MD every time a new field is acquired, so that the dataarray returned has the correct stage position.

TODO: A proper fix would be to have a settingsMD which includes MD such as the dwell time. And in the next call we would call mergeMD and add the settingsMD via updateMD call. Thus, we make sure that the generic settings such as the dwell time is for all fields the one that was set in the beginning of the megafield acquisition, but the stage position is updated correctly per field.