### PR TITLE
gui comp buttons TabButton: allow to call .Enable() without argument

### DIFF
--- a/src/odemis/gui/comp/buttons.py
+++ b/src/odemis/gui/comp/buttons.py
@@ -721,7 +721,7 @@ class TabButton(GraphicRadioButton):
 
         self.highlighted = False
 
-    def Enable(self, enable):
+    def Enable(self, enable=True):
         if enable:
             if self.highlighted:
                 self.SetForegroundColour(FG_COLOUR_HIGHLIGHT)


### PR DESCRIPTION
All the wxPython components support Enable() == Enable(True).
So let's do it here too.