### PR TITLE
util fluo: add support for pass-through filter

### DIFF
--- a/src/odemis/gui/cont/streams.py
+++ b/src/odemis/gui/cont/streams.py
@@ -956,9 +956,9 @@ class StreamController(object):
         r = self.stream_panel.add_dye_emission_ctrl(band, readonly, center_wl_color)
         lbl_ctrl, value_ctrl, self._lbl_em_peak, self._btn_emission = r
 
-        if isinstance(em, basestring):
+        if isinstance(em, basestring) and em != fluo.PASS_THROUGH:
             if not readonly:
-                logging.error("Emission band is a string, but not readonly")
+                logging.error("Emission band is a string (%s), but not readonly", em)
             return
 
         self.update_peak_label_fit(self._lbl_em_peak, self._btn_emission, None, band)

--- a/src/odemis/gui/cont/streams.py
+++ b/src/odemis/gui/cont/streams.py
@@ -23,7 +23,6 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 
 from __future__ import division
 
-import re
 from builtins import str
 from past.builtins import basestring, long
 from collections import OrderedDict
@@ -33,8 +32,6 @@ import gc
 import locale
 import logging
 import numpy
-
-import odemis.acq.fastem
 from odemis import model, util
 from odemis.acq.stream import MeanSpectrumProjection, FastEMOverviewStream
 from odemis.gui import FG_COLOUR_DIS, FG_COLOUR_WARNING, FG_COLOUR_ERROR, \
@@ -53,10 +50,12 @@ from odemis.util.conversion import wave2rgb
 from odemis.util.filename import make_unique_name
 from odemis.util.fluo import to_readable_band, get_one_center
 from odemis.util.units import readable_str
+import re
 import time
 import wx
 from wx.lib.pubsub import pub
 
+import odemis.acq.fastem
 import odemis.acq.stream as acqstream
 import odemis.gui.model as guimodel
 
@@ -2740,7 +2739,7 @@ class SparcStreamsController(StreamBarController):
             choices = stream.axisFilter.choices
             if isinstance(choices, dict):
                 for pos, desc in choices.items():
-                    if desc == "pass-through":  # that's an official constant
+                    if desc == model.BAND_PASS_THROUGH:
                         stream.axisFilter.value = pos
                         logging.debug("Picking pass-through filter (%d) for spectrum stream", pos)
                         break

--- a/src/odemis/model/_metadata.py
+++ b/src/odemis/model/_metadata.py
@@ -101,6 +101,8 @@ MD_AT_TEMPSPECTRUM = "Temporal Spectrum"
 MD_AT_TEMPORAL = "Temporal"
 MD_AT_SLIT = "Slit view"  # View of the spectrograph slit for SPARCv2 alignment
 
+BAND_PASS_THROUGH = "pass-through"  # Special "filter" name when there is no filter: all light passes
+
 MD_AR_POLE = "Angular resolved pole position" # px, px (tuple of float), position of pole (aka hole center) in raw acquisition of SPARC AR
 MD_AR_XMAX = "Polar xmax"  # m, the distance between the parabola origin and the cutoff position
 MD_AR_HOLE_DIAMETER = "Hole diameter"  # m, diameter the hole in the mirror

--- a/src/odemis/util/fluo.py
+++ b/src/odemis/util/fluo.py
@@ -18,11 +18,10 @@ You should have received a copy of the GNU General Public License along with Ode
 # various functions to help with computations related to fluorescence microscopy
 
 from __future__ import division
-from past.builtins import basestring # For Python 2 & 3
 
 import collections
-import logging
-
+from odemis.model import BAND_PASS_THROUGH
+from past.builtins import basestring  # For Python 2 & 3
 
 # constants to indicate how well a emission/excitation setting fits a dye
 # emission/excitation (peak)
@@ -30,18 +29,15 @@ FIT_GOOD = 2 # Should be fine
 FIT_BAD = 1 # Might work, but not at its best
 FIT_IMPOSSIBLE = 0 # Unlikely to work
 
-# Special filter name when there is no filter
-PASS_THROUGH = "pass-through"
-
 
 def get_center(band):
     """
     Return the center wavelength(es) of a emission/excitation band
-    band ((list of) tuple of 2 or 5 floats): either the min/max
+    band ((list of) tuple of 2 or 5 floats, or BAND_PASS_THROUGH): either the min/max
       of the band or the -99%, -25%, middle, +25%, +99% of the band in m.
     return ((tuple of) float): wavelength in m or list of wavelength for each band
     """
