### PR TITLE
piezomotor: referencing, bugfixes, scan function

### DIFF
--- a/install/linux/usr/share/odemis/hwtest/piezomotor.odm.yaml
+++ b/install/linux/usr/share/odemis/hwtest/piezomotor.odm.yaml
@@ -14,17 +14,28 @@ Piezomotor: {
                 axis_number: 1,
                 speed: 0.001, # m/s
                 closed_loop: True,
+                range: [-25e-3, 25e-3],  # m
+                motorstep_resolution: 4.5e-6,  # m / step
+                encoder_resolution: 6.103515625e-10,  # m / count, should be 20 µm / 2 ** 14 = 1.22e-9, why factor 2?
                 },
             'y': {
                 axis_number: 2,
                 speed: 0.001, # m/s
                 closed_loop: True,
+                range: [-25e-3, 25e-3],  # m
+                motorstep_resolution: 4.5e-6,  # m / step
+                encoder_resolution: 6.103515625e-10,  # m / count
                 },
             'z': {
                 axis_number: 3,
-                speed: 0.001, # m/s
+                speed: 2e-5, # m/s, 0.001 * tan(2)
                 closed_loop: True,
+                range: [-85e-6, 5e-6],  # m
+                motorstep_resolution: 7.85478e-8,  # m / step, 4.5e-6 * tan(1)
+                encoder_resolution: 2.13623e-11,  # m / count, 20e-6 / 2**14 / 2 * tan(1)
                 },
         },
+        inverted: {'x', 'y', 'z'},
+        param_file: "../../../install/linux/usr/share/odemis/hwtest/pmd401.pmd.tsv",
     },
 }

--- a/install/linux/usr/share/odemis/hwtest/pmd401.pmd.tsv
+++ b/install/linux/usr/share/odemis/hwtest/pmd401.pmd.tsv
@@ -1,0 +1,33 @@
+# Parameters for PMD301/PMD401
+# Axis	Address	Value	Description
+# Axis 1 = x
+1	2	2		    # Limit type (2 for active-low)
+1	3	-30000000	# Target mode position limit A (Target mode will stop when encoder count<A)
+1	4	30000000	# Target mode position limit B (Target mode will stop when encoder count>B)
+1	5	1500	    # Stop range, number of encoder counts from target where it is optimal to stop the motor.
+1	6	1		    # Encoder counting direction (0 for positive in forward direction, 1 for negative in forward direction)
+1	11	79		    # SPC (motor steps per encoder count), determined by config script, ~50 * encoder resolution in nm
+1	12	3		    # Target mode model (3 for avoiding overshoot in both directions)
+1	13	1		    # Encoder type (1 for quadrature encoder)
+
+# Axis 2 = y
+2	2	2		    # Limit type (2 for active-low)
+2	3	-30000000	# Target mode position limit A (Target mode will stop when encoder count<A)
+2	4	30000000	# Target mode position limit B (Target mode will stop when encoder count>B)
+2	5	400	        # Stop range, number of encoder counts from target where it is optimal to stop the motor.
+2	6	1		    # Encoder counting direction (0 for positive in forward direction, 1 for negative in forward direction)
+2	11	79		    # SPC (motor steps per encoder count), determined by config script, ~50 * encoder resolution in nm
+2	12	3		    # Target mode model (3 for avoiding overshoot in both directions)
+2	13	1		    # Encoder type (1 for quadrature encoder)
+
+
+# Axis 3 = z
+3	2	2		    # Limit type (2 for active-low)
+3	3	-30000000	# Target mode position limit A (Target mode will stop when encoder count<A)
+3	4	30000000	# Target mode position limit B (Target mode will stop when encoder count>B)
+3	5	1000        # Stop range, number of encoder counts from target where it is optimal to stop the motor.
+3	6	1		    # Encoder counting direction (0 for positive in forward direction, 1 for negative in forward direction)
+3	11	79		    # SPC (motor steps per encoder count), determined by config script, ~50 * encoder resolution in nm
+3	12	3		    # Target mode model (3 for avoiding overshoot in both directions)
+3	13	1		    # Encoder type (1 for quadrature encoder)
+

