### PR TITLE
Modify 3dof Stage referencing procedure

### DIFF
--- a/src/odemis/driver/smaract.py
+++ b/src/odemis/driver/smaract.py
@@ -2549,15 +2549,12 @@ class MCS2(model.Actuator):
             self._set_accel(channel, accel)
             self._set_hold_time(channel, hold_time)
 
-            try:
-                # Log referencing mode, and warn if it's not normal (autozero)
-                ref_mode = self.GetProperty_i32(SA_CTLDLL.SA_CTL_PKEY_POSITIONER_TYPE, channel)
-                log_lvl = logging.INFO
-                if ref_mode & SA_CTLDLL.SA_CTL_REF_OPT_BIT_AUTO_ZERO:
-                    log_lvl = logging.WARNING
-                logging.log(log_lvl, "Current referencing mode = {}.".format(ref_mode))
-            except SA_CTLError:
-                    raise
+            # Log referencing mode, and warn if it's not normal (autozero)
+            ref_mode = self.GetProperty_i32(SA_CTLDLL.SA_CTL_PKEY_POSITIONER_TYPE, channel)
+            log_lvl = logging.INFO
+            if ref_mode & SA_CTLDLL.SA_CTL_REF_OPT_BIT_AUTO_ZERO:
+                log_lvl = logging.WARNING
+            logging.log(log_lvl, "Current referencing mode = {}.".format(ref_mode))
 
         self.position = model.VigilantAttribute({}, readonly=True)
 

--- a/src/odemis/driver/smaract.py
+++ b/src/odemis/driver/smaract.py
@@ -2550,14 +2550,13 @@ class MCS2(model.Actuator):
             self._set_hold_time(channel, hold_time)
 
             try:
-                # Log referencing mode, and warn if it's not normal
+                # Log referencing mode, and warn if it's not normal (autozero)
                 ref_mode = self.GetProperty_i32(SA_CTLDLL.SA_CTL_PKEY_POSITIONER_TYPE, channel)
                 log_lvl = logging.INFO
-                if ref_mode != SA_CTLDLL.SA_CTL_REF_OPT_BIT_NORMAL:
+                if ref_mode & SA_CTLDLL.SA_CTL_REF_OPT_BIT_AUTO_ZERO:
                     log_lvl = logging.WARNING
                 logging.log(log_lvl, "Current referencing mode = {}.".format(ref_mode))
             except SA_CTLError:
-                if locator != "fake":
                     raise
 
         self.position = model.VigilantAttribute({}, readonly=True)
@@ -3162,6 +3161,7 @@ class FakeMCS2_DLL(object):
             SA_CTLDLL.SA_CTL_PKEY_CALIBRATION_OPTIONS: [0, 0, 0],
             SA_CTLDLL.SA_CTL_PKEY_LOGICAL_SCALE_OFFSET: [0, 0, 0],
             SA_CTLDLL.SA_CTL_PKEY_POSITIONER_TYPE_NAME: [b"F4K3", b"F4K3", b"F4K3"],
+            SA_CTLDLL.SA_CTL_PKEY_POSITIONER_TYPE: [0, 0, 0],
         }
 
         # Specify ranges

--- a/util/saconfig
+++ b/util/saconfig
@@ -62,23 +62,26 @@ def calibrate(dev, channels):
         logging.info("Calibrating channel %d", channel)
         # set calibration options
         dev.SetProperty_i32(smaract.SA_CTLDLL.SA_CTL_PKEY_CALIBRATION_OPTIONS,
-                        channel, calibration_options)
+                            channel, calibration_options)
 
         dev.Calibrate(channel)
 
 
-def autozero(dev, channels):
+# Reference mode to set
+NORMAL_REF, AUTO_ZERO_REF = 0, 1
+
+
+def set_autozero_reference(dev, channels):
     if not channels:
         return
