### PR TITLE
gui comp text: Fix number ctrl accepting - even if negative values are forbidden

### DIFF
--- a/src/odemis/gui/comp/text.py
+++ b/src/odemis/gui/comp/text.py
@@ -438,7 +438,7 @@ class _NumberValidator(wx.Validator):
         }
 
         if (
-                (min_val is None or min_val < 0) or
+                (min_val is not None and min_val < 0) or
                 (max_val is not None and max_val < 0) or
                 (choices and min(choices) < 0)
         ):


### PR DESCRIPTION
We have code that check that "-" is not allowed, but due to a mistake in
the logic, it would basically always consider it allowed.