### PR TITLE
gui win acquisition OverviewAcquisitionDialog: improve area computation reliability

### DIFF
--- a/src/odemis/gui/win/acquisition.py
+++ b/src/odemis/gui/win/acquisition.py
@@ -682,7 +682,7 @@ class OverviewAcquisitionDialog(xrcfr_overview_acq):
         # The list of streams ready for acquisition (just used as a cache)
         self._acq_streams = {}
 
-        # Find every settings, and listen to it
+        # Find every setting, and listen to it
         self._orig_entries = get_global_settings_entries(self._settings_controller)
         for sc in self.streambar_controller.stream_controllers:
             self._orig_entries += get_local_settings_entries(sc)
@@ -814,7 +814,7 @@ class OverviewAcquisitionDialog(xrcfr_overview_acq):
 
         pos = self._tab_data_model.main.stage.position.value
         # Note the area can accept LTRB or LBRT.
-        self.area = self.get_ROA_rect(w, h, pos, self._tiling_rng)
+        self.area = self.clip_tiling_area_to_range(w, h, pos, self._tiling_rng)
         if self.area is None:
             # there is no intersection
             logging.warning("Couldn't find intersection between stage pos %s and tiling range %s" % (pos, self._tiling_rng))
@@ -894,21 +894,20 @@ class OverviewAcquisitionDialog(xrcfr_overview_acq):
             raise TypeError("Unsupported Stream %s, it doesn't have a .guessFoV()" % (s,))
 
     @staticmethod
-    def get_ROA_rect(w, h, pos, tiling_rng):
+    def clip_tiling_area_to_range(w, h, pos, tiling_rng):
         """
-        Finds the intersection between the requested tiling area
-            and the tiling range.
+        Finds the intersection between the requested tiling area and the tiling range.
         w (float): width of the tiling area
         h (float): height of the tiling area
         pos (dict -> float): current position of the stage
-        tiling_rng (dict -> list): the tiling range along x and y axes
+        tiling_rng (dict -> list): the tiling range along x and y axes as
+          (xmin, ymin, xmax, ymax), or (xmin, ymax, xmax, ymin)
         return (None or tuple of 4 floats): None if there is no intersection, or
-          the rectangle representing the intersection
+          the rectangle representing the intersection as (xmin, ymin, xmax, ymax).
         """
-        area_req = (pos["x"] - w / 2, pos["y"] + h / 2,
-                    pos["x"] + w / 2, pos["y"] - h / 2)
+        area_req = (pos["x"] - w / 2, pos["y"] - h / 2,
+                    pos["x"] + w / 2, pos["y"] + h / 2)
         # clip the tiling area, if needed (or find the intersection between the active range and the requested area)
-        # Note: the input is LTRB. The output is LBRT assuming y axis upwards, or LTRB assuming y axis downwards.
         return rect_intersect(area_req,
             (tiling_rng["x"][0], tiling_rng["y"][1], tiling_rng["x"][1], tiling_rng["y"][0]))
 

--- a/src/odemis/gui/win/test/acquisition_test.py
+++ b/src/odemis/gui/win/test/acquisition_test.py
@@ -29,9 +29,9 @@ from odemis.gui.win.acquisition import OverviewAcquisitionDialog
 logging.getLogger().setLevel(logging.DEBUG)
 
 
-class TestgetROARectMethod(unittest.TestCase):
+class TestClipTilingArea(unittest.TestCase):
     """
-    This test case is to test the method get_ROA_rect()
+    This test case is to test the method clip_tiling_area_to_range()
     """
     def test_clipping_is_performed_same_width_and_height(self):
         # move the stage close to the bottom left corner of the active range (200 micrometers 
@@ -42,7 +42,7 @@ class TestgetROARectMethod(unittest.TestCase):
         ovv_rng = {'x': [-1e-3, 1e-3], 'y': [-1.1e-3, 1.1e-3]}
         pos = {"x": ovv_rng["x"][0] + 200e-6,
                "y": ovv_rng["y"][0] + 200e-6}
