### PR TITLE
driver-lakeshore: avoid false positive syntax error in runtest script

### DIFF
--- a/src/odemis/driver/lakeshore.py
+++ b/src/odemis/driver/lakeshore.py
@@ -274,7 +274,8 @@ class Lakeshore(model.HwComponent):
                 errors.append(STATUS_BYTE[err])
 
         if errors:
-            raise LakeshoreError(status_byte, "Error %s (Status byte: 0x%X)" % (", ".join(errors), status_byte))
+            error_msg = "Error %s (Status byte: 0x%X)" % (", ".join(errors), status_byte)
+            raise LakeshoreError(status_byte, error_msg)
 
     def GetIdentifier(self):
         """


### PR DESCRIPTION
The script looks for commas in the error message. Usually this is a sign of a syntax error since arguments need to be passed by '%' instead of ','. However, in this case, the comma has a different meaning, so it's not an error. To avoid the false positive warning, just move the string to a variable.