### PR TITLE
Added MD_FIELD_FREE_SHIFT to configure MS_POS_COR of the scanner base…

### DIFF
--- a/install/linux/usr/share/odemis/sim/fastem-sim-asm.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/fastem-sim-asm.odm.yaml
@@ -47,6 +47,8 @@ FASTEM-sim: {
         PIXEL_SIZE_COR: [1.05, 1.05], # ratio
         SINGLE_BEAM_ROTATION: 0.,  # rad; rotation for overview image acquisition
         MULTI_BEAM_ROTATION: 0.0157,  # rad; rotation for multibeam image acquisition (~0.9°)
+        # Correction for the shift in (x, y) between immersion mode and field free mode:
+        FIELD_FREE_POS_SHIFT: [90.0e-6, 50.0e-6],  # [m]
     },
     persistent: {
         metadata: [PIXEL_SIZE_COR],

--- a/install/linux/usr/share/odemis/sim/fastem-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/fastem-sim.odm.yaml
@@ -39,7 +39,9 @@ FASTEM-sim: {
         # This is useful for the overview image acquisition.
         PIXEL_SIZE_COR: [1.05, 1.05], # ratio
         SINGLE_BEAM_ROTATION: 0,  # rad
-        MULTI_BEAM_ROTATION: 0.015707963  # rad = 0.9 degrees
+        MULTI_BEAM_ROTATION: 0.015707963,  # rad = 0.9 degrees
+        # Correction for the shift in (x, y) between immersion mode and field free mode:
+        FIELD_FREE_POS_SHIFT: [90.0e-6, 50.0e-6],  # [m]
     },
     persistent: {
         metadata: [PIXEL_SIZE_COR],

--- a/src/odemis/acq/fastem_conf.py
+++ b/src/odemis/acq/fastem_conf.py
@@ -91,7 +91,7 @@ def configure_scanner(scanner, mode):
     # Immersion needs to be set before changing the horizontalFoV, as the range is updated
     scanner.immersion.value = conf["immersion"]
 
-    if scanner.immersion.value is False:
+    if scanner.immersion.value:
         # When the scanner is in immersion mode set the position correction to [0, 0]
         scanner.updateMetadata({model.MD_POS_COR: [0, 0]})
     else:

--- a/src/odemis/acq/fastem_conf.py
+++ b/src/odemis/acq/fastem_conf.py
@@ -91,6 +91,15 @@ def configure_scanner(scanner, mode):
     # Immersion needs to be set before changing the horizontalFoV, as the range is updated
     scanner.immersion.value = conf["immersion"]
 
+    if scanner.immersion.value is False:
+        # When the scanner is in immersion mode set the position correction to [0, 0]
+        scanner.updateMetadata({model.MD_POS_COR: [0, 0]})
+    else:
+        # Correct for shift in image between immersion mode and field free mode.
+        # If MD_FIELD_FREE_SHIFT is not provided fall back to a correction of [0, 0]
+        pos_cor = scanner.getMetadata().get(model.MD_FIELD_FREE_POS_SHIFT, [0, 0])
+        scanner.updateMetadata({model.MD_POS_COR: pos_cor})
+
     if "horizontalFoV" in conf:
         scanner.horizontalFoV.value = conf["horizontalFoV"]  # m
     else:

--- a/src/odemis/acq/test/fastem_conf_test.py
+++ b/src/odemis/acq/test/fastem_conf_test.py
@@ -123,6 +123,9 @@ class TestFASTEMConfig(unittest.TestCase):
         # check that rotation is the same as was specified for the scanner (e-beam) for megafield imaging
         self.assertEqual(self.multibeam.getMetadata()[model.MD_ROTATION], math.radians(10))
 
+        # check that the MD_POS_COR is set to [0, 0] for live stream imaging.
+        self.assertListEqual([0, 0], self.scanner.getMetadata()[model.MD_POS_COR])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/odemis/acq/test/fastem_conf_test.py
+++ b/src/odemis/acq/test/fastem_conf_test.py
@@ -60,7 +60,8 @@ class TestFASTEMConfig(unittest.TestCase):
 
         # change the rotation for single and multibeam mode to check the correct one is selected depending on the mode
         cls.scanner.updateMetadata({model.MD_SINGLE_BEAM_ROTATION: math.radians(5),
-                                    model.MD_MULTI_BEAM_ROTATION: math.radians(10)})
+                                    model.MD_MULTI_BEAM_ROTATION: math.radians(10),
+                                    model.MD_FIELD_FREE_POS_SHIFT: [90.0e-6, 50.0e-6]})
 
     def test_configure_scanner_overview(self):
         """Check that for the overview mode, the correct HW settings are set on the respective scanner VAs."""
@@ -74,8 +75,13 @@ class TestFASTEMConfig(unittest.TestCase):
         self.assertGreater(self.scanner.horizontalFoV.value, 1.e-3)  # should be big FoV for overview
         self.assertEqual(self.scanner.rotation.value, math.radians(5))
 
+        scanner_md = self.scanner.getMetadata()
+
+        # check that the MD_POS_COR is correctly set for overview imaging.
+        self.assertListEqual(scanner_md[model.MD_FIELD_FREE_POS_SHIFT], scanner_md[model.MD_POS_COR])
+
         # check rotation set is also stored in MD as rotation correction
-        self.assertEqual(self.scanner.getMetadata()[model.MD_ROTATION_COR], math.radians(5))
+        self.assertEqual(scanner_md[model.MD_ROTATION_COR], math.radians(5))
 
         # acquire an image and check the MD is correct: ROTATION - ROTATION_COR == 0
         image = self.sed.data.get()
@@ -94,6 +100,10 @@ class TestFASTEMConfig(unittest.TestCase):
         self.assertFalse(self.scanner.blanker.value)
         self.assertTrue(self.scanner.immersion.value)
         self.assertEqual(self.scanner.rotation.value, math.radians(5))
+
+        scanner_md = self.scanner.getMetadata()
+        # check that the MD_POS_COR is set to [0, 0] for live stream imaging.
+        self.assertListEqual([0, 0], scanner_md[model.MD_POS_COR])
 
     def test_configure_scanner_megafield(self):
         """Check that for megafield mode, the correct HW settings are set on the respective scanner VAs."""

--- a/src/odemis/model/_metadata.py
+++ b/src/odemis/model/_metadata.py
@@ -232,3 +232,6 @@ MD_SCAN_AMPLITUDE_CALIB = "Scan amplitude calibrated"  # tuple in [a.u.]
 MD_CELL_TRANSLATION = "Cell translation"  # nested tuple [px], origin of effective cell image in overscanned cell image
 MD_CELL_DARK_OFFSET = "Cell dark offset"  # nested tuple, the offset in image intensity per cell
 MD_CELL_DIGITAL_GAIN = "Cell digital gain"  # nested tuple, the digital gain intensity per cell
+
+# Fastem: Correction for the shift in (x, y) between immersion mode and field free mode
+MD_FIELD_FREE_POS_SHIFT = "Field free position shift"  # tuple [m]


### PR DESCRIPTION
…d on the status of the immersion mode VA.

MD_POS_COR shifts the single beam image. When immersion is off (field free on) shift the overview image by a calibrated factor with MD_POS_COR, then set back MD_POS_COR to [0, 0] during live stream imaging (immersion on).
This way the overview image is shifted compared to the live stream, since the live stream is somewhat calibrated with the megafield this also calibrates the overview image with the megafield.