### PR TITLE
technolution driver: change definition of scanGain to scanAmplitude

### DIFF
--- a/src/odemis/driver/technolution.py
+++ b/src/odemis/driver/technolution.py
@@ -597,9 +597,9 @@ class EBeamScanner(model.Emitter):
         # In x we typically scan from negative to positive centered around zero and
         # in y from positive to negative centered around zero.
         # the start of the sawtooth scanning signal
-        self.scanOffset = model.TupleContinuous((0.0, 0.0), range=((-1.0, -1.0), (1.0, 1.0)))
+        self.scanOffset = model.TupleContinuous((0.0, 0.0), range=((-1.0, -1.0), (1.0, 1.0)), cls=(int, float))
         # heights of the sawtooth scanner signal (it does not include the offset!)
-        self.scanAmplitude = model.TupleContinuous((0.1, -0.1), range=((-1.0, -1.0), (1.0, 1.0)))
+        self.scanAmplitude = model.TupleContinuous((0.1, -0.1), range=((-1.0, -1.0), (1.0, 1.0)), cls=(int, float))
         # FIXME add a check that offset + amplitude >! 2**15 - 1 and offset + amplitude <! -2**15
 
         # delay between the trigger signal to start the acquisition and the scanner to start scanning
@@ -883,9 +883,9 @@ class MirrorDescanner(model.Emitter):
         # direction of the executed descan
         self.rotation = model.FloatContinuous(0, range=(0, 2 * math.pi), unit='rad')
         # start of the sawtooth descanner signal
-        self.scanOffset = model.TupleContinuous((0.0, 0.0), range=((-1, -1), (1, 1)))
+        self.scanOffset = model.TupleContinuous((0.0, 0.0), range=((-1, -1), (1, 1)), cls=(int, float))
         # heights of the sawtooth descanner signal (it does not include the offset!)
-        self.scanAmplitude = model.TupleContinuous((0.008, 0.008), range=((-1, -1), (1, 1)))
+        self.scanAmplitude = model.TupleContinuous((0.008, 0.008), range=((-1, -1), (1, 1)), cls=(int, float))
         # FIXME add a check that offset + amplitude >! 2**15 - 1 and offset + amplitude <! -2**15
 
         clockFrequencyData = self.parent.asmApiGetCall("/scan/descan_control_frequency", 200)  # [1/sec]

--- a/src/odemis/driver/test/technolution_test.py
+++ b/src/odemis/driver/test/technolution_test.py
@@ -569,6 +569,10 @@ class TestEBeamScanner(unittest.TestCase):
             self.EBeamScanner.scanOffset.value = (1.2 * min_scanOffset, 1.2 * min_scanOffset)
         self.assertEqual(self.EBeamScanner.scanOffset.value, (0.9 * max_scanOffset, 0.9 * max_scanOffset))
 
+        # Check if int value is allowed
+        self.EBeamScanner.scanOffset.value = (0, 0)
+        self.assertEqual(self.EBeamScanner.scanOffset.value, (0, 0))
+
     def test_scanAmplitude_VA(self):
         """Testing the scanner gain VA. It defines the heights of the sawtooth scanning signal for the scanner."""
         min_scan_amplitude = self.EBeamScanner.scanAmplitude.range[0][0]
@@ -590,6 +594,10 @@ class TestEBeamScanner(unittest.TestCase):
         with self.assertRaises(IndexError):
             self.EBeamScanner.scanAmplitude.value = (1.2 * min_scan_amplitude, 1.2 * min_scan_amplitude)
         self.assertEqual(self.EBeamScanner.scanAmplitude.value, (0.9 * max_scan_amplitude, 0.9 * max_scan_amplitude))
+
+        # Check if int value is allowed
+        self.EBeamScanner.scanAmplitude.value = (0, 0)
+        self.assertEqual(self.EBeamScanner.scanAmplitude.value, (0, 0))
 
     def test_scanDelay_VA(self):
         """Testing of the scanner delay VA. It is the delay between the start the acquisition trigger and the
@@ -849,6 +857,10 @@ class TestMirrorDescanner(unittest.TestCase):
             self.MirrorDescanner.scanOffset.value = (1.2 * min_scanOffset, 1.2 * min_scanOffset)
         self.assertEqual(self.MirrorDescanner.scanOffset.value, (0.9 * max_scanOffset, 0.9 * max_scanOffset))
 
+        # Check if int value is allowed
+        self.EBeamScanner.scanOffset.value = (0, 0)
+        self.assertEqual(self.EBeamScanner.scanOffset.value, (0, 0))
+
     def test_scanAmplitude_VA(self):
         """Testing the descanner gain VA. It defines the heights of the sawtooth scanning signal for the descanner."""
         min_scan_amplitude = self.MirrorDescanner.scanAmplitude.range[0][0]
@@ -870,6 +882,10 @@ class TestMirrorDescanner(unittest.TestCase):
         with self.assertRaises(IndexError):
             self.MirrorDescanner.scanAmplitude.value = (1.2 * min_scan_amplitude, 1.2 * min_scan_amplitude)
         self.assertEqual(self.MirrorDescanner.scanAmplitude.value, (0.9 * max_scan_amplitude, 0.9 * max_scan_amplitude))
+
+        # Check if int value is allowed
+        self.EBeamScanner.scanAmplitude.value = (0, 0)
+        self.assertEqual(self.EBeamScanner.scanAmplitude.value, (0, 0))
 
     def test_physicalFlybackTime_VA(self):
         """Testing the physical flyback time VA. The physical flyback time is the time the descanner has to

