### PR TITLE
gui main: fix standalone GUI not starting

### DIFF
--- a/src/odemis/gui/main.py
+++ b/src/odemis/gui/main.py
@@ -133,7 +133,7 @@ class OdemisGUIApp(wx.App):
         # TODO: if microscope.ghost is not empty => wait and/or display a special
         # "hardware status" tab.
 
-        if microscope.role == "mbsem":
+        if microscope and microscope.role == "mbsem":
             self.main_data = guimodel.FastEMMainGUIData(microscope)
         else:
             self.main_data = guimodel.MainGUIData(microscope)


### PR DESCRIPTION
Commit 206595afa78 (FastEM GUI: overview tab) added support for a special version of the
MainGUIData, for the "mbsem". However, it broke the viewer, which has
no microscope.