### PR TITLE
gui cont tabs SPARC2Align: also update the optical path when changing the detector

### DIFF
--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -5201,6 +5201,11 @@ class Sparc2AlignTab(Tab):
         stream.should_update.value = True
         stream.is_active.value = True
 
+        # Move the optical path selectors for the detector (spec-det-selector in particular)
+        # The moves will happen in the background.
+        opm = self.tab_data_model.main.opm
+        opm.selectorsToPath(stream.detector.name)
+
     def add_combobox_control(self, label_text, value=None, conf=None):
         """ Add a combo box to the focus panel
         # Note: this is a hack. It must be named so, to look like a StreamPanel


### PR DESCRIPTION
The new manual focus option allow to switch the detector. For now it
just select which stream plays. That's not enough as each detector is
selected by a mirror to switch the optical path.

=> Call the optical path manager to update move the mirror(s) to the
right position.