### PR TITLE
driver pmtctrl test: PH300RawDetector got renamed to RawDetector

### DIFF
--- a/src/odemis/driver/test/pmtctrl_test.py
+++ b/src/odemis/driver/test/pmtctrl_test.py
@@ -58,7 +58,8 @@ class FakePH300(model.Component):
     def GetCountRate(self, channel):
         return random.randint(0, 5000)
 
-CLASS_TR_CTRL = picoquant.PH300RawDetector
+
+CLASS_TR_CTRL = picoquant.RawDetector
 KWARGS_TR_CTRL = dict(name="Photon counter signal", role="photo-detector", parent=FakePH300("fake"), channel=0, shutter_name='shutter1')
 
 CLASS_PMT = pmtctrl.PMT


### PR DESCRIPTION
In the picoquant driver, the class got renamed, and I hadn't realised it
was used by some other code... breaking this test cases.