### PR TITLE
Plugin merge_RGB is updated to read a DataArrayShadow properly

### DIFF
--- a/plugins/merge_RGB.py
+++ b/plugins/merge_RGB.py
@@ -238,9 +238,9 @@ class MergeChannelsPlugin(Plugin):
         """
         if len(data.shape) > 3:
             raise ValueError("Image format not supported")
-        elif len(data.shape) == 3:
-            if isinstance(data, model.DataArrayShadow):
-                data = data.getData()
+        if isinstance(data, model.DataArrayShadow):
+            data = data.getData()
+        if len(data.shape) == 3:
             data = img.ensureYXC(data)
             if (numpy.all(data[:, :, 0] == data[:, :, 1]) and
                 numpy.all(data[:, :, 0] == data[:, :, 2])):


### PR DESCRIPTION
* Once you open a new image a simple DataArray is used for the crop, shift functionality and to store the image directory.
  * The plugin takes care to get a DataArray from the DataArrayShadow and assign the corresponding tint to it.
  * Before this was supported only for 3D data.