### PR TITLE
driver smaract MCS2: check reference axes

### DIFF
--- a/src/odemis/driver/smaract.py
+++ b/src/odemis/driver/smaract.py
@@ -3063,6 +3063,8 @@ class MCS2(model.Actuator):
 
     @isasync
     def reference(self, axes):
+        self._checkReference(axes)
+
         f = self._createMoveFuture()
         f = self._executor.submitf(f, self._doReference, f, axes)
         return f


### PR DESCRIPTION
It didn't check the axes. Eventually, passing incorrect axes would fail,
but normally we immediately fail on the call.