-        rect_pts = OverviewAcquisitionDialog.get_ROA_rect(w, h, pos, ovv_rng)
+        rect_pts = OverviewAcquisitionDialog.clip_tiling_area_to_range(w, h, pos, ovv_rng)
         # Note: the return rect_pts is LBRT assuming y axis upwards, or LTRB assuming y axis downwards.
         # check if the intersection happened
         self.assertAlmostEqual(rect_pts[0], ovv_rng["x"][0])
@@ -59,7 +59,7 @@ class TestgetROARectMethod(unittest.TestCase):
         ovv_rng = {'x': [-1e-3, 1e-3], 'y': [-1.1e-3, 1.1e-3]}
         pos = {"x": ovv_rng["x"][0] + 200e-6,
                "y": ovv_rng["y"][0] + 200e-6}
-        rect_pts = OverviewAcquisitionDialog.get_ROA_rect(w, h, pos, ovv_rng)
+        rect_pts = OverviewAcquisitionDialog.clip_tiling_area_to_range(w, h, pos, ovv_rng)
         # Note: the return rect_pts is LBRT assuming y axis upwards, or LTRB assuming y axis downwards.
         # check if the intersection happened
         self.assertAlmostEqual(rect_pts[0], ovv_rng["x"][0])
@@ -76,7 +76,7 @@ class TestgetROARectMethod(unittest.TestCase):
         ovv_rng = {'x': [-1e-3, 1e-3], 'y': [-1.1e-3, 1.1e-3]}
         pos = {"x": sum(ovv_rng["x"]) / 2,
                "y": sum(ovv_rng["y"]) / 2}
-        rect_pts = OverviewAcquisitionDialog.get_ROA_rect(w, h, pos, ovv_rng)
+        rect_pts = OverviewAcquisitionDialog.clip_tiling_area_to_range(w, h, pos, ovv_rng)
         # Note: the return rect_pts is LBRT assuming y axis upwards, or LTRB assuming y axis downwards.
         # check if the intersection area is the same as the tl and br of the requested area.
         # tl and br are found by the current position +/- half of the width and height
@@ -94,7 +94,7 @@ class TestgetROARectMethod(unittest.TestCase):
         ovv_rng = {'x': [-1e-3, 1e-3], 'y': [-1.1e-3, 1.1e-3]}
         pos = {"x": sum(ovv_rng["x"]) / 2,
                "y": sum(ovv_rng["y"]) / 2}
-        rect_pts = OverviewAcquisitionDialog.get_ROA_rect(w, h, pos, ovv_rng)
+        rect_pts = OverviewAcquisitionDialog.clip_tiling_area_to_range(w, h, pos, ovv_rng)
         # Note: the return rect_pts is LBRT assuming y axis upwards, or LTRB assuming y axis downwards.
         # check if the intersection area is the same as the tl and br of the requested area.
         # tl and br are found by the current position +/- half of the width and height