-    # Set auto-zero mode
+    # Set auto-zero referencing mode
     for channel in channels:
         logging.info("Setting auto-zero mode for channel %d", channel)
         dev.SetProperty_i32(smaract.SA_CTLDLL.SA_CTL_PKEY_REFERENCING_OPTIONS,
                             channel, smaract.SA_CTLDLL.SA_CTL_REF_OPT_BIT_AUTO_ZERO)  # auto zero
-    reference(dev)
 
 
-def normal_reference(dev, channels):
+def set_normal_reference(dev, channels):
     if not channels:
         return
     # Set normal referencing mode
@@ -86,10 +89,14 @@ def normal_reference(dev, channels):
         logging.info("Setting the reference mode to normal for channel %d", channel)
         dev.SetProperty_i32(smaract.SA_CTLDLL.SA_CTL_PKEY_REFERENCING_OPTIONS,
                             channel, smaract.SA_CTLDLL.SA_CTL_REF_OPT_BIT_NORMAL)  # normal
-    reference(dev)
 
 
-def reference(dev):
+def reference(dev, channels, mode=NORMAL_REF):
+    # Set referencing mode, currently either normal or autozero
+    if mode == NORMAL_REF:
+        set_normal_reference(dev, channels)
+    elif mode == AUTO_ZERO_REF:
+        set_autozero_reference(dev, channels)
     # Run the referencing
     logging.info("Starting reference...")
     dev.reference().result()
@@ -99,7 +106,7 @@ def reference(dev):
 
 def set_zero(dev, channels):
     """
-    Using the scale offset, set the current position of the controller to 0.
+    Set current position directly to zero, automatically adjusting the logical scale offset.
     """
     if not channels:
         return
@@ -112,7 +119,8 @@ def set_zero(dev, channels):
     #     # set the new scale offset
     #     dev.SetProperty_i64(smaract.SA_CTLDLL.SA_CTL_PKEY_LOGICAL_SCALE_OFFSET, channel, scale_offset + position)
 
-    logging.info("Setting current position to 0. This automatically adjusts the logical scale offset.")
+    logging.info(
+        f"Setting current position: {dev.position.value} to 0. This automatically adjusts the logical scale offset.")
     for channel in channels:
         dev.SetProperty_i64(smaract.SA_CTLDLL.SA_CTL_PKEY_POSITION, channel, 0)
 
@@ -136,9 +144,9 @@ def main(args):
                         help="Run the calibration command. Specify the channel to calibrate (0, 1, 2)")
 
     parser.add_argument('--autozero', metavar='N', type=int, nargs='+', default=[],
-                        help="Run referencing with autozero functionality. Specify the channel to calibrate (0, 1, 2)")
+                        help="Run referencing with set_autozero_reference functionality. Specify the channel to calibrate (0, 1, 2)")
 
