### PR TITLE
FASTEM overview: update the estimated acquisition time when changing …

### DIFF
--- a/src/odemis/acq/fastem_conf.py
+++ b/src/odemis/acq/fastem_conf.py
@@ -3,9 +3,9 @@
 """
 Created on 13 Oct 2021
 
-@author: Philip Winkler
+@author: Philip Winkler, Sabrina Rossberger
 
-Copyright © 2021 Philip Winkler, Delmic
+Copyright © 2021-2022 Philip Winkler, Delmic
 
 This file is part of Odemis.
 
@@ -45,8 +45,12 @@ SCANNER_CONFIG = {
         # the beam here.
         "blanker": False,
         "immersion": False,  # disable to get a larger field of view
-        "horizontalFoV": 1.5e-3,
-        "resolution": (1024, 884),  # px
+        "horizontalFoV": 1.5e-3,  # maximum FoV without seeing the pole-piece (with T1, immersion off).
+        # XT usually uses a rectangular ratio for the resolution such as 1536 x 1024. Thus, for a fixed FoV the maximum
+        # width is reached earlier, but the heights could be in principle still increased. By using a more square
+        # aspect ratio, it is possible to increase the physically scanned area per tile and thus reduce the number
+        # of tiles that need to be acquired.
+        "resolution": (1024, 884),  # [px]
     },
     LIVESTREAM_MODE: {
         "multiBeamMode": False,

--- a/src/odemis/acq/test/fastem_conf_test.py
+++ b/src/odemis/acq/test/fastem_conf_test.py
@@ -4,7 +4,7 @@ Created on 03 December 2021
 
 @author: Sabrina Rossberger, Éric Piel
 
-Copyright © 2021 Sabrina Rossberger, Delmic
+Copyright © 2021-2022 Sabrina Rossberger, Delmic
 
 This file is part of Odemis.
 

--- a/src/odemis/gui/cont/acquisition.py
+++ b/src/odemis/gui/cont/acquisition.py
@@ -1702,6 +1702,9 @@ class FastEMOverviewAcquiController(object):
         # Warning that no scintillators are selected
         self.update_acquisition_time()
 
+        # If scanner dwell time is changed, update the estimated acquisition time.
+        tab_data.main.ebeam.dwellTime.subscribe(self.update_acquisition_time)
+
     def _on_selection_button(self, evt):
         # add/remove scintillator number to/from selected_scintillators set and toggle button colour
         btn = evt.GetEventObject()
@@ -1733,7 +1736,7 @@ class FastEMOverviewAcquiController(object):
     def check_acquire_button(self):
         self.btn_acquire.Enable(True if self._tab_data_model.selected_scintillators.value else False)
 
-    def update_acquisition_time(self):
+    def update_acquisition_time(self, _=None):
         lvl = None  # icon status shown
         if not self._main_data_model.active_scintillators.value:
             lvl = logging.WARN


### PR DESCRIPTION
…the dwell time

Update the estimated acquisition time when the dwell time on the ebeam scanner is adjusted.
Also improve the estimated acquisition time. Now it used an fixed estimate per tile based on a dwell time of 1us. Now calculate the time per tile based on the number of pixels per tile plus some fixed overhead for stage movements etc.