### PR TITLE
gui comp DichotomyOverlay: fix error when cursor hovers out of FoV

### DIFF
--- a/src/odemis/gui/comp/overlay/view.py
+++ b/src/odemis/gui/comp/overlay/view.py
@@ -983,9 +983,9 @@ class DichotomyOverlay(base.ViewOverlay):
 
         # Change the cursor into a hand if the quadrant being hovered over
         # can be selected. Use the default cursor otherwise
-        if idx >= self.max_len:
+        if idx is None:
             self.cnvs.reset_dynamic_cursor()
-            idx, quad = (None, None)
+            idx, quad = None, None
         else:
             self.cnvs.set_dynamic_cursor(wx.CURSOR_HAND)
 


### PR DESCRIPTION
If the cursor happens to be outside the FoV, quad_hover() returns (None, None).
In Python 2, this was not an issue as it's possible to compare None to
an int. It didn't do the right thing, but it ended up having roughly the
right effect. That's not true for Python 3, which complains loudly about such
comparison.

=> Explicitly check for None.
Drop the comparaison to max_len as anyway it should never happen.