### PR TITLE
config: update bash completion

### DIFF
--- a/debian/odemis.dirs
+++ b/debian/odemis.dirs
@@ -1,5 +1,4 @@
 etc/sudoers.d
 etc/logrotate.d
-etc/bash_completion.d
+usr/share/bash-completion/completions
 usr/lib/odemis/plugins
-usr/lib/odemis/python2

--- a/debian/odemis.install
+++ b/debian/odemis.install
@@ -1,4 +1,4 @@
 install/linux/etc/logrotate.d/odemisd etc/logrotate.d/
 install/linux/etc/sudoers.d/odemis etc/sudoers.d/
-install/linux/etc/bash_completion.d/odemis-cli etc/bash_completion.d/
-install/linux/etc/bash_completion.d/odemis-convert etc/bash_completion.d/
+install/linux/usr/share/bash-completion/completions/odemis-cli usr/share/bash-completion/completions/
+install/linux/usr/share/bash-completion/completions/odemis-convert usr/share/bash-completion/completions/

--- a/debian/odemis.links
+++ b/debian/odemis.links
@@ -1,0 +1,1 @@
+usr/bin/odemis-cli usr/bin/odemis

--- a/install/linux/usr/share/bash-completion/completions/odemis-cli
+++ b/install/linux/usr/share/bash-completion/completions/odemis-cli
@@ -1,6 +1,6 @@
 # bash completion for odemis-cli
 
-have odemis-cli &&
+_have odemis-cli &&
 _odemis_cli()
 {
     local cur prev
@@ -8,7 +8,7 @@ _odemis_cli()
     _get_comp_words_by_ref cur prev
     # TODO: handle 2nd argument for --set-attr (=type:va)
     case $prev in
-        --list-prop|-L|--move|-m|--position|-p|--reference|--set-attr|-s|--update-metadata|-u|--acquire|-a|--live)
+        --list-prop|-L|list-prop|--move|-m|move|--position|-p|position|--reference|reference|--set-attr|-s|set-attr|--update-metadata|-u|update-metadata|--acquire|-a|acquire|--live|live)
             # TODO: For some commands, only actuators or detectors are valid.
             odemis-cli --check || return 0
             local components=$(odemis-cli --list --machine | cut -f 1,2 | sed -e "s/\\t/\\n/" | grep -v "role:None" | sed -e "s/^role://")
@@ -27,17 +27,20 @@ _odemis_cli()
 
     case $cur in
         *)
-            COMPREPLY=( $(compgen -W '--help --log-level --machine \
-                --kill --check --scan --list --list-prop --set-attr \
-                --update-metadata --move --position --reference --stop \
-                --acquire --output --live --version --big-distance' -- "$cur") )
+            COMPREPLY=( $(compgen -W '--help help --log-level --machine \
+                --kill kill --check check --scan scan --list list --list-prop list-prop \
+                --set-attr set-attr --update-metadata update-metadata \
+                --move move --position position --reference reference --stop stop \
+                --acquire acquire --output --live live --version version --big-distance' -- "$cur") )
             return 0
             ;;
     esac
 
     return 0
-} &&
-complete -F _odemis_cli odemis-cli -o filenames
+}
+
+_have odemis-cli && complete -F _odemis_cli odemis-cli -o filenames
+_have odemis && complete -F _odemis_cli odemis -o filenames
 
 # Local variables:
 # mode: shell-script

--- a/install/linux/usr/share/bash-completion/completions/odemis-convert
+++ b/install/linux/usr/share/bash-completion/completions/odemis-convert
@@ -1,6 +1,6 @@
 # bash completion for odemis-convert
 
-have odemis-convert &&
+_have odemis-convert &&
 _odemis_convert()
 {
     local cur prev
@@ -22,8 +22,9 @@ _odemis_convert()
     esac
 
     return 0
-} &&
-complete -F _odemis_convert odemis-convert -o filenames
+}
+
+_have odemis-convert && complete -F _odemis_convert odemis-convert -o filenames
 
 # Local variables:
 # mode: shell-script


### PR DESCRIPTION
Also complete "action" style arguments.

Provide odemis link to "odemis-cli", as a short-cut.

Move to "new" directory /usr/share/bash-completion/ (available since
Ubuntu 16.04).

Use new _have function