### PR TITLE
driver andocam2: fix error when trying to recover from error

### DIFF
--- a/src/odemis/driver/andorcam2.py
+++ b/src/odemis/driver/andorcam2.py
@@ -2170,7 +2170,7 @@ class AndorCam2(model.DigitalCamera):
                         self.Reinitialize()
                     else:
                         time.sleep(0.1)
-                        logging.warning("trying again to acquire image after error %s", ex.strerr)
+                        logging.warning("trying again to acquire image after error %s", ex)
                     need_reinit = True
                     continue
                 else:


### PR DESCRIPTION
The Excetion doesn't have any .strerr attribute, it's called .strerror.
This caused the acquisition to completely fail instead of trying again.

Typically, the log would look like:
2021-04-13 09:59:51,508	ERROR	andorcam2:2190:	Failure during acquisition
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/odemis/driver/andorcam2.py", line 2139, in _acquire_thread_synchronized
    self.WaitForAcquisition(0.1)
  File "/usr/lib/python3/dist-packages/odemis/driver/andorcam2.py", line 1147, in WaitForAcquisition
    self.atcore.WaitForAcquisitionTimeOut(timeout_ms)
  File "/usr/lib/python3/dist-packages/odemis/driver/andorcam2.py", line 288, in at_errcheck
    (str(func.__name__), result, AndorV2DLL.err_code[result]))
odemis.driver.andorcam2.AndorV2Error: Call to WaitForAcquisitionTimeOut failed with error code 20024: DRV_NO_NEW_DATA

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/odemis/driver/andorcam2.py", line 2173, in _acquire_thread_synchronized
    logging.warning("trying again to acquire image after error %s", ex.strerr)
AttributeError: 'AndorV2Error' object has no attribute 'strerr'