-    parser.add_argument('--normalref', metavar='N', type=int, nargs='+', default=[],
+    parser.add_argument('--reference', metavar='N', type=int, nargs='+', default=[],
                         help="Run referencing with normal functionality. Specify the channel to calibrate (0, 1, 2)")
 
     parser.add_argument('--setzero', metavar='N', type=int, nargs='+', default=[],
@@ -155,14 +163,14 @@ def main(args):
     logging.getLogger().setLevel(loglev)
 
     locator = options.locator
-    channels = set(options.calibrate + options.autozero + options.normalref + options.setzero)
+    channels = set(options.calibrate + options.autozero + options.reference + options.setzero)
     axes = {str(c): {"range": [-1, 1], "unit": "m", "channel": c} for c in channels}
 
     dev = smaract.MCS2(locator=locator, axes=axes, **CONFIG_3DOF)
 
     calibrate(dev, options.calibrate)
-    autozero(dev, options.autozero)
-    normal_reference(dev, options.normalref)
+    reference(dev, options.autozero, mode=AUTO_ZERO_REF)
+    reference(dev, options.reference, mode=NORMAL_REF)
     set_zero(dev, options.setzero)
 
     logging.info("Completed all operations.")

--- a/util/saconfig
+++ b/util/saconfig
@@ -99,7 +99,7 @@ def reference(dev, channels, mode=NORMAL_REF):
         set_autozero_reference(dev, channels)
     # Run the referencing
     logging.info("Starting reference...")
-    dev.reference().result()
+    dev.reference(axes=[str(ch) for ch in channels]).result()
     time.sleep(0.1)
     logging.info("Complete")
 
@@ -144,10 +144,10 @@ def main(args):
                         help="Run the calibration command. Specify the channel to calibrate (0, 1, 2)")
 
     parser.add_argument('--autozero', metavar='N', type=int, nargs='+', default=[],
-                        help="Run referencing with set_autozero_reference functionality. Specify the channel to calibrate (0, 1, 2)")
+                        help="Run referencing with autozero reference mode. Specify the channel to calibrate (0, 1, 2)")
 
     parser.add_argument('--reference', metavar='N', type=int, nargs='+', default=[],
-                        help="Run referencing with normal functionality. Specify the channel to calibrate (0, 1, 2)")
+                        help="Run referencing with normal reference mode. Specify the channel to calibrate (0, 1, 2)")
 
     parser.add_argument('--setzero', metavar='N', type=int, nargs='+', default=[],
                         help="Force the current position on a channel to be 0. Specify the channel to calibrate (0, 1, 2)")
@@ -168,10 +168,14 @@ def main(args):
 
     dev = smaract.MCS2(locator=locator, axes=axes, **CONFIG_3DOF)
 
-    calibrate(dev, options.calibrate)
-    reference(dev, options.autozero, mode=AUTO_ZERO_REF)
-    reference(dev, options.reference, mode=NORMAL_REF)
-    set_zero(dev, options.setzero)
+    if options.calibrate:
+        calibrate(dev, options.calibrate)
+    elif options.autozero:
+        reference(dev, options.autozero, mode=AUTO_ZERO_REF)
+    elif options.reference:
+        reference(dev, options.reference, mode=NORMAL_REF)
+    elif options.setzero:
+        set_zero(dev, options.setzero)
 
     logging.info("Completed all operations.")
 

--- a/util/saconfig
+++ b/util/saconfig
@@ -71,37 +71,37 @@ def calibrate(dev, channels):
 NORMAL_REF, AUTO_ZERO_REF = 0, 1
 
 
-def set_autozero_reference(dev, channels):
+
+def set_reference_autozero(dev, channels):
     if not channels:
         return
     # Set auto-zero referencing mode
     for channel in channels:
-        logging.info("Setting auto-zero mode for channel %d", channel)
+        logging.info(f"Setting auto-zero mode for channel {channel}")
         dev.SetProperty_i32(smaract.SA_CTLDLL.SA_CTL_PKEY_REFERENCING_OPTIONS,
                             channel, smaract.SA_CTLDLL.SA_CTL_REF_OPT_BIT_AUTO_ZERO)  # auto zero
 
+    reference(dev, channels)
 
-def set_normal_reference(dev, channels):
+
+def set_reference_normal(dev, channels):
     if not channels:
         return
     # Set normal referencing mode
     for channel in channels:
-        logging.info("Setting the reference mode to normal for channel %d", channel)
+        logging.info(f"Setting the reference mode to normal for channel {channel}")
         dev.SetProperty_i32(smaract.SA_CTLDLL.SA_CTL_PKEY_REFERENCING_OPTIONS,
                             channel, smaract.SA_CTLDLL.SA_CTL_REF_OPT_BIT_NORMAL)  # normal
 
 
-def reference(dev, channels, mode=NORMAL_REF):
-    # Set referencing mode, currently either normal or autozero
-    if mode == NORMAL_REF:
-        set_normal_reference(dev, channels)
-    elif mode == AUTO_ZERO_REF:
-        set_autozero_reference(dev, channels)
+def reference(dev, channels):
     # Run the referencing
     logging.info("Starting reference...")
