### PR TITLE
Enable Cryo tab buttons on imaging only

### DIFF
--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -641,13 +641,6 @@ class LocalizationTab(Tab):
         assert (show != self.IsShown())  # we assume it's only called when changed
         super(LocalizationTab, self).Show(show)
 
-        # Enable the tab if the stage is in imaging position, disable it otherwise
-        stage = self.tab_data_model.main.stage
-        if getCurrentPositionLabel(stage.position.value, stage) is IMAGING:
-            self.panel.Enable()
-        else:
-            self.panel.Disable()
-
         # pause streams when not displayed
         if not show:
             self._streambar_controller.pauseStreams()

--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -61,6 +61,7 @@ from odemis import dataio, model
 from odemis.acq import calibration, leech
 from odemis.acq.align import AutoFocus
 from odemis.acq.align.autofocus import Sparc2AutoFocus, Sparc2ManualFocus
+from odemis.acq.move import getCurrentPositionLabel, IMAGING
 from odemis.gui.conf.util import create_axis_entry
 from odemis.acq.align.autofocus import GetSpectrometerFocusingDetectors
 from odemis.acq.stream import OpticalStream, SpectrumStream, TemporalSpectrumStream, \
@@ -627,6 +628,13 @@ class LocalizationTab(Tab):
     def Show(self, show=True):
         assert (show != self.IsShown())  # we assume it's only called when changed
         super(LocalizationTab, self).Show(show)
+
+        # Enable the tab if the stage is in imaging position, disable it otherwise
+        stage = self.tab_data_model.main.stage
+        if getCurrentPositionLabel(stage.position.value, stage) is IMAGING:
+            self.panel.Enable()
+        else:
+            self.panel.Disable()
 
         # pause streams when not displayed
         if not show:
@@ -3418,8 +3426,16 @@ class SecomAlignTab(Tab):
     def Show(self, show=True):
         Tab.Show(self, show=show)
 
-        # Store/restore previous confocal settings when entering/leaving the tab
         main_data = self.tab_data_model.main
+        if main_data.role == "cryo-secom":
+            # Enable the tab if the stage is in imaging position, disable it otherwise
+            stage = self.tab_data_model.main.stage
+            if getCurrentPositionLabel(stage.position.value, stage) is IMAGING:
+                self.panel.Enable()
+            else:
+                self.panel.Disable()
+
+        # Store/restore previous confocal settings when entering/leaving the tab
         lm = main_data.laser_mirror
         if show and lm:
             # Must be done before starting the stream

--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -608,7 +608,7 @@ class LocalizationTab(Tab):
         Called when the stage is moved, enable the tab if position is imaging mode, disable otherwise
         :param pos: (dict str->float or None) updated position of the stage
         """
-        guiutil.enable_tab_on_stage_position(self, self.stage, pos, target=IMAGING)
+        guiutil.enable_tab_on_stage_position(self.button, self.stage, pos, target=IMAGING)
 
     def _on_stream_update(self, updated):
         """
@@ -3727,7 +3727,7 @@ class SecomAlignTab(Tab):
         Called when the stage is moved, enable the tab if position is imaging mode, disable otherwise
         :param pos: (dict str->float or None) updated position of the stage
         """
-        guiutil.enable_tab_on_stage_position(self, self.stage, pos, target=IMAGING)
+        guiutil.enable_tab_on_stage_position(self.button, self.stage, pos, target=IMAGING)
 
     def _on_align_pos(self, pos):
         """

--- a/src/odemis/gui/util/__init__.py
+++ b/src/odemis/gui/util/__init__.py
@@ -39,8 +39,7 @@ import wx
 # Decorators & Wrappers
 # They are almost the same but the decorators assume that they are decorating
 # a method of a wx.Object (ie, it has a "self" argument)
-from odemis.acq.move import getCurrentPositionLabel, IMAGING
-
+from odemis.acq.move import getCurrentPositionLabel
 
 @decorator
 def call_in_wx_main(f, self, *args, **kwargs):
@@ -294,7 +293,4 @@ def enable_tab_on_stage_position(button, stage, pos, target):
     :param pos: (dict str->float) current position to check its label
     :param target: (int) target position label (IMAGING, LOADING..etc)
     """
-    if getCurrentPositionLabel(pos, stage) == target:
-        button.Enable(enable=True)
-    else:
-        button.Disable()
+    button.Enable(getCurrentPositionLabel(pos, stage) == target)

--- a/src/odemis/gui/util/__init__.py
+++ b/src/odemis/gui/util/__init__.py
@@ -285,15 +285,16 @@ class AttrDict(dict):
         self.__dict__ = self
 
 
-def enable_cryo_tab_on_stage_position(tab, stage, pos):
+@call_in_wx_main
+def enable_tab_on_stage_position(tab, stage, pos, target):
     """
-    Enable the given tab if the stage is in imaging position, disable it otherwise
-    :param tab:
-    :param stage:
-    :param pos:
-    :return:
+    Enable the given tab if the stage is in target position, disable it otherwise
+    :param tab: (Tab) the Tab object to enable/disable
+    :param stage: (Actuator) the stage driver
+    :param pos: (dict str->float) current position to check its label
+    :param target: (int) target position label (IMAGING, LOADING..etc)
     """
-    if getCurrentPositionLabel(pos, stage) == IMAGING:
+    if getCurrentPositionLabel(pos, stage) == target:
         tab.panel.Enable()
     else:
         tab.panel.Disable()

--- a/src/odemis/gui/util/__init__.py
+++ b/src/odemis/gui/util/__init__.py
@@ -286,15 +286,15 @@ class AttrDict(dict):
 
 
 @call_in_wx_main
-def enable_tab_on_stage_position(tab, stage, pos, target):
+def enable_tab_on_stage_position(button, stage, pos, target):
     """
-    Enable the given tab if the stage is in target position, disable it otherwise
-    :param tab: (Tab) the Tab object to enable/disable
+    Enable the given tab button if the stage is in target position, disable it otherwise
+    :param button: (Button) the Tab button to enable/disable
     :param stage: (Actuator) the stage driver
     :param pos: (dict str->float) current position to check its label
     :param target: (int) target position label (IMAGING, LOADING..etc)
     """
     if getCurrentPositionLabel(pos, stage) == target:
-        tab.panel.Enable()
+        button.Enable(enable=True)
     else:
-        tab.panel.Disable()
+        button.Disable()

--- a/src/odemis/gui/util/__init__.py
+++ b/src/odemis/gui/util/__init__.py
@@ -39,6 +39,7 @@ import wx
 # Decorators & Wrappers
 # They are almost the same but the decorators assume that they are decorating
 # a method of a wx.Object (ie, it has a "self" argument)
+from odemis.acq.move import getCurrentPositionLabel, IMAGING
 
 
 @decorator
@@ -282,3 +283,17 @@ class AttrDict(dict):
     def __init__(self, *args, **kwargs):
         super(AttrDict, self).__init__(*args, **kwargs)
         self.__dict__ = self
+
+
+def enable_cryo_tab_on_stage_position(tab, stage, pos):
+    """
+    Enable the given tab if the stage is in imaging position, disable it otherwise
+    :param tab:
+    :param stage:
+    :param pos:
+    :return:
+    """
+    if getCurrentPositionLabel(pos, stage) == IMAGING:
+        tab.panel.Enable()
+    else:
+        tab.panel.Disable()


### PR DESCRIPTION
Previously `enable_tab_on_stage_position` was taking the tab as parameter and enable/disable its panel on imaging position. But what was actually required is to enable/disable the tab buttons.