### PR TITLE
driver andorcam2: Add support for using SW trigger

### DIFF
--- a/src/odemis/driver/andorcam2.py
+++ b/src/odemis/driver/andorcam2.py
@@ -796,7 +796,7 @@ class AndorCam2(model.DigitalCamera):
         self.request_hw = []
 
         self.data = AndorCam2DataFlow(self)
-        # Convenience event for the user to connect and fire. It also a way to
+        # Convenience event for the user to connect and fire. It is also a way to
         # indicate that the DataFlow supports synchronization.
         self.softwareTrigger = model.Event()
 
@@ -2021,7 +2021,7 @@ class AndorCam2(model.DigitalCamera):
 
     def set_trigger(self, sync):
         """
-        Specify of the acquisition should be synchronized or not.
+        Specify if the acquisition should be synchronized or not.
         sync (bool): True if should be triggered
         """
         self._synchronized = sync
@@ -2111,7 +2111,7 @@ class AndorCam2(model.DigitalCamera):
         """
         Block until a trigger is received, or a stop message.
         Note: it expects that the acquisition is running. Also, if some triggers
-        were previously received, it'll use immediately the oldest one.
+        were recently received, it'll use the oldest once first.
         return (bool): True if needs to stop, False if a trigger is received
         raise TerminationRequested: if a terminate message was received
         """
@@ -2510,7 +2510,7 @@ class AndorCam2DataFlow(model.DataFlow):
     def start_generate(self):
         comp = self.component()
         if comp is None:
-            # Camera has been deleted, it's all fine, this DataFlow be gone soon too
+            # Camera has been deleted, it's all fine, this DataFlow will be gone soon too
             return
 
         comp.start_generate()
@@ -2518,7 +2518,7 @@ class AndorCam2DataFlow(model.DataFlow):
     def stop_generate(self):
         comp = self.component()
         if comp is None:
-            # Camera has been deleted, it's all fine, this DataFlow be gone soon too
+            # Camera has been deleted, it's all fine, this DataFlow will be gone soon too
             return
 
         comp.stop_generate()
@@ -2528,7 +2528,7 @@ class AndorCam2DataFlow(model.DataFlow):
         Synchronize the acquisition on the given event. Every time the event is
           triggered, the DataFlow will start a new acquisition.
         Behaviour is unspecified if the acquisition is already running.
-        (Currently it will automatically switch on the next image)
+        (Currently it will automatically be adjusted after the current image)
         event (model.Event or None): event to synchronize with. Use None to
           disable synchronization.
         The DataFlow can be synchronize only with one Event at a time.

--- a/src/odemis/driver/test/andorcam2_test.py
+++ b/src/odemis/driver/test/andorcam2_test.py
@@ -42,7 +42,7 @@ CLASS_SIM = andorcam2.FakeAndorCam2
 CLASS = andorcam2.AndorCam2
 
 KWARGS = dict(name="camera", role="ccd", device=0, transpose=[2, -1],
-              # emgains=[[10e6, 1, 50], [1e6, 1, 150]]
+              # emgains=[[10e6, 1, 50], [1e6, 1, 150]]  # For EM-CCDs
               )
 KWARGS_SIM = dict(name="camera", role="ccd", device=0, transpose=[2, -1],
                   emgains=[[10e6, 1, 50], [1e6, 1, 150]],

--- a/src/odemis/driver/test/andorcam2_test.py
+++ b/src/odemis/driver/test/andorcam2_test.py
@@ -42,7 +42,8 @@ CLASS_SIM = andorcam2.FakeAndorCam2
 CLASS = andorcam2.AndorCam2
 
 KWARGS = dict(name="camera", role="ccd", device=0, transpose=[2, -1],
-              emgains=[[10e6, 1, 50], [1e6, 1, 150]])
+              # emgains=[[10e6, 1, 50], [1e6, 1, 150]]
+              )
 KWARGS_SIM = dict(name="camera", role="ccd", device=0, transpose=[2, -1],
                   emgains=[[10e6, 1, 50], [1e6, 1, 150]],
                   image="andorcam2-fake-clara.tiff")
@@ -89,7 +90,8 @@ class TestAndorCam2(VirtualTestCam, unittest.TestCase):
 #@skip("simple")
 class TestSynchronized(VirtualTestSynchronized, unittest.TestCase):
     """
-    Test the synchronizedOn(Event) interface
+    Test the synchronizedOn(Event) interface.
+    If the test is using the simulator, that's using the legacy method start/stop.
     """
     camera_type = CLASS
     camera_kwargs = KWARGS

--- a/src/odemis/driver/test/andorcam2_test.py
+++ b/src/odemis/driver/test/andorcam2_test.py
@@ -31,7 +31,7 @@ from unittest.case import skip
 
 from cam_test_abs import VirtualTestCam, VirtualStaticTestCam, VirtualTestSynchronized
 
