### PR TITLE
fastem: Unblank beam before live view and overview image acquisition

### DIFF
--- a/src/odemis/acq/fastem_conf.py
+++ b/src/odemis/acq/fastem_conf.py
@@ -40,7 +40,10 @@ SCANNER_CONFIG = {
     OVERVIEW_MODE: {
         "multiBeamMode": False,
         "external": False,  # fullframe mode; controlled by SEM itself
-        "blanker": None,  # automatic: unblanked when acquiring; blanked when not acquiring
+        # manual: unblank when acquiring and the beam is blanked after the acquisition. Note that autoblanking does not
+        # work reliably for the XTTKDetector, therefore (contrary to Odemis convention) we need to unblank
+        # the beam here.
+        "blanker": False,
         "immersion": False,  # disable to get a larger field of view
         "horizontalFoV": 1.5e-3,
         "resolution": (1024, 884),  # px
@@ -48,7 +51,10 @@ SCANNER_CONFIG = {
     LIVESTREAM_MODE: {
         "multiBeamMode": False,
         "external": False,  # fullframe mode; controlled by SEM itself
-        "blanker": None,  # automatic: unblanked when acquiring; blanked when not acquiring
+        # manual: unblank when acquiring and the beam is blanked after the acquisition. Note that autoblanking does not
+        # work reliably for the XTTKDetector, therefore (contrary to Odemis convention) we need to unblank
+        # the beam here.
+        "blanker": False,
         "immersion": True,
     },
     MEGAFIELD_MODE: {

--- a/src/odemis/acq/test/fastem_conf_test.py
+++ b/src/odemis/acq/test/fastem_conf_test.py
@@ -69,7 +69,7 @@ class TestFASTEMConfig(unittest.TestCase):
 
         self.assertFalse(self.scanner.multiBeamMode.value)
         self.assertFalse(self.scanner.external.value)
-        self.assertIsNone(self.scanner.blanker.value)
+        self.assertFalse(self.scanner.blanker.value)
         self.assertFalse(self.scanner.immersion.value)
         self.assertGreater(self.scanner.horizontalFoV.value, 1.e-3)  # should be big FoV for overview
         self.assertEqual(self.scanner.rotation.value, math.radians(5))
@@ -91,7 +91,7 @@ class TestFASTEMConfig(unittest.TestCase):
 
         self.assertFalse(self.scanner.multiBeamMode.value)
         self.assertFalse(self.scanner.external.value)
-        self.assertIsNone(self.scanner.blanker.value)
+        self.assertFalse(self.scanner.blanker.value)
         self.assertTrue(self.scanner.immersion.value)
         self.assertEqual(self.scanner.rotation.value, math.radians(5))
 


### PR DESCRIPTION
We pause the stream in between each acquired image, this already blanks the beam. Forcing blanking and subsequent unblanking of the beam caused it to blanked during acquisition sometimes.
In the fastem configuration set the blanking to False for live view and overview imaging, so it's unblanked during acquisition.