### PR TITLE
config: fix ENZEL not reaching imaging mode

### DIFF
--- a/install/linux/usr/share/odemis/sim/enzel-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/enzel-sim.odm.yaml
@@ -199,6 +199,7 @@ ENZEL-Sim: {
         # It supports 4 filters
         positions: {
             # pos (rad) -> m,m
+             0.366519082: "pass-through", # no filter
              1.48352985: [589.e-9, 625.e-9], # FF01-607/36-25
              2.26892802: [510.e-9, 540.e-9], # FF01-525/30-25
              3.05432618: [420.e-9, 460.e-9], # FF01-440/40-25
@@ -349,7 +350,7 @@ ENZEL-Sim: {
     # Allowed range when in FM/SEM imaging mode. The X/Y ranges are also used
     # as default area for the overview acquisition.
     # X/Y range is small, to fit the limited simulated range of the camera
-    POS_ACTIVE_RANGE: { 'x': [ -23.e-6, 23.e-6 ], 'y': [ -33.e-6, 33.e-6 ], 'z': [ -0.003, 0.0 ], } ,
+    POS_ACTIVE_RANGE: { 'x': [-23.e-6, 23.e-6], 'y': [-33.e-6, 33.e-6], 'z': [0.0, 0.003]},
     # Initial position to start alignment from
     FAV_POS_ALIGN: { 'rx': 0.4886, 'rz': 0, 'x': 0.0, 'y': 0.00, 'z': 0.001 },
     # Initial position when going to FM/SEM imaging.


### PR DESCRIPTION
The FAV_POS_ACTIVE was not within the ACTIVE_RANGE, so couldn't reach
IMAGING mode.

Also add pass-through filter position.