-
+logging.basicConfig(format="%(asctime)s  %(levelname)-7s %(module)-15s: %(message)s")
 logging.getLogger().setLevel(logging.DEBUG)
 
 # Export TEST_NOHW=1 to force using only the simulator and skipping test cases
@@ -41,12 +41,13 @@ TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
 CLASS_SIM = andorcam2.FakeAndorCam2
 CLASS = andorcam2.AndorCam2
 
+KWARGS = dict(name="camera", role="ccd", device=0, transpose=[2, -1],
+              emgains=[[10e6, 1, 50], [1e6, 1, 150]])
 KWARGS_SIM = dict(name="camera", role="ccd", device=0, transpose=[2, -1],
                   emgains=[[10e6, 1, 50], [1e6, 1, 150]],
                   image="andorcam2-fake-clara.tiff")
-#                  image="andorcam2-fake-spots.h5")
-KWARGS = dict(name="camera", role="ccd", device=0, transpose=[2, -1],
-              emgains=[[10e6, 1, 50], [1e6, 1, 150]])
+KWARGS_SIM_SW_TRIG = KWARGS_SIM.copy()
+KWARGS_SIM_SW_TRIG["sw_trigger"] = True
 
 if TEST_NOHW:
     CLASS = CLASS_SIM
@@ -88,13 +89,19 @@ class TestAndorCam2(VirtualTestCam, unittest.TestCase):
 #@skip("simple")
 class TestSynchronized(VirtualTestSynchronized, unittest.TestCase):
     """
-    Test the synchronizedOn(Event) interface, using the fake SEM
+    Test the synchronizedOn(Event) interface
     """
     camera_type = CLASS
     camera_kwargs = KWARGS
 
 
+class TestSynchronizedSimSWTrigger(VirtualTestSynchronized, unittest.TestCase):
+    """
+    Test the synchronizedOn(Event) interface, using the fake camera with software trigger
+    """
+    camera_type = CLASS_SIM
+    camera_kwargs = KWARGS_SIM_SW_TRIG
+
+
 if __name__ == '__main__':
     unittest.main()
-
-# vim:tabstop=4:shiftwidth=4:expandtab:spelllang=en_gb:spell:

--- a/src/odemis/driver/test/cam_test_abs.py
+++ b/src/odemis/driver/test/cam_test_abs.py
@@ -651,9 +651,10 @@ class VirtualTestSynchronized(with_metaclass(ABCMeta, object)):
 
         time.sleep(0.1)
 
-    def test_trigger_removal(self):
+    def test_synchronization_removal(self):
         """
-        Check that when the synchronisation is removed, the acquisition continues
+        Check that when the synchronisation is removed, the acquisition continues,
+        without waiting for an event anymore.
         """
         if not hasattr(self.ccd, "softwareTrigger"):
             self.skipTest("Camera doesn't support software trigger")
@@ -664,40 +665,66 @@ class VirtualTestSynchronized(with_metaclass(ABCMeta, object)):
         readout = numpy.prod(self.ccd_size) / self.ccd.readoutRate.value
         duration = exp + readout  # approximate time for one frame
 
-        numbert = 6
-        self.ccd_left = numbert
+        number_acq = 6  # total number of images to acquire
+        self.ccd_left = number_acq  # unsubscribe after receiving
 
+        # Start with software trigger
         self.ccd.data.synchronizedOn(self.ccd.softwareTrigger)
         self.ccd.data.subscribe(self.receive_ccd_image)
 
-        try:
-            # Get one image
-            self.got_image.clear()
-            self.ccd.softwareTrigger.notify()
-            gi = self.got_image.wait(duration + 10)
-            self.assertTrue(gi, "image not received after %g s" % (duration + 10))
+        # Get one image
+        self.got_image.clear()  # Reset the image event
+        self.ccd.softwareTrigger.notify()
+        # wait for the image to be received
+        gi = self.got_image.wait(duration + 10)
+        self.assertTrue(gi, "image not received after %g s" % (duration + 10))
 
-            # make sure it's waiting
-            time.sleep(0.1)
-            self.ccd.data.synchronizedOn(None)
+        # make sure it's waiting
+        time.sleep(0.1)
+        self.ccd.data.synchronizedOn(None)  # No more synchronized
 
-            # Check we receive the other images
-            for i in range(1, numbert):
-                try:
-                    self._data.get(timeout=duration + 10)
-                except queue.Empty:
-                    self.fail("No data %d received after %s s" % (i, duration))
+        # Check we now receive the next images without sending an event
+        for i in range(1, number_acq):
+            try:
+                self._data.get(timeout=duration + 10)
+            except queue.Empty:
+                self.fail("No data %d received after %s s" % (i, duration))
 
