### PR TITLE
gui util updater: fix download on Python 3

### DIFF
--- a/src/odemis/gui/util/test/updater_test.py
+++ b/src/odemis/gui/util/test/updater_test.py
@@ -24,9 +24,11 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 
 # test the functions of the gui.util.updater module
 from __future__ import division
-from odemis.gui.util import updater
+
 import logging
 import unittest
+import wx
+from odemis.gui.util import updater
 
 logging.getLogger().setLevel(logging.DEBUG)
 
@@ -43,7 +45,17 @@ class TestWindowsUpdater(unittest.TestCase):
 
         # u.check_for_update()
 
+    def test_downloader(self):
+        app = wx.App()
+        app.main_frame = wx.Frame()
+        u = updater.WindowsUpdater()
+        rv = u.get_remote_version()
+        self.assertIsInstance(rv, str)
+        u.download_installer(rv)
+        # u.show_update_dialog(rv)
+
     # TODO: test more methods
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The way to get the headers of the HTTPResponse have change in Python 3.
(It wasn't really anything official in Python 2).

Also modify a little bit the function to make it testable (on Linux)...
and add a test case.