### PR TITLE
TEST_NOHW updated the consistency of getting the environment variable.

### DIFF
--- a/src/odemis/acq/align/test/delphi_test.py
+++ b/src/odemis/acq/align/test/delphi_test.py
@@ -36,7 +36,7 @@ logging.getLogger().setLevel(logging.DEBUG)
 
 # Export TEST_NOHW=1 to force using only the simulator and skipping test cases
 # needing real hardware
-TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 if TEST_NOHW:
     CONFIG_PATH = os.path.dirname(odemis.__file__) + "/../../install/linux/usr/share/odemis/"

--- a/src/odemis/acq/test/fastem_conf_test.py
+++ b/src/odemis/acq/test/fastem_conf_test.py
@@ -39,7 +39,7 @@ logging.basicConfig(format="%(asctime)s  %(levelname)-7s %(module)s:%(lineno)d %
 # * TEST_NOHW = 1: use simulator (asm/sam and xt adapter simulators need to be running)
 # * TEST_NOHW = 0: connected to the real hardware (backend needs to be running)
 # technolution_asm_simulator/simulator2/run_the_simulator.py
-TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default is HW testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default is HW testing
 
 CONFIG_PATH = os.path.dirname(odemis.__file__) + "/../../install/linux/usr/share/odemis/"
 FASTEM_CONFIG = CONFIG_PATH + "sim/fastem-sim-asm.odm.yaml"

--- a/src/odemis/driver/test/andorcam2_test.py
+++ b/src/odemis/driver/test/andorcam2_test.py
@@ -36,7 +36,7 @@ logging.getLogger().setLevel(logging.DEBUG)
 
 # Export TEST_NOHW=1 to force using only the simulator and skipping test cases
 # needing real hardware
-TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 CLASS_SIM = andorcam2.FakeAndorCam2
 CLASS = andorcam2.AndorCam2

--- a/src/odemis/driver/test/andorshrk_test.py
+++ b/src/odemis/driver/test/andorshrk_test.py
@@ -32,7 +32,7 @@ logging.basicConfig(format="%(asctime)s  %(levelname)-7s %(module)-15s: %(messag
 
 # Export TEST_NOHW=1 to force using only the simulator and skipping test cases
 # needing real hardware
-TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 KWARGS_SPG = dict(name="sr303", role="spectrograph", device=0)
 KWARGS_SPG_SIM = dict(name="sr303", role="spectrograph", device="fake")

--- a/src/odemis/driver/test/avantes_test.py
+++ b/src/odemis/driver/test/avantes_test.py
@@ -36,7 +36,7 @@ logging.getLogger().setLevel(logging.DEBUG)
 
 # Export TEST_NOHW=1 to force using only the simulator and skipping test cases
 # needing real hardware
-TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 KWARGS = {"name": "spec", "role": "spectrometer", "sn": None}
 if TEST_NOHW:

--- a/src/odemis/driver/test/blinkstick_test.py
+++ b/src/odemis/driver/test/blinkstick_test.py
@@ -29,7 +29,7 @@ logger = logging.getLogger().setLevel(logging.DEBUG)
 # Test using the hardware
 # Export TEST_NOHW=1 to force using only the simulator and skipping test cases
 # needing real hardware
-TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 CLASS = blinkstick.WhiteLed
 KWARGS = dict(name="test", role="light", max_power=1.0, inversed=True)

--- a/src/odemis/driver/test/cam_test_abs.py
+++ b/src/odemis/driver/test/cam_test_abs.py
@@ -40,7 +40,7 @@ import unittest
 
 # Export TEST_NOHW=1 to force using only the simulator and skipping test cases
 # needing real hardware
-TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 #gc.set_debug(gc.DEBUG_LEAK | gc.DEBUG_STATS)
 # arguments used for the creation of the SEM simulator

--- a/src/odemis/driver/test/focustracker_test.py
+++ b/src/odemis/driver/test/focustracker_test.py
@@ -34,7 +34,7 @@ import unittest
 logging.basicConfig(level=logging.DEBUG)
 logging.basicConfig(format="%(asctime)s  %(levelname)-7s %(module)s:%(lineno)d %(message)s")
 
-TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 KWARGS = {"name": "Focus Tracker",
           "role": "focus-position",

--- a/src/odemis/driver/test/lakeshore_test.py
+++ b/src/odemis/driver/test/lakeshore_test.py
@@ -34,7 +34,7 @@ logging.basicConfig(format="%(asctime)s  %(levelname)-7s %(module)s:%(lineno)d %
 
 # Export TEST_NOHW=1 to force using only the simulator and skipping test cases
 # needing real hardware
-TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 # arguments used for the creation of basic components
 CONFIG = {"name": "Lakeshore Test",
@@ -122,4 +122,3 @@ class TestLakeshore(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/src/odemis/driver/test/lle_test.py
+++ b/src/odemis/driver/test/lle_test.py
@@ -33,7 +33,7 @@ logging.getLogger().setLevel(logging.DEBUG)
 
 # Export TEST_NOHW=1 to force using only the simulator and skipping test cases
 # needing real hardware
-TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 if os.name == "nt":
     PORT = "COM1"

--- a/src/odemis/driver/test/nfpm_test.py
+++ b/src/odemis/driver/test/nfpm_test.py
@@ -30,7 +30,7 @@ logging.getLogger().setLevel(logging.DEBUG)
 
 # Export TEST_NOHW=1 to force using only the simulator and skipping test cases
 # needing real hardware
-TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 CLASS = nfpm.PM8742
 KWARGS = dict(name="test", role="fiber-align", address="autoip",
@@ -317,4 +317,3 @@ class TestActuator(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/src/odemis/driver/test/npmc_test.py
+++ b/src/odemis/driver/test/npmc_test.py
@@ -36,7 +36,7 @@ logging.basicConfig(format="%(asctime)s  %(levelname)-7s %(module)s:%(lineno)d %
 
 # Export TEST_NOHW=1 to force using only the simulator and skipping test cases
 # needing real hardware
-TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 # arguments used for the creation of basic components
 CONFIG = {"name": "Delay Stage",
@@ -269,4 +269,3 @@ class TestNPMC(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/src/odemis/driver/test/omicronxx_test.py
+++ b/src/odemis/driver/test/omicronxx_test.py
@@ -27,7 +27,7 @@ logging.getLogger().setLevel(logging.DEBUG)
 
 # Export TEST_NOHW=1 to force using only the simulator and skipping test cases
 # needing real hardware
-TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 if TEST_NOHW:
     MXXPORTS = "/dev/fakeone"  # TODO: no simulator

--- a/src/odemis/driver/test/orsay_test.py
+++ b/src/odemis/driver/test/orsay_test.py
@@ -32,7 +32,7 @@ from odemis.driver import orsay
 from odemis.model import HwError
 from odemis import model
 
-TEST_NOHW = os.environ.get("TEST_NOHW", 0)  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 if not TEST_NOHW == "sim":
     TEST_NOHW = TEST_NOHW == "1"  # make sure values other than "sim", 0 and 1 are converted to 0
 # For simulation, make sure to have the Orsay Physics Control Server installed and running.

--- a/src/odemis/driver/test/phenom_test.py
+++ b/src/odemis/driver/test/phenom_test.py
@@ -38,7 +38,7 @@ logging.getLogger().setLevel(logging.DEBUG)
 logging.basicConfig(format="%(asctime)s  %(levelname)-7s %(module)-15s: %(message)s")
 
 # If no hardware, we pretty much cannot test anything :-(
-TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 # logging.getLogger().setLevel(logging.DEBUG)
 # arguments used for the creation of basic components

--- a/src/odemis/driver/test/pi_test.py
+++ b/src/odemis/driver/test/pi_test.py
@@ -36,7 +36,7 @@ logging.getLogger().setLevel(logging.INFO)
 
 # Export TEST_NOHW=1 to force using only the simulator and skipping test cases
 # needing real hardware
-TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 if TEST_NOHW:
     CLASS = pi.FakePIRedStone  # (serial controller) simulator

--- a/src/odemis/driver/test/picoquant_test.py
+++ b/src/odemis/driver/test/picoquant_test.py
@@ -28,7 +28,7 @@ logging.getLogger().setLevel(logging.DEBUG)
 
 # Export TEST_NOHW=1 to force using only the simulator and skipping test cases
 # needing real hardware
-TEST_NOHW = os.environ.get("TEST_NOHW", 0) != 0  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 # arguments used for the creation of basic components
 CONFIG_SYNC = {"name": "Sync", "role": "cl-detector"}

--- a/src/odemis/driver/test/piezomotor_test.py
+++ b/src/odemis/driver/test/piezomotor_test.py
@@ -35,7 +35,7 @@ logging.getLogger().setLevel(logging.DEBUG)
 
 # Export TEST_NOHW=1 to force using only the simulator and skipping test cases
 # needing real hardware
-TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 if TEST_NOHW:
     PORT = "/dev/fake"

--- a/src/odemis/driver/test/pigcs_test.py
+++ b/src/odemis/driver/test/pigcs_test.py
@@ -41,7 +41,7 @@ logging.basicConfig(format="%(asctime)s  %(levelname)-7s %(module)s:%(lineno)d %
 
 # Export TEST_NOHW=1 to force using only the simulator and skipping test cases
 # needing real hardware
-TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 if os.name == "nt":
     PORT = "COM1"
@@ -725,4 +725,3 @@ if __name__ == "__main__":
 #MVR 1 1.0
 #MAC END
 #MAC START NA
-

--- a/src/odemis/driver/test/pmtctrl_test.py
+++ b/src/odemis/driver/test/pmtctrl_test.py
@@ -34,7 +34,7 @@ logging.basicConfig(format="%(asctime)s  %(levelname)-7s %(module)-15s: %(messag
 
 # Export TEST_NOHW=1 to force using only the simulator and skipping test cases
 # needing real hardware
-TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 if TEST_NOHW:
     # Test using the simulator

--- a/src/odemis/driver/test/powerctrl_test.py
+++ b/src/odemis/driver/test/powerctrl_test.py
@@ -27,7 +27,7 @@ logger = logging.getLogger().setLevel(logging.DEBUG)
 
 # Export TEST_NOHW=1 to force using only the simulator and skipping test cases
 # needing real hardware
-TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 CLASS = powerctrl.PowerControlUnit
 if TEST_NOHW:

--- a/src/odemis/driver/test/pvcam_test.py
+++ b/src/odemis/driver/test/pvcam_test.py
@@ -33,7 +33,7 @@ from cam_test_abs import VirtualTestCam, VirtualStaticTestCam, VirtualTestSynchr
 logging.getLogger().setLevel(logging.DEBUG)
 
 # Export TEST_NOHW=1 to prevent using the real hardware
-TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 CLASS = pvcam.PVCam
 # device can also be "rspiusb", but 0 is more generic
@@ -116,4 +116,3 @@ if __name__ == '__main__':
 #
 #p._setStaticSettings()
 #p.Reinitialize()
-

--- a/src/odemis/driver/test/pwrcomedi_test.py
+++ b/src/odemis/driver/test/pwrcomedi_test.py
@@ -32,7 +32,7 @@ logging.getLogger().setLevel(logging.DEBUG)
 
 # Export TEST_NOHW=1 to force using only the simulator and skipping test cases
 # needing real hardware
-TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 KWARGS = {"name": "test", "role": "light", "device": "/dev/comedi/usbdux",
           "channels": [0, 2],

--- a/src/odemis/driver/test/rigol_test.py
+++ b/src/odemis/driver/test/rigol_test.py
@@ -32,7 +32,7 @@ logging.basicConfig(format="%(asctime)s  %(levelname)-7s %(module)s:%(lineno)d %
 
 # Export TEST_NOHW=1 to force using only the simulator and skipping test cases
 # needing real hardware
-TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 # arguments used for the creation of basic components
 CONFIG_DG1000Z = {"name": "Rigol Wave Gen", "role": "pc-emitter",
@@ -90,4 +90,3 @@ class TestWaveGenerator(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/src/odemis/driver/test/scpi_test.py
+++ b/src/odemis/driver/test/scpi_test.py
@@ -33,7 +33,7 @@ logging.basicConfig(format="%(asctime)s  %(levelname)-7s %(module)s:%(lineno)d %
 
 # Export TEST_NOHW=1 to force using only the simulator and skipping test cases
 # needing real hardware
-TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 # arguments used for the creation of basic components
 CONFIG_K6485 = {"name": "Keithley 6485", "role": "pc-detector",

--- a/src/odemis/driver/test/semcomedi_test.py
+++ b/src/odemis/driver/test/semcomedi_test.py
@@ -49,7 +49,7 @@ import gc
 logging.getLogger().setLevel(logging.DEBUG)
 #comedi.comedi_loglevel(3)
 
-TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 # arguments used for the creation of basic components
 CONFIG_SED = {"name": "sed", "role": "sed", "channel":5, "limits": [-3, 3]}

--- a/src/odemis/driver/test/smaract_test.py
+++ b/src/odemis/driver/test/smaract_test.py
@@ -36,7 +36,7 @@ logging.basicConfig(format="%(asctime)s  %(levelname)-7s %(module)s:%(lineno)d %
 
 # Export TEST_NOHW=1 to force using only the simulator and skipping test cases
 # needing real hardware
-TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 COMP_ARGS = {
     "atol": 1e-7,

--- a/src/odemis/driver/test/spectrometer_test.py
+++ b/src/odemis/driver/test/spectrometer_test.py
@@ -36,7 +36,7 @@ logging.getLogger().setLevel(logging.DEBUG)
 
 # Export TEST_NOHW=1 to force using only the simulator and skipping test cases
 # needing real hardware
-TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 if os.name == "nt":
     PORT_SPG = "COM1"

--- a/src/odemis/driver/test/tescan_test.py
+++ b/src/odemis/driver/test/tescan_test.py
@@ -39,7 +39,7 @@ logging.basicConfig(format="%(asctime)s  %(levelname)-7s %(module)s:%(lineno)d %
 
 # Export TEST_NOHW=1 to force using only the simulator and skipping test cases
 # needing real hardware
-TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 # Note: there is a simulator, but it must be run in Windows (on a virtual machine)
 # However, not everything behaves exactly as on the real hardware, so beware

--- a/src/odemis/driver/test/tfsbc_test.py
+++ b/src/odemis/driver/test/tfsbc_test.py
@@ -29,7 +29,7 @@ import logging
 import os
 import time
 
-TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 logging.getLogger().setLevel(logging.DEBUG)
 logging.basicConfig(format="%(asctime)s  %(levelname)-7s %(module)s:%(lineno)d %(message)s")
@@ -140,4 +140,3 @@ class TestBeamShiftController(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/src/odemis/driver/test/tlaptmf_test.py
+++ b/src/odemis/driver/test/tlaptmf_test.py
@@ -32,7 +32,7 @@ CLASS = tlaptmf.MFF
 
 # Export TEST_NOHW=1 to force using only the simulator and skipping test cases
 # needing real hardware
-TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 KWARGS_SIM = dict(name="test", role="switch", port="/dev/fake", axis="r",
                   inverted=["r"], positions=[[0, "off"], [1, "on"]])

--- a/src/odemis/driver/test/tlfw_test.py
+++ b/src/odemis/driver/test/tlfw_test.py
@@ -33,7 +33,7 @@ else:
 
 # Export TEST_NOHW=1 to force using only the simulator and skipping test cases
 # needing real hardware
-TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 if TEST_NOHW:
     CLASS = tlfw.FakeFW102c

--- a/src/odemis/driver/test/tmcm_test.py
+++ b/src/odemis/driver/test/tmcm_test.py
@@ -30,7 +30,7 @@ logging.getLogger().setLevel(logging.DEBUG)
 
 # Export TEST_NOHW=1 to force using only the simulator and skipping test cases
 # needing real hardware
-TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 if os.name == "nt":
     PORT = "COM1"

--- a/src/odemis/driver/test/ueye_test.py
+++ b/src/odemis/driver/test/ueye_test.py
@@ -36,7 +36,7 @@ from cam_test_abs import VirtualTestCam, VirtualStaticTestCam, VirtualTestSynchr
 logging.getLogger().setLevel(logging.DEBUG)
 
 # Export TEST_NOHW=1 to prevent using the real hardware
-TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 CLASS = ueye.Camera
 KWARGS = dict(name="camera", role="ccd", device=None, transp=[2, -1])
@@ -101,5 +101,3 @@ class TestSynchronized(VirtualTestSynchronized, unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-
-

--- a/src/odemis/driver/test/zeiss_test.py
+++ b/src/odemis/driver/test/zeiss_test.py
@@ -31,7 +31,7 @@ import unittest
 from unittest.case import skip
 
 
-TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 logging.getLogger().setLevel(logging.DEBUG)
 logging.basicConfig(format="%(asctime)s  %(levelname)-7s %(module)s:%(lineno)d %(message)s")

--- a/src/odemis/gui/test/dev_rotknob_test.py
+++ b/src/odemis/gui/test/dev_rotknob_test.py
@@ -32,7 +32,7 @@ from odemis.gui.evt import EVT_KNOB_ROTATE
 import odemis.gui.test as test
 
 # Export TEST_NOHW=1 to indicate no hardware present is not a failure
-TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0)  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 test.goto_manual()
 


### PR DESCRIPTION
In some places it was defined as TEST_NOHW = (os.environ.get("TEST_NOHW", 0) != 0). This usually worked because often we set TEST_NOHW = "1".
However environment variables are always strings and if TEST_NOHW = "0", the above will evaluate to ("0" != 0 ) = True.
TEST_NOHW is now everywhere defined as TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")