### PR TITLE
driver test actuator: wait a little after canceling a move to check the position

### DIFF
--- a/src/odemis/driver/smaract.py
+++ b/src/odemis/driver/smaract.py
@@ -1646,6 +1646,8 @@ class MC_5DOF(model.Actuator):
         logging.debug("Expecting a move of %f s, will wait up to %g s", dur, max_dur)
 
         try:
+            # TODO: the period is only updated on the next repetition, so it might
+            # take up to 1s before the first position update happens.
             self.update_position_timer.period = 0.05
             with future._moving_lock:
                 if future._must_stop:
@@ -1942,8 +1944,11 @@ class FakeMC_5DOF_DLL(object):
                 timedout = True
                 break
             if self.stopping.wait(0.05):
-                stopped = True
                 break
+
+        # Check if it was cancelled (cancelling sets the current move to now,
+        # so it might come out of the loop due to the while)
+        stopped = stopped or self.stopping.is_set()
 
         ev.type = MC_5DOF_DLL.SA_MC_EVENT_MOVEMENT_FINISHED
         if not stopped:

--- a/src/odemis/driver/test/actuator_test.py
+++ b/src/odemis/driver/test/actuator_test.py
@@ -1666,6 +1666,7 @@ class TestLinkedHeightActuator(unittest.TestCase):
         cancelled = f.cancel()
         self.assertTrue(cancelled)
         # Assert that initial position is not reached (during focus adjustment)
+        time.sleep(0.01)  # give some time to update all the positions
         logging.debug(focus.position.value)
         test.assert_pos_not_almost_equal(focus.position.value, initial_foc_pos, atol=ATOL_LENS)
 
@@ -1676,7 +1677,9 @@ class TestLinkedHeightActuator(unittest.TestCase):
         time.sleep(0.1)
         cancelled = f.cancel()
         self.assertTrue(cancelled)
+
         # Assert that stage position is neither initial nor target positions
+        time.sleep(0.01)  # give some time to update all the positions
         logging.debug(stage.position.value)
         test.assert_pos_not_almost_equal(initial_stage_pos, stage.position.value, atol=ATOL_STAGE)
         test.assert_pos_not_almost_equal(stage.position.value, target_pos, match_all=False, atol=ATOL_STAGE)


### PR DESCRIPTION
The test case failed because it *thought* that the position hasn't
changed. However, the driver does update the position, it's just that
the .position VA is updated *after* the .cancel() returns. That's what is causing the failure.

I think that could force cancel() to wait for the move function is complete, but that's hard to do, and probably would be annoying in some cases.

So let's just accept that it behaves as-is.
We can modify the test cases to wait a bit before reading the stage position, and then it works.