### PR TITLE
gui conf data: don't arbitrarily limit the minimum spectrum exposure to 10ms

### DIFF
--- a/src/odemis/gui/conf/data.py
+++ b/src/odemis/gui/conf/data.py
@@ -377,7 +377,7 @@ HW_SETTINGS_CONFIG = {
             ("exposureTime", {
                 "control_type": odemis.gui.CONTROL_SLIDER,
                 "scale": "log",
-                "range": (0.01, 500.0),
+                "range": (1e-6, 500.0),
                 "type": "float",
                 "accuracy": 2,
             }),


### PR DESCRIPTION
10 ms is quite long, and some sample can do with much less. It should be
limited only by the hardware exposure time.
=> Put a 1 µs limit, which should work with pretty much any hardware.