### PR TITLE
Refactoring of FindGridSpots and ancillary functions

### DIFF
--- a/src/odemis/util/__init__.py
+++ b/src/odemis/util/__init__.py
@@ -19,77 +19,6 @@ PURPOSE. See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along with
 Odemis. If not, see http://www.gnu.org/licenses/.
 
-
-The function `check_random_state()` is copied from scikit-learn
-utils/validation.py, which is licenced under the following terms and
-conditions:
-
-    BSD 3-Clause License
-
-    Copyright (c) 2007-2021 The scikit-learn developers.
-    All rights reserved.
-
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright notice,
-      this list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above copyright notice,
-      this list of conditions and the following disclaimer in the documentation
-      and/or other materials provided with the distribution.
-
-    * Neither the name of the copyright holder nor the names of its
-      contributors may be used to endorse or promote products derived from
-      this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
-    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-    POSSIBILITY OF SUCH DAMAGE.
-
-
-The function `rng_integers()` is copied from scipy _lib/_util, which is
-licensed under the following terms and conditions:
-
-    Copyright (c) 2001-2002 Enthought, Inc.  2003-2019, SciPy Developers.
-    All rights reserved.
-
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions
-    are met:
-
-    1. Redistributions of source code must retain the above copyright
-       notice, this list of conditions and the following disclaimer.
-
-    2. Redistributions in binary form must reproduce the above
-       copyright notice, this list of conditions and the following
-       disclaimer in the documentation and/or other materials provided
-       with the distribution.
-
-    3. Neither the name of the copyright holder nor the names of its
-       contributors may be used to endorse or promote products derived
-       from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 """
 
 # Various helper functions that have a generic usefulness
@@ -102,7 +31,6 @@ import inspect
 import itertools
 import logging
 import math
-import numbers
 import queue
 import signal
 import sys
@@ -119,118 +47,18 @@ from decorator import decorator
 
 from . import weak
 
-try:
-    from numpy.random import Generator as Generator
-except ImportError:
-
-    class Generator:  # type: ignore[no-redef]
-        pass
-
-
+# Used in the type signature of `pairwise()` below such that we can define the
+# return type as a function of the input type.
 T = TypeVar("T")
 
 
 # helper functions
 def pairwise(iterable: Iterable[T]) -> Iterable[Tuple[T, T]]:
-    "s -> (s0,s1), (s1,s2), (s2, s3), ..."
+    """s -> (s0,s1), (s1,s2), (s2, s3), ..."""
     # will be added to itertools in Python 3.10
     a, b = itertools.tee(iterable)
     next(b, None)
     return zip(a, b)
-
-
-def check_random_state(seed):
-    """
-    Turn `seed` into a `numpy.random.RandomState` instance.
-
-    Parameters
-    ----------
-    seed : {None, int, `numpy.random.Generator`, `numpy.random.RandomState`}, optional
-        If `seed` is None (or `numpy.random`), the `numpy.random.RandomState`
-        singleton is used.
-        If `seed` is an int, a new ``RandomState`` instance is used,
-        seeded with `seed`.
-        If `seed` is already a ``Generator`` or ``RandomState`` instance then
-        that instance is used.
-
-    Returns
-    -------
-    seed : {`numpy.random.Generator`, `numpy.random.RandomState`}
-        Random number generator.
-
-    """
-    if seed is None or seed is numpy.random:
-        return numpy.random.mtrand._rand
-    if isinstance(seed, (numbers.Integral, numpy.integer)):
-        return numpy.random.RandomState(seed)
-    if isinstance(seed, (numpy.random.RandomState, Generator)):
-        return seed
-
-    raise ValueError(
-        "%r cannot be used to seed a numpy.random.RandomState instance" % seed
-    )
-
-
-def rng_integers(gen, low, high=None, size=None, dtype="int64", endpoint=False):
-    """
-    Return random integers from low (inclusive) to high (exclusive), or if
-    endpoint=True, low (inclusive) to high (inclusive). Replaces
-    `RandomState.randint` (with endpoint=False) and
-    `RandomState.random_integers` (with endpoint=True).
-
-    Return random integers from the "discrete uniform" distribution of the
-    specified dtype. If high is None (the default), then results are from
-    0 to low.
-
-    Parameters
-    ----------
-    gen : {None, numpy.random.RandomState, numpy.random.Generator}
-        Random number generator. If None, then the numpy.random.RandomState
-        singleton is used.
-    low : int or array-like of ints
-        Lowest (signed) integers to be drawn from the distribution (unless
-        high=None, in which case this parameter is 0 and this value is used
-        for high).
-    high : int or array-like of ints
-        If provided, one above the largest (signed) integer to be drawn from
-        the distribution (see above for behavior if high=None). If array-like,
-        must contain integer values.
-    size : array-like of ints, optional
-        Output shape. If the given shape is, e.g., (m, n, k), then m * n * k
-        samples are drawn. Default is None, in which case a single value is
-        returned.
-    dtype : {str, dtype}, optional
-        Desired dtype of the result. All dtypes are determined by their name,
-        i.e., 'int64', 'int', etc, so byteorder is not available and a specific
-        precision may have different C types depending on the platform.
-        The default value is numpy.int_.
-    endpoint : bool, optional
-        If True, sample from the interval [low, high] instead of the default
-        [low, high) Defaults to False.
-
-    Returns
-    -------
-    out: int or ndarray of ints
-        size-shaped array of random integers from the appropriate distribution,
-        or a single such random int if size not provided.
-
-    """
-    if isinstance(gen, Generator):
-        return gen.integers(low, high=high, size=size, dtype=dtype, endpoint=endpoint)
-    else:
-        if gen is None:
-            # default is RandomState singleton used by np.random.
-            gen = numpy.random.mtrand._rand
-        if endpoint:
-            # inclusive of endpoint
-            # remember that low and high can be arrays, so don't modify in place
-            if high is None:
-                return gen.randint(low + 1, size=size, dtype=dtype)
-            if high is not None:
-                return gen.randint(low, high=high + 1, size=size, dtype=dtype)
-
-        # exclusive
-        return gen.randint(low, high=high, size=size, dtype=dtype)
 
 
 def get_best_dtype_for_acc(idtype, count):

--- a/src/odemis/util/__init__.py
+++ b/src/odemis/util/__init__.py
@@ -32,6 +32,7 @@ from concurrent.futures import CancelledError
 from decorator import decorator
 from functools import wraps
 import inspect
+import itertools
 import logging
 import math
 import numpy
@@ -39,13 +40,24 @@ import signal
 import sys
 import threading
 import time
+from typing import Iterable, Tuple, TypeVar
 import weakref
 import types
 
 from . import weak
 
+T = TypeVar("T")
+
 
 # helper functions
+def pairwise(iterable: Iterable[T]) -> Iterable[Tuple[T, T]]:
+    "s -> (s0,s1), (s1,s2), (s2, s3), ..."
+    # will be added to itertools in Python 3.10
+    a, b = itertools.tee(iterable)
+    next(b, None)
+    return zip(a, b)
+
+
 def get_best_dtype_for_acc(idtype, count):
     """
     Computes the smallest dtype that allows to integrate the number of inputs without overflowing.

--- a/src/odemis/util/__init__.py
+++ b/src/odemis/util/__init__.py
@@ -24,26 +24,25 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 # Various helper functions that have a generic usefulness
 # Warning: do not put anything that has dependencies on non default python modules
 
-from __future__ import absolute_import, division
+from __future__ import division, absolute_import
 
+import queue
 import collections
+from concurrent.futures import CancelledError
+from decorator import decorator
+from functools import wraps
 import inspect
 import itertools
 import logging
 import math
-import queue
+import numpy
 import signal
 import sys
 import threading
 import time
-import types
 import weakref
-from concurrent.futures import CancelledError
-from functools import wraps
+import types
 from typing import Iterable, Tuple, TypeVar
-
-import numpy
-from decorator import decorator
 
 from . import weak
 

--- a/src/odemis/util/__init__.py
+++ b/src/odemis/util/__init__.py
@@ -19,32 +19,113 @@ PURPOSE. See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along with
 Odemis. If not, see http://www.gnu.org/licenses/.
 