-    if band == PASS_THROUGH:
+    if band == BAND_PASS_THROUGH:
         return 5000e-9  # Something large, so that if it's sorted, it's after every other band
 
     if isinstance(band, basestring):
@@ -61,18 +57,18 @@ def get_one_band_em(bands, ex_band):
     """
     Return the band given or if it's a multi-band, return just the most likely
     one based on the current excitation band
-    bands ((list of) tuple of 2 or 5 floats): emission band(s)
-    ex_band ((list of) tuple of 2 or 5 floats): excitation band(s)
-    return (tuple of 2 or 5 floats): emission band
+    bands ((list of) tuple of 2 or 5 floats, or BAND_PASS_THROUGH): emission band(s)
+    ex_band ((list of) tuple of 2 or 5 floats, or BAND_PASS_THROUGH): excitation band(s)
+    return (tuple of 2 or 5 floats, or BAND_PASS_THROUGH): emission band
     """
-    if bands == PASS_THROUGH:
+    if bands == BAND_PASS_THROUGH:
         return bands
 
     if not isinstance(next(iter(bands)), collections.Iterable):
         return bands
 
     # Need to guess: the closest above the excitation wavelength
-    if ex_band == PASS_THROUGH:
+    if ex_band == BAND_PASS_THROUGH:
         ex_center = 1e9  # Nothing will match
     elif isinstance(next(iter(ex_band)), collections.Iterable):
         # It's getting tricky, but at least above the smallest one
@@ -97,8 +93,8 @@ def get_one_center_em(bands, ex_band):
     """
     Return the center of an emission band, and if it's a multi-band, return just
     one of the centers based on the current excitation band
-    bands ((list of) tuple of 2 or 5 floats): emission band(s)
-    ex_band ((list of) tuple of 2 or 5 floats): excitation band(s)
+    bands ((list of) tuple of 2 or 5 floats, or BAND_PASS_THROUGH): emission band(s)
+    ex_band ((list of) tuple of 2 or 5 floats, or BAND_PASS_THROUGH): excitation band(s)
     return (float): wavelength in m
     """
     return get_center(get_one_band_em(bands, ex_band))
@@ -109,11 +105,11 @@ def get_one_band_ex(bands, em_band):
     Return the excitation band, and if it's a multi-band, return the band
       fitting best the current emission band: the first excitation wavelength
       below the emission.
-    bands ((list of) tuple of 2 or 5 floats): excitation band(s)
-    em_band ((list of) tuple of 2 or 5 floats): emission band(s)
+    bands ((list of) tuple of 2 or 5 floats, or BAND_PASS_THROUGH): excitation band(s)
+    em_band ((list of) tuple of 2 or 5 floats, or BAND_PASS_THROUGH): emission band(s)
     return (float): wavelength in m
     """
-    if bands == PASS_THROUGH:
+    if bands == BAND_PASS_THROUGH:
         return bands
 
     # FIXME: make it compatible with sets instead of list
@@ -121,7 +117,7 @@ def get_one_band_ex(bands, em_band):
         return bands
 
     # Need to guess: the closest below the emission wavelength
-    if em_band == PASS_THROUGH:
+    if em_band == BAND_PASS_THROUGH:
         em_center = 0  # Nothing will match
     elif isinstance(next(iter(em_band)), collections.Iterable):
         # It's getting tricky, but at least below the biggest one
@@ -147,8 +143,8 @@ def get_one_center_ex(bands, em_band):
     """
     Return the center of an excitation band, and if it's a multi-band, return
     just one of the centers based on the current emission band
-    bands ((list of) tuple of 2 or 5 floats): excitation band(s)
-    em_band ((list of) tuple of 2 or 5 floats): emission band(s)
+    bands ((list of) tuple of 2 or 5 floats, or BAND_PASS_THROUGH): excitation band(s)
+    em_band ((list of) tuple of 2 or 5 floats, or BAND_PASS_THROUGH): emission band(s)
     return (float): wavelength in m
     """
     return get_center(get_one_band_ex(bands, em_band))
@@ -162,7 +158,7 @@ def get_one_center(band):
 
     :return: (float) wavelength in m
     """
