### PR TITLE
Fastem revert changes in overview imaging

### DIFF
--- a/src/odemis/acq/fastem.py
+++ b/src/odemis/acq/fastem.py
@@ -534,9 +534,13 @@ def acquireTiledArea(stream, stage, area, live_stream=None):
     if live_stream:
         raise NotImplementedError("live_stream not supported")
 
-    est_dur = estimateTiledAcquisitionTime(stream, stage, area)
+    # Make a SEMStream copy of the stream, because it is a FastEMSEMStream object, which in its prepare method
+    # overwrites the scanner configuration from overview mode to liveview mode.
+    sem_stream = SEMStream(stream.name.value + " copy", stream.detector, stream.detector.data, stream.emitter)
+
+    est_dur = estimateTiledAcquisitionTime(sem_stream, stage, area)
     f = model.ProgressiveFuture(start=time.time(), end=time.time() + est_dur)
-    _executor.submitf(f, _run_overview_acquisition, f, stream, stage, area, live_stream)
+    _executor.submitf(f, _run_overview_acquisition, f, sem_stream, stage, area, live_stream)
 
     return f
 


### PR DESCRIPTION
The changes in commit 8a07a870b5ef88e33f22112dbaecf4a3fa89d356 caused problems with overview imaging. The commit removed copying the fastem stream object into a sem stream object.
Because a fastem stream object was used the overview image settings were overwritten with the live view image settings, this turned on the immersion mode and only a quarter of the overview image was acquired.