--- a/src/odemis/driver/__init__.py
+++ b/src/odemis/driver/__init__.py
@@ -27,4 +27,4 @@ __all__ = ["andorcam3", "andorcam2", "andorshrk", "pi", "pigcs", "lle",
            "blinkstick", "picoquant", "ueye", "pwrcomedi", "smaract",
            # Modules that do not support scanning because that wouldn't make sense:
            "actuator", "scanner", "spectrometer", "simcam", "simsem", "emitter",
-           "simulated", "static"]
+           "simulated", "static", "piezomotor"]

--- a/src/odemis/driver/piezomotor.py
+++ b/src/odemis/driver/piezomotor.py
@@ -746,9 +746,9 @@ class PMD401Bus(Actuator):
             if not resp.startswith(cmd[:-len(EOL)-1]):
                 raise IOError("Response starts with %s != %s" % (to_str_escape(resp[:len(cmd)]), cmd))
             if b"_??_" in resp:
-                raise ValueError("Received response %s, command %s not understood." % (resp.decode("latin1"), cmd))
+                raise ValueError("Received response %s, command %s not understood." % (to_str_escape(resp), cmd))
             if b"!" in resp:
-                raise PMDError(0, resp.decode("latin1"))
+                raise PMDError(0, to_str_escape(resp))
             # Format:
             #    * for query with response: <cmd>:<ret><EOL> (will return <ret>)
             #    * for set command without response: <cmd><EOL> (will return "")
@@ -862,10 +862,7 @@ class PMD401Bus(Actuator):
         returns (list of 2-tuple): name, kwargs
         Note: it's obviously not advised to call this function if a device is already under use
         """
-        if os.name == "nt":
-            raise NotImplementedError("OS not yet supported")
-        else:
-            ports = list(serial.tools.list_ports.grep('/dev/ttyUSB*'))
+        ports = [p.device for p in serial.tools.list_ports.comports()]
 
         logging.info("Scanning for Piezomotor controllers in progress...")
         found = []  # (list of 2-tuple): name, kwargs

--- a/src/odemis/driver/test/piezomotor_test.py
+++ b/src/odemis/driver/test/piezomotor_test.py
@@ -22,6 +22,7 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 """
 from __future__ import division, print_function
 
+import odemis
 import logging
 import os
 import unittest
@@ -35,22 +36,24 @@ logging.getLogger().setLevel(logging.DEBUG)
 # Export TEST_NOHW=1 to force using only the simulator and skipping test cases
 # needing real hardware
 TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
-MULTIPLE_AXES = (os.environ.get("MULTIPLE_AXES", 0) != 0)  # if available, test 2 axes
 
 if TEST_NOHW:
     PORT = "/dev/fake"
 else:
     PORT = "/dev/ttyUSB*"
 
+CONFIG_PATH = os.path.dirname(odemis.__file__) + "/../../install/linux/usr/share/odemis/"
+PMD_CONFIG = CONFIG_PATH + "hwtest/pmd401.pmd.tsv"
+
 KWARGS_OPEN = dict(name="test", role="test", port=PORT,
-              axes={'x': {'axis_number': 1, 'speed': 0.001, 'closed_loop': False},
-                    'y': {'axis_number': 2, 'speed': 0.001, 'closed_loop': False}}
-              )
+                   axes={'x': {'axis_number': 1, 'speed': 0.001, 'closed_loop': False},
+                         'y': {'axis_number': 2, 'speed': 0.001, 'closed_loop': False}},
+                   param_file=PMD_CONFIG)
 
 KWARGS_CLOSED = dict(name="test", role="test", port=PORT,
-              axes={'x': {'axis_number': 1, 'speed': 0.001, 'closed_loop': True},
-                    'y': {'axis_number': 2, 'speed': 0.001, 'closed_loop': True}}
-              )
+                     axes={'x': {'axis_number': 1, 'speed': 0.001, 'closed_loop': True},
+                           'y': {'axis_number': 2, 'speed': 0.001, 'closed_loop': True}},
+                     param_file=PMD_CONFIG)
 
 
 class TestPMD401OpenLoop(unittest.TestCase):