--- a/src/odemis/driver/test/technolution_test.py
+++ b/src/odemis/driver/test/technolution_test.py
@@ -29,23 +29,26 @@ After installing the simulator it can be starting using the following commands i
 """
 import logging
 import math
-import queue
-
-import numpy
-from odemis import model
-from odemis.util import almost_equal
 import os
 import pickle
+import queue
 import threading
 import time
 import unittest
 
+import matplotlib
+
+matplotlib.use("TkAgg")  # GUI-backend
 import matplotlib.pyplot as plt
+import numpy
+
+from odemis import model
+from odemis.driver.technolution import AcquisitionServer, convertRange, AsmApiException, DATA_CONTENT_TO_ASM, \
+    VOLT_RANGE, I16_SYM_RANGE
+from odemis.util import almost_equal
+from odemis.util import test
 from technolution_asm.models import CalibrationLoopParameters
 from technolution_asm.models.mega_field_meta_data import MegaFieldMetaData
-
-from odemis.driver.technolution import AcquisitionServer, convert2Bits, convertRange, AsmApiException, \
-    DATA_CONTENT_TO_ASM
 
 # Set logger level to debug to observe all the output (useful when a test fails)
 logging.getLogger().setLevel(logging.DEBUG)
@@ -95,21 +98,6 @@ class TestAuxiliaryFunc(unittest.TestCase):
         # Test for positive to negative range
         out = convertRange(7, (5, 10), (-10, -20))
         self.assertEqual(out, -14)
-
-    def test_convertBits(self):
-        # Test input value of zero
-        out = tuple(convert2Bits((0, 0), (-1, 1)))
-        # Due to uneven scaling 0.0 is mapped to 0.5
-        # (uneven scaling means that 0.0 is not mapped to zero but to 0.5 due to the uneven range of INT16)
-        self.assertEqual((-0.5, -0.5), out)
-
-        # Use floor for rounding because the convert2Bits method returns floats and does not round.
-        out = numpy.floor(convert2Bits((-10, 0, 10), (-10, 10)))
-        self.assertEqual(tuple(out), (-2 ** 15, -1, 2 ** 15 - 1))
-
-        # Use floor for rounding because the convert2Bits method returns floats and does not round.
-        out = numpy.floor(convert2Bits((0, 0.5, 1), (0, 1)))
-        self.assertEqual(tuple(out), (-2 ** 15, -1, 2 ** 15 - 1))
 
 
 class TestAcquisitionServer(unittest.TestCase):
@@ -231,28 +219,15 @@ class TestAcquisitionServer(unittest.TestCase):
                                                            force_write=True)
 
     def test_assembleCalibrationMetadata(self):
-        """Check that the calibration metadata is correctly assembled."""
-        MAX_NMBR_POINTS = 4000  # Constant maximum number of setpoints
-        # TODO MAX_NMBR_POINT value of 4000 is sufficient for the entire range of the dwell time because the maximum
-        #  dwell_time is decreased. However, for the original maximum dwell time of 1e-4 seconds, this value
-        #  needs to be increased on the ASM HW to a value above 9000.
-
-        descanner = self.MirrorDescanner
+        """Check that the calibration metadata is correctly assembled and of correct type."""
         scanner = self.EBeamScanner
         ASM = self.ASM_manager
 
-        # choose example value so that line scan time is not integer multiple of descanner clock period
-        scanner.dwellTime.value = 430e-09
-        minimum_dwell_time = scanner.dwellTime.range[0]
-        random_dwell_time = numpy.round(numpy.random.random() * scanner.dwellTime.range[1], 9)
-        scanner.dwellTime.value = max(random_dwell_time, minimum_dwell_time)
-
-        # Total line scan time is equal to period of the calibration signal, the frequency is the inverse
-        total_line_scan_time = self.MPPC.getTotalLineScanTime()
+        scanner.dwellTime.value = 1.e-06
 
         calibration_parameters = ASM._assembleCalibrationMetadata()
 
-        # Check types of calibration parameters (output send to the ASM)
+        # Check types of calibration parameters
         self.assertIsInstance(calibration_parameters, CalibrationLoopParameters)
         self.assertIsInstance(calibration_parameters.descan_rotation, float)
         self.assertIsInstance(calibration_parameters.x_descan_offset, int)
@@ -263,7 +238,6 @@ class TestAcquisitionServer(unittest.TestCase):
         self.assertIsInstance(calibration_parameters.x_scan_offset, float)
         self.assertIsInstance(calibration_parameters.y_scan_offset, float)
 
-        # Check descan setpoints
         self.assertIsInstance(calibration_parameters.x_descan_setpoints, list)
         self.assertIsInstance(calibration_parameters.y_descan_setpoints, list)
         for x_setpoint, y_setpoint in zip(calibration_parameters.x_descan_setpoints,
@@ -271,24 +245,6 @@ class TestAcquisitionServer(unittest.TestCase):
             self.assertIsInstance(x_setpoint, int)
             self.assertIsInstance(y_setpoint, int)
 
-        # Check if the time interval used for the calculation of the descanner setpoints is equal to the
-        # descanner clock period.
-        x_descan_setpoints_time_interval = total_line_scan_time / len(calibration_parameters.x_descan_setpoints)
-        self.assertEqual(numpy.round(x_descan_setpoints_time_interval, 10) % descanner.clockPeriod.value, 0,
-                         "Time interval used for the descanner setpoints is not equal to the descanner clock "
-                         "period")
-
-        # Check if the total scanning time is equal to the total scanning time send to the ASM
-        descan_derived_total_scanning_time = descanner.clockPeriod.value \
-                                             * len(calibration_parameters.x_descan_setpoints)
-        if not almost_equal(descan_derived_total_scanning_time, total_line_scan_time, rtol=0, atol=1e-9):
-            raise ValueError("Total descan time implied by the setpoints send to the ASM is not equal to the "
-                             "scanning time set by the VA's.")
-
-        # Check scan setpoints
-        self.assertLessEqual(len(calibration_parameters.x_scan_setpoints), MAX_NMBR_POINTS)
-        self.assertLessEqual(len(calibration_parameters.y_scan_setpoints), MAX_NMBR_POINTS)
-        self.assertEqual(len(calibration_parameters.x_scan_setpoints), len(calibration_parameters.y_scan_setpoints))
         self.assertIsInstance(calibration_parameters.x_scan_setpoints, list)
         self.assertIsInstance(calibration_parameters.y_scan_setpoints, list)
         for x_setpoint, y_setpoint in zip(calibration_parameters.x_scan_setpoints,
@@ -296,33 +252,23 @@ class TestAcquisitionServer(unittest.TestCase):
             self.assertIsInstance(x_setpoint, float)
             self.assertIsInstance(y_setpoint, float)
 
-        x_scan_setpoints_time_interval = total_line_scan_time / len(calibration_parameters.x_scan_setpoints)
-        # Check if the a whole number of clock periods fits in the time interval
-        self.assertEqual(numpy.round(x_scan_setpoints_time_interval / ASM.clockPeriod.value, 10) % 1, 0,
-                         "Implied sampling period is not a whole multiple of the scanner clock period.")
-
-        if not almost_equal(calibration_parameters.dwell_time % ASM.clockPeriod.value, 0, rtol=0, atol=1e-9):
-            raise ValueError("Total scanning time implied by the setpoints send to the ASM is not equal to the "
-                             "scanning time set by the VA's.")
-
-        # Check if the total scanning time is equal to the total scanning time send to the ASM
-        scan_total_scanning_time = len(calibration_parameters.x_scan_setpoints) * calibration_parameters.dwell_time\
-                                                                                * ASM.clockPeriod.value
-
-        if not almost_equal(scan_total_scanning_time, total_line_scan_time, rtol=0, atol=1e-9):
-            raise ValueError("Total scanning time is not equal to the defined total scanning time.")
-
-    @unittest.skip  # Skip plotting of calibration setpoints, these plots are made for debugging.
+    @unittest.skip  # for debugging only
     def test_plot_calibration_setpoints(self):
-        """Test case for inspecting global behavior of the scan and descan calibration setpoint profiles."""
-        import matplotlib.pyplot as plt
-        self.MirrorDescanner.scanGain.value = (0.5, 0.5)
-        self.EBeamScanner.scanGain.value = (0.5, 0.5)
-        self.ASM_manager.calibrationMode.value = False
+        """Plot the calibration scanner and descanner setpoint profiles.
+        x scanner: sine
+        y scanner: sawtooth
+        x descanner: sine
+        y descanner: flat line
+        """
+        self.EBeamScanner.dwellTime.value = 5.e-06
+        self.MirrorDescanner.scanOffset.value = (0.1, 0.0)
+        self.MirrorDescanner.scanAmplitude.value = (0.5, 0.0)
+        self.EBeamScanner.scanOffset.value = (0.2, 0.1)
+        self.EBeamScanner.scanAmplitude.value = (0.4, 0.5)
         self.ASM_manager.calibrationMode.value = True
 
         calibration_parameters = self.ASM_manager._calibrationParameters
-        total_line_scan_time = calibration_parameters.dwell_time * self.ASM_manager.clockPeriod.value * \
+        total_line_scan_time = calibration_parameters.dwell_time * self.EBeamScanner.clockPeriod.value * \
                                len(calibration_parameters.x_scan_setpoints)
 
         x_descan_setpoints = numpy.array(calibration_parameters.x_descan_setpoints)
@@ -330,17 +276,26 @@ class TestAcquisitionServer(unittest.TestCase):
         x_scan_setpoints = numpy.array(calibration_parameters.x_scan_setpoints)
         y_scan_setpoints = numpy.array(calibration_parameters.y_scan_setpoints)
 
-        time_points_descanner = numpy.arange(0, total_line_scan_time, self.MirrorDescanner.clockPeriod.value)
-        time_points_scanner = numpy.arange(0, total_line_scan_time,
-                                           total_line_scan_time / len(calibration_parameters.x_scan_setpoints))
+        timestamps_descanner = numpy.arange(0, total_line_scan_time, self.MirrorDescanner.clockPeriod.value)
+        timestamps_scanner = numpy.arange(0, total_line_scan_time,
+                                          total_line_scan_time / len(calibration_parameters.x_scan_setpoints))
 
         fig, axs = plt.subplots(2)
+        fig.tight_layout(pad=3.0)  # add some space between subplots so that the axes labels are not hidden
         # Shift scanner values up by 20% of max to make both visible in the same plot.
         upwards_shift = 0.2 * max(x_descan_setpoints)
-        axs[0].plot(time_points_descanner, upwards_shift + x_descan_setpoints, "ro", label="Descanner x setpoints")
-        axs[1].plot(time_points_descanner, upwards_shift + y_descan_setpoints, "bo", label="Descanner y setpoints")
-        axs[0].plot(time_points_scanner, x_scan_setpoints, "rx", label="Scanner x setpoints")
-        axs[1].plot(time_points_scanner, y_scan_setpoints, "bx", label="Scanner y setpoints")
+        axs[0].plot(timestamps_descanner, upwards_shift + x_descan_setpoints, "ro", markersize=0.5,
+                    label="Descanner x setpoints")
+        axs[0].plot(timestamps_descanner, upwards_shift + y_descan_setpoints, "bo", markersize=0.5,
+                    label="Descanner y setpoints")
+        axs[0].set_xlabel("line scanning time [sec]")
+        axs[0].set_ylabel("setpoints [bits]")
+
+        axs[1].plot(timestamps_scanner, x_scan_setpoints, "rx", markersize=0.5, label="Scanner x setpoints")
+        axs[1].plot(timestamps_scanner, y_scan_setpoints, "bx", markersize=0.5, label="Scanner y setpoints")
+        axs[1].set_xlabel("line scanning time [sec]")
+        axs[1].set_ylabel("setpoints [V]")
+
         axs[0].legend(loc="upper left")
         axs[1].legend(loc="upper left")
         plt.show()
@@ -499,6 +454,48 @@ class TestEBeamScanner(unittest.TestCase):
         self.assertIsInstance(self.EBeamScanner.getTicksDwellTime(), int)
         self.assertEqual(self.EBeamScanner.getTicksDwellTime(), int(dwellTime / self.EBeamScanner.clockPeriod.value))
 
+    def test_getCenterScanVolt(self):
+        """Check that center of the scanning ramp is correctly calculated based on the
+        scan offset and scan amplitude. It also includes a conversion from arbitrary units to volt."""
+        # TODO test for other combinations - to +, + to -, - to - etc.
+        scan_start = (0.5, 0.5)
+        scan_amp = (0.2, 0.2)
+        self.EBeamScanner.scanOffset.value = scan_start
+        self.EBeamScanner.scanAmplitude.value = scan_amp
+
+        center = self.EBeamScanner.getCenterScanVolt()
+        exp_scan_start = (0.5, 0.5)
+        exp_scan_end = (0.7, 0.7)  # offset + amplitude
+        exp_center = tuple(convertRange((numpy.array(exp_scan_start) + numpy.array(exp_scan_end)) / 2,
+                                        numpy.array(self.EBeamScanner.scanAmplitude.range)[:, 1],
+                                        VOLT_RANGE))  # [V])
+
+        self.assertIsInstance(center, tuple)
+        self.assertIsInstance(center[0], float)
+        self.assertEqual(len(center), 2)  # x and y
+        test.assert_tuple_almost_equal(center, exp_center, places=10)
+
+    def test_getGradientScanVolt(self):
+        """Check that gradient of the scanning ramp is correctly calculated based on the
+        scan amplitude. It also includes a conversion from arbitrary units to volt."""
+        # TODO test for other combinations - to +, + to -, - to - etc.
+        scan_amp = (0.2, 0.2)
+        self.EBeamScanner.scanAmplitude.value = scan_amp
+        self.MPPC.cellCompleteResolution.value = (800, 800)
+
+        gradient = self.EBeamScanner.getGradientScanVolt()
+        exp_scan_amp = (0.2, 0.2)
+        resolution = numpy.array(self.MPPC.cellCompleteResolution.value)
+        steps = resolution - 1  # number of steps to go from start to end of scanning ramp
+        exp_gradient = tuple(convertRange(exp_scan_amp / steps,
+                                          numpy.array(self.EBeamScanner.scanAmplitude.range)[:, 1],
+                                          VOLT_RANGE))  # [V])
+
+        self.assertIsInstance(gradient, tuple)
+        self.assertIsInstance(gradient[0], float)
+        self.assertEqual(len(gradient), 2)  # x and y
+        test.assert_tuple_almost_equal(gradient, exp_gradient, places=10)
+
     def test_pixelSize_VA(self):
         """Testing the pixel size VA. Physical size of one pixel."""
         min_pixelSize = self.EBeamScanner.pixelSize.range[0][0]
@@ -572,27 +569,27 @@ class TestEBeamScanner(unittest.TestCase):
             self.EBeamScanner.scanOffset.value = (1.2 * min_scanOffset, 1.2 * min_scanOffset)
         self.assertEqual(self.EBeamScanner.scanOffset.value, (0.9 * max_scanOffset, 0.9 * max_scanOffset))
 
-    def test_scanGain_VA(self):
-        """Testing the scanner gain VA. It defines the heights/end of the sawtooth scanning signal for the scanner."""
-        min_scanGain = self.EBeamScanner.scanGain.range[0][0]
-        max_scanGain = self.EBeamScanner.scanGain.range[1][0]
+    def test_scanAmplitude_VA(self):
+        """Testing the scanner gain VA. It defines the heights of the sawtooth scanning signal for the scanner."""
+        min_scan_amplitude = self.EBeamScanner.scanAmplitude.range[0][0]
+        max_scan_amplitude = self.EBeamScanner.scanAmplitude.range[1][0]
 
-        # Check if small scanGain values are allowed
-        self.EBeamScanner.scanGain.value = (0.9 * min_scanGain, 0.9 * min_scanGain)
-        self.assertEqual(self.EBeamScanner.scanGain.value, (0.9 * min_scanGain, 0.9 * min_scanGain))
+        # Check if small scan amplitude values are allowed
+        self.EBeamScanner.scanAmplitude.value = (0.9 * min_scan_amplitude, 0.9 * min_scan_amplitude)
+        self.assertEqual(self.EBeamScanner.scanAmplitude.value, (0.9 * min_scan_amplitude, 0.9 * min_scan_amplitude))
 
-        # Check if big scanGain values are allowed
-        self.EBeamScanner.scanGain.value = (0.9 * max_scanGain, 0.9 * max_scanGain)
-        self.assertEqual(self.EBeamScanner.scanGain.value, (0.9 * max_scanGain, 0.9 * max_scanGain))
+        # Check if big scan amplitude values are allowed
+        self.EBeamScanner.scanAmplitude.value = (0.9 * max_scan_amplitude, 0.9 * max_scan_amplitude)
+        self.assertEqual(self.EBeamScanner.scanAmplitude.value, (0.9 * max_scan_amplitude, 0.9 * max_scan_amplitude))
 
         # Check if VA refuses to set limits outside allowed range
         with self.assertRaises(IndexError):
-            self.EBeamScanner.scanGain.value = (1.2 * max_scanGain, 1.2 * max_scanGain)
-        self.assertEqual(self.EBeamScanner.scanGain.value, (0.9 * max_scanGain, 0.9 * max_scanGain))
+            self.EBeamScanner.scanAmplitude.value = (1.2 * max_scan_amplitude, 1.2 * max_scan_amplitude)
+        self.assertEqual(self.EBeamScanner.scanAmplitude.value, (0.9 * max_scan_amplitude, 0.9 * max_scan_amplitude))
 
         with self.assertRaises(IndexError):
-            self.EBeamScanner.scanGain.value = (1.2 * min_scanGain, 1.2 * min_scanGain)
-        self.assertEqual(self.EBeamScanner.scanGain.value, (0.9 * max_scanGain, 0.9 * max_scanGain))
+            self.EBeamScanner.scanAmplitude.value = (1.2 * min_scan_amplitude, 1.2 * min_scan_amplitude)
+        self.assertEqual(self.EBeamScanner.scanAmplitude.value, (0.9 * max_scan_amplitude, 0.9 * max_scan_amplitude))
 
     def test_scanDelay_VA(self):
         """Testing of the scanner delay VA. It is the delay between the start the acquisition trigger and the
