### PR TITLE
simsem: allow modification of .rotation VA

### DIFF
--- a/src/odemis/driver/simsem.py
+++ b/src/odemis/driver/simsem.py
@@ -198,7 +198,7 @@ class Scanner(model.Emitter):
         # (float) in rad => rotation of the image compared to the original axes
         # TODO: for now it's readonly because no rotation is supported
         self.rotation = model.FloatContinuous(0, [0, 2 * math.pi], unit="rad",
-                                              readonly=True)
+                                              readonly=False)
 
         self.dwellTime = model.FloatContinuous(1e-06, (1e-06, 1000), unit="s")
 


### PR DESCRIPTION
In the FastEM, we want change the .rotation VA. The simulator failed because the VA was readonly. We can allow it to be r/w. Note that the rotation is stored in the metadata in ._simulate_image.