### PR TITLE
gui model: don't show feature toggle button on every view

### DIFF
--- a/src/odemis/gui/model/__init__.py
+++ b/src/odemis/gui/model/__init__.py
@@ -1941,8 +1941,6 @@ class MicroscopeView(StreamView):
     """
     def __init__(self, name, stage=None, **kwargs):
         StreamView.__init__(self, name, stage=stage, **kwargs)
-        # booleanVA to toggle showing/hiding the features
-        self.showFeatures = model.BooleanVA(True)
         if stage:
             self.stage_pos.subscribe(self._on_stage_pos)
 


### PR DESCRIPTION
Not every viewport supports it. So it should only be on the FeatureView
or FeatureOverviewView.

Mistake introduced in commit 01bdf242d9 (gui: add support for meteor in
chamber tab)