### PR TITLE
acq stream: reduce MDStream live update to 0.5 Hz

### DIFF
--- a/src/odemis/acq/stream/_sync.py
+++ b/src/odemis/acq/stream/_sync.py
@@ -171,7 +171,7 @@ class MultipleDetectorStream(with_metaclass(ABCMeta, Stream)):
         self._current_scan_area = None  # l,t,r,b (int)
 
         # Start threading event for live update overlay
-        self._live_update_period = 0.33
+        self._live_update_period = 2
         self._im_needs_recompute = threading.Event()
         self._init_thread(self._live_update_period)
 


### PR DESCRIPTION
Doing the live update has some cost. In particular, for the MDSEMStream,
it means we break down the acquisition in smaller regions.
Starting/stopping the acquisition takes a bit of time, and also might
cause some hardware to go to "idle" mode, which takes extra time to
start again.

The live update is there for the user to see there is something
happening, and that the data is still good. Doing it every 2s, instead
of 3 times per second, should be more than sufficient.