### PR TITLE
gui comp combo: getColorbar() only accepts ints

### DIFF
--- a/src/odemis/gui/comp/combo.py
+++ b/src/odemis/gui/comp/combo.py
@@ -223,7 +223,7 @@ class ColorMapComboBox(ComboBox):
         else:
             # for painting the items in the popup
             # Draw color map
-            colorbar_width = r.width * COLOBAR_WITH_RATIO
+            colorbar_width = int(round(r.width * COLOBAR_WITH_RATIO))
             gradient = getColorbar(color_map, colorbar_width, r.height)
             bmp = wx.Bitmap(*gradient.shape[1::-1])
             bmp.CopyFromBuffer(gradient, format=wx.BitmapBufferFormat_RGB)

--- a/src/odemis/util/img.py
+++ b/src/odemis/util/img.py
@@ -478,6 +478,8 @@ def getColorbar(color_map, width, height, alpha=False):
     alpha: (bool): set to true if you want alpha channel
     return: numpy Array of uint8 RGB tuples
     """
+    assert isinstance(width, int) and width > 0
+    assert isinstance(height, int) and height > 0
     gradient = numpy.linspace(0.0, 1.0, width)
     gradient = numpy.tile(gradient, (height, 1))
     gradient = color_map(gradient)


### PR DESCRIPTION
The new versions of numpy only accepts ints for linspace().
So better be clear and force having width and height as int.