### PR TITLE
ASM API wrapper: allow lists as input for cell VAs

### DIFF
--- a/src/odemis/driver/technolution.py
+++ b/src/odemis/driver/technolution.py
@@ -4,7 +4,7 @@ Created on 11 May 2020
 
 @author: Sabrina Rossberger, Kornee Kleijwegt
 
-Copyright © 2019-2020 Kornee Kleijwegt, Delmic
+Copyright © 2019-2021 Kornee Kleijwegt, Delmic
 
 This file is part of Odemis.
 
@@ -836,6 +836,7 @@ class EBeamScanner(model.Emitter):
         resolution = eff_cell_size * self.parent._mppc.shape[0:2]
 
         return tuple(resolution.astype(int))
+        return tuple(int(i) for i in resolution)
 
 
 class MirrorDescanner(model.Emitter):
@@ -1379,32 +1380,32 @@ class MPPC(model.Detector):
         for row, cellTranslationRow in enumerate(cellTranslation):
             if len(cellTranslationRow) != self._shape[1]:
                 raise ValueError("An incorrect shape of the cell translation parameters is provided.\n"
-                                 "Please change the shape of the cellTranslation parameters according to the shape of "
+                                 "Please change the shape of the cell translation parameters according to the shape of "
                                  "the mppc detector.\n "
                                  "Cell translation parameters remain unchanged.")
 
             for column, eff_origin in enumerate(cellTranslationRow):
-                if not isinstance(eff_origin, tuple) or len(eff_origin) != 2:
+                if not isinstance(eff_origin, (tuple, list)) or len(eff_origin) != 2:
                     raise ValueError("Incorrect cell translation parameters provided, wrong number/type of coordinates "
                                      "for cell (%s, %s) are provided.\n"
-                                     "Please provide an 'x effective origin' and an 'y effective origin' for this cell "
-                                     "image.\n "
                                      "Cell translation parameters remain unchanged." %
                                      (row, column))
 
                 if not isinstance(eff_origin[0], int) or not isinstance(eff_origin[1], int):
                     raise ValueError(
                             "An incorrect type is used for the cell translation coordinates of cell (%s, %s).\n"
-                            "Please use type integer for both 'x effective origin' and and 'y effective "
-                            "origin' for this cell image.\n"
                             "Type expected is: '(%s, %s)' type received '(%s, %s)'\n"
                             "Cell translation parameters remain unchanged." %
                             (row, column, int, int, type(eff_origin[0]), type(eff_origin[1])))
 
-                elif eff_origin[0] < 0 or eff_origin[1] < 0:
+                if eff_origin[0] < 0 or eff_origin[1] < 0:
                     raise ValueError("Please use a minimum of 0 cell translation coordinates of cell (%s, %s).\n"
                                      "Cell translation parameters remain unchanged." %
                                      (row, column))
+
+        # force items to be a tuple
+        cellTranslation = tuple(tuple(tuple(item) for item in row) for row in cellTranslation)
+
         return cellTranslation
 
     def _setCellDigitalGain(self, cellDigitalGain):
@@ -1431,24 +1432,20 @@ class MPPC(model.Detector):
                                  "Digital gain parameters value remain unchanged.")
 
             for column, DigitalGain in enumerate(cellDigitalGain_row):
-                if isinstance(DigitalGain, int):
-                    # Convert all input values to floats.
-                    logging.warning("Input integer values for the digital gain are converted to floats.")
-                    cellDigitalGain = tuple(tuple(float(cellDigitalGain[i][j]) for j in range(0, self.shape[0]))
-                                            for i in range(0, self.shape[0]))
-                    # Call the setter again with all int values converted to floats and return the output
-                    return self._setCellDigitalGain(cellDigitalGain)
 
