### PR TITLE
gui util img: make sure that draw_scale() always fit text inside

### DIFF
--- a/src/odemis/gui/util/img.py
+++ b/src/odemis/gui/util/img.py
@@ -1089,7 +1089,7 @@ def draw_scale(value_range, client_size, orientation, tick_spacing,
         else:
             max_width = max(max_width, lbl_width)
             lpos = pos + (lbl_height // 2)
-            lpos = max(min(lpos, client_size[1]), 2)
+            lpos = max(min(lpos, client_size[1]), lbl_height)
 
             if abs(prev_lpos - lpos) > 20 or i == 0 or i == len(tick_list):
                 if mirror:


### PR DESCRIPTION
The label of the top tick on vertical scale could go slightly off
screen.
=> Don't use arbitrary 2 px safety, but the actual size of the label:
label height.