### PR TITLE
driver hamamatsurx: fix error with Python 3 when decoding camera info

### DIFF
--- a/src/odemis/driver/hamamatsurx.py
+++ b/src/odemis/driver/hamamatsurx.py
@@ -1186,10 +1186,11 @@ class StreakCamera(model.HwComponent):
                             except Exception:
                                 break
                             logging.debug("Received: '%s'", to_str_escape(additional_info))
+
                         try:
-                            additional_info = additional_info.decode("latin1").split(b"\r")
+                            additional_info = additional_info.decode("latin1").split("\r")
                             for item in additional_info[:-1]:
-                                msg_splitted.append(item.strip(b"\n"))
+                                msg_splitted.append(item.strip("\n"))
                             if additional_info[-1]:
                                 logging.warning("Discarding data after CameraInfo '%s'", additional_info[-1])
                         except Exception:


### PR DESCRIPTION
The data is first decoded to string, so all the other functions should
use string, not bytes.

It was not a big issue as the information was fully fetched, which is
the most important, and also logged. So the rest of the execution kept
going fine.

This solves such error:
2021-04-01 10:20:42,602	DEBUG	hamamatsurx:1188:	Received: '\nProduct number: C13440-20C\r\nSerial number: 301730\r\nFirmware: 4.20.B\r\nVersion: 4.20.B03-A19-B02-4.02\r'
2021-04-01 10:20:43,604	ERROR	hamamatsurx:1196:	Failure while decoding readout camera information.
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/odemis/driver/hamamatsurx.py", line 1190, in readCommandResponse
    additional_info = additional_info.decode("latin1").split(b"\r")
TypeError: must be str or None, not bytes