-        finally:
-            self.ccd.data.unsubscribe(self.receive_ccd_image)
+        # Should now be automatically unsubscribed
 
         # check we can still get data normally
         d = self.ccd.data.get()
 
+        # Now do the opposite: first acquire continuously and then add a synchronization
+        self._data = queue.Queue()  # Reset the queue
+        self.ccd_left = number_acq  # unsubscribe after receiving
+
+        self.ccd.data.subscribe(self.receive_ccd_image)
+        # Check we now receive the next images without sending an event
+        for i in range(2):
+            try:
+                self._data.get(timeout=duration + 10)
+            except queue.Empty:
+                self.fail("No data %d received after %s s" % (i, duration))
+
+        # Now synchronized
+        # Note that it's hard to know when the synchronization switched, so we
+        # don't know how many triggers need to be sent. At most number_acq - 2.
+        self.ccd.data.synchronizedOn(self.ccd.softwareTrigger)
+        for i in range(2, number_acq):
+            self.ccd.softwareTrigger.notify()
+            try:
+                self._data.get(timeout=duration + 10)
+            except queue.Empty:
+                self.fail("No data %d received after %s s" % (i, duration))
+
+        self.assertEqual(self.ccd_left, 0)
+        self.ccd.data.synchronizedOn(None)
+
     def test_cropped_data(self):
         """
-        check the synchronization of CCD prevents it from generating images as
-        long as no event is received.
+        check the synchronization of CCD, while the image area is cropped.
+        Some Andorcam2 cameras have special behaviour in such case.
         """
         if not hasattr(self.ccd, "softwareTrigger"):
             self.skipTest("Camera doesn't support software trigger")
@@ -705,12 +732,12 @@ class VirtualTestSynchronized(with_metaclass(ABCMeta, object)):
         self.ccd_size = (self.ccd.shape[0] // 2, self.ccd.shape[1] // 2)
         if (self.ccd.resolution.range[0][0] > self.ccd_size[0] or
             self.ccd.resolution.range[0][1] > self.ccd_size[1]):
-            # cannot divide the size by 2? Then it probably doesn't support AOI
+            # cannot divide the size by 2? Then it probably doesn't support cropping
             self.skipTest("Camera doesn't support area of interest")
 
         self.ccd.resolution.value = self.ccd_size
         if self.ccd.resolution.value == self.ccd.shape[:2]:
-            # cannot divide the size by 2? Then it probably doesn't support AOI
+            # cannot divide the size by 2? Then it probably doesn't support cropping
             self.skipTest("Camera doesn't support area of interest")
 
         self.ccd.exposureTime.value = self.ccd.exposureTime.clip(50e-3)  # s
@@ -719,14 +746,14 @@ class VirtualTestSynchronized(with_metaclass(ABCMeta, object)):
         readout = numpy.prod(self.ccd_size) / self.ccd.readoutRate.value
         duration = exp + readout  # approximate time for one frame
 
-        numbert = 6
-        self.ccd_left = numbert
+        number_acq = 6
+        self.ccd_left = number_acq  # unsubscribe after receiving
 
         self.ccd.data.subscribe(self.receive_ccd_image)
         self.ccd.data.synchronizedOn(self.ccd.softwareTrigger)
 
         # Wait for the image
-        for i in range(numbert):
+        for i in range(number_acq):
             self.got_image.clear()
             self.ccd.softwareTrigger.notify()
             # wait for the image to be received
@@ -734,7 +761,7 @@ class VirtualTestSynchronized(with_metaclass(ABCMeta, object)):
             self.assertTrue(gi, "image not received after %g s" % (duration + 10))
             time.sleep(i * 0.1)  # wait a bit to simulate some processing
 
-        self.ccd.data.unsubscribe(self.receive_ccd_image)
+        self.ccd.data.unsubscribe(self.receive_ccd_image)  # Just to be sure
         self.ccd.data.synchronizedOn(None)
 
     def receive_sem_data(self, dataflow, image):


### PR DESCRIPTION
Some cameras may support software trigger. In this case, it can save
around 20ms when starting the image. For short exposure times (eg, 20
ms), that's quite an improvement in frame rate.

One of the difficulty is that apparently on some cameras, not all
settings (cropping?) are compatible with the software trigger. So we
need to have some extra handling for this. Haven't seen such case yet
though...

So in total we have 3 modes now: non-synchronized, synchronized via
start/stop, and synchronized via software trigger.

To avoid code explosion, we first refactored to use a FSM style
(inspired by the avantes driver). It also supports switching between
synchronized/non-synchronized on the fly.

The garbage collector can take up to 20ms to run. It's not worthy to run
every time. On live mode, it doesn't have too much effect, as the next image would
be under acquistion during that time.
However, with the software trigger, if the next event came early, it would
cause a delay before starting the next frame.
=> Only do it every 10 times (like the andorcam3), while waiting for the
hardware.

Also extend the simulator to support software trigger mode.