### PR TITLE
model remote_test: add debug info to analyse rare failures

### DIFF
--- a/src/odemis/model/test/remote_test.py
+++ b/src/odemis/model/test/remote_test.py
@@ -39,7 +39,7 @@ import time
 import unittest
 from multiprocessing import Process
 
-
+logging.basicConfig(format="%(asctime)s  %(levelname)-7s %(module)-15s: %(message)s")
 logging.getLogger().setLevel(logging.DEBUG)
 #gc.set_debug(gc.DEBUG_LEAK | gc.DEBUG_STATS)
 
@@ -714,6 +714,7 @@ class RemoteTest(unittest.TestCase):
             pass # as it should be
 
     def receive_va_update(self, value):
+        logging.debug("Update va to %s", value)
         self.called += 1
         self.last_value = value
         self.assertIsInstance(value, (int, float))
@@ -757,13 +758,18 @@ class RemoteTest(unittest.TestCase):
         l = self.comp.listval
         self.assertEqual(len(l.value), 2)
         self.called = 0
+
         l.subscribe(self.receive_listva_update)
         l.value += [3]
         self.assertEqual(len(l.value), 3)
         time.sleep(0.01)
+        self.assertEqual(self.called, 1)
+
         l.value[-1] = 4
         self.assertEqual(l.value[-1], 4)
         time.sleep(0.01)
+        self.assertEqual(self.called, 2)
+
         l.value.reverse()
         self.assertEqual(l.value[0], 4)
         time.sleep(0.1)
@@ -771,6 +777,7 @@ class RemoteTest(unittest.TestCase):
         l.unsubscribe(self.receive_listva_update)
 
     def receive_listva_update(self, value):
+        logging.debug("listva changed to %s", value)
         self.called += 1
         self.last_value = value
         self.assertIsInstance(value, list)


### PR DESCRIPTION
In some rare cases the test_list_va or test_va_update fail (because it
didn't get enough update).
Add some extra debug info to hopefully have a clue on what's causing the
failures.