### PR TITLE
gui comp viewport/miccanvas: Fold view.has_stage() into CAN_MOVE_STAGE

### DIFF
--- a/src/odemis/gui/comp/miccanvas.py
+++ b/src/odemis/gui/comp/miccanvas.py
@@ -195,6 +195,10 @@ class DblMicroscopeCanvas(canvas.DraggableCanvas):
         self._calc_bg_offset(phys_pos)
         self.requested_phys_pos = tuple(phys_pos)
 
+        # Disable the linking of the view <> stage position if there is no stage
+        if not self.view.has_stage():
+            self.abilities.discard(CAN_MOVE_STAGE)
+
         # any image changes
         self.view.lastUpdate.subscribe(self._on_view_image_update, init=True)
 
@@ -635,8 +639,8 @@ class DblMicroscopeCanvas(canvas.DraggableCanvas):
         # TODO: this method should be on the View, and it'd update the view_pos
         # and mpp according to the streams (and stage)
         if recenter is None:
-            # recenter only if there is no stage attached
-            recenter = not self.view.has_stage()
+            # Do not recenter if the  view position is linked to the stage position
+            recenter = CAN_MOVE_STAGE not in self.abilities
 
         self.fit_to_content(recenter=recenter)
 

--- a/src/odemis/gui/comp/viewport.py
+++ b/src/odemis/gui/comp/viewport.py
@@ -698,7 +698,7 @@ class FixedOverviewViewport(MicroscopeViewport):
         # we have to allow (and in the worst case the user will be able to move
         # while the chamber is opened)
         if (chamber_state in {CHAMBER_VACUUM, CHAMBER_UNKNOWN} and
-                self._view.has_stage()):
+                CAN_MOVE_STAGE in self.canvas.abilities):
             self.canvas.point_select_overlay.active.value = True
         else:
             self.canvas.point_select_overlay.active.value = False
@@ -707,7 +707,7 @@ class FixedOverviewViewport(MicroscopeViewport):
         """ Set the physical view position
         """
         if self._tab_data_model:
-            if self._view.has_stage():
+            if CAN_MOVE_STAGE in self.canvas.abilities:
                 self._view.moveStageTo(p_pos)
 
 
@@ -736,7 +736,8 @@ class LiveViewport(MicroscopeViewport):
         Used to update the drag/focus capabilities
         """
         self.canvas.play_overlay.hide_pause(is_playing)
-        if CAN_DRAG in self._orig_abilities and self._view.has_stage():
+        # If normally user can drag to move the stage, disable if no stream is playing
+        if CAN_DRAG in self._orig_abilities and CAN_MOVE_STAGE in self.canvas.abilities:
             # disable/enable move
             if is_playing:
                 self.canvas.abilities.add(CAN_DRAG)
@@ -770,7 +771,8 @@ class LiveViewport(MicroscopeViewport):
 class FeatureOverviewViewport(LiveViewport):
     """
     LiveViewport dedicated to show overview map area with bookmarked features.
-    Never allow to move the stage while dragging
+    Do not move the stage by dragging, and instead show the stage position via
+    a crosshair.
     """
     def __init__(self, *args, **kwargs):
         super(FeatureOverviewViewport, self).__init__(*args, **kwargs)
@@ -1923,7 +1925,3 @@ class FastEMOverviewViewport(FeatureOverviewViewport):
         super().setView(view, tab_data)
         self.canvas.add_background_overlay(self._tab_data_model.main.background)
 
-    def _on_stream_play(self, is_playing):
-        # same as superclass function, except allow dragging if stream is paused
-        super()._on_stream_play(is_playing)
-        self.canvas.abilities.add(CAN_DRAG)


### PR DESCRIPTION
Now that we have the CAN_MOVE_STAGE ability, we can use it also
where we used to check if the view has a stage.

At init, if the view doesn't have a stage, drop the CAN_MOVE_STAGE.
Everywhere else, use CAN_MOVE_STAGE.

This is more than cosmetic: now if we have explicitly dropped
CAN_MOVE_STAGE, even if there is a stage, the canvas behaves
really as if there is no stage. That's important in fit_to_content()
and also allowing to drag when paused.