-    dev.reference(axes=[str(ch) for ch in channels]).result()
+    dev.reference(axes=set([str(ch) for ch in channels])).result()
     time.sleep(0.1)
-    logging.info("Complete")
+    logging.info("Referencing complete.")
+    # Always set reference to normal after referencing
+    set_reference_normal(dev, channels)
 
 
 def set_zero(dev, channels):
@@ -110,14 +110,6 @@ def set_zero(dev, channels):
     """
     if not channels:
         return
-
-    # logging.info("Setting scale offsets. Current position: %s", dev.position.value)
-    # for channel in channels:
-    #     logging.info("Setting the scale offset for channel %d", channel)
-    #     scale_offset = dev.GetProperty_i64(smaract.SA_CTLDLL.SA_CTL_PKEY_LOGICAL_SCALE_OFFSET, channel)
-    #     position = dev.GetProperty_i64(smaract.SA_CTLDLL.SA_CTL_PKEY_POSITION, channel)
-    #     # set the new scale offset
-    #     dev.SetProperty_i64(smaract.SA_CTLDLL.SA_CTL_PKEY_LOGICAL_SCALE_OFFSET, channel, scale_offset + position)
 
     logging.info(
         f"Setting current position: {dev.position.value} to 0. This automatically adjusts the logical scale offset.")
@@ -171,9 +163,9 @@ def main(args):
     if options.calibrate:
         calibrate(dev, options.calibrate)
     elif options.autozero:
-        reference(dev, options.autozero, mode=AUTO_ZERO_REF)
+        set_reference_autozero(dev, options.autozero)
     elif options.reference:
-        reference(dev, options.reference, mode=NORMAL_REF)
+        reference(dev, options.reference)
     elif options.setzero:
         set_zero(dev, options.setzero)
 

--- a/util/saconfig
+++ b/util/saconfig
@@ -67,9 +67,21 @@ def calibrate(dev, channels):
         dev.Calibrate(channel)
 
 
-# Reference mode to set
-NORMAL_REF, AUTO_ZERO_REF = 0, 1
+DISTANCE_CODED_MARK_POSITIONER = 304
 
+
+def set_positioner_type(dev, channels, ptype):
+    """
+    Set the type of positioner that is connected to the device channels. The positioner type implicitly gives the
+    controller information about how to calculate positions, handle the referencing, configure the control-loop,
+    etc. See sections 2.5 and 4.4.6 in programmer manual.
+    """
+    if not channels:
+        return
+    for channel in channels:
+        logging.info(f"Setting positioner type for channel {channel} to {ptype}.")
+        dev.SetProperty_i32(smaract.SA_CTLDLL.SA_CTL_PKEY_POSITIONER_TYPE, channel,
+                            ptype)
 
 
 def set_reference_autozero(dev, channels):
@@ -135,6 +147,9 @@ def main(args):
     parser.add_argument('--calibrate', metavar='N', type=int, nargs='+', default=[],
                         help="Run the calibration command. Specify the channel to calibrate (0, 1, 2)")
 
+    parser.add_argument('--postype', metavar='N', type=int, nargs='+', default=[],
+                        help="Set positioner type to distance coded mark. Specify the channel to calibrate (0, 1, 2)")
+
     parser.add_argument('--autozero', metavar='N', type=int, nargs='+', default=[],
                         help="Run referencing with autozero reference mode. Specify the channel to calibrate (0, 1, 2)")
 
@@ -162,6 +177,8 @@ def main(args):
 
     if options.calibrate:
         calibrate(dev, options.calibrate)
+    elif options.postype:
+        set_positioner_type(dev, options.postype, DISTANCE_CODED_MARK_POSITIONER)
     elif options.autozero:
         set_reference_autozero(dev, options.autozero)
     elif options.reference:

--- a/util/saconfig
+++ b/util/saconfig
@@ -22,19 +22,20 @@ You should have received a copy of the GNU General Public License along with
 Odemis. If not, see http://www.gnu.org/licenses/.
 '''
 
-from odemis.driver import smaract
-import sys
 import argparse
 import logging
+import sys
 import time
 
+from odemis.driver import smaract
+
 CONFIG_3DOF = {
-        "name": "3DOF",
-        "role": "stage",
-        "ref_on_init": False,
-        "speed": 0.1,
-        "accel": 0.001,
-        "hold_time": 1.0,
+    "name": "3DOF",
+    "role": "stage",
+    "ref_on_init": False,
+    "speed": 0.1,
+    "accel": 0.001,
+    "hold_time": 1.0,
 }
 
 
@@ -69,24 +70,31 @@ def calibrate(dev, channels):
 def autozero(dev, channels):
     if not channels:
         return
-
     # Set auto-zero mode
     for channel in channels:
         logging.info("Setting auto-zero mode for channel %d", channel)
         dev.SetProperty_i32(smaract.SA_CTLDLL.SA_CTL_PKEY_REFERENCING_OPTIONS,
                             channel, smaract.SA_CTLDLL.SA_CTL_REF_OPT_BIT_AUTO_ZERO)  # auto zero
+    reference(dev)
 
+
+def normal_reference(dev, channels):
+    if not channels:
+        return
+    # Set normal referencing mode
+    for channel in channels:
+        logging.info("Setting the reference mode to normal for channel %d", channel)
+        dev.SetProperty_i32(smaract.SA_CTLDLL.SA_CTL_PKEY_REFERENCING_OPTIONS,
+                            channel, smaract.SA_CTLDLL.SA_CTL_REF_OPT_BIT_NORMAL)  # normal
+    reference(dev)
+
+
+def reference(dev):
     # Run the referencing
     logging.info("Starting reference...")
     dev.reference().result()
     time.sleep(0.1)
     logging.info("Complete")
-
-    # Set normal referencing mode
-    for channel in  channels:
-        logging.info("Setting the reference mode to normal for channel %d", channel)
-        dev.SetProperty_i32(smaract.SA_CTLDLL.SA_CTL_PKEY_REFERENCING_OPTIONS,
-                            channel, smaract.SA_CTLDLL.SA_CTL_REF_OPT_BIT_NORMAL)  # normal
 
 
 def set_zero(dev, channels):
@@ -96,14 +104,17 @@ def set_zero(dev, channels):
     if not channels:
         return
 
-    logging.info("Setting scale offsets. Current position: %s", dev.position.value)
+    # logging.info("Setting scale offsets. Current position: %s", dev.position.value)
+    # for channel in channels:
+    #     logging.info("Setting the scale offset for channel %d", channel)
+    #     scale_offset = dev.GetProperty_i64(smaract.SA_CTLDLL.SA_CTL_PKEY_LOGICAL_SCALE_OFFSET, channel)
+    #     position = dev.GetProperty_i64(smaract.SA_CTLDLL.SA_CTL_PKEY_POSITION, channel)
+    #     # set the new scale offset
+    #     dev.SetProperty_i64(smaract.SA_CTLDLL.SA_CTL_PKEY_LOGICAL_SCALE_OFFSET, channel, scale_offset + position)
 
+    logging.info("Setting current position to 0. This automatically adjusts the logical scale offset.")
     for channel in channels:
-        logging.info("Setting the scale offset for channel %d", channel)
-        scale_offset = dev.GetProperty_i64(smaract.SA_CTLDLL.SA_CTL_PKEY_LOGICAL_SCALE_OFFSET, channel)
-        position = dev.GetProperty_i64(smaract.SA_CTLDLL.SA_CTL_PKEY_POSITION, channel)
-        # set the new scale offset
-        dev.SetProperty_i64(smaract.SA_CTLDLL.SA_CTL_PKEY_LOGICAL_SCALE_OFFSET, channel, scale_offset + position)
+        dev.SetProperty_i64(smaract.SA_CTLDLL.SA_CTL_PKEY_POSITION, channel, 0)
 
     dev._updatePosition()
     logging.info("New position: %s", dev.position.value)
@@ -111,24 +122,27 @@ def set_zero(dev, channels):
 
 
 def main(args):
-
     parser = argparse.ArgumentParser(prog="saconfig",
                                      description='Run a one time config for the SmarAct ')
 
     parser.add_argument('--locator', required=True, type=str,
-                        help='Specify the locator string for the device. e.g. "network:sn:MCS2-00001601" or "fake" for simulator', action="store")
+                        help='Specify the locator string for the device. e.g. "network:sn:MCS2-00001601" or "fake" for simulator',
+                        action="store")
 
     parser.add_argument("--log-level", dest="loglev", metavar="<level>", type=int,
                         default=1, help="set verbosity level (0-2, default = 1)")
 
     parser.add_argument('--calibrate', metavar='N', type=int, nargs='+', default=[],
-                    help="Run the calibration command. Specify the channel to calibrate (0, 1, 2)")
+                        help="Run the calibration command. Specify the channel to calibrate (0, 1, 2)")
 
     parser.add_argument('--autozero', metavar='N', type=int, nargs='+', default=[],
-                    help="Run referencing with autozero functionality. Specify the channel to calibrate (0, 1, 2)")
+                        help="Run referencing with autozero functionality. Specify the channel to calibrate (0, 1, 2)")
+
+    parser.add_argument('--normalref', metavar='N', type=int, nargs='+', default=[],
+                        help="Run referencing with normal functionality. Specify the channel to calibrate (0, 1, 2)")
 
     parser.add_argument('--setzero', metavar='N', type=int, nargs='+', default=[],
-                    help="Force the current position on a channel to be 0 by setting the scale offset. Specify the channel to calibrate (0, 1, 2)")
+                        help="Force the current position on a channel to be 0. Specify the channel to calibrate (0, 1, 2)")
 
     options = parser.parse_args(args[1:])
 
@@ -141,13 +155,14 @@ def main(args):
     logging.getLogger().setLevel(loglev)
 
     locator = options.locator
-    channels = set(options.calibrate + options.autozero + options.setzero)
-    axes = { str(c): {"range": [-1, 1], "unit": "m", "channel": c} for c in channels }
+    channels = set(options.calibrate + options.autozero + options.normalref + options.setzero)
+    axes = {str(c): {"range": [-1, 1], "unit": "m", "channel": c} for c in channels}
 
     dev = smaract.MCS2(locator=locator, axes=axes, **CONFIG_3DOF)
-    
+
     calibrate(dev, options.calibrate)
     autozero(dev, options.autozero)
+    normal_reference(dev, options.normalref)
     set_zero(dev, options.setzero)
 
     logging.info("Completed all operations.")
@@ -156,4 +171,3 @@ def main(args):
 if __name__ == '__main__':
     ret = main(sys.argv)
     exit(ret)
-    

--- a/util/saconfig
+++ b/util/saconfig
@@ -69,7 +69,6 @@ def calibrate(dev, channels):
 
 DISTANCE_CODED_MARK_POSITIONER = 304
 
-
 def set_positioner_type(dev, channels, ptype):
     """
     Set the type of positioner that is connected to the device channels. The positioner type implicitly gives the
