### PR TITLE
gui: only clip stage position if stage is available

### DIFF
--- a/src/odemis/gui/model/__init__.py
+++ b/src/odemis/gui/model/__init__.py
@@ -1655,6 +1655,9 @@ class StreamView(View):
         :param pos (dict): Position to be clipped with keys "x" and "y"
         :return(dict): Position clipped to the stage limits with keys "x" and "y"
         """
+        if not self._stage:
+            return pos
+
         stage_limits = self._getStageLimitsXY()
         if not stage_limits["x"][0] <= pos["x"] <= stage_limits["x"][1]:
             pos["x"] = max(stage_limits["x"][0], min(pos["x"], stage_limits["x"][1]))


### PR DESCRIPTION
PR #1803 introduced a check for the stage limits in the recenter_buffer function in miccanvas. This only works if the view has a stage. To make sure it doesn't fail, this case needs to be handled in the clipping function of the view.