### PR TITLE
model futures: improve updating end time when starting a ProgressiveFuture

### DIFF
--- a/src/odemis/model/_futures.py
+++ b/src/odemis/model/_futures.py
@@ -489,7 +489,7 @@ class ProgressiveFuture(CancellableFuture):
             # Set start to current time and end to estimated endtime (difference between current end and start)
             start, end = self.get_progress()
             startt = time.time()
-            endt = startt + end - start
+            endt = startt + (end - start)  # Force the computation order to reduce floating point error
             self.set_progress(start=startt, end=endt)
 
         return running

--- a/src/odemis/model/test/futures_test.py
+++ b/src/odemis/model/test/futures_test.py
@@ -313,7 +313,8 @@ class TestFutures(unittest.TestCase):
         f.set_running_or_notify_cancel()
         startf, endf = f.get_progress()
         self.assertLessEqual(startf, time.time())
-        self.assertEqual(end, endf)
+        self.assertAlmostEqual(startf + 1, endf)
+        self.assertAlmostEqual(endf, time.time() + 1, delta=0.1)
         time.sleep(0.1)
 
         # "finish" the task


### PR DESCRIPTION
Force the order of computation to reduce floating point error.

More importantly: fix test case which didn't pass anymore now that the
end time is updated immediately.