### PR TITLE
model dataflow/vattribute: don't wait for the other thread in __del__()

### DIFF
--- a/src/odemis/model/_dataflow.py
+++ b/src/odemis/model/_dataflow.py
@@ -498,7 +498,6 @@ class DataFlowProxy(DataFlowBase, Pyro4.Proxy):
                                           self._global_name)
                         Pyro4.Proxy.__getattr__(self, "unsubscribe")(self._proxy_name)
                     self._commands.send(b"STOP")
-                    self._thread.join(1)
                 self._commands.close()
                 # Not needed: called when garbage-collected and it's dangerous
                 # as it blocks until all connections are closed.

--- a/src/odemis/model/_vattributes.py
+++ b/src/odemis/model/_vattributes.py
@@ -474,7 +474,6 @@ class VigilantAttributeProxy(VigilantAttributeBase, Pyro4.Proxy):
                                         self._global_name)
                         Pyro4.Proxy.__getattr__(self, "unsubscribe")(self._proxy_name)
                     self._commands.send(b"STOP")
-                    self._thread.join(1)
                 self._commands.close()
             # self._ctx.term()
         except Exception:


### PR DESCRIPTION
In Python 3, __del__() can be called from the garbage collector. In
practice, it's a very common place for it to be called.

While running the garbage collector, other threads cannot run, so it's
not helpful to wait for it to react to the message. It just ends up
making the gc very slow, as it waits for 1s .

Anyway, in general, it's not useful to wait for the other thread to
finish __del__(). So let's just never wait.