### PR TITLE
gui cont LocalisationTab: don't save focus ACTIVE_POS as soon as it moves

### DIFF
--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -678,19 +678,8 @@ class LocalizationTab(Tab):
         super(LocalizationTab, self).Show(show)
 
         if not show: # if localization tab is not chosen
-        # pause streams when not displayed
             # pause streams when not displayed
             self._streambar_controller.pauseStreams()
-            # stop listening to the focus position
-            self.main_data.focus.position.unsubscribe(self._on_focus_pos_change)
-        else:   # if chosen
-            # start listening to the focus position
-            self.main_data.focus.position.subscribe(self._on_focus_pos_change)
-
-    def _on_focus_pos_change(self, pos):
-        # store the new focus position, so that when going from POS_DEACTIVE to
-        # POS_ACTIVE, the lastest focus is used.
-        self.main_data.focus.updateMetadata({model.MD_FAV_POS_ACTIVE: pos})
 
     def _show_acquired_stream(self, acquired_stream, selected_view):
         """


### PR DESCRIPTION
On the METEOR, it's now allows to access the tab when FM is not active
(just to look at the previous images acquired). However, as the focus
always slightly move, the position is updated, and that cause the
ACTIVE_POS to be updated to the (almost) DEACTIVE_POS.

Anyway, it's not a big deal to go back always to the safe ACTIVE_POS.

Ideally, the chamber tab (acq.move) will be extra clever and
store/restore it, if it's safe.