@@ -635,6 +632,137 @@ class TestEBeamScanner(unittest.TestCase):
             self.EBeamScanner.scanDelay.value = (0.6 * max_scanDelay, 0.6 * max_y_prescan_lines)
         # Check that the scan delay remains unchanged.
         self.assertEqual(self.EBeamScanner.scanDelay.value, (min_scanDelay, min_y_prescan_lines))
+
+    def test_getCalibrationSetpoints(self):
+        """Check that the calibration setpoints are correctly assembled."""
+        scanner = self.EBeamScanner
+
+        # sine for x, sawtooth for y
+        scanner.scanOffset.value = (0.1, 0)  # offset of the sine on x; offset of the sawtooth on y
+        scanner.scanAmplitude.value = (0.5, 0)  # amplitude of sine on x; heigths of the sawtooth on y
+        scanner.dwellTime.value = 5e-06
+
+        # Total line scan time is equal to period of the calibration signal, the frequency is the inverse
+        total_line_scan_time = self.MPPC.getTotalLineScanTime()
+        # TODO Do we need the flyback included for calibration of the scan delay?
+
+        x_scan_setpoints, y_scan_setpoints, calib_dwell_time_ticks = \
+            scanner.getCalibrationSetpoints(total_line_scan_time)
+
+        # use almost equal as the max/min setpoints can be equal or smaller than the absolute amplitude
+        # Note: There is not necessarily a setpoint at the max/min amplitude of the sine.
+        #
+        # *               *  *
+        #   *           *      *
+        # -----------------------------------
+        #     *      *           *
+        #       *  *
+        #
+        # TODO evaluate what accuracy is needed for the calibration
+        # check that the minimum x setpoint of the sine equals offset - amplitude in [V]
+        self.assertAlmostEqual(min(x_scan_setpoints),
+                               convertRange(scanner.scanOffset.value[0] - scanner.scanAmplitude.value[0],
+                                            numpy.array(scanner.scanAmplitude.range)[:, 1],
+                                            VOLT_RANGE), 5)
+
+        # check that the maximum setpoint of the sine equals offset + amplitude in [V]
+        self.assertAlmostEqual(max(x_scan_setpoints),
+                               convertRange(scanner.scanOffset.value[0] + scanner.scanAmplitude.value[0],
+                                            numpy.array(scanner.scanAmplitude.range)[:, 1],
+                                            VOLT_RANGE), 5)
+
+        # check that the minimum x setpoint of the sawtooth equals the offset in [V]
+        self.assertAlmostEqual(min(y_scan_setpoints),
+                               convertRange(scanner.scanOffset.value[1],
+                                            numpy.array(scanner.scanOffset.range)[:, 1],
+                                            VOLT_RANGE), 5)
+
+        # check that the maximum setpoint of the sawtooth equals offset + amplitude in [V]
+        self.assertAlmostEqual(max(y_scan_setpoints),
+                               convertRange(scanner.scanOffset.value[1] + scanner.scanAmplitude.value[1],
+                                            numpy.array(scanner.scanAmplitude.range)[:, 1],
+                                            VOLT_RANGE), 5)
+
+        # check that the calibration dwell time in seconds is an integer multiple of the scanner clock period
+        calib_dwell_time = numpy.round(total_line_scan_time / len(x_scan_setpoints), 10)  # [sec]
+        self.assertAlmostEqual(calib_dwell_time % scanner.clockPeriod.value, 0, 10)  # floating point errors
+
+        # check if the total line scan time matches with the time given by the calculated setpoints
+        total_time_setpoints = len(x_scan_setpoints) * calib_dwell_time_ticks * scanner.clockPeriod.value  # [sec]
+        self.assertAlmostEqual(total_time_setpoints, total_line_scan_time, 10)  # floating point errors
+
+        # check that not more than max possible total number of setpoints
+        MAX_NMBR_POINTS = 4000  # maximum number of setpoints possible
+        self.assertLessEqual(len(x_scan_setpoints), MAX_NMBR_POINTS)
+        self.assertLessEqual(len(y_scan_setpoints), MAX_NMBR_POINTS)
+        # check that same number of setpoints in x in y
+        self.assertEqual(len(x_scan_setpoints), len(y_scan_setpoints))
+
+    def test_getCalibrationDwellTime(self):
+        """Check that the calibration dwell time is correctly calculated."""
+        scanner = self.EBeamScanner
+
+        # sine for x, sawtooth for y
+        scanner.scanOffset.value = (0.1, 0)  # offset of the sine on x; offset of the sawtooth on y
+        scanner.scanAmplitude.value = (0.5, 0)  # amplitude of sine on x; heigths of the sawtooth on y
+        scanner.dwellTime.value = 5e-06  # acquisition dwell time (integer multiple of scanner clock period)
+
+        # get the total line scan time, which is equal to the period of the calibration signal
+        total_line_scan_time = self.MPPC.getTotalLineScanTime()
+        # TODO Do we need the flyback included for calibration of the scan delay?
+
+        # Calculate the total number of setpoints and the calibration dwell time (update frequency of the setpoints).
+        calib_dwell_time_ticks, number_setpoints = scanner.getCalibrationDwellTime(total_line_scan_time)
+
+        # check that the calibration time * the clock period * number of setpoints matches the line scan time
+        self.assertAlmostEqual(calib_dwell_time_ticks * scanner.clockPeriod.value * number_setpoints,
+                               total_line_scan_time, 10)  # floating point errors
+
+        # check that the calibration dwell time in seconds is an integer multiple of the scanner clock period
+        calib_dwell_time = numpy.round(total_line_scan_time / number_setpoints, 10)  # [sec]
+        self.assertAlmostEqual(calib_dwell_time % scanner.clockPeriod.value, 0, 10)  # floating point errors
+
+        # TODO Do we need the flyback included for calibration of the scan delay?
+        #   However, the total line scan time is already always an integer multiple of the descan clock period
+        #   independent of the dwell time.
+        # Check that, if it is not possible to find a calibration dwell time for a given acquisition dwell time,
+        # the descanner clock period is returned as calibration dwell time in ticks.
+        # check that the calibration dwell time [ticks] * scanner clock period [sec] is equal to the
+        # descanner clock period [sec]
+        # self.assertAlmostEqual(calib_dwell_time_ticks * scanner.clockPeriod.value,
+        #                        descanner.clockPeriod.value, 10)  # floating point errors
+
+    @unittest.skip  # for debugging only
+    def test_plot_calibration_setpoints(self):
+        """Plot the calibration scanner setpoint profiles.
+        x scanner: sine
+        y scanner: sawtooth
+        """
+        self.EBeamScanner.dwellTime.value = 5e-6
+        self.EBeamScanner.scanOffset.value = (0.1, 0.2)  # center of the sine on x; start of the sawtooth on y
+        self.EBeamScanner.scanAmplitude.value = (0.5, 0.3)  # amplitude of the sine on x; heights of the sawtooth on y
+
+        # Total line scan time is equal to period of the calibration signal, the frequency is the inverse
+        total_line_scan_time = self.MPPC.getTotalLineScanTime()
+        # TODO Do we need the flyback included for calibration of the scan delay?
+
+        x_scan_setpoints, y_scan_setpoints, calib_dwell_time_ticks = \
+            self.EBeamScanner.getCalibrationSetpoints(total_line_scan_time)
+
+        x_scan_setpoints = numpy.array(x_scan_setpoints)
+        y_scan_setpoints = numpy.array(y_scan_setpoints)
+
+        timestamps_scanner = numpy.arange(0, total_line_scan_time, total_line_scan_time / len(x_scan_setpoints))
+
+        fig, axs = plt.subplots(1)
+
+        axs.plot(timestamps_scanner, x_scan_setpoints, "rx", markersize=0.5, label="Scanner x setpoints")
+        axs.plot(timestamps_scanner, y_scan_setpoints, "bx", markersize=0.5, label="Scanner y setpoints")
+        axs.set_xlabel("scanning time [sec]")
+        axs.set_ylabel("setpoints [V]")
+
+        axs.legend(loc="upper left")
+        plt.show()
 
 
 class TestMirrorDescanner(unittest.TestCase):
