### PR TITLE
GUI conf data: Update the dwelltime range for fastem systems.

### DIFF
--- a/src/odemis/gui/conf/data.py
+++ b/src/odemis/gui/conf/data.py
@@ -657,6 +657,16 @@ HW_SETTINGS_CONFIG_PER_ROLE = {
             },
         },
     },
+    "mbsem": {
+        "e-beam":
+        {
+            "dwellTime":
+            {   # In XT the minimum dwell time can change based on the HFW, 100ns is the highest minimum value, if
+                # a user would set it to a lower value an error might be raised.
+                "range": (100e-9, 1.0),
+            },
+        },
+    },
 }
 
 # The sparc-simplex is identical to the sparc


### PR DESCRIPTION
The dwell time range in XT is dependent on the HFW. For a HFW of 1.5mm, used in overview imaging, the minimum dwell time is 100ns. For lower HFW it is between 25ns and 75ns.
When the dwell time was set to a value lower than 100ns and then the overview image was started the following error was raised:
OSError: [Errno -1037828090] INVALID_RANGE_VALUE Set dwell time failed

For the live view 100ns is also a fine minimum, therefore overwrite the dwell time range in the GUI so that the user cannot set it to a value lower than 100ns.