### PR TITLE
model vattributes: in case the value is reject due to its type, indicate the type

### DIFF
--- a/src/odemis/model/_vattributes.py
+++ b/src/odemis/model/_vattributes.py
@@ -1191,8 +1191,9 @@ class TupleContinuous(VigilantAttribute, Continuous):
 
     def _check(self, value):
         if not all(isinstance(v, self._cls) for v in value):
-            msg = "Value '%s' must be a tuple only consisting of types %s."
-            raise TypeError(msg % (value, self._cls))
+            msg = "Value '%s' must be a tuple only consisting of types %s, but also got %s."
+            bad_classes = set(v.__class__.__name__ for v in value if not isinstance(v, self._cls))
+            raise TypeError(msg % (value, self._cls, bad_classes))
         Continuous._check(self, value)
 
 


### PR DESCRIPTION
On Windows, we sometimes get errors like:
TypeError: Value '(5.615522460937501e-07, 6.356466064453125e-07)' must be a tuple only consisting of types (<class 'int'>, <class 'int'>, <class 'float'>).

It's extrermly hard to reproduce, and this has been going on for a year, with little extra findings.
Hopefully this information will hint us a little bit more.