-                elif not isinstance(DigitalGain, float):
+                if not isinstance(DigitalGain, (int, float)):
                     raise ValueError("An incorrect type is used for the digital gain parameters of cell (%s, %s).\n"
-                                     "Please use type float for digital gain parameters for this cell image.\n"
-                                     "Type expected is: '%s' type received '%s' \n"
+                                     "Type expected is: '%s' or '%s'; type received '%s' \n"
                                      "Digital gain parameters value remain unchanged." %
-                                     (row, column, float, type(DigitalGain)))
-                elif DigitalGain < 0:
+                                     (row, column, float, int, type(DigitalGain)))
+
+                if DigitalGain < 0:
                     raise ValueError("Please use a minimum of 0 for digital gain parameters of cell image (%s, %s).\n"
                                      "Digital gain parameters value remain unchanged." %
                                      (row, column))
+
+        # force items to be a tuple
+        cellDigitalGain = tuple(tuple(item) for item in cellDigitalGain)
 
         return cellDigitalGain
 
@@ -1456,9 +1453,8 @@ class MPPC(model.Detector):
         """
         Setter for the dark offset of the cells, each cell has a dark offset stored as an integer (compensating for
         the offset in darkness in each detector cell). The dark offset  values for a full row are nested in a tuple.
-        And finally, all dark offset values per row are nested in a another tuple
-        representing the full cell image. This setter checks the correct shape of the nested tuples, the type and
-        minimum value.
+        And finally, all dark offset values per row are nested in a another tuple representing the full cell image.
+        This setter checks the correct shape of the nested tuples, the type and minimum value.
 
         :param cellDarkOffset: (nested tuple of ints)
         :return: cellDarkOffset: (nested tuple of ints)
@@ -1467,7 +1463,8 @@ class MPPC(model.Detector):
             raise ValueError("An incorrect shape of the dark offset parameters is provided.\n"
                              "Please change the shape of the dark offset parameters according to the shape of the mppc "
                              "detector.\n "
-                             "Dark offset parameters value remain unchanged.")
+                             "Dark offset parameters value remain unchanged."
+                             "%s, %s, %s", cellDarkOffset, len(cellDarkOffset), self._shape)
 
         for row, cellDarkOffsetRow in enumerate(cellDarkOffset):
             if len(cellDarkOffsetRow) != self._shape[1]:
@@ -1485,10 +1482,13 @@ class MPPC(model.Detector):
                                      "Dark offset parameters value remain unchanged." %
                                      (row, column, int, type(DarkOffset)))
 
-                elif DarkOffset < 0:
+                if DarkOffset < 0:
                     raise ValueError("Please use a minimum of 0 for dark offset parameters of cell image (%s, %s).\n"
                                      "Dark offset parameters value remain unchanged." %
                                      (row, column))
+
+        # force items to be a tuple
+        cellDarkOffset = tuple(tuple(item) for item in cellDarkOffset)
 
         return cellDarkOffset
 

--- a/src/odemis/driver/technolution.py
+++ b/src/odemis/driver/technolution.py
@@ -836,7 +836,6 @@ class EBeamScanner(model.Emitter):
         resolution = eff_cell_size * self.parent._mppc.shape[0:2]
 
         return tuple(resolution.astype(int))
-        return tuple(int(i) for i in resolution)
 
 
 class MirrorDescanner(model.Emitter):
@@ -1375,32 +1374,32 @@ class MPPC(model.Detector):
             raise ValueError("An incorrect shape of the cell translation parameters is provided.\n "
                              "Please change the shape of the cell translation parameters according to the shape of the "
                              "mppc detector.\n "
-                             "Cell translation parameters remain unchanged.")
+                             "Cell translation parameter values remain unchanged.")
 
         for row, cellTranslationRow in enumerate(cellTranslation):
             if len(cellTranslationRow) != self._shape[1]:
                 raise ValueError("An incorrect shape of the cell translation parameters is provided.\n"
                                  "Please change the shape of the cell translation parameters according to the shape of "
                                  "the mppc detector.\n "
-                                 "Cell translation parameters remain unchanged.")
+                                 "Cell translation parameter values remain unchanged.")
 
             for column, eff_origin in enumerate(cellTranslationRow):
                 if not isinstance(eff_origin, (tuple, list)) or len(eff_origin) != 2:
                     raise ValueError("Incorrect cell translation parameters provided, wrong number/type of coordinates "
                                      "for cell (%s, %s) are provided.\n"
-                                     "Cell translation parameters remain unchanged." %
+                                     "Cell translation parameter values remain unchanged." %
                                      (row, column))
 
                 if not isinstance(eff_origin[0], int) or not isinstance(eff_origin[1], int):
                     raise ValueError(
                             "An incorrect type is used for the cell translation coordinates of cell (%s, %s).\n"
                             "Type expected is: '(%s, %s)' type received '(%s, %s)'\n"
-                            "Cell translation parameters remain unchanged." %
+                            "Cell translation parameter values remain unchanged." %
                             (row, column, int, int, type(eff_origin[0]), type(eff_origin[1])))
 
                 if eff_origin[0] < 0 or eff_origin[1] < 0:
                     raise ValueError("Please use a minimum of 0 cell translation coordinates of cell (%s, %s).\n"
-                                     "Cell translation parameters remain unchanged." %
+                                     "Cell translation parameter values remain unchanged." %
                                      (row, column))
 
         # force items to be a tuple
@@ -1422,26 +1421,26 @@ class MPPC(model.Detector):
         if len(cellDigitalGain) != self._shape[0]:
             raise ValueError("An incorrect shape of the digital gain parameters is provided. Please change the "
                              "shape of the digital gain parameters according to the shape of the mppc detector.\n"
-                             "Digital gain parameters value remain unchanged.")
+                             "Digital gain parameter values remain unchanged.")
 
         for row, cellDigitalGain_row in enumerate(cellDigitalGain):
             if len(cellDigitalGain_row) != self._shape[1]:
                 raise ValueError("An incorrect shape of the digital gain parameters is provided.\n"
                                  "Please change the shape of the digital gain parameters according to the shape of the "
                                  "mppc detector.\n "
-                                 "Digital gain parameters value remain unchanged.")
+                                 "Digital gain parameter values remain unchanged.")
 
             for column, DigitalGain in enumerate(cellDigitalGain_row):
 
                 if not isinstance(DigitalGain, (int, float)):
                     raise ValueError("An incorrect type is used for the digital gain parameters of cell (%s, %s).\n"
                                      "Type expected is: '%s' or '%s'; type received '%s' \n"
-                                     "Digital gain parameters value remain unchanged." %
+                                     "Digital gain parameter values remain unchanged." %
                                      (row, column, float, int, type(DigitalGain)))
 
                 if DigitalGain < 0:
                     raise ValueError("Please use a minimum of 0 for digital gain parameters of cell image (%s, %s).\n"
-                                     "Digital gain parameters value remain unchanged." %
+                                     "Digital gain parameter values remain unchanged." %
                                      (row, column))
 
         # force items to be a tuple
@@ -1463,15 +1462,14 @@ class MPPC(model.Detector):
             raise ValueError("An incorrect shape of the dark offset parameters is provided.\n"
                              "Please change the shape of the dark offset parameters according to the shape of the mppc "
                              "detector.\n "
-                             "Dark offset parameters value remain unchanged."
-                             "%s, %s, %s", cellDarkOffset, len(cellDarkOffset), self._shape)
+                             "Dark offset parameter values remain unchanged.")
 
         for row, cellDarkOffsetRow in enumerate(cellDarkOffset):
             if len(cellDarkOffsetRow) != self._shape[1]:
                 raise ValueError("An incorrect shape of the dark offset parameters is provided.\n"
                                  "Please change the shape of the dark offset parameters according to the shape of the "
                                  "mppc detector.\n "
-                                 "Dark offset parameters value remain unchanged.")
+                                 "Dark offset parameter values remain unchanged.")
 
             for column, DarkOffset in enumerate(cellDarkOffsetRow):
                 if not isinstance(DarkOffset, int):
@@ -1479,12 +1477,12 @@ class MPPC(model.Detector):
                                      "%s). \n"
                                      "Please use type integer for dark offset for this cell image.\n"
                                      "Type expected is: '%s' type received '%s' \n"
-                                     "Dark offset parameters value remain unchanged." %
+                                     "Dark offset parameter values remain unchanged." %
                                      (row, column, int, type(DarkOffset)))
 
                 if DarkOffset < 0:
                     raise ValueError("Please use a minimum of 0 for dark offset parameters of cell image (%s, %s).\n"
-                                     "Dark offset parameters value remain unchanged." %
+                                     "Dark offset parameter values remain unchanged." %
                                      (row, column))
 
         # force items to be a tuple

--- a/src/odemis/driver/test/technolution_test.py
+++ b/src/odemis/driver/test/technolution_test.py
@@ -432,49 +432,6 @@ class TestEBeamScanner(unittest.TestCase):
         self.EBeamScanner.resolution.value = (6385, 6385)
         self.assertEqual(self.EBeamScanner.resolution.value, (6400, 6400))
 
-#     +  #################################### ===================
-#     +  # This test fails as soon as you set values on the mppc.cellCompleteResolution VA and scanner.resolution VA
-#     +  # I used the same values as already put on the VA and it fails.
-#     +
-#     +  # This error does not pop up ad the VA tests do not upload the changed values. It might be worse if we extend
-#     +  # the VA tests, to actually upload the values via start megafield calls to capture errors there. What do you think?
-#     +
-#     +
-#
-#     def test_cellCompleteResolution_Resolution_acqImage(self):
-#         +
-#
-#     +  # Check if small resolution values are allowed
-#     +        self.MPPC.cellCompleteResolution.value = (900, 900)
-#     +        self.EBeamScanner.resolution.value = (6400, 6400)
-#     +  # self.MPPC.cellCompleteResolution.value = (12, 12)   # min values as used in scan2mp script (20,20)
-#     +  # self.EBeamScanner.resolution.value = (96, 96)  # min values as used in scan2mp script
-#     +
-#     +        self.EBeamScanner.scanOffset.value = (0.0, 0.0)
-#     +        self.EBeamScanner.scanGain.value = (0.3, 0.3)
-#     +        self.MirrorDescanner.scanOffset.value = (0.0, 0.0)
-#     +        self.MirrorDescanner.scanGain.value = (0.007, 0.007)
-#     +
-#     +        self.MPPC.filename.value = time.strftime("testing_megafield_id-%Y-%m-%d-%H-%M-%S")
-#     +        dataflow = self.MPPC.data
-#     +
-#     +        image = dataflow.get()
-#     +  # image = dataflow.get(dataContent="empty")
-#     +        self.assertIsInstance(image, model.DataArray)
-#
-# ############################################
-#     # Check if small resolution values are allowed
-#     -        self.MPPC.cellCompleteResolution.value = (900, 900)
-#     -        self.EBeamScanner.resolution.value = (6400, 6400)
-#     -  # self.MPPC.cellCompleteResolution.value = (12, 12)   # min values as used in scan2mp script (20,20)
-#     -  # self.EBeamScanner.resolution.value = (96, 96)  # min values as used in scan2mp script
-#     +  # self.MPPC.cellCompleteResolution.value = (900, 900)
-#     +  # self.EBeamScanner.resolution.value = (6400, 6400)
-#     +        self.MPPC.cellCompleteResolution.value = (70, 70)  # min values as used in scan2mp script (20,20)
-#     +        self.EBeamScanner.resolution.value = (96, 96)  # min values as used in scan2mp script
-
-    ###################################################################################################
-
     def test_dwellTimeVA(self):
         min_dwellTime = self.EBeamScanner.dwellTime.range[0]
         max_dwellTime = self.EBeamScanner.dwellTime.range[1]

--- a/src/odemis/driver/test/technolution_test.py
+++ b/src/odemis/driver/test/technolution_test.py
@@ -5,7 +5,7 @@ Created on 11 May 2020
 
 @author: Sabrina Rossberger, Kornee Kleijwegt
 
-Copyright © 2019-2020 Kornee Kleijwegt, Delmic
+Copyright © 2019-2021 Kornee Kleijwegt, Delmic
 
 This file is part of Odemis.
 
@@ -431,6 +431,49 @@ class TestEBeamScanner(unittest.TestCase):
 
         self.EBeamScanner.resolution.value = (6385, 6385)
         self.assertEqual(self.EBeamScanner.resolution.value, (6400, 6400))
+
+#     +  #################################### ===================
+#     +  # This test fails as soon as you set values on the mppc.cellCompleteResolution VA and scanner.resolution VA
+#     +  # I used the same values as already put on the VA and it fails.
+#     +
+#     +  # This error does not pop up ad the VA tests do not upload the changed values. It might be worse if we extend
+#     +  # the VA tests, to actually upload the values via start megafield calls to capture errors there. What do you think?
+#     +
+#     +
+#
+#     def test_cellCompleteResolution_Resolution_acqImage(self):
+#         +
+#
+#     +  # Check if small resolution values are allowed
+#     +        self.MPPC.cellCompleteResolution.value = (900, 900)
+#     +        self.EBeamScanner.resolution.value = (6400, 6400)
+#     +  # self.MPPC.cellCompleteResolution.value = (12, 12)   # min values as used in scan2mp script (20,20)
+#     +  # self.EBeamScanner.resolution.value = (96, 96)  # min values as used in scan2mp script
+#     +
+#     +        self.EBeamScanner.scanOffset.value = (0.0, 0.0)
+#     +        self.EBeamScanner.scanGain.value = (0.3, 0.3)
+#     +        self.MirrorDescanner.scanOffset.value = (0.0, 0.0)
+#     +        self.MirrorDescanner.scanGain.value = (0.007, 0.007)
+#     +
+#     +        self.MPPC.filename.value = time.strftime("testing_megafield_id-%Y-%m-%d-%H-%M-%S")
+#     +        dataflow = self.MPPC.data
+#     +
+#     +        image = dataflow.get()
+#     +  # image = dataflow.get(dataContent="empty")
+#     +        self.assertIsInstance(image, model.DataArray)
+#
+# ############################################
+#     # Check if small resolution values are allowed
+#     -        self.MPPC.cellCompleteResolution.value = (900, 900)
+#     -        self.EBeamScanner.resolution.value = (6400, 6400)
+#     -  # self.MPPC.cellCompleteResolution.value = (12, 12)   # min values as used in scan2mp script (20,20)
+#     -  # self.EBeamScanner.resolution.value = (96, 96)  # min values as used in scan2mp script
+#     +  # self.MPPC.cellCompleteResolution.value = (900, 900)
+#     +  # self.EBeamScanner.resolution.value = (6400, 6400)
+#     +        self.MPPC.cellCompleteResolution.value = (70, 70)  # min values as used in scan2mp script (20,20)
+#     +        self.EBeamScanner.resolution.value = (96, 96)  # min values as used in scan2mp script
+
+    ###################################################################################################
 
     def test_dwellTimeVA(self):
         min_dwellTime = self.EBeamScanner.dwellTime.range[0]
@@ -931,7 +974,7 @@ class TestMPPC(unittest.TestCase):
         self.assertEqual(self.MPPC.dataContent.value, key)  # Check if variable remains unchanged
 
     def test_cellTranslationVA(self):
-        """ Testing assigning of different values to the tuple structure"""
+        """ Testing the cell translation VA (position of the cell image within the overscanned cell image)"""
         # The test values below are also handy for debugging, these values are chosen such that their number corresponds
         # to a row based numbering with the first row of x values being from 10 to 17, and for y values from 100 to
         # 107. This allows to have a human readable check on the tuple structure created while testing input values.
@@ -939,8 +982,7 @@ class TestMPPC(unittest.TestCase):
             tuple(tuple((10 + j, 100 + j) for j in range(i, i + self.MPPC.shape[0]))
                   for i in range(0, self.MPPC.shape[1] * self.MPPC.shape[0], self.MPPC.shape[0]))
 
-        self.assertEqual(
-                self.MPPC.cellTranslation.value,
+        self.assertEqual(self.MPPC.cellTranslation.value,
                 tuple(tuple((10 + j, 100 + j) for j in range(i, i + self.MPPC.shape[0]))
                       for i in range(0, self.MPPC.shape[1] * self.MPPC.shape[0], self.MPPC.shape[0])))
 
@@ -993,26 +1035,27 @@ class TestMPPC(unittest.TestCase):
             self.MPPC.cellTranslation.value = tuple(tuple((50, 50.0) for i in range(0, self.MPPC.shape[0]))
                                                     for i in range(0, self.MPPC.shape[1]))
         self.assertEqual(self.MPPC.cellTranslation.value,
-                         tuple(tuple((50, 50) for i in range(0, self.MPPC.shape[0])) for i in
-                               range(0, self.MPPC.shape[1])))
+                         tuple(tuple((50, 50) for i in range(0, self.MPPC.shape[0]))
+                               for i in range(0, self.MPPC.shape[1])))
 
         # Negative number for x
         with self.assertRaises(ValueError):
             self.MPPC.cellTranslation.value = tuple(tuple((-1, 50) for i in range(0, self.MPPC.shape[0]))
                                                     for i in range(0, self.MPPC.shape[1]))
         self.assertEqual(self.MPPC.cellTranslation.value,
-                         tuple(tuple((50, 50) for i in range(0, self.MPPC.shape[0])) for i in
-                               range(0, self.MPPC.shape[1])))
+                         tuple(tuple((50, 50) for i in range(0, self.MPPC.shape[0]))
+                               for i in range(0, self.MPPC.shape[1])))
 
         # Negative number for y
         with self.assertRaises(ValueError):
             self.MPPC.cellTranslation.value = tuple(tuple((50, -1) for i in range(0, self.MPPC.shape[0]))
                                                     for i in range(0, self.MPPC.shape[1]))
         self.assertEqual(self.MPPC.cellTranslation.value,
-                         tuple(tuple((50, 50) for i in range(0, self.MPPC.shape[0])) for i in
-                               range(0, self.MPPC.shape[1])))
+                         tuple(tuple((50, 50) for i in range(0, self.MPPC.shape[0]))
+                               for i in range(0, self.MPPC.shape[1])))
 
     def test_cellDarkOffsetVA(self):
+        """ Testing the dark offset VA (background noise per cell)"""
         # The test values below are also handy for debugging, these values are chosen such that their number corresponds
         # to a row based numbering with the first row of values being from 0 to 7. This allows to have a human
         # readable check on the tuple structure created while testing input values.
@@ -1020,15 +1063,13 @@ class TestMPPC(unittest.TestCase):
             tuple(tuple(j for j in range(i, i + self.MPPC.shape[0]))
                   for i in range(0, self.MPPC.shape[1] * self.MPPC.shape[0], self.MPPC.shape[0]))
 
-        self.assertEqual(
-                self.MPPC.cellDarkOffset.value,
-                tuple(tuple(j for j in range(i, i + self.MPPC.shape[0]))
-                      for i in range(0, self.MPPC.shape[1] * self.MPPC.shape[0], self.MPPC.shape[0]))
-        )
+        self.assertEqual(self.MPPC.cellDarkOffset.value,
+                         tuple(tuple(j for j in range(i, i + self.MPPC.shape[0]))
+                               for i in range(0, self.MPPC.shape[1] * self.MPPC.shape[0], self.MPPC.shape[0])))
 
-        # Changing the digital gain back to something simple
-        self.MPPC.cellDarkOffset.value = tuple(
-                tuple(0 for i in range(0, self.MPPC.shape[0])) for i in range(0, self.MPPC.shape[1]))
+        # Changing the dark offset back to something simple
+        self.MPPC.cellDarkOffset.value = \
+            tuple(tuple(0 for i in range(0, self.MPPC.shape[0])) for i in range(0, self.MPPC.shape[1]))
 
         # Test missing rows
         with self.assertRaises(ValueError):
@@ -1059,6 +1100,7 @@ class TestMPPC(unittest.TestCase):
                          tuple(tuple(0 for i in range(0, self.MPPC.shape[0])) for i in range(0, self.MPPC.shape[1])))
 
     def test_cellDigitalGainVA(self):
+        """ Testing the digital gain VA (amplification value per cell)"""
         # The test values below are also handy for debugging, these values are chosen such that their number corresponds
         # to a row based numbering with the first row of values being from 0.0 to 7.0. This allows to have a human
         # readable check on the tuple structure created while testing input values.
@@ -1066,15 +1108,13 @@ class TestMPPC(unittest.TestCase):
             tuple(tuple(float(j) for j in range(i, i + self.MPPC.shape[0]))
                   for i in range(0, self.MPPC.shape[1] * self.MPPC.shape[0], self.MPPC.shape[0]))
 
-        self.assertEqual(
-                self.MPPC.cellDigitalGain.value,
-                tuple(tuple(float(j) for j in range(i, i + self.MPPC.shape[0]))
-                      for i in range(0, self.MPPC.shape[1] * self.MPPC.shape[0], self.MPPC.shape[0]))
-        )
+        self.assertEqual(self.MPPC.cellDigitalGain.value,
+                         tuple(tuple(float(j) for j in range(i, i + self.MPPC.shape[0]))
+                               for i in range(0, self.MPPC.shape[1] * self.MPPC.shape[0], self.MPPC.shape[0])))
 
         # Changing the digital gain back to something simple
-        self.MPPC.cellDigitalGain.value = tuple(
-                tuple(0.0 for i in range(0, self.MPPC.shape[0])) for i in range(0, self.MPPC.shape[1]))
+        self.MPPC.cellDigitalGain.value = \
+            tuple(tuple(0.0 for i in range(0, self.MPPC.shape[0])) for i in range(0, self.MPPC.shape[1]))
 
         # Test missing rows
         with self.assertRaises(ValueError):
@@ -1087,12 +1127,6 @@ class TestMPPC(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.MPPC.cellDigitalGain.value = tuple(tuple(0.0 for i in range(0, self.MPPC.shape[0]))
                                                     for i in range(0, self.MPPC.shape[1] - 1))
-        self.assertEqual(self.MPPC.cellDigitalGain.value,
-                         tuple(tuple(0.0 for i in range(0, self.MPPC.shape[0])) for i in range(0, self.MPPC.shape[1])))
-
-        # Test int as type for input value (should be converted to a float)
-        self.MPPC.cellDigitalGain.value = tuple(
-                tuple(int(0) for i in range(0, self.MPPC.shape[0])) for i in range(0, self.MPPC.shape[1]))
         self.assertEqual(self.MPPC.cellDigitalGain.value,
                          tuple(tuple(0.0 for i in range(0, self.MPPC.shape[0])) for i in range(0, self.MPPC.shape[1])))
 


### PR DESCRIPTION
* cellTranslation, cellDigitalGain, cellDarkOffset should also accept lists as input type as this is the format that needs to be provided in the yaml files
* simplify setters for readability
* cellDigitalGain: int can be considered a special case of float; simulator accepts ints and floats
* some reformatting and adding docstring to tests