### PR TITLE
driver-simcam: increase range of exposure time

### DIFF
--- a/src/odemis/driver/simcam.py
+++ b/src/odemis/driver/simcam.py
@@ -118,7 +118,7 @@ class Camera(model.DigitalCamera):
                                               cls=(int, long), setter=self._setTranslation)
 
         self._orig_exp = self._img.metadata.get(model.MD_EXP_TIME, 0.1)  # s
-        self.exposureTime = model.FloatContinuous(self._orig_exp, (1e-3, 10), unit="s")
+        self.exposureTime = model.FloatContinuous(self._orig_exp, (1e-3, 20), unit="s")
 
         # Some code care about the readout rate to know how long an acquisition will take
         self.readoutRate = model.FloatVA(1e9, unit="Hz", readonly=True)

--- a/src/odemis/driver/simcam.py
+++ b/src/odemis/driver/simcam.py
@@ -118,7 +118,7 @@ class Camera(model.DigitalCamera):
                                               cls=(int, long), setter=self._setTranslation)
 
         self._orig_exp = self._img.metadata.get(model.MD_EXP_TIME, 0.1)  # s
-        self.exposureTime = model.FloatContinuous(self._orig_exp, (1e-3, 20), unit="s")
+        self.exposureTime = model.FloatContinuous(self._orig_exp, range=(1e-3, max(10, self._orig_exp * 2)), unit="s")
 
         # Some code care about the readout rate to know how long an acquisition will take
         self.readoutRate = model.FloatVA(1e9, unit="Hz", readonly=True)


### PR DESCRIPTION
The image "andorcam2-fake-spots.h5" which can be used for the simulator has an integration time of 19.6 s. This causes an error to be raised since the range only accepts values up to 10. This is a simulator, so it shouldn't be a problem to increase the range to 20s even though such long exposure times are maybe not common in practice.