### PR TITLE
gui model: give clear error messages when a required component is missing

### DIFF
--- a/src/odemis/gui/model/__init__.py
+++ b/src/odemis/gui/model/__init__.py
@@ -307,6 +307,22 @@ class MainGUIData(object):
             if self.spectrometer is None and self.spectrometers:
                 self.spectrometer = self.spectrometers[0]
 
+            # Check for the most known microscope types that the basics are there
+            required_roles = []
+            if self.role in ("secom", "delphi", "cryo-secom"):
+                required_roles += ["e-beam", "light", "stage", "focus"]
+                if self.role == "secom":
+                    required_roles += ["align", "se-detector"]
+            elif self.role in ("sparc", "sparc2"):
+                required_roles += ["e-beam", "mirror", "lens"]
+            elif self.role == "mbsem":
+                required_roles += ["e-beam", "stage"]
+
+            for crole in required_roles:
+                attrname = self._ROLE_TO_ATTR[crole]
+                if getattr(self, attrname) is None:
+                    raise KeyError("Microscope (%s) is missing the '%s' component" % (self.role, crole))
+
             # Check that the components that can be expected to be present on an actual microscope
             # have been correctly detected.
 

--- a/src/odemis/gui/model/test/model_test.py
+++ b/src/odemis/gui/model/test/model_test.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+'''
+Created on 21 June 2013
+
+@author: Éric Piel
+
+Copyright © 2021 Éric Piel, Delmic
+
+This file is part of Odemis.
+
+Odemis is free software: you can redistribute it and/or modify it under the terms
+of the GNU General Public License version 2 as published by the Free Software
+Foundation.
+
+Odemis is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+Odemis. If not, see http://www.gnu.org/licenses/.
+'''
+import logging
+from odemis import model
+import odemis
+from odemis.gui.model import MainGUIData
+from odemis.util import test
+import os
+import unittest
+from unittest.case import skip
+
+logging.getLogger().setLevel(logging.DEBUG)
+
+CONFIG_PATH = os.path.dirname(odemis.__file__) + "/../../install/linux/usr/share/odemis/"
+
+
+# @skip("simple")
+class MainGUIDataTestCase(unittest.TestCase):
+    
+    def test_secom_missing_stage(self):
+        """
+        Check it properly detects that a SECOM is missing a component
+        """
+        # Start the backend
+        try:
+            broken_config_path = os.path.dirname(__file__) + "/secom-sim-no-stage.odm.yaml"
+            test.start_backend(broken_config_path)
+        except LookupError:
+            logging.info("A running backend is already found, skipping tests")
+            self.skipTest("Running backend found")
+        except IOError as exp:
+            logging.error(str(exp))
+            raise
+
+        # Check it fails
+        microscope = model.getMicroscope()
+        with self.assertRaises(KeyError):
+            MainGUIData(microscope)
+
+        test.stop_backend()
+
+    def test_secom(self):
+        """
+        Check it properly detects that a SECOM is missing a component
+        """
+        # Start the backend
+        try:
+            broken_config_path = CONFIG_PATH + "sim/secom-sim.odm.yaml"
+            test.start_backend(broken_config_path)
+        except LookupError:
+            logging.info("A running backend is already found, skipping tests")
+            self.skipTest("Running backend found")
+        except IOError as exp:
+            logging.error(str(exp))
+            raise
+
+        # Check it fails
+        microscope = model.getMicroscope()
+        gdata = MainGUIData(microscope)
+
+        self.assertEqual(gdata.microscope, microscope)
+        self.assertEqual(gdata.role, microscope.role)
+
+        self.assertIsInstance(gdata.ccd, model.ComponentBase)
+        self.assertIn(gdata.ccd, gdata.ccds)
+        self.assertIsInstance(gdata.stage, model.ComponentBase)
+        self.assertIsNone(gdata.spectrograph)
+
+        self.assertIsNotNone(gdata.opm)
+        self.assertIsNotNone(gdata.settings_obs)
+
+        test.stop_backend()
+
+    def test_no_microscope(self):
+        """
+        Check it handles fine when GUI is started in "standalone" mode (aka Viewer)
+        """
+
+        gdata = MainGUIData(None)
+        self.assertIsNone(gdata.microscope)
+        self.assertIsNone(gdata.role)
+
+        self.assertIsNone(gdata.ccd)
+        self.assertEqual(len(gdata.ccds), 0)
+        self.assertIsNone(gdata.spectrograph)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/odemis/gui/model/test/secom-sim-no-stage.odm.yaml
+++ b/src/odemis/gui/model/test/secom-sim-no-stage.odm.yaml
@@ -1,0 +1,168 @@
+# Special version of the SECOM simulator with a stage missing, for testing
+SimSECOM: {
+    class: Microscope,
+    role: secom,
+    emitters: ["Light Engine", "Optical Objective", "Optical Emission Filter", "SEM E-beam"],
+    detectors: ["Camera", "SEM Detector"],
+    actuators: ["Sample Stage", "Objective Stage", "Optical Focus", "EBeam Focus"],
+}
+
+"Light Engine": {
+    class: lle.FakeLLE,
+    role: light,
+    init: {
+        port: "/dev/ttyLLE",
+        # source name -> 99% low, 25% low, centre, 25% high, 99% high wavelength in m
+        sources: {"red": [615.e-9, 625.e-9, 633.e-9, 640.e-9, 650.e-9],
+                  "green": [525.e-9, 540.e-9, 550.e-9, 555.e-9, 560.e-9],
+                  "cyan": [455.e-9, 465.e-9, 475.e-9, 485.e-9, 495.e-9],
+                  "UV": [375.e-9, 390.e-9, 400.e-9, 402.e-9, 405.e-9],
+                  "yellow": [565.e-9, 570.e-9, 575.e-9, 580.e-9, 595.e-9],
+                  "blue": [420.e-9, 430.e-9, 438.e-9, 445.e-9, 455.e-9],
+                  "teal": [495.e-9, 505.e-9, 513.e-9, 520.e-9, 530.e-9],
+                 }
+        },
+    affects: ["Camera"],
+}
+
+"SEM Scan Interface": {
+    class: simsem.SimSEM,
+    role: null,
+    init: {
+           image: "simsem-fake-output.h5", # any large 16 bit image is fine
+           drift_period: 5, # s, comment out to disable drift
+    },
+    children: {scanner: "SEM E-beam",
+               detector0: "SEM Detector",
+               focus: "EBeam Focus",
+    }
+}
+
+"SEM E-beam": {
+    # Internal child of SimSEM, so no class
+    role: e-beam,
+    init: {},
+    properties: {
+        dwellTime: 10.e-6, # s
+    },
+    affects: ["SEM Detector", "Camera"] # affects the CCD in case of cathodoluminescence
+}
+
+"SEM Detector": { # aka ETD
+    # Internal child of SimSEM, so no class
+    role: se-detector,
+    init: {},
+}
+
+"EBeam Focus": {
+    # Internal child of SimSEM, so no class
+    role: ebeam-focus,
+}
+
+"Optical Objective": {
+    class: static.OpticalLens,
+    role: lens,
+    init: {
+       mag: 100.0, # ratio, (actually of the complete light path)
+       na: 0.95, # ratio, numerical aperture
+       ri: 1.0, # ratio, refractive index
+    },
+    affects: ["Camera"]
+}
+
+#"Optical Emission Filter": {
+#    class: static.LightFilter,
+#    role: filter,
+#    init: {band: [[420.e-9, 460.e-9],
+#                  [510.e-9, 532.e-9], 
+#                  [590.e-9, 624.e-9],
+#                  [677.e-9, 723.e-9]]}, # m,m
+#    affects: ["Camera"]
+#}
+
+# Thorlabs FW102C with 6 filters
+"Optical Emission Filter": {
+    class: tlfw.FakeFW102c,
+    role: filter,
+    init: {port: "/dev/ttyFTDI*", # will automatically find the right port
+           bands: {1: [420.e-9, 460.e-9], # pos -> m,m
+                   2: [500.e-9, 550.e-9], 
+                   3: [553.e-9, 577.e-9],
+                   4: [582.e-9, 636.e-9],
+                   5: [635.e-9, 675.e-9],
+                   6: [633.e-9, 1200.e-9]}, 
+           },
+    affects: ["Camera"]
+}
+
+
+# Axes: X is horizontal on screen (going left->right), physical: far->close when looking at the door
+#       Y is vertical on screen (going bottom->top), physical: left->right when looking at the door
+"Camera": {
+    class: andorcam2.FakeAndorCam2,
+    role: ccd,
+    init: {device: 0,
+           transp: [2, -1], # rotated 90° clockwise
+           # Look-up table for recommended EMCCD Real Gain
+           # readout rate, gain, real gain (integer)
+           emgains: [[10.e+6, 1, 50],
+                     [1.e+6, 1, 150],
+                    ],
+           image: "andorcam2-fake-clara.tiff", # only for simulator
+    },
+    properties: {
+        targetTemperature: -75, # °C
+    }
+}
+
+# Use 3 MultiplexActuators to separate the axes of the PIGCS over different roles
+
+# Axes should be synchronized with the camera
+# Stage axes are moving the sample, so they should opposite direction than convention
+# (so the stage "position" is the current position observed)
+"Sample Stage": {
+    class: actuator.MultiplexActuator,
+    role: not-a-stage,   # Wrong role
+    affects: ["Camera", "SEM E-beam"],
+    dependencies: {"x": "Stage Actuators", "y": "Stage Actuators"},
+    init: {
+        axes_map: {"x": "x", "y": "y"},
+        inverted: ["x"],
+    },
+}
+
+"Objective Stage": {
+    class: actuator.MultiplexActuator,
+    role: align,
+    affects: ["Camera"],
+    dependencies: {"a": "Stage Actuators", "b": "Stage Actuators"},
+    init: {
+        axes_map: {"a": "a", "b": "b"},
+        inverted: ["a", "b"]
+    },
+}
+
+# Axis Z: (Physical) bottom->top when looking at the door
+#         (On screen) bottom->top (so distance to sample is smaller when going up)    
+"Optical Focus": {
+    class: actuator.MultiplexActuator,
+    role: focus,
+    affects: ["Camera"],
+    dependencies: {"z": "Stage Actuators"},
+    init: {
+        axes_map: {"z": "z"}
+    },
+}
+
+"Stage Actuators": {
+    class: pigcs.FakeBus,
+    role: null,
+    init: {
+        port: "/dev/ttyPIGCS",
+        # axis -> controller, channel, closed-loop?
+        axes: {"a": [1, 1, False], "b": [2, 1, False], "z": [3, 1, False],
+               "x": [4, 1, False], "y": [5, 1, False]},
+    },
+}
+
+


