### PR TITLE
fastem: use different rotations for single and multi beam acqusition

### DIFF
--- a/install/linux/usr/share/odemis/sim/fastem-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/fastem-sim.odm.yaml
@@ -36,10 +36,13 @@ FASTEM-sim: {
         # stage movement and SEM image *AT LOW MAGNIFICATIONS*.
         # This is useful for the overview image acquisition.
         PIXEL_SIZE_COR: [1.05, 1.05], # ratio
+        SINGLE_BEAM_ROTATION: 0,  # rad
+        MULTI_BEAM_ROTATION: 0.015707963  # rad = 0.9 degrees
     },
     persistent: {
         metadata: [PIXEL_SIZE_COR],
     },
+    #affects: ["MultiBeam Scanner"],  # simulator doesn't have multibeam scanner component
 }
 
 "EBeam Focus": {

--- a/src/odemis/acq/fastem.py
+++ b/src/odemis/acq/fastem.py
@@ -217,6 +217,8 @@ def _configure_overview_hw(scanner):
         scanner.rotation.value = SINGLE_BEAM_ROTATION_DEFAULT
         logging.warning("Scanner doesn't have SINGLE_BEAM_ROTATION metadata, using %s rad.",
                         scanner.rotation.value)
+    md[model.MD_ROTATION_COR] = -scanner.rotation.value
+    scanner.updateMetadata(md)
 
 
 def _run_overview_acquisition(f, stream, stage, area, live_stream):

--- a/src/odemis/acq/fastem.py
+++ b/src/odemis/acq/fastem.py
@@ -28,7 +28,7 @@ import time
 
 
 SINGLE_BEAM_ROTATION_DEFAULT = 0  # 0 is typically a good guess (better than multibeam rotation of ~0.0157 rad)
-MULTI_BEAM_ROTATION_DEFAULT = 0.015707963  # 0.9 degrees
+MULTI_BEAM_ROTATION_DEFAULT = 0
 
 # The executor is a single object, independent of how many times the module is loaded.
 _executor = model.CancellableThreadPoolExecutor(max_workers=1)

--- a/src/odemis/model/_metadata.py
+++ b/src/odemis/model/_metadata.py
@@ -207,3 +207,7 @@ MD_EXTRA_SETTINGS = "Extra settings"
 # Constant for TINT
 TINT_FIT_TO_RGB = "fitrgb"
 TINT_RGB_AS_IS = "rgbasis"
+
+# Rotation for FastEM multi-beam and single-beam scanner
+MD_SINGLE_BEAM_ROTATION = "Single-beam rotation"
+MD_MULTI_BEAM_ROTATION = "Multi-beam rotation"

--- a/src/odemis/odemisd/mdupdater.py
+++ b/src/odemis/odemisd/mdupdater.py
@@ -378,7 +378,7 @@ class MetadataUpdater(model.Component):
         """Add ebeam rotation to multibeam metadata to make sure that the thumbnails
         are displayed correctly."""
 
-        if not comp_affected.role == "multibeam":
+        if comp_affected.role != "multibeam":
             return False
 
         def updateRotation(rot, comp_affected=comp_affected):

--- a/src/odemis/odemisd/mdupdater.py
+++ b/src/odemis/odemisd/mdupdater.py
@@ -121,6 +121,8 @@ class MetadataUpdater(model.Component):
                 elif a.role == "streak-lens":
                     # update the magnification of the streak lens
                     observed = self.observeStreakLens(a, d)
+                elif a.role == "e-beam":
+                    observed = self.observeEbeam(a, d)
                 else:
                     observed = False
 
@@ -369,6 +371,22 @@ class MetadataUpdater(model.Component):
 
         streak_lens.magnification.subscribe(updateMagnification, init=True)
         self._onTerminate.append((streak_lens.magnification.unsubscribe, (updateMagnification,)))
+
+        return True
+
+    def observeEbeam(self, ebeam, comp_affected):
+        """Add ebeam rotation to multibeam metadata to make sure that the thumbnails
+        are displayed correctly."""
+
+        if not comp_affected.role == "multibeam":
+            return False
+
+        def updateRotation(rot, comp_affected=comp_affected):
+            md = {model.MD_ROTATION: rot}
+            comp_affected.updateMetadata(md)
+
+        ebeam.rotation.subscribe(updateRotation, init=True)
+        self._onTerminate.append((ebeam.rotation.unsubscribe, (updateRotation,)))
 
         return True
 


### PR DESCRIPTION
The rotations will be specified as metadata to the e-beam component.

Is it ok to use default values or should we make the metadata required?