### PR TITLE
Fastem acquisition manager: Fixed stage movement in ROA acquisition a…

### DIFF
--- a/src/odemis/acq/fastem.py
+++ b/src/odemis/acq/fastem.py
@@ -406,15 +406,15 @@ class AcquisitionTask(object):
         px_size = self._multibeam.pixelSize.value
         field_res = self._multibeam.resolution.value
 
-        # Get the coordinate of the top left of the ROA, this corresponds to the (xmin, ymax) coordinate in the
-        # role=stage coordinate system.
+        # Get the coordinate of the top left corner of the ROA, this corresponds to the (xmin, ymax) coordinate in the
+        # role='stage' coordinate system.
         xmin_roa, _, _, ymax_roa = self._roa.coordinates.value
 
         # The position of the stage when acquiring the top/left tile needs to be matching the center of that tile.
         # The stage coordinate system is pointing to the right in the x direction, and upwards in the y direction,
         # therefore add half a field in the x-direction and subtract half a field in the y-direction.
-        pos_first_tile = (xmin_roa + field_res[0]/2. * px_size[0],
-                          ymax_roa - field_res[1]/2. * px_size[1])
+        pos_first_tile = (xmin_roa + field_res[0]/2 * px_size[0],
+                          ymax_roa - field_res[1]/2 * px_size[1])
 
         rel_move_hor = self.field_idx[0] * px_size[0] * field_res[0]  # in meter
         rel_move_vert = self.field_idx[1] * px_size[1] * field_res[1]  # in meter

--- a/src/odemis/acq/test/fastem_test.py
+++ b/src/odemis/acq/test/fastem_test.py
@@ -29,6 +29,7 @@ import time
 import unittest
 from concurrent.futures._base import CancelledError
 from datetime import datetime
+from unittest.mock import Mock
 
 import numpy
 
@@ -433,6 +434,85 @@ class TestFastEMAcquisition(unittest.TestCase):
         self.start = start
         self.end = end
         self.updates += 1
+
+
+class TestFastEMAcquisitionTask(unittest.TestCase):
+    """Test methods of the fastem.AcquistionTask class."""
+
+    @classmethod
+    def setUpClass(cls):
+        if TEST_NOHW:
+            # If we are testing without hardware we just need a few attributes to be set correctly.
+            cls.scanner = None
+            cls.asm = None
+
+            # Use Mocks of the classes to be able to call the fake VAs as for instance mppc.dataContent.value
+            cls.mppc = Mock()
+            cls.mppc.dataContent.value = 'empty'
+
+            cls.multibeam = Mock()
+            cls.multibeam.pixelSize.value = (4.0e-9, 4.0e-9)
+            cls.multibeam.resolution.value = (800, 800)
+
+            cls.descanner = None
+            cls.stage = None
+            cls.ccd = None
+            cls.beamshift = None
+            cls.lens = None
+        else:
+            # get the hardware components from the simulators or hardware
+            cls.scanner = model.getComponent(role='e-beam')
+            cls.asm = model.getComponent(role="asm")
+            cls.mppc = model.getComponent(role="mppc")
+            cls.multibeam = model.getComponent(role="multibeam")
+            cls.descanner = model.getComponent(role="descanner")
+            cls.stage = model.getComponent(
+                role="stage")  # TODO replace with stage-scan when ROA conversion method available
+            cls.ccd = model.getComponent(role="diagnostic-ccd")
+            cls.beamshift = model.getComponent(role="ebeam-shift")
+            cls.lens = model.getComponent(role="lens")
+
+    def test_get_abs_stage_movement(self):
+        """Test the correct initial and final stage position is returned for ROAs of different field sizes."""
+        res_x, res_y = self.multibeam.resolution.value  # single field size
+        px_size_x, px_size_y = self.multibeam.pixelSize.value
+
+        # Loop over different x and y field sizes.
+        for x_fields, y_fields in zip((1, 2, 40, 34, 5), (1, 22, 43, 104, 25)):
+            # The coordinates of the ROA in meters.
+            xmin, ymin, xmax, ymax = (0, 0, res_x * px_size_x * x_fields, res_y * px_size_y * y_fields)
+            coordinates = (xmin, ymin, xmax, ymax)  # in m
+
+            # Create an ROC, because it is needed to initialize the ROA.
+            roc = fastem.FastEMROC("roc_name", coordinates=(0, 0, 1, 1))
+
+            # Create an ROA with the coordinates of the field.
+            roa_name = time.strftime("test_megafield_id-%Y-%m-%d-%H-%M-%S")
+            roa = fastem.FastEMROA(roa_name, coordinates, roc,
+                                   self.asm, self.multibeam, self.descanner,
+                                   self.mppc
+                                   )
+
+            task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner,
+                                          self.mppc, self.stage, self.ccd,
+                                          self.beamshift, self.lens,
+                                          roa, path=None, future=None)
+
+            # Verify the stage position of the first field is half a field to
+            # the bottom right of the top left of the ROA.
+            task.field_idx = (0, 0)  # (0, 0) is the index of the first field
+            expected_position = (xmin + res_x / 2 * px_size_x,
+                                 ymax - res_x / 2 * px_size_y)
+            actual_position = task.get_abs_stage_movement()
+            numpy.testing.assert_allclose(actual_position, expected_position)
+
+            # Verify the stage position of the last field is half a field to
+            # the top left of the bottom right of the ROA.
+            task.field_idx = (x_fields - 1, y_fields - 1)  # index of the last field
+            expected_position = (xmax - res_x / 2 * px_size_x,
+                                 ymin + res_x / 2 * px_size_y)
+            actual_position = task.get_abs_stage_movement()
+            numpy.testing.assert_allclose(actual_position, expected_position)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…nd added test cases to verify the stage position.

The position of the first tile was calculated incorrectly, and therefore the ROA was acquired in the wrong position.