+
+The function `check_random_state()` is copied from scikit-learn
+utils/validation.py, which is licenced under the following terms and
+conditions:
+
+    BSD 3-Clause License
+
+    Copyright (c) 2007-2021 The scikit-learn developers.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived from
+      this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+
+
+The function `rng_integers()` is copied from scipy _lib/_util, which is
+licensed under the following terms and conditions:
+
+    Copyright (c) 2001-2002 Enthought, Inc.  2003-2019, SciPy Developers.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above
+       copyright notice, this list of conditions and the following
+       disclaimer in the documentation and/or other materials provided
+       with the distribution.
+
+    3. Neither the name of the copyright holder nor the names of its
+       contributors may be used to endorse or promote products derived
+       from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 """
 
 # Various helper functions that have a generic usefulness
 # Warning: do not put anything that has dependencies on non default python modules
 
-from __future__ import division, absolute_import
+from __future__ import absolute_import, division
 
-import queue
 import collections
-from concurrent.futures import CancelledError
-from decorator import decorator
-from functools import wraps
 import inspect
 import itertools
 import logging
 import math
-import numpy
+import numbers
+import queue
 import signal
 import sys
 import threading
 import time
-from typing import Iterable, Tuple, TypeVar
-import weakref
 import types
+import weakref
+from concurrent.futures import CancelledError
+from functools import wraps
+from typing import Iterable, Tuple, TypeVar
+
+import numpy
+from decorator import decorator
 
 from . import weak
+
+try:
+    from numpy.random import Generator as Generator
+except ImportError:
+
+    class Generator:  # type: ignore[no-redef]
+        pass
+
 
 T = TypeVar("T")
 
@@ -56,6 +137,100 @@ def pairwise(iterable: Iterable[T]) -> Iterable[Tuple[T, T]]:
     a, b = itertools.tee(iterable)
     next(b, None)
     return zip(a, b)
+
+
+def check_random_state(seed):
+    """
+    Turn `seed` into a `numpy.random.RandomState` instance.
+
+    Parameters
+    ----------
+    seed : {None, int, `numpy.random.Generator`, `numpy.random.RandomState`}, optional
+        If `seed` is None (or `numpy.random`), the `numpy.random.RandomState`
+        singleton is used.
+        If `seed` is an int, a new ``RandomState`` instance is used,
+        seeded with `seed`.
+        If `seed` is already a ``Generator`` or ``RandomState`` instance then
+        that instance is used.
+
+    Returns
+    -------
+    seed : {`numpy.random.Generator`, `numpy.random.RandomState`}
+        Random number generator.
+
+    """
+    if seed is None or seed is numpy.random:
+        return numpy.random.mtrand._rand
+    if isinstance(seed, (numbers.Integral, numpy.integer)):
+        return numpy.random.RandomState(seed)
+    if isinstance(seed, (numpy.random.RandomState, Generator)):
+        return seed
+
+    raise ValueError(
+        "%r cannot be used to seed a numpy.random.RandomState instance" % seed
+    )
+
+
+def rng_integers(gen, low, high=None, size=None, dtype="int64", endpoint=False):
+    """
+    Return random integers from low (inclusive) to high (exclusive), or if
+    endpoint=True, low (inclusive) to high (inclusive). Replaces
+    `RandomState.randint` (with endpoint=False) and
+    `RandomState.random_integers` (with endpoint=True).
+
+    Return random integers from the "discrete uniform" distribution of the
+    specified dtype. If high is None (the default), then results are from
+    0 to low.
+
+    Parameters
+    ----------
+    gen : {None, numpy.random.RandomState, numpy.random.Generator}
+        Random number generator. If None, then the numpy.random.RandomState
+        singleton is used.
+    low : int or array-like of ints
+        Lowest (signed) integers to be drawn from the distribution (unless
+        high=None, in which case this parameter is 0 and this value is used
+        for high).
+    high : int or array-like of ints
+        If provided, one above the largest (signed) integer to be drawn from
+        the distribution (see above for behavior if high=None). If array-like,
+        must contain integer values.
+    size : array-like of ints, optional
+        Output shape. If the given shape is, e.g., (m, n, k), then m * n * k
+        samples are drawn. Default is None, in which case a single value is
+        returned.
+    dtype : {str, dtype}, optional
+        Desired dtype of the result. All dtypes are determined by their name,
+        i.e., 'int64', 'int', etc, so byteorder is not available and a specific
+        precision may have different C types depending on the platform.
+        The default value is numpy.int_.
+    endpoint : bool, optional
+        If True, sample from the interval [low, high] instead of the default
+        [low, high) Defaults to False.
+
+    Returns
+    -------
+    out: int or ndarray of ints
+        size-shaped array of random integers from the appropriate distribution,
+        or a single such random int if size not provided.
+
+    """
+    if isinstance(gen, Generator):
+        return gen.integers(low, high=high, size=size, dtype=dtype, endpoint=endpoint)
+    else:
+        if gen is None:
+            # default is RandomState singleton used by np.random.
+            gen = numpy.random.mtrand._rand
+        if endpoint:
+            # inclusive of endpoint
+            # remember that low and high can be arrays, so don't modify in place
+            if high is None:
+                return gen.randint(low + 1, size=size, dtype=dtype)
+            if high is not None:
+                return gen.randint(low, high=high + 1, size=size, dtype=dtype)
+
+        # exclusive
+        return gen.randint(low, high=high, size=size, dtype=dtype)
 
 
 def get_best_dtype_for_acc(idtype, count):

--- a/src/odemis/util/graph.py
+++ b/src/odemis/util/graph.py
@@ -176,7 +176,16 @@ class GraphBase(UserList, metaclass=ABCMeta):
                     visited[t].add(s)
 
     def remove_triangles(self) -> None:
-        """Remove all triangles (3-cycles) from the graph."""
+        """
+        Removes all triangles (3-cycles) from the graph.
+
+        Triangles are removed by deleting the least amount of edges from the
+        graph. This is done using a greedy algorithm where edges that are
+        contained in more than one triangle are removed first. If two edges are
+        contained in the same amount of triangles, the edge that has the
+        largest edge weight (distance) is removed first.
+
+        """
         triangles = set(self.iter_triangles())
         if not triangles:
             return  # Quick return if possible

--- a/src/odemis/util/graph.py
+++ b/src/odemis/util/graph.py
@@ -25,12 +25,11 @@ USA.
 """
 import collections
 import itertools
+import sys
 from abc import ABCMeta, abstractmethod
 from typing import Any, Dict, Iterator, List, Optional, Sequence, Set, Tuple, Union
 
 import numpy
-import sys
-
 
 if sys.version_info < (3, 7, 4):
     from collections import UserList as _UserList
@@ -63,6 +62,23 @@ class GraphBase(UserList, metaclass=ABCMeta):
         n_or_initlist: Optional[Union[int, Sequence[Any]]] = None,
         directed: bool = True,
     ) -> None:
+        """
+        Initializer for GraphBase.
+
+        Parameters
+        ----------
+        n_or_initlist : int or sequence, optional
+            If `None` (default) initializes a graph of zero order and zero size
+            (i.e. no vertices and no edges). If int, initializes a graph of
+            order `n_or_initlist` and zero size. Otherwise initialize the graph
+            using the sequence `n_or_initlist`.
+        directed : bool
+            If `False` the graph is undirected and symmetry of the adjacency
+            matrix is enforced when adding or removing edges. For undirected
+            graphs this means that `j in graph[i]` is True if and only if
+            `i in graph[j]`.
+
+        """
         self._directed = directed
         if n_or_initlist is None:
             super().__init__()
@@ -203,14 +219,12 @@ class GraphBase(UserList, metaclass=ABCMeta):
 
 class WeightedGraph(GraphBase):
     """
-    represented as a list of dicts.
+    Weighted graph represented as a list of dicts.
 
-    Each list item is a dictionary of which
-    the keys are the vertices to which the vertex represented by that list
-    item is connected to. The dictionary values contain the edge weights.
-    For example, `graph[0]` is the set of `(neighbor, distance)` pairs of
-    vertex 0. The graph is undirected, which means that `j in graph[i]` is
-    true if and only if `i in graph[j]`.
+    Each list item describes the set of neighbors of a particular vertex and
+    their associated weights. For example, `graph[j]` is a dictionary of which
+    the keys form the set of neighbors of vertex `j` and the values contain the
+    edge weights.
 
     """
 
@@ -235,14 +249,10 @@ class WeightedGraph(GraphBase):
 
 class UnweightedGraph(GraphBase):
     """
-    represented as a list of sets.
+    Unweighted graph represented as a list of sets.
 
-    Each list item is a dictionary of which
-    the keys are the vertices to which the vertex represented by that list
-    item is connected to. The dictionary values contain the edge weights.
-    For example, `graph[0]` is the set of `(neighbor, distance)` pairs of
-    vertex 0. The graph is undirected, which means that `j in graph[i]` is
-    true if and only if `i in graph[j]`.
+    Each list item describes the set of neighbors of a particular vertex in the
+    graph. For example, `graph[j]` is the set of neighbors of vertex `j`.
 
     """
 
@@ -261,4 +271,5 @@ class UnweightedGraph(GraphBase):
             self.data[i].remove(j)
 
     def get_edge_weight(self, edge: Tuple[int, int]) -> float:
+        # Always return an edge weight of 1 for an unweighted graph
         return 1

--- a/src/odemis/util/graph.py
+++ b/src/odemis/util/graph.py
@@ -29,9 +29,31 @@ from abc import ABCMeta, abstractmethod
 from typing import Any, Dict, Iterator, List, Optional, Sequence, Set, Tuple, Union
 
 import numpy
+import sys
 
 
-class GraphBase(collections.UserList, metaclass=ABCMeta):
+if sys.version_info < (3, 7, 4):
+    from collections import UserList as _UserList
+
+    class UserList(_UserList):
+        """
+        Backport of bugfix for when using Python v3.7.3 or lower.
+        For more informations see: https://bugs.python.org/issue27639
+
+        """
+
+        def __getitem__(self, i):
+            if isinstance(i, slice):
+                return self.__class__(self.data[i])
+            else:
+                return self.data[i]
+
+
+else:
+    from collections import UserList
+
+
+class GraphBase(UserList, metaclass=ABCMeta):
     """Abstract base class for graphs."""
 
     _item_type = object

