### PR TITLE
driver-piezomotor: document behaviour of open-loop simulator

### DIFF
--- a/src/odemis/driver/piezomotor.py
+++ b/src/odemis/driver/piezomotor.py
@@ -1053,6 +1053,8 @@ class PMDSimulator(object):
                 else:
                     raise ValueError()
             elif cmd == "J":
+                # TODO: check hardware behaviour in open loop. What does the E command return if no encoder is
+                #  connected? Probably 0, so don't update .current_pos here.
                 if not args:
                     if self.is_moving:
                         self._output_buf += ":222"

--- a/src/odemis/driver/test/piezomotor_test.py
+++ b/src/odemis/driver/test/piezomotor_test.py
@@ -76,6 +76,7 @@ class TestPMD401OpenLoop(unittest.TestCase):
 
         self.stage.moveAbsSync({'x': 0.01})
         self.stage.moveAbsSync({'x': 0})
+        # don't check .position in open loop (always 0 if no encoder is connected?)
 
         self.stage.moveRelSync({'x': 0.01})
         self.stage.moveRelSync({'x': -0.01})


### PR DESCRIPTION
Currently, the position returned by the simulator is always 0 in open-loop. This might be the same behaviour as on the hardware if no encoder is connected (should be checked!)