@@ -721,28 +849,27 @@ class TestMirrorDescanner(unittest.TestCase):
             self.MirrorDescanner.scanOffset.value = (1.2 * min_scanOffset, 1.2 * min_scanOffset)
         self.assertEqual(self.MirrorDescanner.scanOffset.value, (0.9 * max_scanOffset, 0.9 * max_scanOffset))
 
-    def test_scanGain_VA(self):
-        """Testing the descanner gain VA. It defines the heights/end of the sawtooth scanning signal for the
-        descanner."""
-        min_scanGain = self.MirrorDescanner.scanGain.range[0][0]
-        max_scanGain = self.MirrorDescanner.scanGain.range[1][0]
+    def test_scanAmplitude_VA(self):
+        """Testing the descanner gain VA. It defines the heights of the sawtooth scanning signal for the descanner."""
+        min_scan_amplitude = self.MirrorDescanner.scanAmplitude.range[0][0]
+        max_scan_amplitude = self.MirrorDescanner.scanAmplitude.range[1][0]
 
-        # Check if small scanGain values are allowed
-        self.MirrorDescanner.scanGain.value = (0.9 * min_scanGain, 0.9 * min_scanGain)
-        self.assertEqual(self.MirrorDescanner.scanGain.value, (0.9 * min_scanGain, 0.9 * min_scanGain))
+        # Check if small scan amplitude values are allowed
+        self.MirrorDescanner.scanAmplitude.value = (0.9 * min_scan_amplitude, 0.9 * min_scan_amplitude)
+        self.assertEqual(self.MirrorDescanner.scanAmplitude.value, (0.9 * min_scan_amplitude, 0.9 * min_scan_amplitude))
 