### PR DESCRIPTION
For the SECOM/SPARC/DELPHI, we have some basic expectations in the code
in terms of which component has to be present.

So far, if the user doesn't have this component in the microscope file
(or, more likely, the component role has a typo), very unclear messages
are shown, such as:
2021-06-04 10:44:24,114	ERROR	main:381:	Traceback (most recent call last):
  File "/home/cryo-poc/development/odemis/src/odemis/gui/main.py", line 140, in OnInit
    self.init_gui()
  File "/home/cryo-poc/development/odemis/src/odemis/gui/main.py", line 237, in init_gui
    self.tab_controller = tabs.TabBarController(tab_defs, self.main_frame, self.main_data)
  File "/home/cryo-poc/development/odemis/src/odemis/gui/cont/tabs.py", line 5433, in __init__
    tab_list, default_tab = self._create_needed_tabs(tab_defs, main_frame, main_data)
  File "/home/cryo-poc/development/odemis/src/odemis/gui/cont/tabs.py", line 5509, in _create_needed_tabs
    tpnl, main_frame, main_data)
  File "/home/cryo-poc/development/odemis/src/odemis/gui/cont/tabs.py", line 3322, in __init__
    hwemtvas=get_local_vas(main_data.ebeam, main_data.hw_settings_config),
  File "/home/cryo-poc/development/odemis/src/odemis/gui/conf/data.py", line 936, in get_local_vas
    config_vas = get_hw_config(hw_comp, hw_settings)
  File "/home/cryo-poc/development/odemis/src/odemis/gui/conf/data.py", line 894, in get_hw_config
    role = hw_comp.role
AttributeError: 'NoneType' object has no attribute 'role'

It would now show:
KeyError: Microscope (secom) is missing the 'e-beam' component