### PR TITLE
FASTEM overview acq: remove connection of progress of the underlying future to the main future

### DIFF
--- a/src/odemis/acq/fastem.py
+++ b/src/odemis/acq/fastem.py
@@ -737,7 +737,9 @@ def _run_overview_acquisition(f, stream, stage, area, live_stream):
     sf = stitching.acquireTiledArea([stream], stage, area, overlap, registrar=REGISTER_IDENTITY,
                                     focusing_method=FocusingMethod.NONE)
     # Connect the progress of the underlying future to the main future
-    sf.add_update_callback(_pass_future_progress)
+    # FIXME removed to provide better progress update in GUI
+    #  When _tiledacq.py has proper time update implemented, add this line here again.
+    # sf.add_update_callback(_pass_future_progress)
     das = sf.result()
 
     if len(das) != 1:


### PR DESCRIPTION
This ensures a better progress update on the progress bar in the GUI. tiledacq.py does not have a good time estimation yet. It updates the progress based on the original estimation and assumes a fixed duration per tile. After each tile it removes this fixed time per tile from the original estimation. However, if the estimation was wrong, the update is always wrong. Solution is to temporarily remove the connection to the sub-future and just show the progress in the GUI based on the estimated time, which simply counts down for now.