@@ -84,36 +83,27 @@ def set_positioner_type(dev, channels, ptype):
                             ptype)
 
 
-def set_reference_autozero(dev, channels):
-    if not channels:
-        return
-    # Set auto-zero referencing mode
+def set_reference_autozero(dev, channel, autozero):
+    logging.info(f"Setting the reference autozero mode to {autozero} for channel {channel}")
+    ref_opt = dev.GetProperty_i32(smaract.SA_CTLDLL.SA_CTL_PKEY_REFERENCING_OPTIONS, channel)
+    if autozero:
+        ref_opt |= smaract.SA_CTLDLL.SA_CTL_REF_OPT_BIT_AUTO_ZERO
+    else:
+        ref_opt &= ~smaract.SA_CTLDLL.SA_CTL_REF_OPT_BIT_AUTO_ZERO
+
+def reference(dev, channels, autozero=False):
     for channel in channels:
-        logging.info(f"Setting auto-zero mode for channel {channel}")
-        dev.SetProperty_i32(smaract.SA_CTLDLL.SA_CTL_PKEY_REFERENCING_OPTIONS,
-                            channel, smaract.SA_CTLDLL.SA_CTL_REF_OPT_BIT_AUTO_ZERO)  # auto zero
-
-    reference(dev, channels)
-
-
-def set_reference_normal(dev, channels):
-    if not channels:
-        return
-    # Set normal referencing mode
-    for channel in channels:
-        logging.info(f"Setting the reference mode to normal for channel {channel}")
-        dev.SetProperty_i32(smaract.SA_CTLDLL.SA_CTL_PKEY_REFERENCING_OPTIONS,
-                            channel, smaract.SA_CTLDLL.SA_CTL_REF_OPT_BIT_NORMAL)  # normal
-
-
-def reference(dev, channels):
+        set_reference_autozero(dev, channel, autozero)
     # Run the referencing
     logging.info("Starting reference...")
