### PR TITLE
driver zeiss: don't set FoV when it changes

### DIFF
--- a/src/odemis/driver/zeiss.py
+++ b/src/odemis/driver/zeiss.py
@@ -786,7 +786,6 @@ class Scanner(model.Emitter):
         return self.parent.GetAccelerationVoltage()
 
     def _onHorizontalFoV(self, fov):
-        self._setHorizontalFoV(fov)
         self._updateDepthOfField()
 
     def _updateDepthOfField(self):


### PR DESCRIPTION
It doesn't make sense to ask to set the FoV to the same value as we
received it.
Probably some copy/paste error.