-        # Check if big scanGain values are allowed
-        self.MirrorDescanner.scanGain.value = (0.9 * max_scanGain, 0.9 * max_scanGain)
-        self.assertEqual(self.MirrorDescanner.scanGain.value, (0.9 * max_scanGain, 0.9 * max_scanGain))
+        # Check if big scan amplitude values are allowed
+        self.MirrorDescanner.scanAmplitude.value = (0.9 * max_scan_amplitude, 0.9 * max_scan_amplitude)
+        self.assertEqual(self.MirrorDescanner.scanAmplitude.value, (0.9 * max_scan_amplitude, 0.9 * max_scan_amplitude))
 
         # Check if VA refuses to set limits outside allowed range
         with self.assertRaises(IndexError):
-            self.MirrorDescanner.scanGain.value = (1.2 * max_scanGain, 1.2 * max_scanGain)
-        self.assertEqual(self.MirrorDescanner.scanGain.value, (0.9 * max_scanGain, 0.9 * max_scanGain))
+            self.MirrorDescanner.scanAmplitude.value = (1.2 * max_scan_amplitude, 1.2 * max_scan_amplitude)
+        self.assertEqual(self.MirrorDescanner.scanAmplitude.value, (0.9 * max_scan_amplitude, 0.9 * max_scan_amplitude))
 
         with self.assertRaises(IndexError):
