### PR TITLE
driver smaract: fix 5DoF sim not using requested ranges

### DIFF
--- a/src/odemis/driver/smaract.py
+++ b/src/odemis/driver/smaract.py
@@ -1813,7 +1813,7 @@ class FakeMC_5DOF_DLL(object):
             # adjust internal range with the requested one
             for a, ad in axes.items():
                 orig_rng = self._range[a]
-                self._range[a] = (min(orig_rng[0], ad['range'][0]), max(orig_rng[1], ad['range'][1]))
+                self._range[a] = (max(orig_rng[0], ad['range'][0]), min(orig_rng[1], ad['range'][1]))
 
         self.stopping = threading.Event()
 


### PR DESCRIPTION
Commit 126021111 (5DOF simulator range should always fit requested
range) had a bug which essentially caused it to be a no-op.
Fix the range limit so that when passing a smaller range,
the axis range is really smaller that the initial range.

This fixes test case test_unreachable_position_error.