### PR TITLE
xtclient testcases: when testing with simulator, skip before trying t…

### DIFF
--- a/src/odemis/driver/test/xt_client_test.py
+++ b/src/odemis/driver/test/xt_client_test.py
@@ -108,7 +108,7 @@ class TestMicroscope(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if TEST_NOHW is True:
-            raise unittest.SkipTest("No hardware available.")
+            raise unittest.SkipTest("No simulator available.")
 
         cls.microscope = xt_client.SEM(**CONFIG_SEM)
 
@@ -540,7 +540,7 @@ class TestMicroscopeInternal(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if TEST_NOHW is True:
-            raise unittest.SkipTest("No hardware available.")
+            raise unittest.SkipTest("No simulator available.")
 
         cls.microscope = xt_client.SEM(**CONFIG_SEM)
 
@@ -1003,6 +1003,8 @@ class TestFIBScanner(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        if TEST_NOHW is True:
+            raise unittest.SkipTest("No simulator available.")
 
         cls.microscope = xt_client.SEM(**CONFIG_FIB_SEM)
 
@@ -1013,8 +1015,6 @@ class TestFIBScanner(unittest.TestCase):
                 cls.detector = child
 
     def setUp(self):
-        if TEST_NOHW:
-            self.skipTest("No hardware available.")
         if self.microscope.get_vacuum_state() != 'vacuum':
             self.skipTest("Chamber needs to be in vacuum, please pump.")
 
@@ -1034,6 +1034,8 @@ class TestDualModeMicroscope(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        if TEST_NOHW is True:
+            raise unittest.SkipTest("No simulator available.")
 
         cls.microscope = xt_client.SEM(**CONFIG_DUAL_MODE_SEM)
 
@@ -1046,8 +1048,6 @@ class TestDualModeMicroscope(unittest.TestCase):
                 cls.detector = child
 
     def setUp(self):
-        if TEST_NOHW:
-            self.skipTest("No hardware available.")
         if self.microscope.get_vacuum_state() != 'vacuum':
             self.skipTest("Chamber needs to be in vacuum, please pump.")
 
@@ -1149,7 +1149,7 @@ class TestMBScanner(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if TEST_NOHW is True:
-            raise unittest.SkipTest("No hardware available.")
+            raise unittest.SkipTest("No simulator available.")
 
         cls.microscope = xt_client.SEM(**CONFIG_MB_SEM)
 


### PR DESCRIPTION
…o create the microscope.

The test cases failed because it tried to create the microscope object while this was not possible.
Because the skiptest was in setup and not in setupClass it first tried to create the microscope object and never reached the call toskiptest.