### PR TITLE
ENZEL: Move lens aligner to its ACTIVE position on IMAGING

### DIFF
--- a/src/odemis/acq/move.py
+++ b/src/odemis/acq/move.py
@@ -203,6 +203,7 @@ def _doCryoSwitchSamplePosition(future, stage, focus, align, target):
         stage_coating = stage_md[model.MD_FAV_POS_COATING]
         focus_deactive = focus_md[model.MD_FAV_POS_DEACTIVE]
         align_deactive = align_md[model.MD_FAV_POS_DEACTIVE]
+        align_active = align_md[model.MD_FAV_POS_ACTIVE]
         # Fail early when required axes are not found on the positions metadata
         required_axes = {'x', 'y', 'z', 'rx', 'rz'}
         for stage_position in [stage_active, stage_deactive, stage_coating]:
@@ -268,6 +269,7 @@ def _doCryoSwitchSamplePosition(future, stage, focus, align, target):
             #  the FM stream (in which case it’d be handled by the optical path manager)
             if target == IMAGING:
                 sub_moves.append((focus, focus_active))
+                sub_moves.append((align, align_active))
         else:
             raise ValueError("Unknown target value %s." % target)
 
@@ -327,6 +329,7 @@ def _doCryoTiltSample(future, stage, focus, align, rx, rz):
         stage_active_range = stage_md[model.MD_POS_ACTIVE_RANGE]
         focus_deactive = focus_md[model.MD_FAV_POS_DEACTIVE]
         align_deactive = align_md[model.MD_FAV_POS_DEACTIVE]
+        align_active = align_md[model.MD_FAV_POS_ACTIVE]
         current_pos = stage.position.value
 
         # Check that the stage X,Y,Z are within the limits
@@ -347,6 +350,8 @@ def _doCryoTiltSample(future, stage, focus, align, rx, rz):
             rx = stage_active['rx']
             sub_moves.append((stage, {'rz': rz}))
             sub_moves.append((stage, {'rx': rx}))
+            # Move lens aligner to its active position
+            sub_moves.append((align, align_active))
         else:
             # Move lens aligner to its Deactive position
             sub_moves.append((align, align_deactive))

--- a/src/odemis/acq/test/move_test.py
+++ b/src/odemis/acq/test/move_test.py
@@ -62,6 +62,7 @@ class TestCryoMove(unittest.TestCase):
         cls.stage_coating = cls.stage.getMetadata()[model.MD_FAV_POS_COATING]
         cls.focus_deactive = cls.focus.getMetadata()[model.MD_FAV_POS_DEACTIVE]
         cls.align_deactive = cls.aligner.getMetadata()[model.MD_FAV_POS_DEACTIVE]
+        cls.align_active = cls.aligner.getMetadata()[model.MD_FAV_POS_ACTIVE]
 
         # Make sure the lens is referenced too (small move will only complete after the referencing)
         cls.aligner.moveRelSync({"x": 1e-6})
@@ -103,6 +104,8 @@ class TestCryoMove(unittest.TestCase):
         f = cryoSwitchSamplePosition(IMAGING)
         f.result()
         test.assert_pos_almost_equal(stage.position.value, self.stage_active, atol=ATOL_LINEAR_POS, match_all=False)
+        # align should be in active position
+        test.assert_pos_almost_equal(align.position.value, self.align_active, atol=ATOL_LINEAR_POS)
 
         # Get the stage to coating position
         f = cryoSwitchSamplePosition(COATING)
@@ -153,6 +156,8 @@ class TestCryoMove(unittest.TestCase):
         f = cryoTiltSample(rx=0)
         f.result()
         test.assert_pos_almost_equal(stage.position.value, self.stage_active, atol=ATOL_LINEAR_POS, match_all=False)
+        # align should be in active position
+        test.assert_pos_almost_equal(align.position.value, self.align_active, atol=ATOL_LINEAR_POS)
 
     def test_invalid_switch_movements(self):
         """


### PR DESCRIPTION
When going to “Imaging” mode, align should go to align.MD_FAV_POS_ACTIVE.

Formerly we did it in the SecomAlign tab, but it makes more sense to have it in the move module. 