### PR TITLE
gui model: On METEOR, check that the stage.POS_ACTIVE_RANGE is within stage-bare.FM_IMAGING_RANGE

### DIFF
--- a/src/odemis/gui/model/__init__.py
+++ b/src/odemis/gui/model/__init__.py
@@ -840,6 +840,17 @@ class CryoChamberGUIData(CryoGUIData):
         self.stage_align_slider_va = model.FloatVA(1e-6)
         self.show_advaned = model.BooleanVA(False)
 
+        # Some extra checks about the microscope config
+        # The active range should be within the FM range (which can be wider)
+        stage_fm_imaging_rng = main.stage_bare.getMetadata()[model.MD_FM_IMAGING_RANGE]
+        stage_rng = main.stage.getMetadata()[model.MD_POS_ACTIVE_RANGE]
+        for axis in ("x", "y"):
+            fm_rng = stage_fm_imaging_rng[axis]
+            if not all(fm_rng[0] <= r <= fm_rng[1] for r in stage_rng[axis]):
+                raise ValueError(f"stage.POS_ACTIVE_RANGE should be within stage-bare.FM_IMAGING_RANGE "
+                                 f"but got axis {axis} with range {stage_rng[axis]} out of {fm_rng}")
+
+
 class AnalysisGUIData(MicroscopyGUIData):
     """
     Represent an interface used to show the recorded microscope data. Typically


### PR DESCRIPTION
It's a little bit confusing as these 2 metadata are quite a little bit
redundant, and not on the same component. So it's easy to update one
while forgetting to update the other one. Doing so would cause very odd
stage movement from the GUI.

=> Detect something is wrong early.