### PR TITLE
cli: allow to pass the "action" without "--"

### DIFF
--- a/src/odemis/cli/main.py
+++ b/src/odemis/cli/main.py
@@ -53,6 +53,11 @@ status_to_xtcode = {BACKEND_RUNNING: 0,
 VAS_COMPS = {"alive", "dependencies"}
 VAS_HIDDEN = {"children", "affects"}
 
+# Command line arguments which can have "--" omitted
+ACTION_NAMES = ("kill", "check", "list", "list-prop", "set-attr", "update-metadata",
+                "move", "position", "stop", "reference", "acquire", "live", "scan",
+                "version", "help")
+
 
 # small object that can be remotely executed for scanning
 class Scanner(model.Component):
@@ -861,6 +866,15 @@ def main(args):
     # arguments handling
     parser = argparse.ArgumentParser(prog="odemis-cli",
                                      description=odemis.__fullname__)
+
+    # argparse doesn't allow optional arguments without dash. So to support
+    # action-like arguments, we add "--" on the fly.
+    for i, arg in enumerate(args):
+        if arg in ACTION_NAMES:
+            args[i] = "--" + arg
+            # Only do it on the first match, as a "safety" in case an argument
+            # (eg, component role) would be matching action too.
+            break
 
     parser.add_argument('--version', dest="version", action='store_true',
                         help="show program's version number and exit")

--- a/src/odemis/cli/test/main_test.py
+++ b/src/odemis/cli/test/main_test.py
@@ -164,6 +164,22 @@ class TestWithBackend(unittest.TestCase):
         self.assertTrue(b"Light Engine" in output)
         self.assertTrue(b"Camera" in output)
 
+    def test_list_no_dash(self):
+        try:
+            # change the stdout
+            out = BytesIO()
+            sys.stdout = out
+
+            cmdline = "cli --log-level 1 list"
+            ret = main.main(cmdline.split())
+        except SystemExit as exc:
+            ret = exc.code
+        self.assertEqual(ret, 0, "trying to run '%s'" % cmdline)
+
+        output = out.getvalue()
+        self.assertTrue(b"Light Engine" in output)
+        self.assertTrue(b"Camera" in output)
+
     def test_check(self):
         try:
             cmdline = "cli --check"


### PR DESCRIPTION
Make the command line easier to type and read by ommitting the "--"
before an action, à la git.
The "--" are still allowed.

So now, instead of writting "odemis-cli --list", one can write
"odemis-cli list".

This only works for "actions", not the options, like "--machine".