-    if isinstance(band[0], collections.Iterable) and band != PASS_THROUGH:
+    if isinstance(band[0], collections.Iterable) and band != BAND_PASS_THROUGH:
         return get_center(band[0])
     else:
         return get_center(band)
@@ -173,11 +169,11 @@ def estimate_fit_to_dye(wl, band):
     Estimate how well the light settings of the hardware fit for a given dye
     emission or excitation wavelength.
     wl (float): the wavelength of peak of the dye
-    band ((list of) tuple of 2 or 5 floats): either the min/max
+    band ((list of) tuple of 2 or 5 floats, or BAND_PASS_THROUGH): either the min/max
       of the band or the -99%, -25%, middle, +25%, +99% of the band in m.
     return (FIT_*): how well it fits (the higher the better)
     """
-    if band == PASS_THROUGH:
+    if band == BAND_PASS_THROUGH:
         return FIT_IMPOSSIBLE
     # TODO: support multiple-peak/band/curve for the dye
 
@@ -198,11 +194,11 @@ def quantify_fit_to_dye(wl, band):
     Quantifies how well the given wavelength matches the given
       band: the better the match, the higher the return value will be.
     wl (float): the wavelength of peak of the dye
-    band ((list of) tuple of 2 or 5 floats): either the min/max
+    band ((list of) tuple of 2 or 5 floats, or BAND_PASS_THROUGH): either the min/max
       of the band or the -99%, -25%, middle, +25%, +99% of the band in m.
     return (0<float): the more, the merrier
     """
-    if band == PASS_THROUGH:
+    if band == BAND_PASS_THROUGH:
         return 0  # Pass-through is never good for fluorescence microscopy
 
     # if multi-band: get the best of all
@@ -230,7 +226,7 @@ def find_best_band_for_dye(wl, bands):
     """
     Pick the best band for the given dye emission or excitation.
     wl (float): the wavelength of peak of the dye
-    bands (set of (list of) tuple of 2 or 5 floats): set of either the min/max
+    bands ({(list of) tuple of 2 or 5 floats or BAND_PASS_THROUGH}): set of either the min/max
       of the band or the -99%, -25%, middle, +25%, +99% of the band in m.
     return ((list of) tuple of 2 or 5 floats): the best fitting bands
     """

--- a/src/odemis/util/test/fluo_test.py
+++ b/src/odemis/util/test/fluo_test.py
@@ -35,6 +35,10 @@ class FluoTestCase(unittest.TestCase):
             out = fluo.get_center(inp)
             self.assertEqual(exp, out, "Failed while running with %s and got %s" % (inp, out))
 
+        # Special case for "pass-through": any number > 0 is fine
+        out = fluo.get_center("pass-through")
+        self.assertGreaterEqual(out, 0)
+
     def test_one_band_em(self):
         em_band = (490e-9, 497e-9, 500e-9, 503e-9, 510e-9)
         em_bands = ((650e-9, 660e-9, 675e-9, 678e-9, 680e-9),
@@ -50,6 +54,10 @@ class FluoTestCase(unittest.TestCase):
                   ((em_bands, ((490e-9, 510e-9), (550e-9, 570e-9))), em_bands[0]),
                   # It should also work with lists (although not very officially supported
                   (([[400e-9, 500e-9], [500e-9, 600e-9]], [490e-9, 510e-9]), (500e-9, 600e-9)),  # smallest above 500nm
+                  # Try with a pass-through
+                  ((em_band, "pass-through"), em_band),
+                  ((em_bands, "pass-through"), em_bands[-1]),  # biggest
+                  (("pass-through", (490e-9, 510e-9)), "pass-through"),
                   ]
         for args, exp in in_exp:
             out = fluo.get_one_band_em(*args)
@@ -66,6 +74,10 @@ class FluoTestCase(unittest.TestCase):
                   ((em_bands, (690e-9, 697e-9, 700e-9, 703e-9, 710e-9)), fluo.get_center(em_bands[1])), # smallest above 700nm
                   ((em_bands, (790e-9, 797e-9, 800e-9, 803e-9, 810e-9)), fluo.get_center(em_bands[2])), # smallest above 800nm
                   ((em_bands[0:2], (790e-9, 797e-9, 800e-9, 803e-9, 810e-9)), fluo.get_center(em_bands[1])), # biggest