--- a/src/odemis/util/graph.py
+++ b/src/odemis/util/graph.py
@@ -1,0 +1,242 @@
+# -*- encoding: utf-8 -*-
+"""
+graph.py : tools for constructing and modifying graphs, i.e. sets of vertices
+connected by edges.
+
+@author: Andries Effting
+
+Copyright (C) 2021  Andries Effting, Delmic
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+"""
+import collections
+import itertools
+from abc import ABCMeta, abstractmethod
+from typing import Any, Dict, Iterator, List, Optional, Sequence, Set, Tuple, Union
+
+import numpy
+
+
+class GraphBase(collections.UserList, metaclass=ABCMeta):
+    """Abstract base class for graphs."""
+
+    _item_type = object
+
+    def __init__(
+        self,
+        n_or_initlist: Optional[Union[int, Sequence[Any]]] = None,
+        directed: bool = True,
+    ) -> None:
+        self._directed = directed
+        if n_or_initlist is None:
+            super().__init__()
+        elif isinstance(n_or_initlist, int):
+            super().__init__((self._item_type() for _ in range(n_or_initlist)))
+        elif isinstance(n_or_initlist, collections.abc.Sequence):
+            super().__init__(map(self._item_type, n_or_initlist))
+        else:
+            raise ValueError(
+                "Unsupported type '{}', expected int or sequence".format(
+                    type(n_or_initlist).__name__
+                )
+            )
+
+    @abstractmethod
+    def add_edge(self, edge: Tuple[int, int]) -> None:
+        pass
+
+    @abstractmethod
+    def remove_edge(self, edge: Tuple[int, int]) -> None:
+        pass
+
+    @abstractmethod
+    def get_edge_weight(self, edge: Tuple[int, int]) -> float:
+        pass
+
+    def adjacency_matrix(self) -> numpy.ndarray:
+        """
+        Return the adjacency matrix of the graph.
+
+        Returns
+        -------
+        matrix : ndarray
+            The adjacency matrix.
+
+        """
+        n = len(self.data)
+        matrix = numpy.zeros((n, n))
+        for vertex, neighbors in enumerate(self.data):
+            for neighbor in neighbors:
+                matrix[vertex, neighbor] = self.get_edge_weight((vertex, neighbor))
+        return matrix
+
+    def iter_edges(self, directed: Optional[bool] = None) -> Iterator[Tuple[int, int]]:
+        """
+        Iterator over all the edges in the graph.
+
+        Parameters
+        ----------
+        directed : bool, optional
+            If `True` the edges `(j, i)` and `(i, j)` will be considered as
+            being two separate edges. If `False`, only yield edges `(j, i)`
+            with `j < i`. If not specified, uses `self.directed`.
+
+        Yields
+        ------
+        edge : tuple `(j, i)`
+            The edge connecting two vertices.
+
+        """
+        directed = self._directed if directed is None else directed
+        for vertex, neighbors in enumerate(self.data):
+            for neighbor in neighbors:
+                if not directed and vertex > neighbor:
+                    continue
+                yield (vertex, neighbor)
+
+    def iter_triangles(self) -> Iterator[Tuple[int, int, int]]:
+        """
+        Iterator over all triangles (3-cycles) in the graph.
+
+        Yields
+        -------
+        triangle : 3-tuple `(s, t, v)`
+            The vertices that form a triangle, in increasing order.
+
+        References
+        ----------
+        .. [1] Schank, T., & Wagner, D. (2005, May). Finding, counting and
+        listing all triangles in large graphs, an experimental study. In
+        International workshop on experimental and efficient algorithms
+        (pp. 606-609). Springer, Berlin, Heidelberg.
+
+        """
+        n = len(self.data)
+        degree = list(map(len, self.data))
+        vertices = numpy.argsort(degree)[::-1]
+        index = numpy.argsort(vertices)
+        visited: List[Set[int]] = [set() for _ in range(n)]
+        for s in vertices:
+            for t in self.data[s]:
+                if index[s] < index[t]:
+                    for v in visited[s].intersection(visited[t]):
+                        yield tuple(sorted((v, s, t)))
+                    visited[t].add(s)
+
+    def remove_triangles(self) -> None:
+        """Remove all triangles (3-cycles) from the graph."""
+        triangles = set(self.iter_triangles())
+        if not triangles:
+            return  # Quick return if possible
+
+        edge_counter: Dict[Tuple[int, int], int] = collections.Counter()
+        edge_to_triangles_map = collections.defaultdict(set)
+        triangle_to_edges_map = collections.defaultdict(set)
+        for triangle in triangles:
+            for edge in itertools.combinations(triangle, 2):
+                edge_counter[edge] += 1
+                edge_to_triangles_map[edge].add(triangle)
+                triangle_to_edges_map[triangle].add(edge)
+
+        # First consider all edges that are contained in at least two
+        # triangles. Remove the edge that is contained in the largest number
+        # of triangles and has the largest edge weight (distance).
+        while True:
+            count = max(edge_counter.values(), default=0)
+            if count < 2:
+                break
+            edges = [edge for edge, n in edge_counter.items() if n == count]
+            selected = max(edges, key=self.get_edge_weight)
+            self.remove_edge(selected)
+            # To prevent a RuntimeError loop over a copy of the set.
+            for triangle in edge_to_triangles_map[selected].copy():
+                for edge in triangle_to_edges_map[triangle]:
+                    edge_counter[edge] -= 1
+                    edge_to_triangles_map[edge].remove(triangle)
+                del triangle_to_edges_map[triangle]
+                triangles.remove(triangle)
+
+        # For triangles that are isolated (i.e. those that do not contain an
+        # edge contained in another triangle), remove the edge that has the
+        # largest edge weight (distance).
+        for triangle in triangles:
+            edges = list(itertools.combinations(triangle, 2))
+            selected = max(edges, key=self.get_edge_weight)
+            self.remove_edge(selected)
+
+
+class WeightedGraph(GraphBase):
+    """
+    represented as a list of dicts.
+
+    Each list item is a dictionary of which
+    the keys are the vertices to which the vertex represented by that list
+    item is connected to. The dictionary values contain the edge weights.
+    For example, `graph[0]` is the set of `(neighbor, distance)` pairs of
+    vertex 0. The graph is undirected, which means that `j in graph[i]` is
+    true if and only if `i in graph[j]`.
+
+    """
+
+    _item_type = dict
+
+    def add_edge(self, edge: Tuple[int, int], weight: float = 1) -> None:
+        j, i = edge
+        self.data[j][i] = weight
+        if not self._directed:
+            self.data[i][j] = weight
+
+    def remove_edge(self, edge: Tuple[int, int]) -> None:
+        j, i = edge
+        del self.data[j][i]
+        if not self._directed:
+            del self.data[i][j]
+
+    def get_edge_weight(self, edge: Tuple[int, int]) -> float:
+        j, i = edge
+        return self.data[j][i]
+
+
+class UnweightedGraph(GraphBase):
+    """
+    represented as a list of sets.
+
+    Each list item is a dictionary of which
+    the keys are the vertices to which the vertex represented by that list
+    item is connected to. The dictionary values contain the edge weights.
+    For example, `graph[0]` is the set of `(neighbor, distance)` pairs of
+    vertex 0. The graph is undirected, which means that `j in graph[i]` is
+    true if and only if `i in graph[j]`.
+
+    """
+
+    _item_type = set
+
+    def add_edge(self, edge: Tuple[int, int]) -> None:
+        j, i = edge
+        self.data[j].add(i)
+        if not self._directed:
+            self.data[i].add(j)
+
+    def remove_edge(self, edge: Tuple[int, int]) -> None:
+        j, i = edge
+        self.data[j].remove(i)
+        if not self._directed:
+            self.data[i].remove(j)
+
+    def get_edge_weight(self, edge: Tuple[int, int]) -> float:
+        return 1

--- a/src/odemis/util/random.py
+++ b/src/odemis/util/random.py
@@ -1,0 +1,177 @@
+# -*- coding: utf-8 -*-
+"""
+The function `check_random_state()` is copied from scikit-learn
+utils/validation.py, which is licenced under the following terms and
+conditions:
+
+    BSD 3-Clause License
+
+    Copyright (c) 2007-2021 The scikit-learn developers.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+
+    * Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived from
+      this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+    LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+    CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+    SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+    INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+    CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGE.
+
+
+The function `rng_integers()` is copied from scipy _lib/_util, which is
+licensed under the following terms and conditions:
+
+    Copyright (c) 2001-2002 Enthought, Inc.  2003-2019, SciPy Developers.
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above
+       copyright notice, this list of conditions and the following
+       disclaimer in the documentation and/or other materials provided
+       with the distribution.
+
+    3. Neither the name of the copyright holder nor the names of its
+       contributors may be used to endorse or promote products derived
+       from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+import numbers
+
+import numpy
+
+try:
+    from numpy.random import Generator as Generator
+except ImportError:
+
+    class Generator:  # type: ignore[no-redef]
+        pass
+
+
+def check_random_state(seed):
+    """
+    Turn `seed` into a `numpy.random.RandomState` instance.
+
+    Parameters
+    ----------
+    seed : {None, int, `numpy.random.Generator`, `numpy.random.RandomState`}, optional
+        If `seed` is None (or `numpy.random`), the `numpy.random.RandomState`
+        singleton is used.
+        If `seed` is an int, a new ``RandomState`` instance is used,
+        seeded with `seed`.
+        If `seed` is already a ``Generator`` or ``RandomState`` instance then
+        that instance is used.
+
+    Returns
+    -------
+    seed : {`numpy.random.Generator`, `numpy.random.RandomState`}
+        Random number generator.
+
+    """
+    if seed is None or seed is numpy.random:
+        return numpy.random.mtrand._rand
+    if isinstance(seed, (numbers.Integral, numpy.integer)):
+        return numpy.random.RandomState(seed)
+    if isinstance(seed, (numpy.random.RandomState, Generator)):
+        return seed
+
+    raise ValueError(
+        "%r cannot be used to seed a numpy.random.RandomState instance" % seed
+    )
+
+
+def rng_integers(gen, low, high=None, size=None, dtype="int64", endpoint=False):
+    """
+    Return random integers from low (inclusive) to high (exclusive), or if
+    endpoint=True, low (inclusive) to high (inclusive). Replaces
+    `numpy.RandomState.randint` (with endpoint=False) and
+    `numpy.RandomState.random_integers` (with endpoint=True).
+
+    Return random integers from the "discrete uniform" distribution of the
+    specified dtype. If high is None (the default), then results are from
+    0 to low.
+
+    Parameters
+    ----------
+    gen : {None, numpy.random.RandomState, numpy.random.Generator}
+        Random number generator. If None, then the numpy.random.RandomState
+        singleton is used.
+    low : int or array-like of ints
+        Lowest (signed) integers to be drawn from the distribution (unless
+        high=None, in which case this parameter is 0 and this value is used
+        for high).
+    high : int or array-like of ints
+        If provided, one above the largest (signed) integer to be drawn from
+        the distribution (see above for behavior if high=None). If array-like,
+        must contain integer values.
+    size : array-like of ints, optional
+        Output shape. If the given shape is, e.g., (m, n, k), then m * n * k
+        samples are drawn. Default is None, in which case a single value is
+        returned.
+    dtype : {str, dtype}, optional
+        Desired dtype of the result. All dtypes are determined by their name,
+        i.e., 'int64', 'int', etc, so byteorder is not available and a specific
+        precision may have different C types depending on the platform.
+        The default value is numpy.int_.
+    endpoint : bool, optional
+        If True, sample from the interval [low, high] instead of the default
+        [low, high) Defaults to False.
+
+    Returns
+    -------
+    out: int or ndarray of ints
+        size-shaped array of random integers from the appropriate distribution,
+        or a single such random int if size not provided.
+
+    """
+    if isinstance(gen, Generator):
+        return gen.integers(low, high=high, size=size, dtype=dtype, endpoint=endpoint)
+    else:
+        if gen is None:
+            # default is RandomState singleton used by np.random.
+            gen = numpy.random.mtrand._rand
+        if endpoint:
+            # inclusive of endpoint
+            # remember that low and high can be arrays, so don't modify in place
+            if high is None:
+                return gen.randint(low + 1, size=size, dtype=dtype)
+            if high is not None:
+                return gen.randint(low, high=high + 1, size=size, dtype=dtype)
+
+        # exclusive
+        return gen.randint(low, high=high, size=size, dtype=dtype)

--- a/src/odemis/util/registration.py
+++ b/src/odemis/util/registration.py
@@ -63,10 +63,10 @@ from typing import Iterator, Optional, Tuple, Type, TypeVar
 import numpy
 import scipy.cluster
 import scipy.spatial
-from odemis.util import check_random_state, rng_integers
 from odemis.util.graph import WeightedGraph
+from odemis.util.random import check_random_state, rng_integers
 from odemis.util.spot import find_spot_positions
-from odemis.util.transform import (
+from odemis.util.transform import (  # noqa: F401
     AffineTransform,
     GeometricTransform,
     _transformation_matrix_to_implicit,
@@ -160,7 +160,8 @@ def bijective_matching(
 
 def unit_gridpoints(shape: Tuple[int, int], *, mode: str) -> numpy.ndarray:
     """
