### PR TITLE
driver piezomotor: add missing import

### DIFF
--- a/src/odemis/driver/piezomotor.py
+++ b/src/odemis/driver/piezomotor.py
@@ -31,6 +31,7 @@ import os
 import threading
 import time
 import serial
+import serial.tools.list_ports
 import re
 from threading import Thread
 import copy


### PR DESCRIPTION
For serial, we need to explicitly load the submodules.