### PR TITLE
fastem-asm-sim yaml: add calibrated metadata for simulator.

### DIFF
--- a/install/linux/usr/share/odemis/sim/fastem-sim-asm.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/fastem-sim-asm.odm.yaml
@@ -257,6 +257,8 @@ FASTEM-sim: {
         # Factory calibrations of the scanner amplitude and offset
         SCAN_OFFSET: [-0.0935, 0.0935],  # [a.u._scan] the start of the sawtooth scanning signal
         SCAN_AMPLITUDE: [0.187, -0.187],  # [a.u._scan] the amplitude of the sawtooth scanning signal
+        SCAN_OFFSET_CALIB: [-0.0935, 0.0935],  # [a.u_scan] only needed for simulator
+        SCAN_AMPLITUDE_CALIB: [0.187, -0.187],  # [a.u_scan] only needed for simulator
     },
 }
 


### PR DESCRIPTION
On the metadata of the MultiBeam Scanner the SCAN_OFFSET_CALIB and SCAN_AMPLITUDE_CALIB have been added.
Normally these are calculated in the calibrations but these calibrations do not run with the simulator.