### PR TITLE
gui main XRC: make the top-left SECOM normal again

### DIFF
--- a/src/odemis/gui/main.xrc
+++ b/src/odemis/gui/main.xrc
@@ -5808,10 +5808,10 @@
       </object>
       <object class="sizeritem">
         <object class="ViewportGrid" name="pnl_secom_grid">
-          <object class="FixedOverviewViewport" name="vp_secom_tl">
+          <object class="LiveViewport" name="vp_secom_tl">
             <fg>#BFBFBF</fg>
             <bg>#000000</bg>
-            <XRCED>FixedOverviewViewport
+            <XRCED>
               <assign_var>1</assign_var>
             </XRCED>
           </object>

--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -6712,10 +6712,10 @@ def __init_resources():
       </object>
       <object class="sizeritem">
         <object class="ViewportGrid" name="pnl_secom_grid">
-          <object class="FixedOverviewViewport" name="vp_secom_tl">
+          <object class="LiveViewport" name="vp_secom_tl">
             <fg>#BFBFBF</fg>
             <bg>#000000</bg>
-            <XRCED>FixedOverviewViewport
+            <XRCED>
               <assign_var>1</assign_var>
             </XRCED>
           </object>


### PR DESCRIPTION
Probably due to some confusion with the Cryo interface, that viewport
got also converted to a "Overview" viewport.
That broke a bit the SECOM interface.

=> Revert.