-    dev.reference(axes=set([str(ch) for ch in channels])).result()
-    time.sleep(0.1)
-    logging.info("Referencing complete.")
-    # Always set reference to normal after referencing
-    set_reference_normal(dev, channels)
+    try:
+        dev.reference(axes=set(str(ch) for ch in channels)).result()
+        time.sleep(0.1)
+        logging.info("Referencing complete.")
+    finally:
+        # Always set reference to normal after referencing
+        for channel in channels:
+            set_reference_autozero(dev, channel, False)
 
 
 def set_zero(dev, channels):
@@ -148,7 +138,7 @@ def main(args):
                         help="Run the calibration command. Specify the channel to calibrate (0, 1, 2)")
 
     parser.add_argument('--postype', metavar='N', type=int, nargs='+', default=[],
-                        help="Set positioner type to distance coded mark. Specify the channel to calibrate (0, 1, 2)")
+                        help="Set positioner type to distance coded mark. Specify the channel to change (0, 1, 2)")
 
     parser.add_argument('--autozero', metavar='N', type=int, nargs='+', default=[],
                         help="Run referencing with autozero reference mode. Specify the channel to calibrate (0, 1, 2)")
@@ -170,7 +160,7 @@ def main(args):
     logging.getLogger().setLevel(loglev)
 
     locator = options.locator
-    channels = set(options.calibrate + options.autozero + options.reference + options.setzero)
+    channels = set(options.calibrate + options.autozero + options.reference + options.setzero + options.postype)
     axes = {str(c): {"range": [-1, 1], "unit": "m", "channel": c} for c in channels}
 
     dev = smaract.MCS2(locator=locator, axes=axes, **CONFIG_3DOF)
@@ -180,7 +170,7 @@ def main(args):
     elif options.postype:
         set_positioner_type(dev, options.postype, DISTANCE_CODED_MARK_POSITIONER)
     elif options.autozero:
-        set_reference_autozero(dev, options.autozero)
+        reference(dev, options.autozero, autozero=True)
     elif options.reference:
         reference(dev, options.reference)
     elif options.setzero:


### PR DESCRIPTION
This is an updated calibration procedure for referencing the 3dof stage. It entails:

- Separate autozero referencing mode from normal mode.
- Set zero position directly to automatically adjust the logical scale offset.