-            self.MirrorDescanner.scanGain.value = (1.2 * min_scanGain, 1.2 * min_scanGain)
-        self.assertEqual(self.MirrorDescanner.scanGain.value, (0.9 * max_scanGain, 0.9 * max_scanGain))
+            self.MirrorDescanner.scanAmplitude.value = (1.2 * min_scan_amplitude, 1.2 * min_scan_amplitude)
+        self.assertEqual(self.MirrorDescanner.scanAmplitude.value, (0.9 * max_scan_amplitude, 0.9 * max_scan_amplitude))
 
     def test_physicalFlybackTime_VA(self):
         """Testing the physical flyback time VA. The physical flyback time is the time the descanner has to
@@ -769,170 +896,346 @@ class TestMirrorDescanner(unittest.TestCase):
         self.assertEqual(self.MirrorDescanner.physicalFlybackTime.value, 0.9 * max_flyback)
 
     def test_getXAcqSetpoints(self):
-        """For multiple settings the x acquisition setpoints are checked on total number of setpoints (length) and the
-        expected range of the setpoints."""
-        descanner = self.MirrorDescanner
+        """Check that the setpoints in y are calculated correctly."""
         scanner = self.EBeamScanner
+        descanner = self.MirrorDescanner
         mppc = self.MPPC
-        # Change values such that it is easy to follow the calculation by head. (The setpoint have an increase of
-        # 20 bits per setpoint in the scanning ramp)
+
+        # TODO have example - to +, + to -. + to +, - to - for both offset and amplitude (8 combinations)
+
+        # example here: setpoints have an increase of 20 bits per setpoint in the scanning ramp.
         descanner.scanOffset.value = (0.09767299916075389, 0.09767299916075389)
-        descanner.scanGain.value = (0.646387426565957, 0.646387426565957)
+        descanner.scanAmplitude.value = (0.646387426565957, 0.646387426565957)
         scanner.dwellTime.value = descanner.clockPeriod.value
-        def expected_setpoint_length(dwellTime, physcicalFlybackTime, X_cell_size, descan_period):
-            # Ceil round the number of scanning points so that if a half descan period is left at least a full extra
-            # setpoint is added to allow the scan to be properly finished
-            scanning_setpoints = math.ceil(numpy.round((dwellTime * X_cell_size) / descan_period, 10))
-            flyback_setpoints = math.ceil(physcicalFlybackTime / descan_period)
-            return scanning_setpoints + flyback_setpoints
 
-        # Check default values
-        X_descan_setpoints = descanner.getXAcqSetpoints()
-        self.assertEqual(len(X_descan_setpoints),
-                         expected_setpoint_length(scanner.dwellTime.value,
-                                                  descanner.physicalFlybackTime.value,
-                                                  mppc.cellCompleteResolution.value[0],
-                                                  descanner.clockPeriod.value))
+        x_descan_setpoints = descanner.getXAcqSetpoints()
 
-        self.assertEqual(min(X_descan_setpoints),
-                         numpy.floor(convert2Bits(descanner.scanOffset.value,
-                                                  numpy.array(descanner.scanOffset.range)[:, 1])[0]))
-        self.assertEqual(max(X_descan_setpoints),
-                         numpy.floor(convert2Bits(descanner.scanGain.value,
-                                                  numpy.array(descanner.scanGain.range)[:, 1])[0]))
+        # check that the number of setpoints in x equals the size of an overscanned cell image + flyback
+        self.assertEqual(len(x_descan_setpoints), self.number_expected_setpoints_x(scanner.dwellTime.value,
+                                                                                   descanner.physicalFlybackTime.value,
+                                                                                   mppc.cellCompleteResolution.value[0],
+                                                                                   descanner.clockPeriod.value))
 
-        # TODO find example for floating point error and use it, as with the current implementation there is still
-        #  a change, that there is never a floating point error triggered.
-        # Check with randomly changing the dwell_time to also catch floating point errors.
-        for test_repetition in range(0, 1000):
-            minimum_dwell_time = scanner.dwellTime.range[0]
-            random_dwell_time = numpy.round(numpy.random.random() * scanner.dwellTime.range[1], 6)
-            scanner.dwellTime.value = max(random_dwell_time, minimum_dwell_time)
+        # check that the minimum setpoint (start of the scanning ramp) equals the offset in [bits]
+        self.assertEqual(min(x_descan_setpoints),
+                         numpy.floor(convertRange(descanner.scanOffset.value[0],
+                                                  numpy.array(descanner.scanOffset.range)[:, 0],
+                                                  I16_SYM_RANGE)))
 
-            X_descan_setpoints = descanner.getXAcqSetpoints()
-            self.assertEqual(len(X_descan_setpoints),
-                             expected_setpoint_length(scanner.dwellTime.value,
-                                                      descanner.physicalFlybackTime.value,
-                                                      mppc.cellCompleteResolution.value[0],
-                                                      descanner.clockPeriod.value))
+        # check that the maximum setpoint (end of scanning ramp) equals offset + amplitude in [bits]
+        self.assertEqual(max(x_descan_setpoints),
+                         numpy.floor(convertRange(descanner.scanAmplitude.value[0] + descanner.scanOffset.value[0],
+                                                  numpy.array(descanner.scanAmplitude.range)[:, 0],
+                                                  I16_SYM_RANGE)))
 
-            self.assertEqual(min(X_descan_setpoints),
-                             numpy.floor(convert2Bits(descanner.scanOffset.value,
-                                                      numpy.array(descanner.scanOffset.range)[:, 1])[0]))
-            self.assertEqual(max(X_descan_setpoints),
-                             numpy.floor(convert2Bits(descanner.scanGain.value,
-                                                      numpy.array(descanner.scanGain.range)[:, 1])[0]))
+    def test_setpoints_x_floating_point_error(self):
+        """Check that floating point errors in the calculation of the scanning time are handled when
+        calculating the setpoints."""
+        scanner = self.EBeamScanner
+        descanner = self.MirrorDescanner
+        mppc = self.MPPC
 
-        # Check values when descan offset equals descan gain meaning a flat line is found for the descan points.
-        descanner.scanOffset.value = (0.5, 0.5)
-        descanner.scanGain.value = (0.5, 0.5)
-        X_descan_setpoints = descanner.getXAcqSetpoints()
-        self.assertEqual(len(numpy.unique(numpy.round(X_descan_setpoints))), 1)  # Check if all values are the same
-        self.assertEqual(numpy.unique(numpy.round(X_descan_setpoints)),
-                         numpy.round(convert2Bits(descanner.scanGain.value,
-                                                  numpy.array(descanner.scanGain.range)[:, 1])[0]))
-        self.assertEqual(len(X_descan_setpoints),
-                         expected_setpoint_length(scanner.dwellTime.value,
-                                                  descanner.physicalFlybackTime.value,
-                                                  mppc.cellCompleteResolution.value[0],
-                                                  descanner.clockPeriod.value))
+        # dwell time * cell complete size / descan period = scanning time (3.e-05 * 900 / 1e-05 = 2699.9999999999995)
+        scanner.dwellTime.value = 3.e-5
+        mppc.cellCompleteResolution.value = (900, 900)
 
-        self.assertEqual(min(X_descan_setpoints),
-                         numpy.floor(convert2Bits(descanner.scanOffset.value,
-                                                  numpy.array(descanner.scanOffset.range)[:, 1])[0]))
-        self.assertEqual(max(X_descan_setpoints),
-                         numpy.floor(convert2Bits(descanner.scanGain.value,
-                                                  numpy.array(descanner.scanGain.range)[:, 1])[0]))
+        x_descan_setpoints = descanner.getXAcqSetpoints()
+
+        # check that the number of setpoints in x equals the size of an overscanned cell image + flyback
+        self.assertEqual(len(x_descan_setpoints), self.number_expected_setpoints_x(scanner.dwellTime.value,
+                                                                                   descanner.physicalFlybackTime.value,
+                                                                                   mppc.cellCompleteResolution.value[0],
+                                                                                   descanner.clockPeriod.value))
+
+        # check that the minimum setpoint (start of the scanning ramp) equals the offset in [bits]
+        self.assertEqual(min(x_descan_setpoints),
+                         numpy.floor(convertRange(descanner.scanOffset.value[0],
+                                                  numpy.array(descanner.scanOffset.range)[:, 0],
+                                                  I16_SYM_RANGE)))
+
+        # check that the maximum setpoint (end of scanning ramp) equals offset + amplitude in [bits]
+        self.assertEqual(max(x_descan_setpoints),
+                         numpy.floor(convertRange(descanner.scanAmplitude.value[0] + descanner.scanOffset.value[0],
+                                                  numpy.array(descanner.scanAmplitude.range)[:, 0],
+                                                  I16_SYM_RANGE)))
+
+    def test_setpoints_x_remainder_scanning_time(self):
+        """Check that the setpoints are correctly calculated also when the scanning time
+        (dwell time * number overscanned pixels) is not an integer multiple of the descan period (update rate)."""
+        scanner = self.EBeamScanner
+        descanner = self.MirrorDescanner
+        mppc = self.MPPC
+
+        # dwell time * cell complete size / descan period = scanning time (2.2e-05*900/1.e-05 = 1979.9999999999995)
+        scanner.dwellTime.value = 2.2e-5
+
+        x_descan_setpoints = descanner.getXAcqSetpoints()
+
+        # check that the number of setpoints in x equals the size of an overscanned cell image + flyback
+        self.assertEqual(len(x_descan_setpoints), self.number_expected_setpoints_x(scanner.dwellTime.value,
+                                                                                   descanner.physicalFlybackTime.value,
+                                                                                   mppc.cellCompleteResolution.value[0],
+                                                                                   descanner.clockPeriod.value))
+
+        # check that the minimum setpoint (start of the scanning ramp) equals the offset in [bits]
+        self.assertEqual(min(x_descan_setpoints),
+                         numpy.floor(convertRange(descanner.scanOffset.value[0],
+                                                  numpy.array(descanner.scanOffset.range)[:, 0],
+                                                  I16_SYM_RANGE)))
+
+        # check that the maximum setpoint (end of scanning ramp) equals offset + amplitude in [bits]
+        self.assertEqual(max(x_descan_setpoints),
+                         numpy.floor(convertRange(descanner.scanAmplitude.value[0] + descanner.scanOffset.value[0],
+                                                  numpy.array(descanner.scanAmplitude.range)[:, 0],
+                                                  I16_SYM_RANGE)))
+
+    def test_flat_line_x(self):
+        """Check that if the amplitude is 0, a flat line of acquisition setpoints is returned."""
+        scanner = self.EBeamScanner
+        descanner = self.MirrorDescanner
+        mppc = self.MPPC
+
+        # no descanning = scanning amplitude equals 0 (= flat line of setpoints at offset level)
+        descanner.scanOffset.value = (0.5, 0.5)  # random offset
+        descanner.scanAmplitude.value = (0.0, 0.0)  # no amplitude
+
+        x_descan_setpoints = descanner.getXAcqSetpoints()
+
+        # check that the setpoints are all of the same value (flat line)
+        self.assertEqual(len(numpy.unique(numpy.round(x_descan_setpoints))), 1)
+        # check that the setpoints have the correct value (offset level)
+        self.assertEqual(numpy.unique(numpy.round(x_descan_setpoints)),
+                         numpy.round(convertRange(descanner.scanAmplitude.value[0] + descanner.scanOffset.value[0],
+                                                  numpy.array(descanner.scanAmplitude.range)[:, 0],
+                                                  I16_SYM_RANGE)))
+
+        # check that the number of setpoints in x equals the size of an overscanned cell image + flyback
+        self.assertEqual(len(x_descan_setpoints), self.number_expected_setpoints_x(scanner.dwellTime.value,
+                                                                                   descanner.physicalFlybackTime.value,
+                                                                                   mppc.cellCompleteResolution.value[0],
+                                                                                   descanner.clockPeriod.value))
+
+        # check that the minimum setpoint (start of the scanning ramp) equals the offset in [bits]
+        self.assertEqual(min(x_descan_setpoints),
+                         numpy.floor(convertRange(descanner.scanOffset.value[0],
+                                                  numpy.array(descanner.scanOffset.range)[:, 0],
+                                                  I16_SYM_RANGE)))
+
+        # check that the maximum setpoint (end of scanning ramp) equals offset + amplitude in [bits]
+        self.assertEqual(max(x_descan_setpoints),
+                         numpy.floor(convertRange(descanner.scanAmplitude.value[0] + descanner.scanOffset.value[0],
+                                                  numpy.array(descanner.scanAmplitude.range)[:, 0],
+                                                  I16_SYM_RANGE)))
+
+    def test_max_amp_x(self):
+        """Check that if the amplitude is maximal (=1) that the returned max setpoint is of value 2**15 - 1."""
+        descanner = self.MirrorDescanner
+
+        # amplitude = 1 is mapped to 2**15, however, ASM only accepts 2**15 - 1
+        # check that amplitude = 1 is mapped to 2**15 - 1 before sending it to the ASM
+        descanner.scanOffset.value = (0.0, 0.0)
+        descanner.scanAmplitude.value = (1.0, 1.0)  # max amplitude
+
+        x_descan_setpoints = descanner.getXAcqSetpoints()
+
+        # check that the maximum setpoint (end of scanning ramp) is reduced by one bit 2**15 -1 = 32767
+        # as this is the maximum value the ASM accepts
+        self.assertEqual(max(x_descan_setpoints), 32767)
+
+    def number_expected_setpoints_x(self, dwellTime, physcicalFlybackTime, X_cell_size, descan_period):
+        """Calculate the number of setpoints in x for an overscanned cell image including flyback."""
+        # Ceil round the number of scanning points so that if a half descan period is left at least a full extra
+        # setpoint is added to allow the scan to be properly finished
+        scanning_setpoints = math.ceil(numpy.round((dwellTime * X_cell_size) / descan_period, 10))
+        flyback_setpoints = math.ceil(physcicalFlybackTime / descan_period)
+
+        return scanning_setpoints + flyback_setpoints
 
     def test_getYAcqSetpoints(self):
-        """For multiple settings the y acquisition setpoints are checked on total number of setpoints (length) and the
-        expected range of the setpoints."""
+        """Check that the setpoints in y are calculated correctly."""
+        scanner = self.EBeamScanner
         descanner = self.MirrorDescanner
         mppc = self.MPPC
-        # Change values such that it is easy to follow the calculation
+
+        # TODO have example - to +, + to -. + to +, - to - for both offset and amplitude (8 combinations)
+
+        # example here: setpoints have an increase of 20 bits per setpoint in the scanning ramp.
         descanner.scanOffset.value = (0.09767299916075389, 0.09767299916075389)
-        descanner.scanGain.value = (0.646387426565957, 0.646387426565957)
+        descanner.scanAmplitude.value = (0.646387426565957, 0.646387426565957)
+        scanner.dwellTime.value = descanner.clockPeriod.value  # dwell time = descanner period
 
-        # Check default values
-        Y_descan_setpoints = descanner.getYAcqSetpoints()
-        self.assertEqual(min(Y_descan_setpoints),
-                         math.floor(convert2Bits(descanner.scanOffset.value,
-                                                 numpy.array(descanner.scanOffset.range)[:, 1])[1])
-                         )
-        self.assertEqual(max(Y_descan_setpoints),
-                         math.floor(convert2Bits(descanner.scanGain.value[1],
-                                                 numpy.array(descanner.scanGain.range)[:, 1]))
-                         )
-        self.assertEqual(len(Y_descan_setpoints), mppc.cellCompleteResolution.value[1])
+        y_descan_setpoints = descanner.getYAcqSetpoints()
 
-        # TODO find example for floating point error and use it, as with the current implementation there is still
-        #  a change, that there is never a floating point error triggered.
-        # Check with randomly changing the dwell_time to also catch floating point errors.
-        for test_repetition in range(0, 1000):
-            minimum_dwell_time = self.EBeamScanner.dwellTime.range[0]
-            random_dwell_time = numpy.round(numpy.random.random() * self.EBeamScanner.dwellTime.range[1], 6)
-            self.EBeamScanner.dwellTime.value = max(random_dwell_time, minimum_dwell_time)
+        # check that the minimum setpoint (start of the scanning ramp) equals the offset in [bits]
+        self.assertEqual(min(y_descan_setpoints),
+                         math.floor(convertRange(descanner.scanOffset.value[1],
+                                                 numpy.array(descanner.scanOffset.range)[:, 1],
+                                                 I16_SYM_RANGE)))
 
-            # Check with changing gain
-            # Change y value to a value which has an irregular difference between the value of thesetpoints which
-            # makes it an interesting test case.
-            descanner.scanGain.value = (0.1, 0.7)
-            Y_descan_setpoints = descanner.getYAcqSetpoints()
-            self.assertEqual(min(Y_descan_setpoints),
-                             math.floor(convert2Bits(descanner.scanOffset.value,
-                                                     numpy.array(descanner.scanOffset.range)[:, 1])[1])
-                             )
-            self.assertEqual(max(Y_descan_setpoints),
-                             math.floor(convert2Bits(descanner.scanGain.value[1],
-                                                     numpy.array(descanner.scanGain.range)[:, 1]))
-                             )
-            self.assertEqual(len(Y_descan_setpoints), mppc.cellCompleteResolution.value[1])
+        # check that the maximum setpoint (end of scanning ramp) equals offset + amplitude in [bits]
+        self.assertEqual(max(y_descan_setpoints),
+                         math.floor(convertRange(descanner.scanAmplitude.value[1] + descanner.scanOffset.value[1],
+                                                 numpy.array(descanner.scanAmplitude.range)[:, 1],
+                                                 I16_SYM_RANGE)))
 
-            # Change the cell_size and check if number of setpoints change accordingly.
-            mppc.cellCompleteResolution.value = (777, 777)
-            Y_descan_setpoints = descanner.getYAcqSetpoints()
-            self.assertEqual(min(Y_descan_setpoints),
-                             math.floor(convert2Bits(descanner.scanOffset.value,
-                                                     numpy.array(descanner.scanOffset.range)[:, 1])[1])
-                             )
-            self.assertEqual(max(Y_descan_setpoints),
-                             math.floor(convert2Bits(descanner.scanGain.value[1],
-                                                     numpy.array(descanner.scanGain.range)[:, 1]))
-                             )
-            self.assertEqual(len(Y_descan_setpoints), mppc.cellCompleteResolution.value[1])
+        # check that the number of setpoints in y equals the size of an overscanned cell image
+        self.assertEqual(len(y_descan_setpoints), mppc.cellCompleteResolution.value[1])
 
-            # Check values when descan offset equals descan gain, meaning a flat line is created for the descan points.
-            descanner.scanOffset.value = (0.5, 0.5)
-            descanner.scanGain.value = (0.5, 0.5)
-            Y_descan_setpoints = descanner.getYAcqSetpoints()
-            self.assertEqual(len(numpy.unique(numpy.round(Y_descan_setpoints))), 1)  # Check if all values are the same
-            self.assertEqual(numpy.unique(numpy.round(Y_descan_setpoints)),
-                             numpy.round(convert2Bits(descanner.scanGain.value,
-                                                      numpy.array(descanner.scanGain.range)[:, 1])[1]))
-            self.assertEqual(min(Y_descan_setpoints),
-                             math.floor(convert2Bits(descanner.scanOffset.value,
-                                                     numpy.array(descanner.scanOffset.range)[:, 1])[1])
-                             )
-            self.assertEqual(max(Y_descan_setpoints),
-                             math.floor(convert2Bits(descanner.scanGain.value[1],
-                                                     numpy.array(descanner.scanGain.range)[:, 1]))
-                             )
-            self.assertEqual(len(Y_descan_setpoints), mppc.cellCompleteResolution.value[1])
+    def test_flat_line_y(self):
+        """Check that if the amplitude is 0, a flat line of acquisition setpoints is returned."""
+        descanner = self.MirrorDescanner
+        mppc = self.MPPC
 
-    @unittest.skip  # Skip plotting of acq setpoints, these plots are made for debugging.
+        # no descanning = scanning amplitude equals 0 (= flat line of setpoints at offset level)
+        descanner.scanOffset.value = (0.5, 0.5)  # random offset
+        descanner.scanAmplitude.value = (0.0, 0.0)  # no amplitude
+
+        y_descan_setpoints = descanner.getYAcqSetpoints()
+
+        # check that the setpoints are all of the same value (flat line)
+        self.assertEqual(len(numpy.unique(numpy.round(y_descan_setpoints))), 1)
+        # check that the setpoints have the correct value (offset level)
+        self.assertEqual(numpy.unique(numpy.round(y_descan_setpoints)),
+                         numpy.round(convertRange(descanner.scanAmplitude.value[1] + descanner.scanOffset.value[1],
+                                                  numpy.array(descanner.scanAmplitude.range)[:, 1],
+                                                  I16_SYM_RANGE)))
+
+        # check that the minimum setpoint (start of the scanning ramp) equals the offset in [bits]
+        self.assertEqual(min(y_descan_setpoints),
+                         math.floor(convertRange(descanner.scanOffset.value[1],
+                                                 numpy.array(descanner.scanOffset.range)[:, 1],
+                                                 I16_SYM_RANGE)))
+
+        # check that the maximum setpoint (end of scanning ramp) equals offset + amplitude in [bits]
+        self.assertEqual(max(y_descan_setpoints),
+                         math.floor(convertRange(descanner.scanAmplitude.value[1] + descanner.scanOffset.value[1],
+                                                 numpy.array(descanner.scanAmplitude.range)[:, 1],
+                                                 I16_SYM_RANGE)))
+
+        # check that the number of setpoints in y equals the size of an overscanned cell image
+        self.assertEqual(len(y_descan_setpoints), mppc.cellCompleteResolution.value[1])
+
+    def test_max_amp_y(self):
+        """Check that if the amplitude is maximal (=1) that the returned max setpoint is of value 2**15 - 1."""
+        descanner = self.MirrorDescanner
+
+        # amplitude = 1 is mapped to 2**15, however, ASM only accepts 2**15 - 1
+        # check that amplitude = 1 is mapped to 2**15 - 1 before sending it to the ASM
+        descanner.scanOffset.value = (0.0, 0.0)
+        descanner.scanAmplitude.value = (1.0, 1.0)  # max amplitude
+
+        y_descan_setpoints = descanner.getXAcqSetpoints()
+
+        # check that the maximum setpoint (end of scanning ramp) is reduced by one bit 2**15 -1 = 32767
+        # as this is the maximum value the ASM accepts
+        self.assertEqual(max(y_descan_setpoints), I16_SYM_RANGE[1] - 1)
+
+    @unittest.skip  # for debugging only
     def test_plot_getAcqSetpoints(self):
-        """Test case for inspecting global behavior of the acquisition descan setpoint profiles."""
-        self.EBeamScanner.dwellTime.value = 4e-6  # Increase dwell time to see steps in the profile better
-        self.MirrorDescanner.physicalFlybackTime.value = 1.e-4  # Increase flybacktime to see its effect in the profile better
+        """Plot the acquisition descan setpoint profiles."""
+        self.EBeamScanner.dwellTime.value = 5e-6  # Increase dwell time to see steps in the profile better
+        self.MirrorDescanner.physicalFlybackTime.value = 25e-4  # Increase to see its effect in the profile better
 
-        X_descan_setpoints = self.MirrorDescanner.getXAcqSetpoints()
-        Y_descan_setpoints = self.MirrorDescanner.getYAcqSetpoints()
+        x_descan_setpoints = self.MirrorDescanner.getXAcqSetpoints()
+        y_descan_setpoints = self.MirrorDescanner.getYAcqSetpoints()
 
         fig, axs = plt.subplots(2)
-        axs[0].plot(numpy.tile(X_descan_setpoints, 4), "xb", label="x descan setpoints (scanning of 4 rows)")
-        axs[1].plot(Y_descan_setpoints[::], "or", label="y descan setpoints (scanning of an entire field image)")
+        fig.tight_layout(pad=3.0)  # add some space between subplots so that the axes labels are not hidden
+        axs[0].plot(x_descan_setpoints, "xb", markersize=0.5,
+                    label="x descan setpoints (scanning of one row within a cell image)")
+        axs[0].set_xlabel("overscanned cell image row plus flyback [us]")
+        axs[0].set_ylabel("x setpoints [bits]")
+        axs[1].plot(y_descan_setpoints[::], "or", markersize=0.5,
+                    label="y descan setpoints (scanning of one column within a cell image)")
+        axs[1].set_xlabel("overscanned cell image column [px]")
+        axs[1].set_ylabel("y setpoints [bits]")
         axs[0].legend(loc="upper left")
         axs[1].legend(loc="upper left")
+        plt.show()
+
+    def test_getCalibrationSetpoints(self):
+        """Check that the calibration setpoints are correctly assembled."""
+
+        descanner = self.MirrorDescanner
+        scanner = self.EBeamScanner
+
+        # sine for x, flat line at 0 in y
+        descanner.scanOffset.value = (0.1, 0)  # offset of the sine on x
+        descanner.scanAmplitude.value = (0.5, 0)  # amplitude of sine on x
+        scanner.dwellTime.value = 5e-06
+
+        # Total line scan time is equal to period of the calibration signal, the frequency is the inverse
+        total_line_scan_time = self.MPPC.getTotalLineScanTime()
+        # TODO Do we need the flyback included for calibration of the scan delay?
+
+        x_descan_setpoints, y_descan_setpoints = descanner.getCalibrationSetpoints(total_line_scan_time)
+
+        # check that the minimum x setpoint of the sine equals offset - amplitude in [bits]
+        # use almost equal as the max/min setpoints can be equal or smaller than the absolute amplitude
+        # Note: There is not necessarily a setpoint at the max/min amplitude of the sine.
+        #
+        # *               *  *
+        #   *           *      *
+        # -----------------------------------
+        #     *      *           *
+        #       *  *
+        #
+        self.assertAlmostEqual(min(x_descan_setpoints),
+                               math.floor(convertRange(descanner.scanOffset.value[0] - descanner.scanAmplitude.value[0],
+                                                       numpy.array(descanner.scanOffset.range)[:, 1],
+                                                       I16_SYM_RANGE)), -10)
+
+        # check that the maximum setpoint of the sine equals offset + amplitude in [bits]
+        self.assertAlmostEqual(max(x_descan_setpoints),
+                              math.floor(convertRange(descanner.scanOffset.value[0] + descanner.scanAmplitude.value[0],
+                                                      numpy.array(descanner.scanAmplitude.range)[:, 1],
+                                                      I16_SYM_RANGE)), -10)
+
+        # check that the y setpoints are all of the same value (flat line)
+        self.assertEqual(len(numpy.unique(numpy.round(y_descan_setpoints))), 1)
+        # check that the setpoints have the correct value (offset level)
+        self.assertEqual(numpy.unique(numpy.round(y_descan_setpoints)),
+                         numpy.round(convertRange(descanner.scanAmplitude.value[1] + descanner.scanOffset.value[1],
+                                                  numpy.array(descanner.scanAmplitude.range)[:, 1],
+                                                  I16_SYM_RANGE)))
+
+        # check that time interval between two setpoints is equal to the descanner clock period
+        x_setpoints_time_interval = total_line_scan_time / len(x_descan_setpoints)
+        self.assertAlmostEqual(x_setpoints_time_interval, descanner.clockPeriod.value, 10)  # floating point errors
+
+        # check that same number of setpoints in x in y
+        self.assertEqual(len(x_descan_setpoints), len(y_descan_setpoints))
+
+    @unittest.skip  # for debugging only
+    def test_plot_calibration_setpoints(self):
+        """Plot the calibration descanner setpoint profiles.
+        x descanner: sine
+        y descanner: flat line
+        """
+        self.EBeamScanner.dwellTime.value = 5e-6
+        self.MirrorDescanner.scanOffset.value = (0.1, 0.0)  # center of the sine on x; y flat line
+        self.MirrorDescanner.scanAmplitude.value = (0.5, 0.0)  # amplitude of the sine on x; y flat line
+
+        # Total line scan time is equal to period of the calibration signal, the frequency is the inverse
+        total_line_scan_time = self.MPPC.getTotalLineScanTime()
+        # TODO Do we need the flyback included for calibration of the scan delay?
+
+        x_descan_setpoints, y_descan_setpoints = self.MirrorDescanner.getCalibrationSetpoints(total_line_scan_time)
+
+        x_descan_setpoints = numpy.array(x_descan_setpoints)
+        y_descan_setpoints = numpy.array(y_descan_setpoints)
+
+        timestamps_descanner = numpy.arange(0, total_line_scan_time, self.MirrorDescanner.clockPeriod.value)
+
+        fig, axs = plt.subplots(1)
+        axs.plot(timestamps_descanner, x_descan_setpoints, "ro", markersize=0.5,
+                    label="Descanner x setpoints")
+        axs.plot(timestamps_descanner, y_descan_setpoints, "bo", markersize=0.5,
+                    label="Descanner y setpoints")
+        axs.set_xlabel("scanning time [sec]")
+        axs.set_ylabel("setpoints [bits]")
+
+        axs.legend(loc="upper left")
         plt.show()
 
 
@@ -1376,7 +1679,7 @@ class Test_ASMDataFlow(unittest.TestCase):
         pass
 
     def setUp(self):
-        self.ASM_manager = AcquisitionServer("ASM", "asm", URL, CHILDREN_ASM, EXTRNAL_STORAGE)
+        self.ASM_manager = AcquisitionServer("ASM", "asm", URL, CHILDREN_ASM, EXTERNAL_STORAGE)
         for child in self.ASM_manager.children.value:
             if child.name == CONFIG_MPPC["name"]:
                 self.MPPC = child


### PR DESCRIPTION
The scanGain defined the end of the scanning ramp (offset + amplitude). So whenever the user wanted to change the amplitude, they needed to add the offset. Or whenever the offset was changed, the gain needed to be changed accordingly. Redefine the scanGain to scanAmplitude. Change the behavior of the code, so that the scanAmplitude is truely independent of the scanOffset.

* rename scanGain to scanAmplitude
* split up the test cases to cover a single item
* improved/fixed some tests, comments and doc strings
* fixed typo in EXTERNAL_STORAGE
* added tests for calculation of scanner offset and gradient as defined in the asm
* reordered imports
* made bit range for descanner also global variable similar to volt range for scanner
* improved plotting test cases and changed import for matplotlib to use GUI backend, so plots are shown
* removed the random loops in the tests and replaced by an example for floating point error for x setpoints; didn't find a case for y - could not identify the part of the method, that can introduce such a case
* adjusted the bit range: The range accepted by the ASM is `[-2**15, 2**15 -1]` - so no symmetrical around 0. 0 counts with the positive values. However, the user can select offset and amplitude symmetrically around 0. So what happend was that an amplitude of 0 a.u. was mapped to -0.5 bits and not 0 bits. If the user wants a flat line (no amplitude) there would have been always 1 bit being removed of whatever offset was choosen. So offset + amplitude in bits was not the same value as just the offset. Changed the behavior to map from a.u. [-1, 1] symmetrically to` [-2**15, 2**15]` and in case +1 is selected as amplitude the corresponding bit value 2**15 is reduced by 1 bit to match the requirements of the ASM. This should be no problem as one bit change in the descanner position is of no significance.