### PR TITLE
acq align fastem: don't completely fail time estimation if fastem_calibration is missing

### DIFF
--- a/src/odemis/acq/align/fastem.py
+++ b/src/odemis/acq/align/fastem.py
@@ -117,8 +117,8 @@ def estimate_calibration_time(calibrations):
     :param calibrations: (list[Calibrations]) List of calibrations that should be run.
     :return (0 <= float): The estimated time for the requested calibrations in s.
     """
-
-    return sum(c.value.estimate_calibration_time() for c in calibrations)
+    # Note: the check for None is only in case fastem_calibrations is missing
+    return sum(c.value.estimate_calibration_time() for c in calibrations if c.value is not None)
 
 
 class CalibrationTask(object):


### PR DESCRIPTION
In case fastem_calibration is missing, all calibrations are considered
None. So calling .estimate_calibration_time() doesn't work. We need to
explicitly check for it.