### PR TITLE
technolution driver: add hack to skip the first field image

### DIFF
--- a/src/odemis/driver/technolution.py
+++ b/src/odemis/driver/technolution.py
@@ -1145,6 +1145,13 @@ class MPPC(model.Detector):
                     dataContent = args[1]  # Specifies the type of image to return (empty, thumbnail or full)
                     notifier_func = args[2]  # Return function (usually, dataflow.notify or acquire_single_field queue)
 
+                    # FIXME: Hack: The current ASM HW does not scan the very first field image correctly. This issue
+                    #  needs to be fixed in HW. However, until this is done, we need to "through away" the first field
+                    #  image and scan it a second time to receive a good first field image. To do so, just always scan
+                    #  the first image twice.
+                    if field_data.position_x == 0 and field_data.position_y == 0:
+                        self.parent.asmApiPostCall("/scan/scan_field", 204, field_data.to_dict())
+
                     self.parent.asmApiPostCall("/scan/scan_field", 204, field_data.to_dict())
 
                     if DATA_CONTENT_TO_ASM[dataContent] is None:

--- a/src/odemis/driver/technolution.py
+++ b/src/odemis/driver/technolution.py
@@ -1146,7 +1146,7 @@ class MPPC(model.Detector):
                     notifier_func = args[2]  # Return function (usually, dataflow.notify or acquire_single_field queue)
 
                     # FIXME: Hack: The current ASM HW does not scan the very first field image correctly. This issue
-                    #  needs to be fixed in HW. However, until this is done, we need to "through away" the first field
+                    #  needs to be fixed in HW. However, until this is done, we need to "throw away" the first field
                     #  image and scan it a second time to receive a good first field image. To do so, just always scan
                     #  the first image twice.
                     if field_data.position_x == 0 and field_data.position_y == 0:

--- a/src/odemis/driver/technolution.py
+++ b/src/odemis/driver/technolution.py
@@ -1150,6 +1150,7 @@ class MPPC(model.Detector):
                     #  image and scan it a second time to receive a good first field image. To do so, just always scan
                     #  the first image twice.
                     if field_data.position_x == 0 and field_data.position_y == 0:
+                        logging.debug("Rescanning first field to workaround hardware limitations.")
                         self.parent.asmApiPostCall("/scan/scan_field", 204, field_data.to_dict())
 
                     self.parent.asmApiPostCall("/scan/scan_field", 204, field_data.to_dict())


### PR DESCRIPTION
The current ASM HW does not scan the very first field image correctly. This issue needs to be fixed in HW. However, until this is done, we need to "through away" the first field image and scan it a second time to receive a good first field image. To do so, just always scan the first image twice and overwrite on disc (external storage).