### PR TITLE
gui comp text: fix usage of old ValidatorClass

### DIFF
--- a/src/odemis/gui/comp/text.py
+++ b/src/odemis/gui/comp/text.py
@@ -612,7 +612,7 @@ def _step_from_range(min_val, max_val):
         logging.exception(msg)
 
 
-class PatternValidator(ValidatorClass):
+class PatternValidator(wx.Validator):
 
     def __init__(self, pattern):
         """ pattern (str): regex pattern of allowed entries """


### PR DESCRIPTION
Commit db20de403cf (gui: remove code for wxPython < 4) removed the
wrapper class.
=> Use the wx.Validator class directly.