### PR TITLE
Fix tiledacq_test errors due to unreferenced stage 

### DIFF
--- a/src/odemis/driver/smaract.py
+++ b/src/odemis/driver/smaract.py
@@ -1871,7 +1871,7 @@ class FakeMC_5DOF_DLL(object):
 
     def SA_MC_GetPose(self, id, p_pose):
         if not self.properties[MC_5DOF_DLL.SA_MC_PKEY_IS_REFERENCED].value:
-            raise SA_MCError(MC_5DOF_DLL.SA_MC_ERROR_NOT_REFERENCED, "error")
+            raise SA_MCError(MC_5DOF_DLL.SA_MC_ERROR_NOT_REFERENCED, "Not referenced error")
 
         self._update_current_pos()
 


### PR DESCRIPTION
- Make sure both lens and sample stage are referenced in tiledacq_test.py setup
- Modify test_move_to_tiles test as it before assuming starting_position to be left,bottom now -> left,top
- Clarify 5dof stage not referenced error