### PR TITLE
fastem overview tab: show scale and scaled pixelsize

### DIFF
--- a/src/odemis/acq/stream/_live.py
+++ b/src/odemis/acq/stream/_live.py
@@ -534,16 +534,17 @@ class FastEMSEMStream(SEMStream):
     """
 
     def __init__(self, name, detector, dataflow, emitter, blanker=None, **kwargs):
-        super().__init__(name, detector, dataflow, emitter, blanker=None, **kwargs)
-        self.pixelSize = model.VigilantAttribute(0, unit="m", readonly=True)
-        emitter.pixelSize.subscribe(self._on_pxsize, init=True)
+        super().__init__(name, detector, dataflow, emitter, blanker=blanker, **kwargs)
+        pxs = (emitter.pixelSize.value[0] * emitter.scale.value[0],
+               emitter.pixelSize.value[1] * emitter.scale.value[1])
+        self.pixelSize = model.VigilantAttribute(pxs, unit="m", readonly=True)
+        emitter.pixelSize.subscribe(self._on_pxsize)
         emitter.scale.subscribe(self._on_pxsize, init=True)
 
     def _on_pxsize(self, _):
         pxs = (self.emitter.pixelSize.value[0] * self.emitter.scale.value[0],
                self.emitter.pixelSize.value[1] * self.emitter.scale.value[1])
         self.pixelSize._set_value(pxs, force_write=True)
-        self.pixelSize.notify(pxs)
 
 
 class SpotSEMStream(LiveStream):

--- a/src/odemis/acq/stream/_live.py
+++ b/src/odemis/acq/stream/_live.py
@@ -528,6 +528,24 @@ class AlignedSEMStream(SEMStream):
 #         super(AlignedSEMStream, self)._onActive(active)
 
 
+class FastEMSEMStream(SEMStream):
+    """
+    SEM stream with special pixelsize VA (driver value is adjusted with scale).
+    """
+
+    def __init__(self, name, detector, dataflow, emitter, blanker=None, **kwargs):
+        super().__init__(name, detector, dataflow, emitter, blanker=None, **kwargs)
+        self.pixelSize = model.VigilantAttribute(0, unit="m", readonly=True)
+        emitter.pixelSize.subscribe(self._on_pxsize, init=True)
+        emitter.scale.subscribe(self._on_pxsize, init=True)
+
+    def _on_pxsize(self, _):
+        pxs = (self.emitter.pixelSize.value[0] * self.emitter.scale.value[0],
+               self.emitter.pixelSize.value[1] * self.emitter.scale.value[1])
+        self.pixelSize._set_value(pxs, force_write=True)
+        self.pixelSize.notify(pxs)
+
+
 class SpotSEMStream(LiveStream):
     """
     Stream which forces the SEM to be in spot mode when active.

--- a/src/odemis/gui/conf/data.py
+++ b/src/odemis/gui/conf/data.py
@@ -648,6 +648,16 @@ HW_SETTINGS_CONFIG_PER_ROLE = {
             },
         },
     },
+    "mbsem": {
+        "e-beam": {
+            "scale": {
+                # Make sure it's displayed as a combobox with choices. If we don't set choices here to None,
+                # the hw choices will not be displayed and instead of a combobox, we get a single readonly
+                # value control.
+                "choices": None,
+            },
+        }
+    }
 }
 
 # The sparc-simplex is identical to the sparc
@@ -689,6 +699,14 @@ STREAM_SETTINGS_CONFIG = {
             ("ccdTemperature", {  # Trick for the sparc-simplex
                 "label": "CCD temperature",
                 "tooltip": u"Current temperature of the spectrometer CCD",
+            }),
+        )),
+    stream.FastEMSEMStream:
+        OrderedDict((
+            # Display the adjusted pixelsize (pixelsize * scale) with the hw VAs.
+            ("pixelSize", {
+                "label": "Pixel size",
+                "control_type": odemis.gui.CONTROL_READONLY,
             }),
         )),
     stream.SpectrumSettingsStream:

--- a/src/odemis/gui/conf/data.py
+++ b/src/odemis/gui/conf/data.py
@@ -705,7 +705,6 @@ STREAM_SETTINGS_CONFIG = {
         OrderedDict((
             # Display the adjusted pixelsize (pixelsize * scale) with the hw VAs.
             ("pixelSize", {
-                "label": "Pixel size",
                 "control_type": odemis.gui.CONTROL_READONLY,
             }),
         )),

--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -1753,12 +1753,12 @@ class FastEMOverviewTab(Tab):
         self.view_controller = viewcont.ViewPortController(tab_data, panel, vpv)
 
         # Single-beam SEM stream
-        vanames = ("resolution", "dwellTime", "horizontalFoV")
+        vanames = ("resolution", "scale", "dwellTime", "horizontalFoV")
         hwemtvas = set()
         for vaname in getVAs(main_data.ebeam):
             if vaname in vanames:
                 hwemtvas.add(vaname)
-        sem_stream = acqstream.SEMStream(
+        sem_stream = acqstream.FastEMSEMStream(
             "Single Beam",
             main_data.sed,
             main_data.sed.data,


### PR DESCRIPTION
Show a combobox control to select the scale (and indirectly the resolution). Display the pixelsize, which is adjusted with the scale.