### PR TITLE
config: change default CAN bus bitrate to 500Kbit/s

### DIFF
--- a/install/linux/lib/udev/rules.d/99-can0.rules
+++ b/install/linux/lib/udev/rules.d/99-can0.rules
@@ -1,2 +1,4 @@
+# Default bitrate for the CAN network. You can override it by copying this file
+# to /etc/udev/rules.d/ (and adjusting the value).
 SUBSYSTEM=="net", KERNEL=="can0", RUN+="/sbin/ip link set can0 type can bitrate 500000"
 SUBSYSTEM=="net", KERNEL=="can0", RUN+="/sbin/ip link set up can0"


### PR DESCRIPTION
We only support 2 hardware via CAN, they both use 500Kbit/s by default.
So let's use that as default.