### PR TITLE
dataio/acq csv: fix extra new line on Windows

### DIFF
--- a/src/odemis/acq/calibration.py
+++ b/src/odemis/acq/calibration.py
@@ -365,7 +365,7 @@ def write_trigger_delay_csv(filename, trig_delays):
     trig_delays (dict float -> float): time range to trigger delay info
     """
 
-    with open(filename, 'w') as csvfile:
+    with open(filename, 'w', newline='') as csvfile:
         calibFile = csv.writer(csvfile, delimiter=':')
         for time_range, trig_delay in trig_delays.items():
             calibFile.writerow([time_range, trig_delay])
@@ -382,7 +382,7 @@ def read_trigger_delay_csv(filename, time_choices, trigger_delay_range):
     raise IOError: if the file doesn't exist
     """
     tr2d = {}
-    with open(filename, 'r') as csvfile:
+    with open(filename, 'r', newline='') as csvfile:
         calibFile = csv.reader(csvfile, delimiter=':')
         for time_range, delay in calibFile:
             try:

--- a/src/odemis/dataio/csv.py
+++ b/src/odemis/dataio/csv.py
@@ -63,7 +63,7 @@ def export(filename, data):
                 spectrum_tuples = data.reshape(data.shape[0], 1)
                 headers = ['# intensity']
 
-            with open(filename, 'w') as fd:
+            with open(filename, 'w', newline='') as fd:
                 csv_writer = csv.writer(fd)
                 csv_writer.writerow(headers)
                 csv_writer.writerows(spectrum_tuples)
@@ -82,7 +82,7 @@ def export(filename, data):
                 time_tuples = data.reshape(data.shape[0], 1)
                 headers = ['# intensity']
 
-            with open(filename, 'w') as fd:
+            with open(filename, 'w', newline='') as fd:
                 csv_writer = csv.writer(fd)
                 csv_writer.writerow(headers)
                 csv_writer.writerows(time_tuples)
@@ -103,7 +103,7 @@ def export(filename, data):
 
             # Data should be in the form of (X, C+1), with the first row and column the
             # distance_from_origin\wavelength
-            with open(filename, 'w') as fd:
+            with open(filename, 'w', newline='') as fd:
                 csv_writer = csv.writer(fd)
                 # Set the 'header' in the 0,0 element
                 first_row = ['distance_from_origin(m)\\wavelength(' + unit + ')'] + spectrum_range
@@ -127,7 +127,7 @@ def export(filename, data):
         headers = ["time(" + unit_t + ")\\wavelength(" + unit_c + ")"] + spectrum_range
         rows = [(t,) + tuple(d) for t, d in zip(time_range, data)]
 
-        with open(filename, 'w') as fd:
+        with open(filename, 'w', newline='') as fd:
             csv_writer = csv.writer(fd)
             csv_writer.writerow(headers)
             csv_writer.writerows(rows)
@@ -135,7 +135,7 @@ def export(filename, data):
     elif data.metadata.get(model.MD_ACQ_TYPE, None) == model.MD_AT_AR:
         logging.debug("Exporting AR data to CSV")
         # Data should be in the form of (Y+1, X+1), with the first row and column the angles
-        with open(filename, 'w') as fd:
+        with open(filename, 'w', newline='') as fd:
             csv_writer = csv.writer(fd)
 
             # TODO: put theta/phi angles in metadata? Read back from MD theta/phi and then add as additional line/column

--- a/src/odemis/dataio/test/csv_test.py
+++ b/src/odemis/dataio/test/csv_test.py
@@ -71,7 +71,7 @@ class TestCSVIO(unittest.TestCase):
         self.assertFalse(raised, 'Failed to read csv file')
 
         # test intensity value is at correct position
-        file = pycsv.reader(open(FILENAME, 'r'))
+        file = pycsv.reader(open(FILENAME, 'r', newline=''))
 
         a = numpy.zeros((91, 361))
         index = 0


### PR DESCRIPTION
This is a known behaviour of the csv module of Python: the file gets
\r\r\n lines endings if not opening it with "newline=''". My
understanding is that it's due to the standard file wrapper to add a
newline, and the CSV writer also adding a newline.

See: https://docs.python.org/3.6/library/csv.html#id3