+                  # Try with a pass-through
+                  ((em_band, "pass-through"), 500e-9),
+                  ((em_bands, "pass-through"), 1100e-9),  # biggest
+                  # (("pass-through", (490e-9, 510e-9)), "pass-through"),
                   ]
         for args, exp in in_exp:
             out = fluo.get_one_center_em(*args)
@@ -81,6 +93,10 @@ class FluoTestCase(unittest.TestCase):
                   ((ex_bands, (490e-9, 497e-9, 500e-9, 503e-9, 510e-9)), ex_bands[0]),  # nothing fitting, but should pick the smallest
                   ((ex_bands, (690e-9, 697e-9, 700e-9, 703e-9, 710e-9)), ex_bands[0]),  # biggest below 700nm
                   ((ex_bands, (790e-9, 797e-9, 800e-9, 803e-9, 810e-9)), ex_bands[1]),  # biggest below 800nm
+                  # Try with a pass-through
+                  ((ex_band, "pass-through"), ex_band),
+                  ((ex_bands, "pass-through"), ex_bands[0]),  # smallest
+                  (("pass-through", (490e-9, 510e-9)), "pass-through"),
                   ]
         for args, exp in in_exp:
             out = fluo.get_one_band_ex(*args)
@@ -109,6 +125,7 @@ class FluoTestCase(unittest.TestCase):
                   ((489e-9, (490e-9, 497e-9, 500e-9, 503e-9, 510e-9)), fluo.FIT_BAD), # almost good
                   ((515e-9, (490e-9, 497e-9, 500e-9, 503e-9, 510e-9)), fluo.FIT_BAD), # almost good
                   ((900e-9, (490e-9, 497e-9, 500e-9, 503e-9, 510e-9)), fluo.FIT_IMPOSSIBLE), # really bad
+                  ((500e-9, "pass-through"), fluo.FIT_IMPOSSIBLE),  # really bad
                   ]
         for args, exp in in_exp:
             out = fluo.estimate_fit_to_dye(*args)
@@ -125,6 +142,7 @@ class FluoTestCase(unittest.TestCase):
                (489e-9, (490e-9, 497e-9, 500e-9, 503e-9, 510e-9)),
                (515e-9, (490e-9, 497e-9, 500e-9, 503e-9, 510e-9)),
                (900e-9, (490e-9, 497e-9, 500e-9, 503e-9, 510e-9)),
+               (500e-9, "pass-through")
                ]
         for args in ins:
             est = fluo.estimate_fit_to_dye(*args)

--- a/src/odemis/util/test/fluo_test.py
+++ b/src/odemis/util/test/fluo_test.py
@@ -18,6 +18,7 @@ from __future__ import division
 
 import collections
 import logging
+from odemis.model import BAND_PASS_THROUGH
 from odemis.util import fluo
 import unittest
 
@@ -36,7 +37,7 @@ class FluoTestCase(unittest.TestCase):
             self.assertEqual(exp, out, "Failed while running with %s and got %s" % (inp, out))
 
         # Special case for "pass-through": any number > 0 is fine
-        out = fluo.get_center("pass-through")
+        out = fluo.get_center(BAND_PASS_THROUGH)
         self.assertGreaterEqual(out, 0)
 
     def test_one_band_em(self):
@@ -55,9 +56,9 @@ class FluoTestCase(unittest.TestCase):
                   # It should also work with lists (although not very officially supported
                   (([[400e-9, 500e-9], [500e-9, 600e-9]], [490e-9, 510e-9]), (500e-9, 600e-9)),  # smallest above 500nm
                   # Try with a pass-through
-                  ((em_band, "pass-through"), em_band),
-                  ((em_bands, "pass-through"), em_bands[-1]),  # biggest
-                  (("pass-through", (490e-9, 510e-9)), "pass-through"),
+                  ((em_band, BAND_PASS_THROUGH), em_band),
+                  ((em_bands, BAND_PASS_THROUGH), em_bands[-1]),  # biggest
+                  ((BAND_PASS_THROUGH, (490e-9, 510e-9)), BAND_PASS_THROUGH),
                   ]
         for args, exp in in_exp:
             out = fluo.get_one_band_em(*args)
