### PR TITLE
gui: remove code for wxPython < 4

### DIFF
--- a/src/odemis/cli/video_displayer.py
+++ b/src/odemis/cli/video_displayer.py
@@ -133,12 +133,8 @@ class ImageWindowApp(wx.App):
         # (but it seems in Linux (GTK) frames don't receive key events anyway
         self.frame.Bind(wx.EVT_KEY_DOWN, self.OnKey)
 
-        if wx.MAJOR_VERSION <= 3:
-            self.img = wx.EmptyImage(*size, clear=True)
-            self.imageCtrl = wx.StaticBitmap(self.panel, wx.ID_ANY, wx.BitmapFromImage(self.img))
-        else:
-            self.img = wx.Image(*size, clear=True)
-            self.imageCtrl = wx.StaticBitmap(self.panel, wx.ID_ANY, wx.Bitmap(self.img))
+        self.img = wx.Image(*size, clear=True)
+        self.imageCtrl = wx.StaticBitmap(self.panel, wx.ID_ANY, wx.Bitmap(self.img))
 
         self.panel.SetFocus()
         self.frame.Show()

--- a/src/odemis/gui/comp/buttons.py
+++ b/src/odemis/gui/comp/buttons.py
@@ -71,17 +71,7 @@ def darken_image(image, mltp=0.5):
       if the result becomes > 255, it will overflow and appear dark instead of
       bright white.
     """
-    # Update data in-place
-    if wx.MAJOR_VERSION <= 3:
-        # On numpy 1.6 (Ubuntu 12.04), asarray() doesn't pick the buffer
-        # correctly. However, with wxPython 4, GetDataBuffer() returns a
-        # memoryview instead of a buffer, which is not accepted by frombuffer().
-        # Luckily, on systems with wxPython 4, we can expect also a newer numpy.
-        # TODO: Once this is not supported anymore, use the cleaner asarray().
-        # Note that both functions allow to directly access and modify the data.
-        data = numpy.frombuffer(image.GetDataBuffer(), dtype=numpy.uint8)
-    else:
-        data = numpy.asarray(image.GetDataBuffer())
+    data = numpy.asarray(image.GetDataBuffer())
     numpy.multiply(data, mltp, out=data, casting="unsafe")
 
 

--- a/src/odemis/gui/comp/text.py
+++ b/src/odemis/gui/comp/text.py
@@ -406,13 +406,7 @@ class SuggestTextCtrl(wx.TextCtrl, listmix.ColumnSorterMixin):
         self.dropdown.SetClientSize(self.popupsize)
 
 
-if wx.MAJOR_VERSION <= 3:
-    ValidatorClass = wx.PyValidator
-else:
-    ValidatorClass = wx.Validator
-
-
-class _NumberValidator(ValidatorClass):
+class _NumberValidator(wx.Validator):
 
     def __init__(self, min_val=None, max_val=None, choices=None, unit=None):
         """ Constructor """

--- a/src/odemis/gui/xmlh/xh_delmic.py
+++ b/src/odemis/gui/xmlh/xh_delmic.py
@@ -761,20 +761,6 @@ class UnitFloatSliderHandler(xrc.XmlResourceHandler):
     def CanHandle(self, node):
         return self.IsOfClass(node, "UnitFloatSlider")
 
-    # TODO: can be removed once it's available in wxPython (3.0... ?)
-    def GetFloat(self, param, defaultv=0):
-        # there is a bug in wxPython, which doesn't export GetFloat
-        # => recreate in Python
-        # self, String param, long defaultv=0
-
-        string = self.GetParamValue(param)
-
-        try:
-            value = float(string)
-        except ValueError:
-            logging.error("Float param incorrect %s", string)
-        return value
-
     def DoCreateResource(self):
         assert self.GetInstance() is None
 


### PR DESCRIPTION
Now that we exclusively support wxPython 4, let's not keep code to
handle old versions of wxPython.