### PR TITLE
driver: fix Exception non-unpicklable

### DIFF
--- a/src/odemis/driver/pigcs.py
+++ b/src/odemis/driver/pigcs.py
@@ -136,10 +136,13 @@ class PIGCSError(Exception):
 
     def __init__(self, errno, *args, **kwargs):
         # Needed for pickling, cf https://bugs.python.org/issue1692335 (fixed in Python 3.3)
-        desc = self._errordict.get(errno, "Unknown error")
-        strerror = "PIGCS error %d: %s" % (errno, desc)
-        Exception.__init__(self, strerror, *args, **kwargs)
+        super(PIGCSError, self).__init__(errno, *args, **kwargs)
         self.errno = errno
+        desc = self._errordict.get(errno, "Unknown error")
+        self.strerror = "PIGCS error %d: %s" % (errno, desc)
+
+    def __str__(self):
+        return self.strerror
 
     _errordict = {
         0: "No error",

--- a/src/odemis/driver/smaract.py
+++ b/src/odemis/driver/smaract.py
@@ -278,9 +278,15 @@ class SmarPodError(Exception):
     """
     SmarPod Exception
     """
-    def __init__(self, error_code):
-        self.errno = error_code
-        super(SmarPodError, self).__init__("Error %d. %s" % (error_code, SmarPodDLL.err_code.get(error_code, "")))
+
+    def __init__(self, errno, *args, **kwargs):
+        # Needed for pickling, cf https://bugs.python.org/issue1692335 (fixed in Python 3.3)
+        super(SmarPodError, self).__init__(errno, *args, **kwargs)
+        self.errno = errno
+        self.strerror = "Error %d. %s" % (errno, SmarPodDLL.err_code.get(errno, ""))
+
+    def __str__(self):
+        return self.strerror
 
 
 class SmarPod(model.Actuator):

--- a/src/odemis/driver/symphotime.py
+++ b/src/odemis/driver/symphotime.py
@@ -542,13 +542,15 @@ class SPTError(HwError):
     Symphotime Error Exception object
     errcode (int): a symphotime error code, as defined in the ERRCODE dictionary
     '''
-    def __init__(self, errcode):
-        if errcode in ERRCODE:
-            text = "Error %d: %s" % (errcode, ERRCODE[errcode])
-        else:
-            text = "Unknown error code."
-        HwError.__init__(self, text)
 
+    def __init__(self, errno, *args, **kwargs):
+        # Needed for pickling, cf https://bugs.python.org/issue1692335 (fixed in Python 3.3)
+        super(SPTError, self).__init__(errno, *args, **kwargs)
+        self.errno = errno
+        self.strerror = "Error %d. %s" % (errno, ERRCODE.get(errno, "Unknown error code."))
+
+    def __str__(self):
+        return self.strerror
 
 class Controller(model.Detector):
     '''

--- a/src/odemis/driver/test/pigcs_test.py
+++ b/src/odemis/driver/test/pigcs_test.py
@@ -23,16 +23,18 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 '''
 from __future__ import division, print_function
 
+from builtins import range
 from concurrent import futures
 import logging
 import math
 from odemis import model
 from odemis.driver import pigcs
+from odemis.driver.pigcs import PIGCSError
 import os
+import pickle
 import time
 import unittest
 from unittest.case import skip
-from builtins import range
 
 logging.getLogger().setLevel(logging.DEBUG)
 logging.basicConfig(format="%(asctime)s  %(levelname)-7s %(module)s:%(lineno)d %(message)s")
@@ -199,6 +201,15 @@ class TestActuator(unittest.TestCase):
 
         self.assertAlmostEqual(orig_pos + move["x"], stage.position.value["x"])
         stage.terminate()
+
+    def test_exception_pickling(self):
+        """
+        Check the exception can be pickled and unpickled (for Pyro4)
+        """
+        ex = PIGCSError(3)
+        p = pickle.dumps(ex)
+        ep = pickle.loads(p)
+        self.assertIsInstance(ep, PIGCSError)
 
 #    @skip("faster")
     def test_sync(self):

--- a/src/odemis/driver/test/smaract_test.py
+++ b/src/odemis/driver/test/smaract_test.py
@@ -22,13 +22,13 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 from __future__ import division
 
 import logging
+from odemis.driver import smaract
+from odemis.util import test
 import os
-
+import pickle
 import time
 import unittest
-from odemis.driver import smaract
-from odemis.driver.smaract import SA_MCError
-from odemis.util import test
+
 import odemis.model as model
 
 logging.getLogger().setLevel(logging.DEBUG)
@@ -92,6 +92,15 @@ class TestSmarPod(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.dev.terminate()
+
+    def test_exception_pickling(self):
+        """
+        Check the exception can be pickled and unpickled (for Pyro4)
+        """
+        ex = smaract.SmarPodError(3)
+        p = pickle.dumps(ex)
+        ep = pickle.loads(p)
+        self.assertIsInstance(ep, smaract.SmarPodError)
 
     def test_reference_cancel(self):
         # Test canceling referencing

--- a/src/odemis/driver/test/symphotime_test.py
+++ b/src/odemis/driver/test/symphotime_test.py
@@ -27,10 +27,11 @@ from __future__ import division
 import logging
 from odemis import model
 from odemis.driver import symphotime
-import threading
-import unittest
 import os
+import pickle
+import threading
 import time
+import unittest
 
 logging.getLogger().setLevel(logging.DEBUG)
 logging.basicConfig(format="%(asctime)s  %(levelname)-7s %(module)s:%(lineno)d %(message)s")
@@ -73,6 +74,20 @@ MD = {
     model.MD_PIXEL_SIZE: (5e-6, 5e-6),
     model.MD_DWELL_TIME: 5e-6
     }
+
+
+class TestStatic(unittest.TestCase):
+
+    def test_exception_pickling(self):
+        """
+        Check the exception can be pickled and unpickled (for Pyro4)
+        """
+        ex = symphotime.SPTError(2)
+        p = pickle.dumps(ex)
+        ep = pickle.loads(p)
+        self.assertIsInstance(ep, symphotime.SPTError)
+        self.assertEqual(str(ex), str(ep))
+
 
 class TestSymphotime(unittest.TestCase):
     @classmethod

--- a/src/odemis/driver/test/technolution_test.py
+++ b/src/odemis/driver/test/technolution_test.py
@@ -33,6 +33,7 @@ import numpy
 from odemis import model
 from odemis.util import almost_equal
 import os
+import pickle
 import threading
 import time
 import unittest
@@ -136,6 +137,23 @@ class TestAcquisitionServer(unittest.TestCase):
 
     def tearDown(self):
         pass
+
+    def test_exception_pickling(self):
+        """
+        Check the exception can be pickled and unpickled (for Pyro4)
+        """
+        # Get an execption by expecting a wrong status
+        try:
+            resp = self.ASM_manager.asmApiGetCall("/scan/clock_frequency", 666, raw_response=True)
+        except AsmApiException as e:
+            ex = e
+        else:
+            raise self.fail("Failed to get an exception")
+
+        p = pickle.dumps(ex)
+        ep = pickle.loads(p)
+        self.assertIsInstance(ep, AsmApiException)
+        self.assertEqual(str(ex), str(ep))
 
     def test_get_API_call(self):
         expected_status_code = 200


### PR DESCRIPTION
We had managed to make sure all the exception were pickable, which is
necessary for the backend to transfer them to the client (via Pyro4).
However, it turns out that an object can be pickable, but not
unpickable... and we had not cheked for it.
This is because the unpickling mechanism is essentially a new
initialisation. So the arguments passed to it must be the same as the
one passed to the super (which stores them for picking).

In addition, with Futures, when an exception is raised, it's sent
back to the client as "one-way" call. So the backend wouldn't know
that unpickling the exception failed. That mained that not only the call
failed, but the client thought it was taking a very long time... and
block.

=> Fix all the exceptions which had this problem.
=> Add test cases to detect such errors.