### PR TITLE
driver andorshkr: add warning if the turret has no grating

### DIFF
--- a/src/odemis/driver/andorshrk.py
+++ b/src/odemis/driver/andorshrk.py
@@ -1366,6 +1366,10 @@ class Shamrock(model.Actuator):
         """
         logging.debug("Current turret: %s", self.GetTurret())
         ngratings = self.GetNumberGratings()
+        if ngratings < 1:
+            logging.warning("No grating found on the current turret %s, it's probably not properly configured",
+                            self.GetTurret())
+
         gchoices = {}
         for g in range(1, ngratings + 1):
             try:


### PR DESCRIPTION
This unlikely case happens if the turret is unknown by the spectrograph.
It's handy to see a warning, so at least it'll clearer in the log that
something is wrong with the spectrograph.