### PR TITLE
futures: batch future for time estimates of multiple ProgressiveFutures

### DIFF
--- a/src/odemis/model/_futures.py
+++ b/src/odemis/model/_futures.py
@@ -486,6 +486,50 @@ class ProgressiveFuture(CancellableFuture):
         """
         running = futures.Future.set_running_or_notify_cancel(self)
         if running:
-            self.set_progress(start=time.time())
+            # Set start to current time and end to estimated endtime (difference between current end and start)
+            start, end = self.get_progress()
+            startt = time.time()
+            endt = startt + end - start
+            self.set_progress(start=startt, end=endt)
 
         return running
+
+
+class ProgressiveBatchFuture(ProgressiveFuture):
+    """
+    Representation of a set of ProgressiveFutures which have already been scheduled for execution. The class
+    takes care of time estimates/updates of the batch task. The result is always None.
+    """
+    def __init__(self, futures):
+        """
+        futures (ProgressiveFuture --> float): dict specifying futures and estimated times
+        """
+        self.futures = futures
+        start = time.time()
+        super().__init__(start=start, end=start + sum(self.futures.values()))
+        self.set_running_or_notify_cancel()
+
+        for f in self.futures:
+            f.add_update_callback(self._on_future_update)
+            f.add_done_callback(self._on_future_done)
+
+    def _on_future_update(self, f, start, end):
+        if f._state == RUNNING:  # only care about future which are running, start/end estimates for others not reliable
+            self.futures[f] = end - start
+            self.set_progress(end=self._estimate_end())
+
+    def _on_future_done(self, f):
+        self.set_progress(end=self._estimate_end())
+        if not any(f._state in (RUNNING, PENDING) for f in self.futures):
+            # always return None, it's not clear what the return value of a batch of tasks should be
+            # alternative would be the return value of the last task, but that is also ambiguous because
+            # we don't require the futures to be carried out sequentially
+            self.set_result(None)
+
+    def _estimate_end(self):
+        start, end = self.get_progress()
+        return start + sum(self.futures[f] for f in self.futures if f._state in (RUNNING, PENDING))
+
+    def cancel(self):
+        [f.cancel() for f in self.futures]
+        super().cancel()

--- a/src/odemis/model/_futures.py
+++ b/src/odemis/model/_futures.py
@@ -523,7 +523,7 @@ class ProgressiveBatchFuture(ProgressiveFuture):
 
         # Set exception if future failed and cancel all other futures
         try:
-            ex = f.exception()
+            ex = f.exception()  # raises CancelledError if cancelled, otherwise returns error
             if ex:
                 self.cancel()
                 self.set_exception(ex)
@@ -542,8 +542,11 @@ class ProgressiveBatchFuture(ProgressiveFuture):
         return start + sum(self.futures[f] for f in self.futures if not f.done())
 
     def cancel(self):
+        super().cancel()
         fs = [f for f in self.futures if not f.done()]
         logging.debug("Canceling %s futures.", len(fs))
+        if not fs:
+            return False  # nothing to cancel
         for f in fs:
             f.cancel()
-        super().cancel()
+        return True


### PR DESCRIPTION
Also updated fastem acquisition to show the correct progress. Some considerations:

* I use a dict as an argument. Alternatively, a list of tuples might be possible to give the futures in order. However, this class also works independent of the order in which futures are started (future can run in parallel), so it doesn't matter.
* The regular ProgressiveFuture always raised a warning (starttime > endtime) every time a future was started after the expected endtime. Since many futures are initialized without endtime, the current time is used for both starttime and endtime, but if the future is started later (because the executor first had to finish another future), the starttime would update to a higher value, while the endtime remained the same (a value that is now in the past). That should be fixed now.
* ProgressiveFutures are in general not very easy to use with executors because we don't know when they are going to start. Instead of start and end arguments, it might make sense to change the interface to start and time_estimate arguments. But that would involve a larger change in odemis. We can discuss if it's a good idea. It would also make the BatchFuture interface easier because we wouldn't need the expected time dictionary as argument.