### PR TITLE
driver simcam: fix pixel coordinates computation sometimes failing

### DIFF
--- a/src/odemis/driver/simcam.py
+++ b/src/odemis/driver/simcam.py
@@ -347,7 +347,11 @@ class Camera(model.DigitalCamera):
             ltrb[1] = 0
         elif ltrb[3] > self._img_res[1] - 1:
             ltrb[1] -= ltrb[3] - (self._img_res[1] - 1)
-        assert(ltrb[0] >= 0 and ltrb[1] >= 0)
+
+        ltrb = [round(v) for v in ltrb]  # Smooth out floating point errors
+
+        if not (ltrb[0] >= 0 and ltrb[1] >= 0):
+            raise IndexError(f"Unexpected range {ltrb} with {center}, {trans}, {stage_shift}, {binning} for res {self._img_res}")
 
         # compute each row and column that will be included
         # TODO: Could use something more hardwarish like that:


### PR DESCRIPTION
In some rare cases, mostly when the stage position is very large,
floating point errors would cause the top-left area position to be not
excatly 0, and slightly negative. This would be considered as a major
error, stopping the image generation.
Instead, just round and realise that it's all fine...