--- a/util/pmconfig
+++ b/util/pmconfig
@@ -65,13 +65,6 @@ def spc_manual_conf(address, stage, steps=200):
     """
     axname = [name for name, num in stage._axis_map.items() if num == address][0]  # get axis name from number
 
-    # Move to a position in the middle of the axis
-    # WARNING:  Moving and referencing might not be very reliable since the hardware hasn't been configured.
-    stage.reference({'x'}).result()
-    # TODO: this move is specific to the current hardware where the reference switch is very close to 0
-    #   In the future, this might need to be extended to be more generic.
-    stage.moveAbsSync({'x': 0.005})
-
     # Move by a certain number of motor steps. Read the encoder position before and after the move.
     # The quotient of encoder counts and motor steps is the spc parameter.
     stage._updatePosition()
@@ -89,7 +82,7 @@ def spc_manual_conf(address, stage, steps=200):
     stage.setParam(address, 11, spc * (65536 * 4))
     time.sleep(1)
     stage.writeParamsToFlash(address)
-    logging.info("SPC value %s saved to flash.", stage.readParam(address, 11))
+    logging.debug("SPC value %s saved to flash.", stage.readParam(address, 11))
 
 
 def main(args):
@@ -129,8 +122,26 @@ def main(args):
     logging.getLogger().setLevel(loglev)
 
     # Initialize driver with one axis ('x'), closed loop
-    axes = {"x": {"axis_number": options.address, "closed_loop": True, 'speed': 0.001}}
-    stage = PMD401Bus("PM Control", "stage", options.port, axes)
+    try:
+        axes = {"x": {"axis_number": options.address, "closed_loop": True, 'speed': 0.001}}
+        stage = PMD401Bus("PM Control", "stage", options.port, axes)
+    except Exception as ex:
+        # Failed to start controller, try to start with different axis numbers to give the user a hint
+        good_axes = []
+        for i in range(5):  # most of the time, it's a small axis number (<5)
+            try:
+                axes = {"x": {"axis_number": i, "closed_loop": True, 'speed': 0.001}}
+                stage = PMD401Bus("PM Control", "stage", options.port, axes)
+                # If it didn't fail, append to good axes
+                good_axes.append(i)
+            except:
+                pass
+            finally:
+                if good_axes:
+                    raise ValueError("Failed to find controller on axis %s, try axes %s."
+                                     % (options.address, good_axes))
+                else:
+                    raise ValueError("Cannot connect to PMD controller! Ex: %s" % ex)
 
     # Address used for spc configuration (if target address is provided, use target address,
     # otherwise use address)


### PR DESCRIPTION
**This is not ready to be merged**
I made a few changes to the stage driver, including
* a new referencing procedure (works differently with encoder, see comments in code)
* the use of a .tsv file to pass the parameters (it turns out that there are more of them then I thought).
* explicit passing of both the motorstep and encoder resolution (the indirect conversion with spc caused problems)
* a timeout factor for the z axis (z axis is attached through a different component, see docstring)
* a scan function and more explicit messages in pmconfig (sometimes it's hard to figure out which axis numbers there are)
* removed referencing in pmconfig, it's too dangerous (especially if there are problems with the limit switch)

I have not tested all the changes on the hardware yet. I expect that I have to make some more adaptations (especially with the scan function).
@pieleric , it would be nice if you could have a first look already and check if you see some major problems. We can wait with the full code review until I tested it next week.