### PR TITLE
acq calibration: fix loading AR background when file contains multiple AR data

### DIFF
--- a/src/odemis/acq/calibration.py
+++ b/src/odemis/acq/calibration.py
@@ -61,8 +61,8 @@ def get_ar_data(das):
     for polmode, ldas in ar_data.items():
         if len(ldas) > 1:
             logging.warning("AR calibration file contained %d AR data, "
-                            "will pick the earliest acquired", len(das))
-            earliest = min(ar_data,
+                            "will pick the earliest acquired", len(ldas))
+            earliest = min(ldas,
                            key=lambda d: d.metadata.get(model.MD_ACQ_DATE, float("inf")))
             ar_data[polmode] = [earliest]
 

--- a/src/odemis/acq/test/calibration_test.py
+++ b/src/odemis/acq/test/calibration_test.py
@@ -65,6 +65,37 @@ class TestAR(unittest.TestCase):
         out = calibration.get_ar_data([data1, calib, data2])
         numpy.testing.assert_equal(out, calib)
 
+    def test_load_multi(self):
+        # AR background data
+        dcalib = numpy.zeros((512, 1024), dtype=numpy.uint16)
+        md = {model.MD_SW_VERSION: "1.0-test",
+             model.MD_HW_NAME: "fake ccd",
+             model.MD_DESCRIPTION: "AR",
+             model.MD_ACQ_DATE: time.time(),
+             model.MD_BPP: 12,
+             model.MD_BINNING: (1, 1),  # px, px
+             model.MD_SENSOR_PIXEL_SIZE: (13e-6, 13e-6),  # m/px
+             model.MD_PIXEL_SIZE: (1e-6, 2e-5),  # m/px
+             model.MD_POS: (1.2e-3, -30e-3),  # m
+             model.MD_EXP_TIME: 1.2,  # s
+             model.MD_AR_POLE: (253.1, 65.1),
+             model.MD_LENS_MAG: 60,  # ratio
+            }
+        calib = model.DataArray(dcalib, md)
+        calib2 = model.DataArray(dcalib + 1, md)
+
+        # Give one DA, the correct one, so expect to get it back
+        out = calibration.get_ar_data([calib, calib2])
+        numpy.testing.assert_equal(out.shape, calib.shape)  # For now, it picks the first one
+
+        # More DataArrays, just to make it slightly harder to find the data
+        data1 = model.DataArray(numpy.ones((1, 1, 1, 520, 230), dtype=numpy.uint16),
+                                metadata={model.MD_POS: (1.2e-3, -30e-3)})
+        data2 = model.DataArray(17 * numpy.ones((1, 1), dtype=numpy.uint16),
+                                metadata={model.MD_POS: (1.2e-3, -30e-3)})
+        out = calibration.get_ar_data([data1, calib2, data2, calib])
+        numpy.testing.assert_equal(out, calib2)
+
     def test_load_full(self):
         """
         Check the whole sequence: saving calibration data to file, loading it


### PR DESCRIPTION
Wrong variable name, due to copy/paste.