### PR TITLE
FASTEM bug fix overview acquisition in GUI: add callback with correct…

### DIFF
--- a/src/odemis/gui/cont/acquisition.py
+++ b/src/odemis/gui/cont/acquisition.py
@@ -34,6 +34,7 @@ from concurrent import futures
 from concurrent.futures._base import CancelledError
 import logging
 import math
+from functools import partial
 
 from odemis import model, dataio
 from odemis.acq import align, acqmng, stream, fastem
@@ -1813,7 +1814,7 @@ class FastEMOverviewAcquiController(object):
                 # Try acquiring the other
                 continue
 
-            f.add_done_callback(lambda f: self.on_acquisition_done(f, num=num))
+            f.add_done_callback(partial(self.on_acquisition_done, num=num))
             acq_futures[f] = t
 
         if acq_futures:


### PR DESCRIPTION
… overview image number

The callback that was added to the future needs to be called with the overview image number. For this purpose a lambda function was used, which did use the number as keyword argument. However, when the callback function is executed it will use the value that was last set as "num". Thus, all overview images where stored with the same number label and as a result only one image at a time was displayed in the GUI though all requested overview images were actually acquired.
Use functools.partial as a wrapper function. It allows to pass the callback function and separate keyword argument for the number. With the keyword argument it is made sure that the current overview image number is stored and that the callback is called with the correct number.