--- a/src/odemis/gui/win/test/acquisition_test.py
+++ b/src/odemis/gui/win/test/acquisition_test.py
@@ -23,102 +23,85 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 """
 
 import unittest
-import os
-import odemis
 import logging
-from odemis.util import test
-from odemis import model
 from odemis.gui.win.acquisition import OverviewAcquisitionDialog
 
 logging.getLogger().setLevel(logging.DEBUG)
 
-CONFIG_PATH = os.path.dirname(odemis.__file__) + "/../../install/linux/usr/share/odemis/"
-ENZEL_CONFIG = CONFIG_PATH + "sim/enzel-sim.odm.yaml"
 
 class TestgetROARectMethod(unittest.TestCase):
     """
     This test case is to test the method get_ROA_rect()
     """
-    @classmethod
-    def setUpClass(cls):
-        test.start_backend(ENZEL_CONFIG)
-
-        # get the stage components
-        cls.stage = model.getComponent(role="stage")
-        cls.stage.reference().result()
-        # cls.stage_bare = model.getComponent(role="stage-bare")
-
-        # get the metadata
-        stage_md = cls.stage.getMetadata()
-        cls.tiling_rng = stage_md[model.MD_POS_ACTIVE_RANGE]
-
-    @classmethod
-    def tearDownClass(cls):
-        pass
-
     def test_clipping_is_performed_same_width_and_height(self):
         # move the stage close to the bottom left corner of the active range (200 micrometers 
-        # # away from the corner in x and y directions).
-        self.stage.moveAbs({"x": self.tiling_rng["x"][0]+200e-6,
-                            "y": self.tiling_rng["y"][0]+200e-6}).result()
+        # away from the corner in x and y directions).
         w = 600e-6
         h = 600e-6
-        rect_pts = OverviewAcquisitionDialog.get_ROA_rect(w, h, self.stage.position.value, self.tiling_rng)
+
+        ovv_rng = {'x': [-1e-3, 1e-3], 'y': [-1.1e-3, 1.1e-3]}
+        pos = {"x": ovv_rng["x"][0] + 200e-6,
+               "y": ovv_rng["y"][0] + 200e-6}
+        rect_pts = OverviewAcquisitionDialog.get_ROA_rect(w, h, pos, ovv_rng)
         # Note: the return rect_pts is LBRT assuming y axis upwards, or LTRB assuming y axis downwards.
         # check if the intersection happened
-        self.assertAlmostEqual(rect_pts[0], self.tiling_rng["x"][0])
-        self.assertAlmostEqual(rect_pts[1], self.tiling_rng["y"][0])
-        self.assertAlmostEqual(rect_pts[2], self.tiling_rng["x"][0] + 200e-6 + w/2)
-        self.assertAlmostEqual(rect_pts[3], self.tiling_rng["y"][0] + 200e-6 + h/2)
+        self.assertAlmostEqual(rect_pts[0], ovv_rng["x"][0])
+        self.assertAlmostEqual(rect_pts[1], ovv_rng["y"][0])
+        self.assertAlmostEqual(rect_pts[2], ovv_rng["x"][0] + 200e-6 + w / 2)
+        self.assertAlmostEqual(rect_pts[3], ovv_rng["y"][0] + 200e-6 + h / 2)
 
     def test_clipping_is_performed_different_width_and_height(self):
         # move the stage close to the bottom left corner of the active range (200 micrometers 
-        # # away from the corner in x and y directions).
-        self.stage.moveAbs({"x": self.tiling_rng["x"][0]+200e-6,
-                            "y": self.tiling_rng["y"][0]+200e-6}).result()
+        # away from the corner in x and y directions).
         w = 700e-6
         h = 600e-6
-        rect_pts = OverviewAcquisitionDialog.get_ROA_rect(w, h, self.stage.position.value, self.tiling_rng)
+
+        ovv_rng = {'x': [-1e-3, 1e-3], 'y': [-1.1e-3, 1.1e-3]}
+        pos = {"x": ovv_rng["x"][0] + 200e-6,
+               "y": ovv_rng["y"][0] + 200e-6}
+        rect_pts = OverviewAcquisitionDialog.get_ROA_rect(w, h, pos, ovv_rng)
         # Note: the return rect_pts is LBRT assuming y axis upwards, or LTRB assuming y axis downwards.
         # check if the intersection happened
-        self.assertAlmostEqual(rect_pts[0], self.tiling_rng["x"][0])
-        self.assertAlmostEqual(rect_pts[1], self.tiling_rng["y"][0])
-        self.assertAlmostEqual(rect_pts[2], self.tiling_rng["x"][0] + 200e-6 + w/2)
-        self.assertAlmostEqual(rect_pts[3], self.tiling_rng["y"][0] + 200e-6 + h/2)
+        self.assertAlmostEqual(rect_pts[0], ovv_rng["x"][0])
+        self.assertAlmostEqual(rect_pts[1], ovv_rng["y"][0])
+        self.assertAlmostEqual(rect_pts[2], ovv_rng["x"][0] + 200e-6 + w / 2)
+        self.assertAlmostEqual(rect_pts[3], ovv_rng["y"][0] + 200e-6 + h / 2)
 
     def test_clipping_is_not_performed_same_width_and_height(self):
         # move the stage to some position away from the edges of the active
         # range so that clipping is not needed (i.e in the middle of the active range).
-        self.stage.moveAbs({"x": (self.tiling_rng["x"][0] + self.tiling_rng["x"][1])/2,
-                            "y": (self.tiling_rng["y"][0] + self.tiling_rng["y"][1])/2}).result()
-        pos = self.stage.position.value
         w = 600e-6
         h = 600e-6
-        rect_pts = OverviewAcquisitionDialog.get_ROA_rect(w, h, pos, self.tiling_rng)
+
+        ovv_rng = {'x': [-1e-3, 1e-3], 'y': [-1.1e-3, 1.1e-3]}
+        pos = {"x": sum(ovv_rng["x"]) / 2,
+               "y": sum(ovv_rng["y"]) / 2}
+        rect_pts = OverviewAcquisitionDialog.get_ROA_rect(w, h, pos, ovv_rng)
         # Note: the return rect_pts is LBRT assuming y axis upwards, or LTRB assuming y axis downwards.
         # check if the intersection area is the same as the tl and br of the requested area.
         # tl and br are found by the current position +/- half of the width and height
-        self.assertAlmostEqual(rect_pts[0], pos["x"] - w/2)
-        self.assertAlmostEqual(rect_pts[1], pos["y"] - h/2)
-        self.assertAlmostEqual(rect_pts[2], pos["x"] + w/2)
-        self.assertAlmostEqual(rect_pts[3], pos["y"] + h/2)
+        self.assertAlmostEqual(rect_pts[0], pos["x"] - w / 2)
+        self.assertAlmostEqual(rect_pts[1], pos["y"] - h / 2)
+        self.assertAlmostEqual(rect_pts[2], pos["x"] + w / 2)
+        self.assertAlmostEqual(rect_pts[3], pos["y"] + h / 2)
 
     def test_clipping_is_not_performed_different_width_and_height(self):
         # move the stage to some position away from the edges of the active
         # range so that clipping is not needed (i.e in the middle of the active range). 
-        self.stage.moveAbs({"x": (self.tiling_rng["x"][0] + self.tiling_rng["x"][1])/2,
-                            "y": (self.tiling_rng["y"][0] + self.tiling_rng["y"][1])/2}).result()
-        pos = self.stage.position.value
         w = 500e-6
         h = 600e-6
-        rect_pts = OverviewAcquisitionDialog.get_ROA_rect(w, h, pos, self.tiling_rng)
+
+        ovv_rng = {'x': [-1e-3, 1e-3], 'y': [-1.1e-3, 1.1e-3]}
+        pos = {"x": sum(ovv_rng["x"]) / 2,
+               "y": sum(ovv_rng["y"]) / 2}
+        rect_pts = OverviewAcquisitionDialog.get_ROA_rect(w, h, pos, ovv_rng)
         # Note: the return rect_pts is LBRT assuming y axis upwards, or LTRB assuming y axis downwards.
         # check if the intersection area is the same as the tl and br of the requested area.
         # tl and br are found by the current position +/- half of the width and height
-        self.assertAlmostEqual(rect_pts[0], pos["x"] - w/2)
-        self.assertAlmostEqual(rect_pts[1], pos["y"] - h/2)
-        self.assertAlmostEqual(rect_pts[2], pos["x"] + w/2)
-        self.assertAlmostEqual(rect_pts[3], pos["y"] + h/2)
+        self.assertAlmostEqual(rect_pts[0], pos["x"] - w / 2)
+        self.assertAlmostEqual(rect_pts[1], pos["y"] - h / 2)
+        self.assertAlmostEqual(rect_pts[2], pos["x"] + w / 2)
+        self.assertAlmostEqual(rect_pts[3], pos["y"] + h / 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
If the stage was at the wrong place, an error would be reported... and
then the rest would fail with an exception.
=> Now handle properly when area cannot be computed by setting .area to None

Also handle zlevels computation corner cases when it's near the focus
range.

Also rearange a little bit the function organization to make it clearer.

Also update the test cases to not depend on a simulator, and actually
pass. (got broken when the simulator was adjusted)

Also remove some unneeded code.