@@ -75,9 +76,9 @@ class FluoTestCase(unittest.TestCase):
                   ((em_bands, (790e-9, 797e-9, 800e-9, 803e-9, 810e-9)), fluo.get_center(em_bands[2])), # smallest above 800nm
                   ((em_bands[0:2], (790e-9, 797e-9, 800e-9, 803e-9, 810e-9)), fluo.get_center(em_bands[1])), # biggest
                   # Try with a pass-through
-                  ((em_band, "pass-through"), 500e-9),
-                  ((em_bands, "pass-through"), 1100e-9),  # biggest
-                  # (("pass-through", (490e-9, 510e-9)), "pass-through"),
+                  ((em_band, BAND_PASS_THROUGH), 500e-9),
+                  ((em_bands, BAND_PASS_THROUGH), 1100e-9),  # biggest
+                  # ((BAND_PASS_THROUGH, (490e-9, 510e-9)), BAND_PASS_THROUGH),
                   ]
         for args, exp in in_exp:
             out = fluo.get_one_center_em(*args)
@@ -94,9 +95,9 @@ class FluoTestCase(unittest.TestCase):
                   ((ex_bands, (690e-9, 697e-9, 700e-9, 703e-9, 710e-9)), ex_bands[0]),  # biggest below 700nm
                   ((ex_bands, (790e-9, 797e-9, 800e-9, 803e-9, 810e-9)), ex_bands[1]),  # biggest below 800nm
                   # Try with a pass-through
-                  ((ex_band, "pass-through"), ex_band),
-                  ((ex_bands, "pass-through"), ex_bands[0]),  # smallest
-                  (("pass-through", (490e-9, 510e-9)), "pass-through"),
+                  ((ex_band, BAND_PASS_THROUGH), ex_band),
+                  ((ex_bands, BAND_PASS_THROUGH), ex_bands[0]),  # smallest
+                  ((BAND_PASS_THROUGH, (490e-9, 510e-9)), BAND_PASS_THROUGH),
                   ]
         for args, exp in in_exp:
             out = fluo.get_one_band_ex(*args)
@@ -125,7 +126,7 @@ class FluoTestCase(unittest.TestCase):
                   ((489e-9, (490e-9, 497e-9, 500e-9, 503e-9, 510e-9)), fluo.FIT_BAD), # almost good
                   ((515e-9, (490e-9, 497e-9, 500e-9, 503e-9, 510e-9)), fluo.FIT_BAD), # almost good
                   ((900e-9, (490e-9, 497e-9, 500e-9, 503e-9, 510e-9)), fluo.FIT_IMPOSSIBLE), # really bad
-                  ((500e-9, "pass-through"), fluo.FIT_IMPOSSIBLE),  # really bad
+                  ((500e-9, BAND_PASS_THROUGH), fluo.FIT_IMPOSSIBLE),  # really bad
                   ]
         for args, exp in in_exp:
             out = fluo.estimate_fit_to_dye(*args)
@@ -142,7 +143,7 @@ class FluoTestCase(unittest.TestCase):
                (489e-9, (490e-9, 497e-9, 500e-9, 503e-9, 510e-9)),
                (515e-9, (490e-9, 497e-9, 500e-9, 503e-9, 510e-9)),
                (900e-9, (490e-9, 497e-9, 500e-9, 503e-9, 510e-9)),
-               (500e-9, "pass-through")
+               (500e-9, BAND_PASS_THROUGH)
                ]
         for args in ins:
             est = fluo.estimate_fit_to_dye(*args)
@@ -246,7 +247,7 @@ class FluoTestCase(unittest.TestCase):
         # inputs, expected
         in_exp = [((490e-9, 510e-9), "500/20 nm"),  # 2-float band
                   (((490e-9, 510e-9), (590e-9, 610e-9)), "500, 600 nm"), # multi-band
-                  ("pass-through", u"pass-through"), # just a string
+                  (BAND_PASS_THROUGH, u"pass-through"),  # just a string
                   ]
         for arg, exp in in_exp:
             out = fluo.to_readable_band(arg)


### PR DESCRIPTION
filter positions indicated as "pass-through" are actually no filter at
all.
So they don't fit for fluorescence microscopy. Essentially, they should
be skipped, or reported unfit.