### PR TITLE
ASM API wrapper: modify filename VA to raise error when invalid name is provided

### DIFF
--- a/src/odemis/driver/technolution.py
+++ b/src/odemis/driver/technolution.py
@@ -1347,15 +1347,14 @@ class MPPC(model.Detector):
 
     def _setFilename(self, file_name):
         """
-        Check if filename complies with set allowed characters
-        :param file_name (string):
-        :return: file_name (string)
+        Check if filename complies with the set of allowed characters.
+        :param file_name: (str) The requested filename for the image data to be acquired.
+        :return: (str) The set filename for the image data to be acquired.
         """
-        ASM_FILE_ILLEGAL_CHARS = r'[^a-z0-9_()-]'
-        if re.search(ASM_FILE_ILLEGAL_CHARS, file_name):
-            logging.warning("File_name contains invalid characters, file_name remains unchanged (only the characters "
-                            "'%s' are allowed)." % ASM_FILE_ILLEGAL_CHARS[2:-1])
-            return self.filename.value
+        ASM_FILE_CHARS = r'[^a-z0-9_()-]'
+        if re.search(ASM_FILE_CHARS, file_name):
+            raise ValueError("Filename contains invalid characters. Only the following characters are allowed: "
+                             "'%s'. Please choose a new filename." % ASM_FILE_CHARS[2:-1])
         else:
             return file_name
 

--- a/src/odemis/driver/test/technolution_test.py
+++ b/src/odemis/driver/test/technolution_test.py
@@ -867,11 +867,13 @@ class TestMPPC(unittest.TestCase):
         time.sleep(0.2)  # wait a bit so that termination calls to the ASM are completed and session is properly closed.
 
     def test_file_name_VA(self):
+        """Testing the filename VA"""
         self.MPPC.filename.value = "testing_file_name"
         self.assertEqual(self.MPPC.filename.value, "testing_file_name")
-        # Test if invalid file name is entered the file name remains unchanged.
-        self.MPPC.filename.value = "@testing_file_name"
-        self.assertEqual(self.MPPC.filename.value, "testing_file_name")
+
+        # Raise an error if invalid filename is provided
+        with self.assertRaises(ValueError):
+            self.MPPC.filename.value = "@testing_file_name"
 
     def test_acqDelay_VA(self):
         max_acqDelay = self.MPPC.acqDelay.range[1]


### PR DESCRIPTION
If an invalid name is provided raise an error which can be captured e.g. by the GUI. A warning in the backend, is not immediantly visible to the user. If the value is just overwritten, we end up overwritting an already acquired image. Raise an error, so the GUI e.g. can request a different name.
Remove ILLEGAL in name for characters as those are the actually allowed characters.