### PR TITLE
model metadata: changes to improve pep8 compliancy

### DIFF
--- a/src/odemis/model/_metadata.py
+++ b/src/odemis/model/_metadata.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-'''
+"""
 Created on 2 Apr 2012
 
 @author: Éric Piel
@@ -20,52 +20,52 @@ You should have received a copy of the GNU General Public License along with
 Odemis. If not, see http://www.gnu.org/licenses/.
 
 These are the conventional metadata available in a DataArray.
-'''
+"""
 
 # This list of constants are used as key for the metadata
-MD_EXP_TIME = "Exposure time" # s
-MD_ACQ_DATE = "Acquisition date" # s since epoch
-MD_AD_LIST = "Acquisition dates" # s since epoch for each element in dimension T
+MD_EXP_TIME = "Exposure time"  # s
+MD_ACQ_DATE = "Acquisition date"  # s since epoch
+MD_AD_LIST = "Acquisition dates"  # s since epoch for each element in dimension T
 # distance between two points on the sample that are seen at the centre of two
 # adjacent pixels considering that these two points are in focus
 MD_PIXEL_SIZE = "Pixel size"  # (m, m) or (m, m, m) if the data has XY or XYZ dimensions
 MD_SHEAR = "Shear"  # float, vertical shear (0, means no shearing)
 MD_FLIP = "Flip"
-MD_BINNING = "Binning" # (px, px), number of pixels acquired as one big pixel, in each dimension
+MD_BINNING = "Binning"  # (px, px), number of pixels acquired as one big pixel, in each dimension
 MD_INTEGRATION_COUNT = "Integration Count"  # number of samples/images acquired/integrated; default: 1
-MD_HW_VERSION = "Hardware version" # str
-MD_SW_VERSION = "Software version" # str
-MD_HW_NAME = "Hardware name" # str, product name of the hardware component (and s/n)
-MD_GAIN = "Gain" # no unit (ratio) voltage multiplication provided by the gain (for CCD/CMOS)
-MD_BPP = "Bits per pixel" # bit
-MD_DIMS = "Dimension names" # str, name of each dimension in the order of the shape. The default is CTZYX (with the first dimensions dropped if shape is smaller). YXC is useful for RGB(A) data
-MD_BASELINE = "Baseline value" # ADU, int or float (same as image data) representing the average value when no signal is received (default is the lowest representable number or 0 for floats)
-MD_READOUT_TIME = "Pixel readout time" # s, time to read one pixel (on a CCD/CMOS)
-MD_SENSOR_PIXEL_SIZE = "Sensor pixel size" # (m, m), distance between the centre of 2 pixels on the detector sensor
-MD_SENSOR_SIZE = "Sensor size" # px, px, maximum resolution that can be acquire by the detector
-MD_SENSOR_TEMP = "Sensor temperature" # C
+MD_HW_VERSION = "Hardware version"  # str
+MD_SW_VERSION = "Software version"  # str
+MD_HW_NAME = "Hardware name"  # str, product name of the hardware component (and s/n)
+MD_GAIN = "Gain"  # no unit (ratio) voltage multiplication provided by the gain (for CCD/CMOS)
+MD_BPP = "Bits per pixel"  # bit
+MD_DIMS = "Dimension names"  # str, name of each dimension in the order of the shape. The default is CTZYX (with the first dimensions dropped if shape is smaller). YXC is useful for RGB(A) data
+MD_BASELINE = "Baseline value"  # ADU, int or float (same as image data) representing the average value when no signal is received (default is the lowest representable number or 0 for floats)
+MD_READOUT_TIME = "Pixel readout time"  # s, time to read one pixel (on a CCD/CMOS)
+MD_SENSOR_PIXEL_SIZE = "Sensor pixel size"  # (m, m), distance between the centre of 2 pixels on the detector sensor
+MD_SENSOR_SIZE = "Sensor size"  # px, px, maximum resolution that can be acquire by the detector
+MD_SENSOR_TEMP = "Sensor temperature"  # C
 MD_POS = "Centre position"  # (m, m) or (m, m, m) if the data has XY or XYZ dimensions.
 # It's the location of the picture *centre*. X goes "right" (ie, pixel index increases),
 # Y goes "up" (ie, pixel index decreases), and Z goes "top" (ie, pixel index increases).
 # Note that for angular resolved acquisitions, MD_POS corresponds to the position of the e-beam on the sample
-MD_ROTATION = "Rotation" # radians (0<=float<2*PI) rotation applied to the image (from its center) counter-clockwise
+MD_ROTATION = "Rotation"  # radians (0<=float<2*PI) rotation applied to the image (from its center) counter-clockwise
 # Note that the following two might be a set of ranges
 MD_PIVOT_POS = "Pivot position for controllers with rotational axes"  # (dict str->float) axis -> pos:
 # Used in SmarAct motion controllers
-MD_IN_WL = "Input wavelength range" # (m, m) or (m, m, m, m, m), lower and upper range of the wavelength input
+MD_IN_WL = "Input wavelength range"  # (m, m) or (m, m, m, m, m), lower and upper range of the wavelength input
 MD_OUT_WL = "Output wavelength range"  # (m, m) or (m, m, m, m, m), lower and upper range of the filtered wavelength before the camera
-MD_LIGHT_POWER = "Light power" # W, power of the emitting light
-MD_LENS_NAME = "Lens name" # str, product name of the lens
-MD_LENS_MAG = "Lens magnification" # float (ratio), magnification factor
+MD_LIGHT_POWER = "Light power"  # W, power of the emitting light
+MD_LENS_NAME = "Lens name"  # str, product name of the lens
+MD_LENS_MAG = "Lens magnification"  # float (ratio), magnification factor
 MD_LENS_NA = "Lens numerical aperture"  # float (ratio), numerical aperture
 MD_LENS_RI = "Lens refractive index"  # float (ratio), refractive index
-MD_FILTER_NAME = "Filter name" # str, product name of the light filter
+MD_FILTER_NAME = "Filter name"  # str, product name of the light filter
 # TODO: might need to merge DWELL_TIME and EXP_TIME into INTEGRATION_TIME: the time each pixel receive energy
 # + SCANNED_DIMENSIONS: list of dimensions which were scanned instead of being acquired simultaneously
-MD_DWELL_TIME = "Pixel dwell time" # s (float), time the electron beam spends per pixel
-MD_EBEAM_VOLTAGE = "Electron beam acceleration voltage" # V (float), voltage used to accelerate the electron beam
+MD_DWELL_TIME = "Pixel dwell time"  # s (float), time the electron beam spends per pixel
+MD_EBEAM_VOLTAGE = "Electron beam acceleration voltage"  # V (float), voltage used to accelerate the electron beam
 MD_EBEAM_CURRENT = "Electron beam emission current"  # A (float), emission current of the electron beam (typically, the probe current is a bit smaller and the spot diameter is linearly proportional)
-MD_EBEAM_SPOT_DIAM = "Electron beam spot diameter" # m (float), approximate diameter of the electron beam spot (typically function of the current)
+MD_EBEAM_SPOT_DIAM = "Electron beam spot diameter"  # m (float), approximate diameter of the electron beam spot (typically function of the current)
 
 MD_STREAK_TIMERANGE = "Streak Time Range"  # (s) Time range for one streak/sweep
 MD_STREAK_MCPGAIN = "Streak MCP Gain"  # (int) Multiplying gain for microchannel plate
@@ -79,7 +79,7 @@ MD_TRIGGER_RATE = "Streak Repetition Rate"  # (Hz) Repetition Rate of the trigge
 # The entries should be ordered by time (the earliest the first)
 MD_EBEAM_CURRENT_TIME = "Electron beam emission current over time"
 
-MD_WL_LIST = "Wavelength list" # m... (list of float), wavelength for each pixel. The list is the same length as the C dimension
+MD_WL_LIST = "Wavelength list"  # m... (list of float), wavelength for each pixel. The list is the same length as the C dimension
 MD_TIME_LIST = "Time list"  # sec (array) containing the corrections for the timestamp corresponding to each px
 
 # Deprecrated: use MD_TIME_LIST
@@ -104,7 +104,7 @@ MD_AT_SLIT = "Slit view"  # View of the spectrograph slit for SPARCv2 alignment
 
 BAND_PASS_THROUGH = "pass-through"  # Special "filter" name when there is no filter: all light passes
 
-MD_AR_POLE = "Angular resolved pole position" # px, px (tuple of float), position of pole (aka hole center) in raw acquisition of SPARC AR
+MD_AR_POLE = "Angular resolved pole position"  # px, px (tuple of float), position of pole (aka hole center) in raw acquisition of SPARC AR
 MD_AR_XMAX = "Polar xmax"  # m, the distance between the parabola origin and the cutoff position
 MD_AR_HOLE_DIAMETER = "Hole diameter"  # m, diameter the hole in the mirror
 MD_AR_FOCUS_DISTANCE = "Focus distance"  # m, the vertical mirror cutoff, iow the min distance between the mirror and the sample
@@ -152,16 +152,16 @@ MD_DT_NORMAL = "Detector normal"  # The detector sends the same level of signal 
 MD_DT_INTEGRATING = "Detector integrating"  # The detector level is proportional to the acq duration (eg, CCD)
 
 # The following tags are not to be filled at acquisition, but by the user interface
-MD_DESCRIPTION = "Description" # (string) User-friendly name that describes what this acquisition is
-MD_USER_NOTE = "User note" # (string) Whatever comment the user has added to the image
+MD_DESCRIPTION = "Description"  # (string) User-friendly name that describes what this acquisition is
+MD_USER_NOTE = "User note"  # (string) Whatever comment the user has added to the image
 MD_USER_TINT = "Display tint"  # Either RGB (3-tuple of 0<int<255): colour to display the (greyscale) image or a matplotlib.colors.Colormap name
 
 MD_HW_NOTE = "Hardware note"  # (string) "Free" description of the hardware status and settings.
 
 # The following metadata is the correction metadata generated by
 # find_overlay.FindOverlay and passed to find_overlay.mergeMetadata
-MD_ROTATION_COR = "Rotation cor" # radians, to be subtracted from MD_ROTATION
-MD_PIXEL_SIZE_COR = "Pixel size cor" # (m, m), to be multiplied with MD_PIXEL_SIZE
+MD_ROTATION_COR = "Rotation cor"  # radians, to be subtracted from MD_ROTATION
+MD_PIXEL_SIZE_COR = "Pixel size cor"  # (m, m), to be multiplied with MD_PIXEL_SIZE
 MD_POS_COR = "Centre position cor"  # (m, m), to be subtracted from MD_POS
 MD_SHEAR_COR = "Shear cor"  # float, vertical shear to be subtracted from MD_SHEAR
 MD_BASELINE_COR = "Baseline cor"  # value, to be added to MD_BASELINE
@@ -190,11 +190,11 @@ MD_POS_ACTIVE_RANGE = "Range for active position"  # dict str → (float, float)
 MD_ION_BEAM_TO_SAMPLE_ANGLE = "Ion beam to sample angle"  # (float) angle between ion beam and sample stage
 MD_SAFE_REL_RANGE = "Safe relative range"  # (float, float) +/- safe range relative to a value
 MD_SAFE_SPEED_RANGE = "Safe speed range"  # (float, float) min, max of the safe speed range
-MD_SAMPLE_CENTERS = "Centers position of grids" # dict str → float representing the centers positions of the 2 grids loaded on the meteor stage
+MD_SAMPLE_CENTERS = "Centers position of grids"  # dict str → float representing the centers positions of the 2 grids loaded on the meteor stage
 MD_SEM_IMAGING_RANGE = "SEM imaging range"  # dict str → [float, float] defining the volume of the SEM imaging area, along x, y and z axes. 
-MD_FM_IMAGING_RANGE = "FM imaging range"    # dict str → [float, float] defining the volume of the FM imaging area, along x, y and z axes.
-MD_FAV_FM_POS_ACTIVE = "Favourite FM position active"   # dict str->float representing the position required for FM imaging
-MD_FAV_SEM_POS_ACTIVE = "Favourite SEM position active"     # dict -> float representing the position required for SEM imaging 
+MD_FM_IMAGING_RANGE = "FM imaging range"  # dict str → [float, float] defining the volume of the FM imaging area, along x, y and z axes.
+MD_FAV_FM_POS_ACTIVE = "Favourite FM position active"  # dict str->float representing the position required for FM imaging
+MD_FAV_SEM_POS_ACTIVE = "Favourite SEM position active"  # dict -> float representing the position required for SEM imaging
 
 # The following metadata is used to store the destination components of the
 # specific known positions for the actuators.


### PR DESCRIPTION
- use triple double quotes instead of triple single quotes for docstring
- make sure there are exactly two spaces between comments and code
- I did not clean up comments that extend the line length, because I think doing so would decrease readability