### PR TITLE
Fastem streams: make red the last color to be picked in the color order.

### DIFF
--- a/src/odemis/gui/cont/streams.py
+++ b/src/odemis/gui/cont/streams.py
@@ -3084,9 +3084,9 @@ class FastEMStreamsController(StreamBarController):
                 canvas.view.addStream(s)
 
 
-# Blue, red, green, cyan, yellow, purple, magenta
-FASTEM_PROJECT_COLOURS = ["#0000ff", "#ff0000", "#00ff00", "#00ffff", "#ffff00", "#ff00ff",
-                          "#ff00bf"]
+# Blue, green, cyan, yellow, purple, magenta, red
+FASTEM_PROJECT_COLOURS = ["#0000ff", "#00ff00", "#00ffff", "#ffff00", "#ff00ff",
+                          "#ff00bf", "#ff0000"]
 
 
 class FastEMProjectBarController(object):


### PR DESCRIPTION
It was confusing to the user that when they added a second ROA in a new project the rectangle was red all of a sudden. To them it indicated something had gone wrong.