### PR TITLE
gui comp canvas: always make sure the buffer size >= 1

### DIFF
--- a/src/odemis/gui/comp/canvas.py
+++ b/src/odemis/gui/comp/canvas.py
@@ -495,7 +495,7 @@ class BufferedCanvas(wx.Panel):
 
     def get_minimum_buffer_size(self):
         """ Return the minimum size needed by the buffer """
-        return self.ClientSize.x, self.ClientSize.y
+        return max(1, self.ClientSize.x), max(1, self.ClientSize.y)
 
     def get_half_buffer_size(self):
         """ Return half the size of the current buffer """
@@ -1679,8 +1679,8 @@ class DraggableCanvas(BitmapCanvas):
     # Buffer and drawing methods
     def get_minimum_buffer_size(self):
         """ Return the minimum size needed by the buffer """
-        return (self.ClientSize.x + self.default_margin * 2,
-                self.ClientSize.y + self.default_margin * 2)
+        return (max(self.MinClientSize.x, self.ClientSize.x) + self.default_margin * 2,
+                max(self.MinClientSize.y, self.ClientSize.y) + self.default_margin * 2)
 
     def _calc_bg_offset(self, new_pos):
         """ Calculate the offset needed for the checkered background after a canvas shift

--- a/src/odemis/gui/comp/viewport.py
+++ b/src/odemis/gui/comp/viewport.py
@@ -425,12 +425,7 @@ class MicroscopeViewport(ViewPort):
 
     @call_in_wx_main
     def _on_view_mpp(self, mpp):
-        fov = self.get_fov_from_mpp()
-        if fov:
-            self.view.fov.value = fov
-        buf_fov = self.get_buffer_fov_from_mpp()
-        if buf_fov:
-            self.view.fov_buffer.value = buf_fov
+        self._set_fov_from_mpp()
 
         if self.bottom_legend:
             self.bottom_legend.scale_win.SetMPP(mpp)
@@ -613,7 +608,7 @@ class MicroscopeViewport(ViewPort):
 
     def get_buffer_fov_from_mpp(self):
         """
-        Return the field of view of the canvas
+        Return the field of view of the buffer (which is larger than the canvas)
         :return: (None or float,float) Field width and height in meters
         """
         return self._get_fov_from_mpp(self.canvas.buffer_size)
@@ -647,9 +642,12 @@ class MicroscopeViewport(ViewPort):
         return (tuple of float): the FoV set
         """
         fov = self.get_fov_from_mpp()
-        if fov is not None and self.view:
-            self.view.fov.value = fov
-            self.view.fov_buffer.value = self.get_buffer_fov_from_mpp()
+        if self.view:
+            if fov:
+                self.view.fov.value = fov
+            buf_fov = self.get_buffer_fov_from_mpp()
+            if buf_fov:
+                self.view.fov_buffer.value = buf_fov
 
         return fov
 


### PR DESCRIPTION
If the client size is 0, the buffer could end up being 0 px image, which
cause some issues. => Make it at least 1.

Also handle the case where buffer size is 0 when updating the mpp, just
in case.