### PR TITLE
re-standardize the chamber axis to "vacuum"

### DIFF
--- a/doc/develop/microscope.rst
+++ b/doc/develop/microscope.rst
@@ -73,7 +73,8 @@ Emitters:
 Actuators:
  * stage: Moves the sample. It can have up to 3 linear axes (x, y, z) and 3 rotational axes (rx, ry, rz).
  * ebeam-focus: Changes the focus position of the e-beam. It has one axis: z.
- * chamber: Manages the pressure and/or sample loading. It must have a "pressure" axis.
+ * chamber: Manages the pressure and/or sample loading. It must have a "vacuum" axis to switch between the different vacuum states.
+   If it also has a sensor to read the actual pressure, it should be provided on the .pressure VA.
  * pinhole: To change the size of the pinhole in a confocal microscope. It has one axis: d.
  * sem-stage: The stage of the DELPHI that moves the (whole) sample holder.
  * align: Alignment actuator for the SECOM and DELPHI microscopes.

--- a/install/linux/usr/share/odemis/sim/fastem-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/fastem-sim.odm.yaml
@@ -3,7 +3,7 @@ FASTEM-sim: {
     class: Microscope,
     role: mbsem,
     children: ["MultiBeam Scanner XT", "EBeam Focus", "EBeam Detector",
-               "Sample Stage",
+               "Chamber", "Sample Stage",
                "Stage Fine Position", "Metrology Module",
                "Beam Shift Controller", "Focus Tracker",
                "Detector Rotator", "Optical Objective",
@@ -31,6 +31,15 @@ FASTEM-sim: {
     properties: {
         dwellTime: 1.e-6, # s
     },
+    metadata: {
+        # Compensation to the pixel size (ie, the FoV) needed to have a good match between
+        # stage movement and SEM image *AT LOW MAGNIFICATIONS*.
+        # This is useful for the overview image acquisition.
+        PIXEL_SIZE_COR: [1.05, 1.05], # ratio
+    },
+    persistent: {
+        metadata: [PIXEL_SIZE_COR],
+    },
 }
 
 "EBeam Focus": {
@@ -42,14 +51,14 @@ FASTEM-sim: {
     # Internal child of SEM, so no class
     role: se-detector,
     init: {},
-    metadata: {
-        # Compensation to the pixel size (ie, the FoV) needed to have a good match between
-        # stage movement and SEM image *AT LOW MAGNIFICATIONS*.
-        # This is useful for the overview image acquisition.
-        PIXEL_SIZE_COR: [1.05, 1.05], # ratio
-    },
-    persistent: {
-        metadata: [PIXEL_SIZE_COR],
+}
+
+# Allows to change pressure in the chamber, normally via the SEM API
+"Chamber": {
+    class: simulated.Chamber,
+    role: chamber,
+    init: {
+        positions: ["vented", "vacuum"],
     },
 }
 

--- a/src/odemis/acq/align/delphi.py
+++ b/src/odemis/acq/align/delphi.py
@@ -203,7 +203,7 @@ def _DoDelphiCalibration(future, main_data):
 
     hw_settings = list_hw_settings(main_data.ebeam, main_data.ccd)
 
-    pressures = main_data.chamber.axes["pressure"].choices
+    pressures = main_data.chamber.axes["vacuum"].choices
     vacuum_pressure = min(pressures.keys())  # Pressure to go to SEM mode
     # vented_pressure = max(pressures.keys())
     for p, pn in pressures.items():
@@ -222,7 +222,7 @@ def _DoDelphiCalibration(future, main_data):
         opt_stage = model.getComponent(role="align")
 
         # Move to the overview position first
-        f = main_data.chamber.moveAbs({"pressure": overview_pressure})
+        f = main_data.chamber.moveAbs({"vacuum": overview_pressure})
         f.result()
         if future._task_state == CANCELLED:
             raise CancelledError()
@@ -271,7 +271,7 @@ def _DoDelphiCalibration(future, main_data):
             raise CancelledError()
 
         # Move to SEM
-        f = main_data.chamber.moveAbs({"pressure": vacuum_pressure})
+        f = main_data.chamber.moveAbs({"vacuum": vacuum_pressure})
         f.result()
         if future._task_state == CANCELLED:
             raise CancelledError()

--- a/src/odemis/acq/align/delphi_man_calib.py
+++ b/src/odemis/acq/align/delphi_man_calib.py
@@ -218,7 +218,7 @@ def man_calib(logpath, keep_loaded=False):
 
     try:
         # Get pressure values
-        pressures = chamber.axes["pressure"].choices
+        pressures = chamber.axes["vacuum"].choices
         vacuum_pressure = min(pressures.keys())
         vented_pressure = max(pressures.keys())
         if overview_ccd:
@@ -273,11 +273,11 @@ def man_calib(logpath, keep_loaded=False):
         # Default value for the stage offset
         position = (offset[0] * scaling[0], offset[1] * scaling[1])
 
-        if keep_loaded and chamber.position.value["pressure"] == vacuum_pressure:
+        if keep_loaded and chamber.position.value["vacuum"] == vacuum_pressure:
             logging.info("Skipped optical lens detection, will use previous value %s", position)
         else:
             # Move to the overview position first
-            f = chamber.moveAbs({"pressure": overview_pressure})
+            f = chamber.moveAbs({"vacuum": overview_pressure})
             f.result()
 
             # Reference the (optical) stage
@@ -304,7 +304,7 @@ def man_calib(logpath, keep_loaded=False):
             f.result()
 
             # Move to SEM
-            f = chamber.moveAbs({"pressure": vacuum_pressure})
+            f = chamber.moveAbs({"vacuum": vacuum_pressure})
             f.result()
 
         # Set basic e-beam settings
@@ -674,7 +674,7 @@ def man_calib(logpath, keep_loaded=False):
         if not keep_loaded:
             # Eject the sample holder
             print_col(ANSI_BLACK, "Calibration ended, now ejecting sample, please wait...")
-            f = chamber.moveAbs({"pressure": vented_pressure})
+            f = chamber.moveAbs({"vacuum": vented_pressure})
             f.result()
 
         ans = input_col(ANSI_MAGENTA, "Press Enter to close")

--- a/src/odemis/acq/align/test/delphi_test.py
+++ b/src/odemis/acq/align/test/delphi_test.py
@@ -89,9 +89,9 @@ class TestCalibration(unittest.TestCase):
             self.skipTest("Running backend found")
 
     def _move_to_vacuum(self):
-        pressures = self.chamber.axes["pressure"].choices
+        pressures = self.chamber.axes["vacuum"].choices
         vacuum_pressure = min(pressures.keys())
-        f = self.chamber.moveAbs({"pressure": vacuum_pressure})
+        f = self.chamber.moveAbs({"vacuum": vacuum_pressure})
         f.result()
 
     # @unittest.skip("skip")

--- a/src/odemis/driver/orsay.py
+++ b/src/odemis/driver/orsay.py
@@ -20,13 +20,15 @@ You should have received a copy of the GNU General Public License along with
 Odemis. If not, see http://www.gnu.org/licenses/.
 """
 
-from odemis import model
-from odemis.model import isasync, CancellableThreadPoolExecutor, HwError
-from ConsoleClient.Communication.Connection import Connection
-
+import logging
+from odemis import model, util
+from odemis.model import isasync, CancellableThreadPoolExecutor, HwError, \
+    InstantaneousFuture
 import threading
 import time
-import logging
+
+from ConsoleClient.Communication.Connection import Connection
+
 
 VALVE_UNDEF = -1
 VALVE_TRANSIT = 0
@@ -409,6 +411,14 @@ class pneumaticSuspension(model.HwComponent):
             self._gauge = None
 
 
+# Very approximate values
+PRESSURE_VENTED = 120e3  # Pa
+PRESSURE_VACUUM = 20  # Pa
+PRESSURE_HV = 50e-3  # Pa
+
+VACUUM_STATUS_TO_PRESSURE = {0: PRESSURE_VENTED, 1: PRESSURE_VACUUM, 2: PRESSURE_HV}
+
+
 class vacuumChamber(model.Actuator):
     """
     This represents the vacuum chamber from Orsay Physics
@@ -425,13 +435,15 @@ class vacuumChamber(model.Actuator):
                     value is _chamber.Pressure.Actual)
         """
 
-        axes = {"vacuum": model.Axis(unit=None, choices={0: "vented", 1: "primary vacuum", 2: "high vacuum"})}
+        axes = {"vacuum": model.Axis(unit=None, choices={PRESSURE_VENTED: "vented",
+                                                         PRESSURE_VACUUM: "primary vacuum",
+                                                         PRESSURE_HV: "high vacuum"})}
 
         model.Actuator.__init__(self, name, role, parent=parent, axes=axes, **kwargs)
 
         self._chamber = None
 
-        self.position = model.VigilantAttribute({"vacuum": 0}, readonly=True)
+        self.position = model.VigilantAttribute({}, readonly=True)
         self.pressure = model.FloatContinuous(VACUUM_CHAMBER_PRESSURE_RNG[0], range=VACUUM_CHAMBER_PRESSURE_RNG,
                                               readonly=True, unit="Pa")
 
@@ -482,8 +494,15 @@ class vacuumChamber(model.Actuator):
         if attributeName != "Actual":
             return
         currentVacuum = int(parameter.Actual)
-        logging.debug("Vacuum status changed to %f." % currentVacuum)
-        self.position._set_value({"vacuum": currentVacuum}, force_write=True)
+        logging.debug("Vacuum status changed to %s.", currentVacuum)
+
+        try:
+            vac = VACUUM_STATUS_TO_PRESSURE[currentVacuum]
+        except KeyError:
+            logging.error("Unexpected vacuum status %s", currentVacuum)
+            return
+
+        self.position._set_value({"vacuum": vac}, force_write=True)
 
     def _updatePressure(self, parameter=None, attributeName="Actual"):
         """
@@ -511,7 +530,7 @@ class vacuumChamber(model.Actuator):
         :return (int): actual state of the vacuum at the end of this function: (0: "vented", 1: "primary vacuum",
                       2: "high vacuum")
         """
-        logging.debug("Setting vacuum status to %s." % self.axes["vacuum"].choices[goal])
+        logging.debug("Setting vacuum status to %s.", goal)
         self._vacuumStatusReached.clear()  # to make sure it will wait
         self._chamber.VacuumStatus.Target = goal
         if not self._vacuumStatusReached.wait(1800):  # wait maximally 30 minutes (generally takes no more than 10)
@@ -524,7 +543,12 @@ class vacuumChamber(model.Actuator):
         Move the axis of this actuator to pos.
         """
         self._checkMoveAbs(pos)
-        return self._executor.submit(self._changeVacuum, goal=pos["vacuum"])
+
+        if "vacuum" in pos:
+            vac_status = util.index_closest(pos["vacuum"], VACUUM_STATUS_TO_PRESSURE)
+            return self._executor.submit(self._changeVacuum, goal=vac_status)
+        else:
+            return InstantaneousFuture()
 
     @isasync
     def moveRel(self, shift):

--- a/src/odemis/driver/phenom.py
+++ b/src/odemis/driver/phenom.py
@@ -1762,7 +1762,7 @@ class ChamberPressure(model.Actuator):
     between the NavCam and SEM areas or even unload it.
     """
     def __init__(self, name, role, parent, ranges=None, **kwargs):
-        axes = {"pressure": model.Axis(unit="Pa",
+        axes = {"vacuum": model.Axis(unit="Pa",
                                        choices={PRESSURE_UNLOADED: "vented",
                                                 PRESSURE_NAVCAM: "overview",
                                                 PRESSURE_SEM: "vacuum"})}
@@ -1789,7 +1789,7 @@ class ChamberPressure(model.Actuator):
 
         # RO, as to modify it the client must use .moveRel() or .moveAbs()
         self.position = model.VigilantAttribute(
-                                    {"pressure": self._position},
+                                    {"vacuum": self._position},
                                     unit="Pa", readonly=True)
         logging.debug("Chamber in position: %s", self._position)
 
@@ -1818,7 +1818,7 @@ class ChamberPressure(model.Actuator):
             self.parent._detector.update_parameters()
         self._updateSampleHolder()
 
-        # Lock taken while "pressure" (= sample loader) is changing, to prevent
+        # Lock taken while "vacuum" (= sample loader) is changing, to prevent
         # position update too early
         self._pressure_changing = threading.Lock()
         # Event to prevent move to start while another move initiated from the
@@ -1841,7 +1841,7 @@ class ChamberPressure(model.Actuator):
 
     def _updatePosition(self):
         """
-        update the position VA and .pressure VA
+        update the position VA
         """
         logging.debug("Updating chamber position...")
         area = self.parent._device.GetProgressAreaSelection().target  # last official position
@@ -1858,7 +1858,7 @@ class ChamberPressure(model.Actuator):
 
         # .position contains the last known/valid position
         # it's read-only, so we change it via _value
-        self.position._set_value({"pressure": self._position}, force_write=True)
+        self.position._set_value({"vacuum": self._position}, force_write=True)
         logging.debug("Chamber in position: %s", self._position)
 
     def _updateSampleHolder(self):
@@ -1924,7 +1924,7 @@ class ChamberPressure(model.Actuator):
         f.task_canceller = self._CancelMove
         f._move_lock = threading.Lock()
 
-        return self._executor.submitf(f, self._changePressure, f, pos["pressure"])
+        return self._executor.submitf(f, self._changePressure, f, pos["vacuum"])
 
     def stop(self, axes=None):
         # Empty the queue for the given axes

--- a/src/odemis/driver/simulated.py
+++ b/src/odemis/driver/simulated.py
@@ -196,7 +196,7 @@ class Chamber(model.Actuator):
                 chp[PRESSURES[p]] = p
             except KeyError:
                 raise ValueError("Pressure position %s is unknown" % (p,))
-        axes = {"pressure": model.Axis(unit="Pa", choices=chp)}
+        axes = {"vacuum": model.Axis(unit="Pa", choices=chp)}
         model.Actuator.__init__(self, name, role, axes=axes, **kwargs)
         # For simulating moves
         self._position = PRESSURE_VENTED # last official position
@@ -206,7 +206,7 @@ class Chamber(model.Actuator):
 
         # RO, as to modify it the client must use .moveRel() or .moveAbs()
         self.position = model.VigilantAttribute(
-                                    {"pressure": self._position},
+                                    {"vacuum": self._position},
                                     unit="Pa", readonly=True)
         if has_pressure:
             # Almost the same as position, but gives the current position
@@ -261,7 +261,7 @@ class Chamber(model.Actuator):
         """
         # .position contains the last known/valid position
         # it's read-only, so we change it via _value
-        self.position._value = {"pressure": self._position}
+        self.position._value = {"vacuum": self._position}
         self.position.notify(self.position.value)
 
     @isasync
@@ -281,7 +281,7 @@ class Chamber(model.Actuator):
             return model.InstantaneousFuture()
         self._checkMoveAbs(pos)
 
-        new_pres = pos["pressure"]
+        new_pres = pos["vacuum"]
         est_start = time.time() + 0.1
         f = model.ProgressiveFuture(start=est_start,
                                     end=est_start + self._getDuration(new_pres))

--- a/src/odemis/driver/tescan.py
+++ b/src/odemis/driver/tescan.py
@@ -1408,7 +1408,7 @@ class ChamberPressure(model.Actuator):
     vent the chamber and get the current pressure of it.
     """
     def __init__(self, name, role, parent, ranges=None, **kwargs):
-        axes = {"pressure": model.Axis(unit="Pa",
+        axes = {"vacuum": model.Axis(unit="Pa",
                                        choices={PRESSURE_VENTED: "vented",
                                                 PRESSURE_PUMPED: "vacuum"})}
         model.Actuator.__init__(self, name, role, parent=parent, axes=axes, **kwargs)
@@ -1459,7 +1459,7 @@ class ChamberPressure(model.Actuator):
 
         # .position contains the last known/valid position
         # it's read-only, so we change it via _value
-        self.position._value = {"pressure": self._position}
+        self.position._value = {"vacuum": self._position}
         self.position.notify(self.position.value)
 
     @isasync
@@ -1478,14 +1478,14 @@ class ChamberPressure(model.Actuator):
         if not pos:
             return model.InstantaneousFuture()
         self._checkMoveAbs(pos)
-        return self._executor.submit(self._changePressure, pos["pressure"])
+        return self._executor.submit(self._changePressure, pos["vacuum"])
 
     def _changePressure(self, p):
         """
         Synchronous change of the pressure
         p (float): target pressure
         """
-        if p["pressure"] == PRESSURE_VENTED:
+        if p["vacuum"] == PRESSURE_VENTED:
             self.parent._device.VacVent()
         else:
             self.parent._device.VacPump()

--- a/src/odemis/driver/test/phenom_test.py
+++ b/src/odemis/driver/test/phenom_test.py
@@ -162,7 +162,7 @@ class TestSEM(unittest.TestCase):
 
         # TODO: a way to group tests, so that all the ones that need to be in
         # SEM mode are together, and all the one for navcam are together?
-        f = self.pressure.moveAbs({"pressure":1e-02})  # move to SEM
+        f = self.pressure.moveAbs({"vacuum":1e-02})  # move to SEM
         f.result()
 
     def tearDown(self):
@@ -438,7 +438,7 @@ class TestSEM(unittest.TestCase):
         """
         Check it's possible to acquire a navcam image
         """
-        f = self.pressure.moveAbs({"pressure":1e04})  # move to NavCam
+        f = self.pressure.moveAbs({"vacuum":1e04})  # move to NavCam
         f.result()
         # Exposure time is fixed, time is mainly spent on the image transfer
         expected_duration = 0.5  # s
@@ -452,7 +452,7 @@ class TestSEM(unittest.TestCase):
         """
         Check it's possible to change the overview focus
         """
-        f = self.pressure.moveAbs({"pressure":1e04})  # move to NavCam
+        f = self.pressure.moveAbs({"vacuum":1e04})  # move to NavCam
         f.result()
         pos = self.navcam_focus.position.value
         f = self.navcam_focus.moveRel({"z":0.1e-3})  # 1 mm
@@ -471,17 +471,17 @@ class TestSEM(unittest.TestCase):
         """
         Check it's possible to change the pressure state
         """
-        f = self.pressure.moveAbs({"pressure":1e-02})  # move to SEM
+        f = self.pressure.moveAbs({"vacuum":1e-02})  # move to SEM
         f.result()
-        new_pos = self.pressure.position.value["pressure"]
+        new_pos = self.pressure.position.value["vacuum"]
         self.assertEqual(1e-02, new_pos)
-        f = self.pressure.moveAbs({"pressure":1e05})  # Unload
+        f = self.pressure.moveAbs({"vacuum":1e05})  # Unload
         f.result()
-        new_pos = self.pressure.position.value["pressure"]
+        new_pos = self.pressure.position.value["vacuum"]
         self.assertEqual(1e05, new_pos)
-        f = self.pressure.moveAbs({"pressure":1e04})  # move to NavCam
+        f = self.pressure.moveAbs({"vacuum":1e04})  # move to NavCam
         f.result()
-        new_pos = self.pressure.position.value["pressure"]
+        new_pos = self.pressure.position.value["vacuum"]
         self.assertEqual(1e04, new_pos)
 
 #     @skip("skip")

--- a/src/odemis/driver/test/simulated_test.py
+++ b/src/odemis/driver/test/simulated_test.py
@@ -221,40 +221,40 @@ class ChamberTest(unittest.TestCase):
 
     def test_simple(self):
         self.assertGreaterEqual(len(self.dev.axes), 1, "Actuator has no axis")
-        press_axis = self.dev.axes["pressure"]
+        press_axis = self.dev.axes["vacuum"]
         self.assertGreaterEqual(len(press_axis.choices), 2)
 
         # if not moving pressure VA and position should be the same
         cur_press = self.dev.pressure.value
-        pos_press = self.dev.position.value["pressure"]
+        pos_press = self.dev.position.value["vacuum"]
         self.assertTrue(pos_press * 0.95 <= cur_press <= pos_press * 1.05) # ±5%
 
     def test_moveAbs(self):
-        pos_press = self.dev.position.value["pressure"]
+        pos_press = self.dev.position.value["vacuum"]
         logging.info("Device is currently at position %s", pos_press)
 
         # don't change position
-        f = self.dev.moveAbs({"pressure": pos_press})
+        f = self.dev.moveAbs({"vacuum": pos_press})
         f.result()
 
-        self.assertEqual(self.dev.position.value["pressure"], pos_press)
+        self.assertEqual(self.dev.position.value["vacuum"], pos_press)
 
         # try every other position
-        axis_def = self.dev.axes["pressure"]
+        axis_def = self.dev.axes["vacuum"]
         for p in axis_def.choices:
             if p != pos_press:
                 logging.info("Testing move to pressure %s", p)
-                f = self.dev.moveAbs({"pressure": p})
+                f = self.dev.moveAbs({"vacuum": p})
                 # Should still be close from the original pressure
                 cur_press = self.dev.pressure.value
                 self.assertTrue(pos_press * 0.95 <= cur_press <= pos_press * 1.05) # ±5%
 
                 f.result()
-                self.assertEqual(self.dev.position.value["pressure"], p)
+                self.assertEqual(self.dev.position.value["vacuum"], p)
                 cur_press = self.dev.pressure.value
                 self.assertTrue(p * 0.95 <= cur_press <= p * 1.05) # ±5%
 
-        if self.dev.position.value["pressure"] == pos_press:
+        if self.dev.position.value["vacuum"] == pos_press:
             self.fail("Failed to find a position different from %d" % pos_press)
 
     def test_stop(self):
@@ -288,7 +288,8 @@ class ChamberTest(unittest.TestCase):
 
         # wrong position
         with self.assertRaises(ValueError):
-            self.dev.moveAbs({"pressure":-5})
+            self.dev.moveAbs({"vacuum":-5})
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This is a double edge PR. Firstly, it makes all the drivers and code use the axis "vacuum" on the chamber to control the vacuum level. Until now some drivers (orsay, xt_client) used "vacuum" while others (phenom, tescan, simulated) used "pressure". As they all only support a very limited set of positions, it makes more sense to call the axis "vacuum". There is a VA "pressure" to read the actual pressure.

Secondly, it extends the FASTEM simulator and fixes the GUI to work again together.