### PR TITLE
ENZEL: Handle clearing stream panel

### DIFF
--- a/src/odemis/gui/cont/streams.py
+++ b/src/odemis/gui/cont/streams.py
@@ -2129,6 +2129,15 @@ class StreamBarController(object):
             s.should_update.value = True
             # it will be activated by the stream scheduler
 
+    def removeStreamPanel(self, stream):
+        """
+        Remove the stream & its panel
+        """
+        sp = next((sp for sp in self._stream_bar.stream_panels if sp.stream == stream), None)
+        if sp:
+            # Simulate clicking the remove stream button (will take care or removing the stream & panel)
+            sp.on_remove_btn(stream)
+
     def removeStream(self, stream):
         """ Removes the given stream
 

--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -513,7 +513,7 @@ class LocalizationTab(Tab):
         streams = data_to_static_streams(data)
 
         for s in streams:
-            self.clear_overview_data(s.name.value)
+            self.clear_overview_streams(s.name.value)
             scont = self._overview_stream_controller.addStream(s, add_to_view=True)
             scont.stream_panel.show_remove_btn(True)
 
@@ -529,18 +529,16 @@ class LocalizationTab(Tab):
                 stream.histogram._value = numpy.empty(0)
                 stream.histogram.notify(stream.histogram._value)
 
-    def clear_overview_data(self, filter_stream_name=None):
+    def clear_overview_streams(self, filter_stream_name=None):
         """
-        Clear the tab data upon resetting the project:
-        - Clear overview map streams
+        Remove overview map (Static) streams and clear them from view and panel.
         @:param filter_stream_name: (StaticStream or None) the newly acquired stream name to filter on, None will remove all static streams
         """
-        # TODO: Remove old streams from the panel as well, currently it's hidden
         static_streams = [stream for stream in self.tab_data_model.streams.value if isinstance(stream, StaticStream)]
         for stream in static_streams:
             if filter_stream_name and stream.name.value != filter_stream_name:
                 continue
-            self._overview_stream_controller.removeStream(stream)
+            self._overview_stream_controller.removeStreamPanel(stream)
 
     def _onAutofocus(self, active):
         # Determine which stream is active
@@ -2154,7 +2152,7 @@ class CryoChamberTab(Tab):
     def _reset_project_data(self):
         try:
             localization_tab = self.tab_data_model.main.getTabByName("cryosecom-localization")
-            localization_tab.clear_overview_data()
+            localization_tab.clear_overview_streams()
             localization_tab.clear_live_streams()
         except LookupError:
             logging.warning("Unable to find localization tab.")

--- a/src/odemis/gui/win/acquisition.py
+++ b/src/odemis/gui/win/acquisition.py
@@ -867,6 +867,8 @@ class OverviewAcquisitionDialog(xrcfr_overview_acq):
             self.acq_future.cancel()
 
         self.terminate_listeners()
+        # Set the streambar controller to None so it wouldn't be a listener to stream.remove
+        self.streambar_controller = None
 
         self.EndModal(wx.ID_CANCEL)
 


### PR DESCRIPTION
Fix the dead listener bug on removing overview streams.
Also fix the issue of removing the stream panel when replacing old overview streams.