### PR TITLE
odemisd start: do not close the GUI window if it's already opened

### DIFF
--- a/src/odemis/odemisd/start.py
+++ b/src/odemis/odemisd/start.py
@@ -563,7 +563,7 @@ def find_window(wm_class):
     wm_class (str): the WM_CLASS to match (eg, as reported by xprop)
     return (bool): True if at least one window is found with this class
     """
-    # Ask xprop for the window (but without actually reading the properties    )
+    # Ask xprop for the window (but without actually reading the properties)
     try:
         found = subprocess.call(["/usr/bin/xprop", "-name", wm_class],
                                 stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)


### PR DESCRIPTION
Calling Odemis-start when Odemis is already started doesn’t restart the
backend. However, it restart the GUI.

That’s bad behaviour, as some customers have multiple icons of odemis.
In such case, it’s easy to call odemis-start by mistake, which kills the
GUI, and brings a new one. Really not fun if the GUI was in the process
of a long acquisition.

=> If GUI is already started, do not restart it.