### PR TITLE
driver xt_client: fix typos

### DIFF
--- a/src/odemis/driver/test/xt_client_test.py
+++ b/src/odemis/driver/test/xt_client_test.py
@@ -208,10 +208,6 @@ class TestMicroscope(unittest.TestCase):
         fov_min = ebeam.horizontalFoV.range[0]
         fov_max = ebeam.horizontalFoV.range[1]
         ebeam.horizontalFoV.value = fov_min
-        self.assertAlmostEqual(fov_min, ebeam.horizontalFoV.value)
-
-        ebeam.horizontalFoV.value = fov_max
-        self.assertAlmostEqual(fov_max, ebeam.horizontalFoV.value)
         self.assertAlmostEqual(fov_min, ebeam.horizontalFoV.value, places=10)
 
         ebeam.horizontalFoV.value = fov_max

--- a/src/odemis/driver/xt_client.py
+++ b/src/odemis/driver/xt_client.py
@@ -2383,7 +2383,7 @@ class XTTKDetector(Detector):
             self.cancel_connection.set_channel_state(self.parent._scanner.channel, False)
             # Stop twice, to make sure the channel fully stops.
             self.cancel_connection.set_channel_state(self.parent._scanner.channel, False)
-        if self.parent.parent._scanner.blanker.value is None:
+        if self.parent._scanner.blanker.value is None:
             self.parent.blank_beam()
         self._genmsg.put(GEN_STOP)
 


### PR DESCRIPTION
Prevented the driver from working, and the tests from passing.