### PR TITLE
gui fastem cont/comp: move hack to zoom out canvas at init

### DIFF
--- a/src/odemis/gui/comp/miccanvas.py
+++ b/src/odemis/gui/comp/miccanvas.py
@@ -1815,21 +1815,6 @@ class FastEMAcquisitionCanvas(DblMicroscopeCanvas):
 
     def __init__(self, *args, **kwargs):
         super(FastEMAcquisitionCanvas, self).__init__(*args, **kwargs)
-        # When starting the GUI, we want to zoom out to show the background overlay. However, calling this function
-        # here in __init__ does not work, probably because some values are not initialized properly yet (.ClientSize?)
-        # As a hack, the zooming is done in on_size, but only once after starting.
-        # TODO: find a better way of implementing this
-        self._starting = True
-
-    def on_size(self, evt):
-        """ Called when the canvas is resized """
-        if self._starting:
-            try:
-                self.zoom_out()
-                self._starting = False
-            except (ValueError, IndexError):
-                logging.debug("Zooming out failed, waiting for initialization.")
-        super(FastEMAcquisitionCanvas, self).on_size(evt)
 
     def add_background_overlay(self, rectangles):
         """

--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -1757,6 +1757,10 @@ class FastEMAcquisitionTab(Tab):
         super(FastEMAcquisitionTab, self).__init__(name, button, panel, main_frame, tab_data)
         self.set_label("ACQUISITION")
 
+        # Flag to indicate the tab has been fully initialized or not. Some initialisation
+        # need to wait for the tab to be shown on the first time.
+        self._initialized_after_show = False
+
         # View Controller
         vp = panel.vp_fastem_acqui
         assert(isinstance(vp, FastEMAcquisitionViewport))
@@ -1848,6 +1852,13 @@ class FastEMAcquisitionTab(Tab):
     def Show(self, show=True):
         super(FastEMAcquisitionTab, self).Show(show)
 
+        if show and not self._initialized_after_show:
+            # At init the canvas has sometimes a weird size (eg, 1000x1 px), which
+            # prevents the fitting to work properly. We need to wait until the
+            # canvas has been resized to the final size. That's quite late...
+            wx.CallAfter(self.panel.vp_fastem_acqui.canvas.zoom_out)
+            self._initialized_after_show = True
+
     @classmethod
     def get_display_priority(cls, main_data):
         # Tab is used only for FastEM
@@ -1875,6 +1886,10 @@ class FastEMOverviewTab(Tab):
 
         super(FastEMOverviewTab, self).__init__(name, button, panel, main_frame, tab_data)
         self.set_label("OVERVIEW")
+
+        # Flag to indicate the tab has been fully initialized or not. Some initialisation
+        # need to wait for the tab to be shown on the first time.
+        self._initialized_after_show = False
 
         # View Controller
         vp = panel.vp_fastem_overview
@@ -1932,6 +1947,7 @@ class FastEMOverviewTab(Tab):
         self.tb = panel.fastem_overview_toolbar
         # Add fit view to content to toolbar
         self.tb.add_tool(TOOL_ACT_ZOOM_FIT, self.view_controller.fitViewToContent)
+        # TODO: add tool to zoom out (ie, all the scintillators, calling canvas.zoom_out())
 
     @property
     def streambar_controller(self):
@@ -1962,6 +1978,13 @@ class FastEMOverviewTab(Tab):
 
     def Show(self, show=True):
         super().Show(show)
+        if show and not self._initialized_after_show:
+            # At init the canvas has sometimes a weird size (eg, 1000x1 px), which
+            # prevents the fitting to work properly. We need to wait until the
+            # canvas has been resized to the final size. That's quite late...
+            wx.CallAfter(self.panel.vp_fastem_overview.canvas.zoom_out)
+            self._initialized_after_show = True
+
         if not show:
             self._stream_controller.pauseStreams()
 


### PR DESCRIPTION
Now that fit_to_bbox() has been moved to the main class, it's been
"improved" and doesn't fail if the scale would be too small.

However that meant the hack to detect that the resizing failed didn't
detect it anymore. Instead of hacking it even more, move the zoom out
request to the tab controller, which is more in charge of deciding when
the view should be changed any way. It allows to make it a little bit
hacky...