-    Returns an ordered array of coordinates of a square grid with unit spacing.
+    Returns an ordered array of coordinates of a square grid with unit spacing
+    centered around zero.
 
     This function returns a row-major ordered array of coordinates of a square
     grid of points with unit spacing. The coordinates are returned either in
@@ -209,7 +210,9 @@ def nearest_neighbor_graph(xy: numpy.ndarray) -> WeightedGraph:
     Returns
     -------
     graph : WeightedGraph
-        Undirected weighted simple graph of 4-connected nearest neighbors.
+        Undirected weighted simple graph of 4-connected nearest neighbors. For
+        points located on the edge of the grid only 3 nearest neighbors are
+        returned, and for the corners only 2.
 
     """
     # Find the closest 4 neighbors (excluding itself) for each point.

--- a/src/odemis/util/registration.py
+++ b/src/odemis/util/registration.py
@@ -133,6 +133,9 @@ def bijective_matching(
     """
     Matching of two un-ordered point sets to determine their correspondences.
 
+    This function can be used as the matching step in the iterative closest
+    point (ICP) algorithm.
+
     Parameters
     ----------
     src : ndarray
@@ -403,7 +406,7 @@ def estimate_grid_orientation(
 
     Returns
     -------
-    tform : GeometricTransform
+    tform : instance of `transform_type`
         The orientation of the pattern.
 
     """
@@ -453,6 +456,11 @@ def estimate_grid_orientation_from_img(
         `num_spots = shape[0] * shape[1]` as default when set to `None`. Set
         `num_spots = 0` to not impose a maximum. Note that this behavior is
         different from odemis.util.spot.find_spot_position().
+
+    Returns
+    -------
+    tform : instance of `transform_type`
+        The orientation of the pattern.
 
     """
     if num_spots is None:

--- a/src/odemis/util/registration.py
+++ b/src/odemis/util/registration.py
@@ -1,0 +1,372 @@
+# -*- encoding: utf-8 -*-
+"""
+registration.py : Utility functions for point set registration.
+
+@author: Andries Effting
+
+Copyright (C) 2021  Andries Effting, Delmic
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+"""
+import math
+from typing import Iterator, Optional, Tuple, Type, TypeVar
+
+import numpy
+import scipy.cluster
+import scipy.spatial
+from odemis.util.graph import WeightedGraph
+from odemis.util.spot import find_spot_positions
+from odemis.util.transform import (
+    AffineTransform,
+    GeometricTransform,
+    _transformation_matrix_to_implicit,
+    cartesian_to_polar,
+    polar_to_cartesian,
+    to_physical_space,
+)
+
+T = TypeVar("T", bound="GeometricTransform")
+
+
+def _bijective_matching(dm: numpy.ndarray) -> Iterator[Tuple[int, int]]:
+    """
+    Matching of two un-ordered point sets to determine their correspondences.
+
+    See `bijective_matching()` for more information.
+
+    Parameters
+    ----------
+    dm : ndarray
+        Distance matrix, where entry `(j, i)` contains the distance between
+        `src[j]` and `dst[i]`.
+
+    Yields
+    ------
+    correspondence : tuple of ints
+        Yields the edges connecting the source and destination point sets,
+        sorted by distance in ascending order.
+
+    """
+    n, m = dm.shape
+    if n > m:
+        j = numpy.argmin(dm, axis=0)
+        i = numpy.arange(m)
+    else:
+        j = numpy.arange(n)
+        i = numpy.argmin(dm, axis=1)
+
+    # Create a list of nearest neigbor pairs `(j, i)` sorted by distance in
+    # ascending order.
+    matches = sorted(zip(j, i), key=dm.__getitem__)
+
+    # Ensure that each vertex can only be part of a single matching edge.
+    mask_src = numpy.ones(n, dtype=bool)
+    mask_dst = numpy.ones(m, dtype=bool)
+    for j, i in matches:
+        if mask_src[j] and mask_dst[i]:
+            # Add correspondence and remove vertices from future consideration.
+            yield (j, i)
+            mask_src[j] = False
+            mask_dst[i] = False
+        else:
+            # Duplicate found: solve the unmatched pairs recursively.
+            map_src = numpy.flatnonzero(mask_src)
+            map_dst = numpy.flatnonzero(mask_dst)
+            tail = _bijective_matching(dm[numpy.ix_(mask_src, mask_dst)])
+            yield from ((map_src[j], map_dst[i]) for j, i in tail)
+            break
+
+
+def bijective_matching(
+    src: numpy.ndarray, dst: numpy.ndarray
+) -> Iterator[Tuple[int, int]]:
+    """
+    Matching of two un-ordered point sets to determine their correspondences.
+
+    Parameters
+    ----------
+    src : ndarray
+        Point set in the source reference frame.
+    dst : ndarray
+        Point set in the destination reference frame.
+
+    Yields
+    ------
+    correspondence : tuple of ints
+        Yields the edges connecting the source and destination point sets,
+        sorted by distance in ascending order.
+
+    References
+    ----------
+    .. [1] Almhdie, A., Léger, C., Deriche, M., & Lédée, R. (2007). 3D
+    registration using a new implementation of the ICP algorithm based on a
+    comprehensive lookup matrix: Application to medical imaging. Pattern
+    Recognition Letters, 28(12), 1523-1533.
+
+    """
+    dm = scipy.spatial.distance.cdist(src, dst, "euclidean")
+    yield from _bijective_matching(dm)
+
+
+def unit_gridpoints(shape: Tuple[int, int], *, mode: str) -> numpy.ndarray:
+    """
+    Returns an ordered array of coordinates of a square grid with unit spacing.
+
+    This function returns a row-major ordered array of coordinates of a square
+    grid of points with unit spacing. The coordinates are returned either in
+    Cartesian or matrix mode.
+
+    Parameters
+    ----------
+    shape : tuple of two ints
+        The shape of the grid given as a tuple `(height, width)`.
+    mode : {"ji", "xy"}
+        Cartesian ("xy") or matrix ("ji") indexing of output.
+
+    Returns
+    -------
+    out : ndarray
+        Array with the coordinates of a square grid of points with unit spacing
+        in row-major order. I.e. for a grid of shape `(n, m)` the first entry
+        `out[0]` is the top-left corner of the grid, `out[m - 1]` is the
+        top-right corner point, `out[(n - 1) * m]` is the bottom-left corner
+        point, and `out[-1]` is the bottom right corner.
+
+    """
+    if mode not in ("ji", "xy"):
+        raise ValueError("Valid values for `mode` are 'ji' and 'xy'.")
+    n, m = shape
+    if mode == "ji":
+        j = numpy.reshape(numpy.arange(n, dtype=float) - 0.5 * float(n - 1), (n, 1))
+        i = numpy.reshape(numpy.arange(m, dtype=float) - 0.5 * float(m - 1), (1, m))
+        return numpy.stack(numpy.broadcast_arrays(j, i), axis=-1).reshape(n * m, 2)
+    # mode == "xy"
+    x = numpy.reshape(numpy.arange(m, dtype=float) - 0.5 * float(m - 1), (1, m))
+    y = numpy.reshape(numpy.arange(n, dtype=float)[::-1] - 0.5 * float(n - 1), (n, 1))
+    return numpy.stack(numpy.broadcast_arrays(x, y), axis=-1).reshape(n * m, 2)
+
+
+def nearest_neighbor_graph(xy: numpy.ndarray) -> WeightedGraph:
+    """
+    Returns a undirected weighted simple graph of 4-connected nearest neighbors
+    of a square grid of points.
+
+    Parameters
+    ----------
+    xy : ndarray of shape (n, 2)
+        Array with the determined coordinates of the grid points.
+
+    Returns
+    -------
+    graph : WeightedGraph
+        Undirected weighted simple graph of 4-connected nearest neighbors.
+
+    """
+    # Find the closest 4 neighbors (excluding itself) for each point.
+    tree = scipy.spatial.cKDTree(xy)
+    # NOTE: Starting SciPy v1.6.0 the `n_jobs` argument will be renamed `workers`
+    distances, indices = tree.query(xy, k=5, n_jobs=-1)
+    distances = distances[:, 1:]  # exclude the point itself
+    indices = indices[:, 1:]  # same
+
+    # Construct an undirected weighted simple graph
+    graph = WeightedGraph(len(xy), directed=False)
+    for vertex, neighbors in enumerate(indices):
+        for neighbor, distance in zip(neighbors, distances[vertex]):
+            # An edge connects two vertices that are each others nearest neighbor.
+            if (vertex < neighbor) and (vertex in indices[neighbor]):
+                graph.add_edge((vertex, neighbor), distance)
+
+    # The code above assumes that each point has 4 nearest neighbors. In
+    # practice we would like to only consider the 2 nearest neighbors for the
+    # points at the corners of the grid, and likewise 3 nearest neighbors for
+    # the points on the sides of the grid. The following line takes care of
+    # that.
+    graph.remove_triangles()
+
+    return graph
+
+
+_PERMUTATION_MATRIX = {
+    -2: numpy.array([(-1, 0), (0, -1)]),
+    -1: numpy.array([(0, -1), (1, 0)]),
+    0: numpy.array([(1, 0), (0, 1)]),
+    1: numpy.array([(0, 1), (-1, 0)]),
+    2: numpy.array([(-1, 0), (0, -1)]),
+}
+
+
+def _canonical_matrix_form(matrix: numpy.ndarray) -> numpy.ndarray:
+    """
+    Returns a transformation matrix in canonical form.
+
+    The multi-probe pattern has a dual mirror symmetry as well as a 4-fold
+    rotational symmetry. Hence there are 8 degenerate orientations of the
+    multi-probe pattern. This function takes as input an estimated
+    transformation matrix and reduces it to canonical form: no reflection and
+    a rotation between -pi/4 and +pi/4.
+
+    Parameters
+    ----------
+    matrix : ndarray
+        Input transformation matrix.
+
+    Returns
+    -------
+    out : ndarray
+        Output transformation matrix.
+
+    """
+    # If the transformation matrix contains a reflection, its determinant will
+    # be negative. In that case, swap the columns of the matrix.
+    if numpy.linalg.det(matrix) < 0:
+        matrix = numpy.fliplr(matrix)
+
+    # Determine the rotation of the input matrix and flip and/or invert the
+    # columns of the matrix to ensure that the resulting matrix has a rotation
+    # part that represents an angle between -pi/4 and +pi/4.
+    #
+    # The rotation follows from a polar decomposition of the input matrix:
+    # `A = R * S`, where `R` is an orthogonal matrix and `S` is
+    # positive-definite. Let `P` be an orthogonal permutation matrix.
+    # Then `A' = A * P` and `S' = Pᵀ * S * P`. By definition `S'` is congruent
+    # to `S`, and is thus also positive-definite. Then by the uniqueness of the
+    # polar decomposition we have `A' = R' * S'`, where `R' = R * P`.
+    _, rotation, _, _ = _transformation_matrix_to_implicit(matrix)
+    k = math.floor(0.5 + 2 * rotation / math.pi)
+    return numpy.matmul(matrix, _PERMUTATION_MATRIX[k])
+
+
+def _initial_estimate_mpp_orientation(xy: numpy.ndarray) -> AffineTransform:
+    """
+    Provide an initial estimate for the orientation of a square grid of points.
+
+    Parameters
+    ----------
+    xy : ndarray of shape (n, 2)
+        Array with the determined coordinates of the grid points.
+
+    Returns
+    -------
+    tform : AffineTransform
+
+    """
+    graph = nearest_neighbor_graph(xy)
+
+    # Create an array `dxy` containing the displacement vectors for all edges
+    # in the graph.
+    a, b = zip(*graph.iter_edges(False))
+    dxy = xy[b, ...] - xy[a, ...]
+
+    # The array `dxy` typically contains the lattice vectors for the 'left',
+    # 'right', 'up', and 'down' directions, but it is not guaranteed that it
+    # will contain all of them, nor that there are equal amounts of edges in
+    # each direction. The solution is to not make any distinction between
+    # 'left' and 'right', or 'up' and 'down'. This is done using a mapping of
+    # `(ρ, θ)` to `(ρ, 2*θ)`. The clustering itself is done in Cartesian
+    # coordinates to not be impacted by the branch cut at `θ = ±π`.
+    rho, theta = cartesian_to_polar(dxy)
+    dpq = polar_to_cartesian(rho, 2 * theta)
+    centroid, _ = scipy.cluster.vq.kmeans2(dpq, 2, minit="++")
+    rho, theta = cartesian_to_polar(centroid)
+    dxy = polar_to_cartesian(rho, 0.5 * theta)
+
+    # Each rows of the array `dxy` now contains a lattice vector (direction).
+    # By transposing the array, these lattice vectors are the columns of the
+    # new matrix. This allows to directly use them as a transformation matrix.
+    # For example: let `x₁` and `x₂` be the two 2-by-1 lattice vectors, then
+    # `(x₁, x₂) * (n, m)ᵀ = n * x₁ + m * x₂`.
+    matrix = _canonical_matrix_form(numpy.transpose(dxy))
+
+    # The estimated translated is the centroid of the input coordinates.
+    translation = numpy.mean(xy, axis=0)
+
+    return AffineTransform(matrix, translation)
+
+
+def estimate_mpp_orientation(
+    xy: numpy.ndarray, shape: Tuple[int, int], transform_type: Type[T]
+) -> T:
+    """
+    Estimate the orientation of a square grid of points.
+
+    Parameters
+    ----------
+    xy : ndarray of shape (n, 2)
+        Array with the determined coordinates of the grid points.
+    shape : tuple of two ints
+        The shape of the grid given as a tuple `(height, width)`.
+    transform_type : GeometricTransform
+        The transform class to use for estimating the orientation.
+
+    Returns
+    -------
+    tform : GeometricTransform
+        The orientation of the pattern.
+
+    """
+    tform = _initial_estimate_mpp_orientation(xy)
+    grid = unit_gridpoints(shape, mode="xy")
+    correspondences = bijective_matching(tform.apply(grid), xy)
+    a, b = zip(*correspondences)
+    return transform_type.from_pointset(grid[a, ...], xy[b, ...])
+
+
+def estimate_mpp_orientation_from_img(
+    image: numpy.ndarray,
+    shape: Tuple[int, int],
+    transform_type: Type[T],
+    sigma: float,
+    threshold_abs: Optional[float] = None,
+    threshold_rel: Optional[float] = None,
+    num_spots: Optional[int] = None,
+) -> T:
+    """
+    Image based estimation of the orientation of a square grid of points.
+
+    Parameters
+    ----------
+    image : ndarray
+        The input image.
+    shape : tuple of two ints
+        The shape of the grid given as a tuple `(height, width)`.
+    transform_type : GeometricTransform
+        The transform class to use for estimating the orientation.
+    sigma : float
+        Expected size of the spots. Assuming the spots are Gaussian shaped,
+        this is the standard deviation.
+    threshold_abs : float, optional
+        Minimum intensity of peaks. By default, the absolute threshold is
+        the minimum intensity of the image.
+    threshold_rel : float, optional
+        If provided, apply a threshold on the minimum intensity of peaks,
+        calculated as `max(image) * threshold_rel`.
+    num_spots : int, optional
+        Maximum number of spots. When the number of spots exceeds `num_spots`,
+        return `num_spots` peaks based on highest spot intensity. Will use
+        `num_spots = shape[0] * shape[1]` as default when set to `None`. Set
+        `num_spots = 0` to not impose a maximum. Note that this behavior is
+        different from odemis.util.spot.find_spot_position().
+
+    """
+    if num_spots is None:
+        num_spots = shape[0] * shape[1]
+    elif num_spots == 0:
+        num_spots = None
+    ji = find_spot_positions(image, sigma, threshold_abs, threshold_rel, num_spots)
+    xy = to_physical_space(ji, image.shape)
+    return estimate_mpp_orientation(xy, shape, transform_type)

--- a/src/odemis/util/test/graph_test.py
+++ b/src/odemis/util/test/graph_test.py
@@ -1,0 +1,197 @@
+# -*- encoding: utf-8 -*-
+"""
+graph_test.py : unit tests for odemis.util.graph
+
+@author: Andries Effting
+
+Copyright (C) 2021  Andries Effting, Delmic
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+"""
+import itertools
+import unittest
+
+from odemis.util import pairwise
+from odemis.util.graph import GraphBase
+
+
+def complete_graph(n, graph_type):
+    """
+    A complete graph is a simple undirected graph in which every pair of
+    distinct vertices is connected by a unique edge.
+
+    Parameters
+    ----------
+    n : int
+        Order of the graph (number of vertices).
+    graph_type : GraphBase
+        Graph type.
+
+    """
+    graph = graph_type(n, directed=False)
+    for j in range(n):
+        for i in range(j + 1, n):
+            graph.add_edge((j, i))
+    return graph
+
+
+def wheel_graph(n, graph_type):
+    """
+    A wheel graph consists of a single universal vertex connected to all
+    vertices of a cycle of `(n - 1)` vertices.
+
+    Parameters
+    ----------
+    n : int
+        Order of the graph (number of vertices).
+    graph_type : GraphBase
+        Graph type.
+
+    """
+    if n < 3:
+        raise ValueError("")
+    graph = graph_type(n, directed=False)
+    for i in range(1, n):
+        graph.add_edge((0, i))
+    for j, i in pairwise(range(1, n)):
+        graph.add_edge((j, i))
+    graph.add_edge((1, n - 1))
+    return graph
+
+
+class IterEdgesTest(unittest.TestCase):
+    """Unit tests for `GraphBase.iter_edges()`."""
+
+    def test_complete_graph_undirected(self):
+        """
+        `iter_edges()` should return all edges in an undirected complete graph.
+        The edges `(j, i)` and `(i, j)` should be treated identical and only
+        reported once as `(j, i)` with `j < i` when `directed=False`.
+
+        """
+        for graph_type in GraphBase.__subclasses__():
+            with self.subTest(graph_type=graph_type.__name__):
+                for n in range(3, 10):
+                    graph = complete_graph(n, graph_type)
+                    edges = itertools.combinations(range(n), 2)
+                    out = list(graph.iter_edges(directed=False))
+                    self.assertCountEqual(edges, out)
+                    for vertex, neighbor in out:
+                        self.assertLess(vertex, neighbor)
+
+    def test_complete_graph_directed(self):
+        """
+        `iter_edges()` should return all edges in a directed complete graph.
+        The edges `(j, i)` and `(i, j)` should be treated as two distinct edges
+        when `directed=True`.
+
+        """
+        for graph_type in GraphBase.__subclasses__():
+            with self.subTest(graph_type=graph_type.__name__):
+                for n in range(3, 10):
+                    graph = complete_graph(n, graph_type)
+                    edges = itertools.permutations(range(n), 2)
+                    out = graph.iter_edges(directed=True)
+                    self.assertCountEqual(edges, out)
+
+
+class IterTrianglesTest(unittest.TestCase):
+    """Unit tests for `GraphBase.iter_triangles()`."""
+
+    _known_data = [
+        (
+            [
+                {1: 1, 2: 1, 3: 1, 4: 1},
+                {0: 1, 2: 1, 3: 1},
+                {0: 1, 1: 1},
+                {0: 1, 1: 1, 4: 1},
+                {0: 1, 3: 1},
+            ],
+            [(0, 1, 2), (0, 1, 3), (0, 3, 4)],
+        ),
+        (
+            [{1: 1, 2: 1}, {0: 1, 2: 1, 3: 1}, {0: 1, 1: 1, 3: 1}, {1: 1, 2: 1}],
+            [(0, 1, 2), (1, 2, 3)],
+        ),
+    ]
+
+    def test_known_data(self):
+        """
+        `iter_triangles()` should return known good results for known input.
+
+        """
+        for graph_type in GraphBase.__subclasses__():
+            with self.subTest(graph_type=graph_type.__name__):
+                for initlist, triangles in self._known_data:
+                    graph = graph_type(initlist)
+                    out = graph.iter_triangles()
+                    self.assertCountEqual(triangles, out)
+
+    def test_complete_graph(self):
+        """
+        `iter_triangles()` should return all triangles in a complete graph.
+
+        """
+        for graph_type in GraphBase.__subclasses__():
+            with self.subTest(graph_type=graph_type.__name__):
+                for n in range(3, 10):
+                    graph = complete_graph(n, graph_type)
+                    triangles = list(itertools.combinations(range(n), 3))
+                    out = graph.iter_triangles()
+                    self.assertCountEqual(triangles, out)
+
+    def test_wheel_graph(self):
+        """`iter_triangles()` should return all triangles in a wheel graph."""
+        for graph_type in GraphBase.__subclasses__():
+            with self.subTest(graph_type=graph_type.__name__):
+                for n in range(3, 10):
+                    graph = wheel_graph(n, graph_type)
+                    triangles = [(0, u, v) for u, v in pairwise(range(1, n))]
+                    if n > 3:
+                        triangles.append((0, 1, n - 1))
+                    if n == 4:
+                        triangles.append((1, 2, 3))
+                    out = graph.iter_triangles()
+                    self.assertCountEqual(triangles, out)
+
+
+class RemoveTrianglesTest(unittest.TestCase):
+    """Unit tests for `GraphBase.remove_triangles()`."""
+
+    def test_complete_graph(self):
+        """`remove_triangles()` should remove all triangles in a complete graph."""
+        for graph_type in GraphBase.__subclasses__():
+            with self.subTest(graph_type=graph_type.__name__):
+                for n in range(3, 10):
+                    graph = complete_graph(n, graph_type)
+                    graph.remove_triangles()
+                    triangles = list(graph.iter_triangles())
+                    self.assertListEqual(triangles, [])
+
+    def test_wheel_graph(self):
+        """`remove_triangles()` should remove all triangles in a wheel graph."""
+        for graph_type in GraphBase.__subclasses__():
+            with self.subTest(graph_type=graph_type.__name__):
+                for n in range(3, 10):
+                    graph = wheel_graph(n, graph_type)
+                    graph.remove_triangles()
+                    triangles = list(graph.iter_triangles())
+                    self.assertListEqual(triangles, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/odemis/util/test/registration_test.py
+++ b/src/odemis/util/test/registration_test.py
@@ -34,7 +34,7 @@ from odemis.util.random import check_random_state
 from odemis.util.registration import (
     _canonical_matrix_form,
     bijective_matching,
-    estimate_mpp_orientation,
+    estimate_grid_orientation,
     nearest_neighbor_graph,
     unit_gridpoints,
 )
@@ -354,8 +354,8 @@ class CanonicalMatrixFormTest(unittest.TestCase):
                 self.assertAlmostEqual(delta - n * 0.5 * numpy.pi, 0)
 
 
-class EstimateMPPOrientationTest(unittest.TestCase):
-    """Unittest for `estimate_mpp_orientation()`."""
+class EstimateGridOrientationTest(unittest.TestCase):
+    """Unittest for `estimate_grid_orientation()`."""
 
     def setUp(self):
         """Ensure reproducible tests."""
@@ -363,18 +363,18 @@ class EstimateMPPOrientationTest(unittest.TestCase):
 
     def test_full_grid(self):
         """
-        `estimate_mpp_orientation()` should return the expected AffineTransform
-        for a full grid.
+        `estimate_grid_orientation()` should return the expected
+        AffineTransform for a full grid.
 
         """
-        for shape in itertools.product((5, 8), repeat=2):
+        for shape in [(5, 5), (8, 8)]:
             for i in range(50):
                 with self.subTest(shape=shape, i=i):
                     n, m = shape
                     shuffle = self._rng.permutation(n * m)
                     tform = random_affine_transform(self._rng)
                     xy = tform.apply(unit_gridpoints(shape, mode="xy")[shuffle])
-                    out = estimate_mpp_orientation(xy, shape, AffineTransform)
+                    out = estimate_grid_orientation(xy, shape, AffineTransform)
                     for name in ("matrix", "translation"):
                         numpy.testing.assert_array_almost_equal(
                             getattr(tform, name), getattr(out, name)
@@ -382,18 +382,18 @@ class EstimateMPPOrientationTest(unittest.TestCase):
 
     def test_incomplete_grid(self):
         """
-        `estimate_mpp_orientation()` should return the expected AffineTransform
-        for a grid with one point missing.
+        `estimate_grid_orientation()` should return the expected
+        AffineTransform for a grid with one point missing.
 
         """
-        for shape in itertools.product((5, 8), repeat=2):
+        for shape in [(5, 5), (8, 8)]:
             for i in range(50):
                 with self.subTest(shape=shape, i=i):
                     n, m = shape
                     shuffle = self._rng.permutation(n * m)
                     tform = random_affine_transform(self._rng)
                     xy = tform.apply(unit_gridpoints(shape, mode="xy")[shuffle])[:-1]
-                    out = estimate_mpp_orientation(xy, shape, AffineTransform)
+                    out = estimate_grid_orientation(xy, shape, AffineTransform)
                     for name in ("matrix", "translation"):
                         numpy.testing.assert_array_almost_equal(
                             getattr(tform, name), getattr(out, name)

--- a/src/odemis/util/test/registration_test.py
+++ b/src/odemis/util/test/registration_test.py
@@ -375,10 +375,10 @@ class EstimateGridOrientationTest(unittest.TestCase):
                     tform = random_affine_transform(self._rng)
                     xy = tform.apply(unit_gridpoints(shape, mode="xy")[shuffle])
                     out = estimate_grid_orientation(xy, shape, AffineTransform)
-                    for name in ("matrix", "translation"):
-                        numpy.testing.assert_array_almost_equal(
-                            getattr(tform, name), getattr(out, name)
-                        )
+                    numpy.testing.assert_array_almost_equal(tform.matrix, out.matrix)
+                    numpy.testing.assert_array_almost_equal(
+                        tform.translation, out.translation
+                    )
 
     def test_incomplete_grid(self):
         """
@@ -394,10 +394,10 @@ class EstimateGridOrientationTest(unittest.TestCase):
                     tform = random_affine_transform(self._rng)
                     xy = tform.apply(unit_gridpoints(shape, mode="xy")[shuffle])[:-1]
                     out = estimate_grid_orientation(xy, shape, AffineTransform)
-                    for name in ("matrix", "translation"):
-                        numpy.testing.assert_array_almost_equal(
-                            getattr(tform, name), getattr(out, name)
-                        )
+                    numpy.testing.assert_array_almost_equal(tform.matrix, out.matrix)
+                    numpy.testing.assert_array_almost_equal(
+                        tform.translation, out.translation
+                    )
 
 
 if __name__ == "__main__":

--- a/src/odemis/util/test/registration_test.py
+++ b/src/odemis/util/test/registration_test.py
@@ -1,0 +1,403 @@
+# -*- encoding: utf-8 -*-
+"""
+registration_test.py : unit tests for odemis.util.registration.
+
+@author: Andries Effting
+
+Copyright (C) 2021  Andries Effting, Delmic
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+"""
+import itertools
+import operator
+import unittest
+
+import numpy
+import scipy
+from odemis.util import pairwise
+from odemis.util.graph import WeightedGraph
+from odemis.util.registration import (
+    _canonical_matrix_form,
+    bijective_matching,
+    estimate_mpp_orientation,
+    nearest_neighbor_graph,
+    unit_gridpoints,
+)
+from odemis.util.transform import AffineTransform
+
+
+class BijectiveMatchingTest(unittest.TestCase):
+    """Unit tests for `bijective_matching()`."""
+
+    def setUp(self):
+        """Ensure reproducible tests."""
+        self._rng = numpy.random.default_rng(12345)
+
+    def test_trivial(self):
+        """Check the trivial case of matching a point set with itself."""
+        n = 100
+        src = self._rng.random((n, 2))
+        correspondences = [(j,) * 2 for j in range(n)]
+        out = bijective_matching(src, src)
+        self.assertCountEqual(correspondences, out)
+
+    def test_permutation(self):
+        """Check that a random permutation of a point set can be recovered."""
+        for n, m in itertools.product((100, 105), repeat=2):
+            with self.subTest(n=n, m=m):
+                k = max(n, m)
+                idx = self._rng.permutation(k)
+                correspondences = [(j, i) for j, i in zip(idx, range(m)) if j < n]
+                points = self._rng.random((k, 2))
+                src = points[:n]
+                dst = points[idx[:m]]
+                out = bijective_matching(src, dst)
+                self.assertCountEqual(correspondences, out)
+
+    def test_maximum_size(self):
+        """Check that the matching has maximum size."""
+        for n, m in itertools.product((100, 105), repeat=2):
+            with self.subTest(n=n, m=m):
+                src = self._rng.random((n, 2))
+                dst = self._rng.random((m, 2))
+                correspondences = bijective_matching(src, dst)
+                self.assertEqual(min(n, m), len(list(correspondences)))
+
+    def test_uniqueness(self):
+        """
+        Check that each `src` or `dst` vertex of the matching is part of
+        exactly one matching edge.
+
+        """
+        for n, m in itertools.product((100, 105), repeat=2):
+            with self.subTest(n=n, m=m):
+                src = self._rng.random((n, 2))
+                dst = self._rng.random((m, 2))
+                correspondences = bijective_matching(src, dst)
+                for i in (0, 1):
+                    vertices = list(map(operator.itemgetter(i), correspondences))
+                    self.assertEqual(len(vertices), len(set(vertices)))
+
+    def test_sorted(self):
+        """
+        The returned list of correspondences should be sorted by distance in
+        ascending order.
+
+        """
+        for n, m in itertools.product((100, 105), repeat=2):
+            with self.subTest(n=n, m=m):
+                src = self._rng.random((n, 2))
+                dst = self._rng.random((m, 2))
+                correspondences = bijective_matching(src, dst)
+                distance = [
+                    scipy.spatial.distance.euclidean(src[j], dst[i])
+                    for j, i in correspondences
+                ]
+                self.assertTrue(all(itertools.starmap(operator.le, pairwise(distance))))
+
+
+class UnitGridPointsTest(unittest.TestCase):
+    """Unit tests for `unit_gridpoints()`."""
+
+    def test_shape(self):
+        """
+        The array returned by `unit_gridpoints()` should have the correct shape.
+
+        """
+        for shape in itertools.product((3, 5, 8), repeat=2):
+            for mode in ("ji", "xy"):
+                with self.subTest(shape=shape, mode=mode):
+                    n, m = shape
+                    pts = unit_gridpoints(shape, mode=mode)
+                    self.assertEqual(pts.ndim, 2)
+                    self.assertEqual(pts.shape[0], n * m)
+                    self.assertEqual(pts.shape[1], 2)
+
+    def test_zero_mean(self):
+        """The array returned by `unit_gridpoints()` should have zero mean."""
+        for shape in itertools.product((3, 5, 8), repeat=2):
+            for mode in ("ji", "xy"):
+                with self.subTest(shape=shape, mode=mode):
+                    pts = unit_gridpoints(shape, mode=mode)
+                    numpy.testing.assert_array_almost_equal(numpy.mean(pts, axis=0), 0)
+
+    def test_orientation(self):
+        """
+        The array returned by `unit_gridpoints()` should have the correct
+        ordering.
+
+        """
+        for shape in itertools.product((3, 5, 8), repeat=2):
+            with self.subTest(shape=shape):
+                n, m = shape
+                a = 0.5 * float(n - 1)
+                b = 0.5 * float(m - 1)
+
+                ji = unit_gridpoints(shape, mode="ji")
+                xy = unit_gridpoints(shape, mode="xy")
+                # `out[0]` is the top-left corner
+                numpy.testing.assert_array_almost_equal(ji[0], (-a, -b))
+                numpy.testing.assert_array_almost_equal(xy[0], (-b, a))
+                # `out[m - 1]` is the top-right corner
+                numpy.testing.assert_array_almost_equal(ji[m - 1], (-a, b))
+                numpy.testing.assert_array_almost_equal(xy[m - 1], (b, a))
+                # `out[(n - 1) * m]` is the bottom-left corner
+                numpy.testing.assert_array_almost_equal(ji[(n - 1) * m], (a, -b))
+                numpy.testing.assert_array_almost_equal(xy[(n - 1) * m], (-b, -a))
+                # `out[-1]` is the bottom right corner
+                numpy.testing.assert_array_almost_equal(ji[-1], (a, b))
+                numpy.testing.assert_array_almost_equal(xy[-1], (b, -a))
+
+    def test_known_values(self):
+        """`unit_gridpoints()` should return known result with known input."""
+        shape = (3, 5)
+        ji = unit_gridpoints(shape, mode="ji")
+        xy = unit_gridpoints(shape, mode="xy")
+        _ji = numpy.column_stack(
+            (
+                [-1, -1, -1, -1, -1, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1],
+                [-2, -1, 0, 1, 2, -2, -1, 0, 1, 2, -2, -1, 0, 1, 2],
+            )
+        )
+        _xy = numpy.column_stack(
+            (
+                [-2, -1, 0, 1, 2, -2, -1, 0, 1, 2, -2, -1, 0, 1, 2],
+                [1, 1, 1, 1, 1, 0, 0, 0, 0, 0, -1, -1, -1, -1, -1],
+            )
+        )
+        numpy.testing.assert_array_almost_equal(xy, _xy)
+        numpy.testing.assert_array_almost_equal(ji, _ji)
+
+
+def random_affine_transform(rng=None):
+    """
+    Return a randomized affine transform.
+
+    Parameters
+    ----------
+    rng : numpy.random.Generator, optional
+        Random number generator
+
+    Returns
+    -------
+    tform : AffineTransform
+        Randomized affine transform.
+
+    """
+    rng = numpy.random.default_rng() if rng is None else rng
+    params = {
+        "scale": 1 + 0.5 * (2 * rng.random() - 1),
+        "rotation": 0.25 * numpy.pi * (2 * rng.random() - 1),
+        "squeeze": 1 + 0.1 * (2 * rng.random() - 1),
+        "shear": 0.1 * (2 * rng.random() - 1),
+        "translation": (2 * rng.random((2,)) - 1),
+    }
+    return AffineTransform(**params)
+
+
+def unit_gridpoints_graph(shape, tform, index):
+    """
+    Return the known good graph of the unit grid.
+
+    Parameters
+    ----------
+    shape : tuple of two ints
+        The shape of the grid given as a tuple `(height, width)`.
+    tform : GeometricTransform
+        The geometric transform to apply to the unit grid.
+    index : ndarray
+        Indices to order the vertices.
+
+    """
+    n, m = shape
+    graph = WeightedGraph(n * m, directed=False)
+    distances = numpy.hypot(*tform.matrix)
+    for j in range(n):
+        for i in range(m - 1):
+            vertex = index[j * m + i]
+            neighbor = index[j * m + i + 1]
+            graph.add_edge((vertex, neighbor), distances[0])
+    for j in range(n - 1):
+        for i in range(m):
+            vertex = index[j * m + i]
+            neighbor = index[(j + 1) * m + i]
+            graph.add_edge((vertex, neighbor), distances[1])
+    return graph
+
+
+class NearestNeighborGraphTest(unittest.TestCase):
+    """Unittest for `nearest_neighbor_graph()`."""
+
+    def setUp(self):
+        """Ensure reproducible tests."""
+        self._rng = numpy.random.default_rng(12345)
+
+    def test_full_grid(self):
+        """
+        `nearest_neighbor_graph()` should return the expected graph for a full
+        grid.
+
+        """
+        for shape in itertools.product((5, 8), repeat=2):
+            for i in range(50):
+                with self.subTest(shape=shape, i=i):
+                    n, m = shape
+                    shuffle = self._rng.permutation(n * m)
+                    index = numpy.argsort(shuffle)
+                    tform = random_affine_transform(self._rng)
+                    xy = tform.apply(unit_gridpoints(shape, mode="xy")[shuffle])
+                    graph = unit_gridpoints_graph(shape, tform, index)
+                    out = nearest_neighbor_graph(xy)
+                    numpy.testing.assert_array_almost_equal(
+                        graph.adjacency_matrix(), out.adjacency_matrix()
+                    )
+
+    def test_incomplete_grid(self):
+        """
+        `nearest_neighbor_graph()` should return the expected graph for a grid
+        with one point missing.
+
+        """
+        for shape in itertools.product((5, 8), repeat=2):
+            for i in range(50):
+                with self.subTest(shape=shape, i=i):
+                    n, m = shape
+                    shuffle = self._rng.permutation(n * m)
+                    index = numpy.argsort(shuffle)
+                    tform = random_affine_transform(self._rng)
+                    xy = tform.apply(unit_gridpoints(shape, mode="xy")[shuffle])[:-1]
+                    _graph = unit_gridpoints_graph(shape, tform, index)
+                    vertex = n * m - 1
+                    # To prevent a RuntimeError loop over a copy
+                    for neighbor in _graph[vertex].copy():
+                        _graph.remove_edge((vertex, neighbor))
+                    graph = _graph[:-1]
+                    out = nearest_neighbor_graph(xy)
+                    numpy.testing.assert_array_almost_equal(
+                        graph.adjacency_matrix(), out.adjacency_matrix()
+                    )
+
+
+class CanonicalMatrixFormTest(unittest.TestCase):
+    """Unittest for `_canonical_matrix_form()`."""
+
+    def setUp(self):
+        """Ensure reproducible tests."""
+        self._rng = numpy.random.default_rng(12345)
+
+    def test_identity(self):
+        """
+        Given one of the symmetrical versions of the canonical grid
+        `_canonical_matrix_form()` should return the identity matrix.
+
+        """
+        for matrix in [
+            [(1, 0), (0, 1)],
+            [(0, 1), (-1, 0)],
+            [(-1, 0), (0, -1)],
+            [(0, -1), (1, 0)],
+            [(0, 1), (1, 0)],
+            [(-1, 0), (0, 1)],
+            [(0, -1), (-1, 0)],
+            [(1, 0), (0, -1)],
+        ]:
+            out = _canonical_matrix_form(matrix)
+            numpy.testing.assert_array_almost_equal(out, numpy.eye(2))
+
+    def test_random_input(self):
+        """
+        `_canonical_matrix_form()` should accept any 2x2 transformation matrix.
+        The resulting matrix should not contain a reflection (have a positive
+        determinant) and have a rotation between ±45°.
+
+        """
+        for i in range(50):
+            matrix = self._rng.standard_normal((2, 2))
+            with self.subTest(matrix=matrix, i=i):
+                matrix = _canonical_matrix_form(matrix)
+                tform = AffineTransform(matrix)
+                self.assertGreater(numpy.linalg.det(matrix), 0)
+                self.assertGreater(tform.rotation, -0.25 * numpy.pi)
+                self.assertLess(tform.rotation, 0.25 * numpy.pi)
+
+    def test_angle_difference(self):
+        """
+        When provided with an input transformation with positive determinant
+        (i.e. no reflection), the resulting change in rotation should be a
+        multiple of 90°.
+
+        """
+        for i in range(50):
+            matrix = self._rng.standard_normal((2, 2))
+            if numpy.linalg.det(matrix) < 0:
+                matrix = numpy.fliplr(matrix)
+            with self.subTest(matrix=matrix, i=i):
+                tform1 = AffineTransform(matrix)
+                tform2 = AffineTransform(_canonical_matrix_form(matrix))
+                delta = tform2.rotation - tform1.rotation
+                n = int(round(delta / (0.5 * numpy.pi)))
+                self.assertAlmostEqual(delta - n * 0.5 * numpy.pi, 0)
+
+
+class EstimateMPPOrientationTest(unittest.TestCase):
+    """Unittest for `estimate_mpp_orientation()`."""
+
+    def setUp(self):
+        """Ensure reproducible tests."""
+        self._rng = numpy.random.default_rng(12345)
+
+    def test_full_grid(self):
+        """
+        `estimate_mpp_orientation()` should return the expected AffineTransform
+        for a full grid.
+
+        """
+        for shape in itertools.product((5, 8), repeat=2):
+            for i in range(50):
+                with self.subTest(shape=shape, i=i):
+                    n, m = shape
+                    shuffle = self._rng.permutation(n * m)
+                    tform = random_affine_transform(self._rng)
+                    xy = tform.apply(unit_gridpoints(shape, mode="xy")[shuffle])
+                    out = estimate_mpp_orientation(xy, shape, AffineTransform)
+                    for name in ("matrix", "translation"):
+                        numpy.testing.assert_array_almost_equal(
+                            getattr(tform, name), getattr(out, name)
+                        )
+
+    def test_incomplete_grid(self):
+        """
+        `estimate_mpp_orientation()` should return the expected AffineTransform
+        for a grid with one point missing.
+
+        """
+        for shape in itertools.product((5, 8), repeat=2):
+            for i in range(50):
+                with self.subTest(shape=shape, i=i):
+                    n, m = shape
+                    shuffle = self._rng.permutation(n * m)
+                    tform = random_affine_transform(self._rng)
+                    xy = tform.apply(unit_gridpoints(shape, mode="xy")[shuffle])[:-1]
+                    out = estimate_mpp_orientation(xy, shape, AffineTransform)
+                    for name in ("matrix", "translation"):
+                        numpy.testing.assert_array_almost_equal(
+                            getattr(tform, name), getattr(out, name)
+                        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/odemis/util/test/registration_test.py
+++ b/src/odemis/util/test/registration_test.py
@@ -28,7 +28,7 @@ import unittest
 
 import numpy
 import scipy
-from odemis.util import pairwise
+from odemis.util import check_random_state, pairwise
 from odemis.util.graph import WeightedGraph
 from odemis.util.registration import (
     _canonical_matrix_form,
@@ -45,12 +45,12 @@ class BijectiveMatchingTest(unittest.TestCase):
 
     def setUp(self):
         """Ensure reproducible tests."""
-        self._rng = numpy.random.default_rng(12345)
+        self._rng = check_random_state(12345)
 
     def test_trivial(self):
         """Check the trivial case of matching a point set with itself."""
         n = 100
-        src = self._rng.random((n, 2))
+        src = self._rng.random_sample((n, 2))
         correspondences = [(j,) * 2 for j in range(n)]
         out = bijective_matching(src, src)
         self.assertCountEqual(correspondences, out)
@@ -62,7 +62,7 @@ class BijectiveMatchingTest(unittest.TestCase):
                 k = max(n, m)
                 idx = self._rng.permutation(k)
                 correspondences = [(j, i) for j, i in zip(idx, range(m)) if j < n]
-                points = self._rng.random((k, 2))
+                points = self._rng.random_sample((k, 2))
                 src = points[:n]
                 dst = points[idx[:m]]
                 out = bijective_matching(src, dst)
@@ -72,8 +72,8 @@ class BijectiveMatchingTest(unittest.TestCase):
         """Check that the matching has maximum size."""
         for n, m in itertools.product((100, 105), repeat=2):
             with self.subTest(n=n, m=m):
-                src = self._rng.random((n, 2))
-                dst = self._rng.random((m, 2))
+                src = self._rng.random_sample((n, 2))
+                dst = self._rng.random_sample((m, 2))
                 correspondences = bijective_matching(src, dst)
                 self.assertEqual(min(n, m), len(list(correspondences)))
 
@@ -85,8 +85,8 @@ class BijectiveMatchingTest(unittest.TestCase):
         """
         for n, m in itertools.product((100, 105), repeat=2):
             with self.subTest(n=n, m=m):
-                src = self._rng.random((n, 2))
-                dst = self._rng.random((m, 2))
+                src = self._rng.random_sample((n, 2))
+                dst = self._rng.random_sample((m, 2))
                 correspondences = bijective_matching(src, dst)
                 for i in (0, 1):
                     vertices = list(map(operator.itemgetter(i), correspondences))
@@ -100,8 +100,8 @@ class BijectiveMatchingTest(unittest.TestCase):
         """
         for n, m in itertools.product((100, 105), repeat=2):
             with self.subTest(n=n, m=m):
-                src = self._rng.random((n, 2))
-                dst = self._rng.random((m, 2))
+                src = self._rng.random_sample((n, 2))
+                dst = self._rng.random_sample((m, 2))
                 correspondences = bijective_matching(src, dst)
                 distance = [
                     scipy.spatial.distance.euclidean(src[j], dst[i])
@@ -183,7 +183,7 @@ class UnitGridPointsTest(unittest.TestCase):
         numpy.testing.assert_array_almost_equal(ji, _ji)
 
 
-def random_affine_transform(rng=None):
+def random_affine_transform(seed=None):
     """
     Return a randomized affine transform.
 
@@ -198,13 +198,13 @@ def random_affine_transform(rng=None):
         Randomized affine transform.
 
     """
-    rng = numpy.random.default_rng() if rng is None else rng
+    rng = check_random_state(seed)
     params = {
-        "scale": 1 + 0.5 * (2 * rng.random() - 1),
-        "rotation": 0.25 * numpy.pi * (2 * rng.random() - 1),
-        "squeeze": 1 + 0.1 * (2 * rng.random() - 1),
-        "shear": 0.1 * (2 * rng.random() - 1),
-        "translation": (2 * rng.random((2,)) - 1),
+        "scale": 1 + 0.5 * rng.uniform(-1, 1),
+        "rotation": 0.25 * numpy.pi * rng.uniform(-1, 1),
+        "squeeze": 1 + 0.1 * rng.uniform(-1, 1),
+        "shear": 0.1 * rng.uniform(-1, 1),
+        "translation": rng.uniform(-1, 1, (2,)),
     }
     return AffineTransform(**params)
 
@@ -244,7 +244,7 @@ class NearestNeighborGraphTest(unittest.TestCase):
 
     def setUp(self):
         """Ensure reproducible tests."""
-        self._rng = numpy.random.default_rng(12345)
+        self._rng = check_random_state(12345)
 
     def test_full_grid(self):
         """
@@ -297,7 +297,7 @@ class CanonicalMatrixFormTest(unittest.TestCase):
 
     def setUp(self):
         """Ensure reproducible tests."""
-        self._rng = numpy.random.default_rng(12345)
+        self._rng = check_random_state(12345)
 
     def test_identity(self):
         """
@@ -358,7 +358,7 @@ class EstimateMPPOrientationTest(unittest.TestCase):
 
     def setUp(self):
         """Ensure reproducible tests."""
-        self._rng = numpy.random.default_rng(12345)
+        self._rng = check_random_state(12345)
 
     def test_full_grid(self):
         """

--- a/src/odemis/util/test/registration_test.py
+++ b/src/odemis/util/test/registration_test.py
@@ -28,8 +28,9 @@ import unittest
 
 import numpy
 import scipy
-from odemis.util import check_random_state, pairwise
+from odemis.util import pairwise
 from odemis.util.graph import WeightedGraph
+from odemis.util.random import check_random_state
 from odemis.util.registration import (
     _canonical_matrix_form,
     bijective_matching,

--- a/src/odemis/util/test/transform_test.py
+++ b/src/odemis/util/test/transform_test.py
@@ -28,7 +28,7 @@ import unittest
 
 import numpy
 from numpy.linalg import LinAlgError
-from odemis.util import check_random_state
+from odemis.util.random import check_random_state
 from odemis.util.spot import GridPoints
 from odemis.util.transform import (
     AffineTransform,

--- a/src/odemis/util/test/transform_test.py
+++ b/src/odemis/util/test/transform_test.py
@@ -28,6 +28,7 @@ import unittest
 
 import numpy
 from numpy.linalg import LinAlgError
+from odemis.util import check_random_state
 from odemis.util.spot import GridPoints
 from odemis.util.transform import (
     AffineTransform,
@@ -57,7 +58,7 @@ class PolarCoordinateTransformationTest(unittest.TestCase):
 
     def setUp(self):
         """Ensure reproducible tests."""
-        self._rng = numpy.random.default_rng(12345)
+        self._rng = check_random_state(12345)
 
     def test_cartesian_to_polar_known_values(self):
         """

--- a/src/odemis/util/test/transform_test.py
+++ b/src/odemis/util/test/transform_test.py
@@ -23,24 +23,24 @@ from __future__ import division
 
 import copy
 import inspect
+import numpy
+from numpy.linalg import LinAlgError
 import operator
 import unittest
 
-import numpy
-from numpy.linalg import LinAlgError
 from odemis.util.random import check_random_state
 from odemis.util.spot import GridPoints
 from odemis.util.transform import (
-    AffineTransform,
-    RigidTransform,
-    ScalingTransform,
-    SimilarityTransform,
     _rotation_matrix_from_angle,
     _rotation_matrix_to_angle,
     cartesian_to_polar,
     polar_to_cartesian,
     to_physical_space,
     to_pixel_index,
+    AffineTransform,
+    ScalingTransform,
+    SimilarityTransform,
+    RigidTransform,
 )
 from transform_known_values import transform_known_values
 

--- a/src/odemis/util/transform.py
+++ b/src/odemis/util/transform.py
@@ -64,6 +64,8 @@ from odemis.util.linalg import qlp, qrp
 T = TypeVar("T", bound="GeometricTransform")
 
 __all__ = [
+    "cartesian_to_polar",
+    "polar_to_cartesian",
     "to_physical_space",
     "to_pixel_index",
     "AffineTransform",
@@ -71,6 +73,51 @@ __all__ = [
     "SimilarityTransform",
     "RigidTransform",
 ]
+
+
+def cartesian_to_polar(xy: numpy.ndarray) -> Tuple[numpy.ndarray, numpy.ndarray]:
+    """
+    Transform Cartesian coordinates to polar coordinates.
+
+    Parameters
+    ----------
+    xy : ndarray
+        Cartesian coordinates.
+
+    Returns
+    -------
+    rho : ndarray
+        Radial coordinates.
+    theta : ndarray
+        Angular coordinates.
+
+    """
+    xy = numpy.asarray(xy)
+    rho = numpy.hypot(xy[..., 0], xy[..., 1])
+    theta = numpy.arctan2(xy[..., 1], xy[..., 0])
+    return rho, theta
+
+
+def polar_to_cartesian(rho: numpy.ndarray, theta: numpy.ndarray) -> numpy.ndarray:
+    """
+    Transform polar coordinates to Cartesian coordinates.
+
+    Parameters
+    ----------
+    rho : ndarray
+        Radial coordinates.
+    theta : ndarray
+        Angular coordinates.
+
+    Returns
+    -------
+    xy : ndarray
+        Cartesian coordinates.
+
+    """
+    x = rho * numpy.cos(theta)
+    y = rho * numpy.sin(theta)
+    return numpy.stack((x, y), axis=-1)
 
 
 def to_physical_space(


### PR DESCRIPTION
Goals:
- improving readability
- improving robustness
- improving test coverage
- bug-fix in handedness

Includes a module to work with graphs (structures made of vertices and edges).

This PR does not deprecate `FindGridSpots` as it is still in use by `/scripts/spot-grid.py` as well as multiple calibrations in `fastem-calibrations`