### PR TITLE
Acquisition fastem: perform pre-calibrations outside the region of ac…

### DIFF
--- a/src/odemis/acq/fastem.py
+++ b/src/odemis/acq/fastem.py
@@ -320,12 +320,17 @@ class AcquisitionTask(object):
         # Update the position of the first tile.
         self._pos_first_tile = self.get_pos_first_tile()
 
-        # Move the stage to the first tile, to ensure the autofocus and image translation pre-align are
-        # done in the correct location and the correct position is stored in the megafield metadata yaml file.
-        self.move_stage_to_next_tile()
-
         if self._pre_calibrate:
+            # Move the stage to the tile with index (-1, -1), to ensure the autofocus and image translation pre-align
+            # are done to the top left of the first field, outside the region of acquisition to limit beam damage.
+            self.field_idx = (-1, -1)
+            self.move_stage_to_next_tile()
             self.pre_calibrate()
+
+        # Move the stage to the first tile, to ensure the correct position is
+        # stored in the megafield metadata yaml file.
+        self.field_idx = (0, 0)
+        self.move_stage_to_next_tile()
 
         # set the sub-directories (<acquisition date>/<project name>) and megafield id
         self._detector.filename.value = os.path.join(self._path, self._roa.name.value)

--- a/src/odemis/acq/fastem.py
+++ b/src/odemis/acq/fastem.py
@@ -321,11 +321,16 @@ class AcquisitionTask(object):
         self._pos_first_tile = self.get_pos_first_tile()
 
         if self._pre_calibrate:
+            # The pre-calibrations should run on a position that lies a full field
+            # outside the ROA, therefore temporarily set the overlap to zero.
+            overlap_init = self._roa.overlap
+            self._roa.overlap = 0
             # Move the stage to the tile with index (-1, -1), to ensure the autofocus and image translation pre-align
             # are done to the top left of the first field, outside the region of acquisition to limit beam damage.
             self.field_idx = (-1, -1)
             self.move_stage_to_next_tile()
             self.pre_calibrate()
+            self._roa.overlap = overlap_init  # set back the overlap to the initial value
 
         # Move the stage to the first tile, to ensure the correct position is
         # stored in the megafield metadata yaml file.

--- a/src/odemis/acq/test/fastem_test.py
+++ b/src/odemis/acq/test/fastem_test.py
@@ -655,17 +655,46 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
             actual_position = task.get_abs_stage_movement()  # [m]
             numpy.testing.assert_allclose(actual_position, expected_position)
 
-            # Verify that for pre-calibrations compared to the top left corner of the ROA, the stage
-            # position is located half a field to the top left (outside the ROA).
-            task.field_idx = (-1, -1)  # (-1, -1) is the index where the pre-calibrations are performed
+    def test_stage_pos_outside_roa(self):
+        """
+        The pre-calibrations need to run outside the ROA. Test that get_abs_stage_movement returns the correct value
+        for a field index of (-1, -1) and that that value is outside the ROA.
+        """
+        res_x, res_y = self.multibeam.resolution.value  # single field size
+        px_size_x, px_size_y = self.multibeam.pixelSize.value
+        x_fields, y_fields = (3, 4)
+        field_size_x = res_x * px_size_x
+        field_size_y = res_y * px_size_y
+        # The coordinates of the ROA in meters.
+        xmin, ymin = (0, 0)
+        xmax, ymax = (field_size_x * x_fields,
+                      field_size_y * y_fields)
+        coordinates = (xmin, ymin, xmax, ymax)  # in m
 
-            # In the role='stage' coordinate system the x-axis points to the right and y-axis to the top.
-            expected_position = (xmin - res_x / 2 * px_size_x,
-                                 ymax + res_x / 2 * px_size_y)  # [m]
-            actual_position = task.get_abs_stage_movement()  # [m]
-            numpy.testing.assert_allclose(actual_position, expected_position)
-            # Verify that the position where the pre-calibration is performed, does not lie inside the ROA coordinates.
-            self.assertFalse(is_point_in_rect(actual_position, coordinates))
+        # Create an ROA with the coordinates of the field.
+        roa_name = time.strftime("test_megafield_id-%Y-%m-%d-%H-%M-%S")
+        roa = fastem.FastEMROA(roa_name, coordinates, None,
+                               self.asm, self.multibeam, self.descanner,
+                               self.mppc)
+
+        task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner,
+                                      self.mppc, self.stage, self.ccd,
+                                      self.beamshift, self.lens,
+                                      roa, path=None, future=None)
+        # Set the _pos_first_tile, which would normally be set in the run function.
+        task._pos_first_tile = task.get_pos_first_tile()
+
+        # Verify that for pre-calibrations compared to the top left corner of the ROA, the stage
+        # position is located half a field to the top left (outside the ROA).
+        task.field_idx = (-1, -1)  # (-1, -1) is the index where the pre-calibrations are performed
+
+        # In the role='stage' coordinate system the x-axis points to the right and y-axis to the top.
+        expected_position = (xmin - res_x / 2 * px_size_x,
+                             ymax + res_x / 2 * px_size_y)  # [m]
+        actual_position = task.get_abs_stage_movement()  # [m]
+        numpy.testing.assert_allclose(actual_position, expected_position)
+        # Verify that the position where the pre-calibration is performed, does not lie inside the ROA coordinates.
+        self.assertFalse(is_point_in_rect(actual_position, coordinates))
 
     def test_pre_calibrate(self):
         """


### PR DESCRIPTION
…quisition

* perform the pre-calibrations on the field with index (-1, -1) to limit beam damage in the actual acquired area.
* do not skip test_get_pos_first_tile in the mock test class, because get_pos_first_tile does work with mocking.
* in the mocked test cases update multibeam.resolution.value from (800, 800) to (6400, 6400), to match the actual system.

Will test on Monday