### PR TITLE
fastem calibration 2: dark/gain calibration per scintillator

### DIFF
--- a/src/odemis/acq/align/fastem.py
+++ b/src/odemis/acq/align/fastem.py
@@ -37,7 +37,9 @@ try:
         descan_gain,
         image_rotation_pre_align,
         image_rotation,
-        image_translation
+        image_translation,
+        dark_offset_correction,
+        digital_gain_correction
     )
     from fastem_calibrations.configure_hw import (
         get_config_asm,
@@ -73,9 +75,11 @@ class Calibrations(Enum):
     IMAGE_TRANSLATION_PREALIGN = image_translation_pre_align
     IMAGE_ROTATION_FINAL = image_rotation
     IMAGE_TRANSLATION_FINAL = image_translation
+    DARK_OFFSET = dark_offset_correction
+    DIGITAL_GAIN = digital_gain_correction
 
 
-def align(scanner, multibeam, descanner, detector, stage, ccd, beamshift, det_rotator, calibrations):
+def align(scanner, multibeam, descanner, detector, stage, ccd, beamshift, det_rotator, calibrations, stage_pos=None):
     """
     Start a calibration task for a given list of calibrations.
 
@@ -89,6 +93,8 @@ def align(scanner, multibeam, descanner, detector, stage, ccd, beamshift, det_ro
     :param beamshift: (tfsbc.BeamShiftController) Component that controls the beamshift deflection.
     :param det_rotator: (actuator) K-mirror controller. Must have a rotational (rz) axis.
     :param calibrations: (list[Calibrations]) List of calibrations that should be run.
+    :param stage_pos: (float, float) Stage position where the calibration should be run. If None,
+                      the calibration is run at the current stage position.
 
     :returns: (ProgressiveFuture) Alignment future object, which can be cancelled.
     """
@@ -100,7 +106,8 @@ def align(scanner, multibeam, descanner, detector, stage, ccd, beamshift, det_ro
     f = model.ProgressiveFuture(start=time.time(), end=time.time() + est_dur)
 
     # Create a task that runs the calibration and alignments.
-    task = CalibrationTask(f, scanner, multibeam, descanner, detector, stage, ccd, beamshift, det_rotator, calibrations)
+    task = CalibrationTask(f, scanner, multibeam, descanner, detector, stage, ccd, beamshift, det_rotator,
+                           calibrations, stage_pos)
 
     f.task_canceller = task.cancel  # lets the future know how to cancel the task.
 
@@ -127,7 +134,7 @@ class CalibrationTask(object):
     """
 
     def __init__(self, future, scanner, multibeam, descanner, detector, stage, ccd, beamshift, det_rotator,
-                 calibrations):
+                 calibrations, stage_pos):
         """
         :param future: (ProgressiveFuture) Acquisition future object, which can be cancelled.
                        (Exception or None): Exception raised during the calibration or None.
@@ -142,6 +149,8 @@ class CalibrationTask(object):
         :param beamshift: (tfsbc.BeamShiftController) Component that controls the beamshift deflection.
         :param det_rotator: (actuator) K-mirror controller. Must have a rotational (rz) axis.
         :param calibrations: (list[Calibrations]) List of calibrations that should be run.
+        :param stage_pos: (float, float) Stage position where the calibration should be run. If None,
+                      the calibration is run at the current stage position.
         """
         self.asm_config = None
         self._scanner = scanner
@@ -156,6 +165,7 @@ class CalibrationTask(object):
         self._future = future
 
         self.calibrations = calibrations
+        self.stage_pos = stage_pos
 
         # List of calibrations to be executed. Used for progress update.
         self._calibrations_remaining = set(calibrations)
@@ -165,9 +175,27 @@ class CalibrationTask(object):
 
     def run(self):
         """
-        Runs a set of calibration procedures.
+        Runs a set of calibration procedures and return the calibrated settings.
         :returns:
-            (None) Calibrations successful.
+            self.asm_config: (nested dict) A dictionary containing factory and/or calibrated settings. Settings
+            that are calibrated or are overwriting factory settings. The content of the dict is:
+            multibeam:
+                scanOffset: (tuple) The x and y start of the scanning movement (start of scan ramp) of the multibeam
+                            scanner in arbitrary units.
+                scanAmplitude: (tuple) The x and y heights of the scan ramp of the multibeam scanner in arbitrary units.
+                dwellTime: (float) The acquisition time for one pixel within a cell image in seconds.
+                resolution: (tuple) The effective resolution of a single field image excluding overscanned pixels
+                                    in pixels.
+            descanner:
+                scanOffset: (tuple) The x and y start of the scanning movement (start of scan ramp) of the descanner
+                            in arbitrary units.
+                scanAmplitude: (tuple) The x and y heights of the scan ramp of the descanner in arbitrary units.
+            mppc:
+                cellCompleteResolution: (tuple) The resolution of a cell image including overscanned pixels in pixels.
+                cellTranslation: (tuple of tuples of shape mppc.shape) The origin for each cell image within the
+                                 overscanned cell image in pixels.
+                cellDarkOffset: (tuple of tuples of shape mppc.shape) The dark offset correction for each cell image.
+                cellDigitalGain: (tuple of tuples of shape mppc.shape) The digital gain correction for each cell image.
         :raise:
             Exception: If a calibration failed.
             CancelledError: If the calibration was cancelled.
@@ -186,6 +214,11 @@ class CalibrationTask(object):
 
             # reset beamshift
             self._beamshift.shift.value = (0, 0)
+
+            if self.stage_pos:
+                # move to region of calibration (ROC) position
+                sf = self._stage.moveAbs({'x': self.stage_pos[0], 'y': self.stage_pos[1]})
+                sf.result()  # wait until stage is at correct position
 
             # loop over calibrations in list (order in list is important!)
             for calib in self.calibrations:
@@ -227,10 +260,11 @@ class CalibrationTask(object):
                 configure_asm(self._multibeam, self._descanner, self._detector, self._dataflow, self.asm_config)
             logging.debug("Calibrations finished.")
 
+        return self.asm_config
+
     def run_calibrations(self, calibration):
         """
         Run a calibration.
-        Note: All calibrations can be run on bare scintillator.
         """
         if calibration == Calibrations.OPTICAL_AUTOFOCUS:
             autofocus_multiprobe.run_autofocus(self._scanner, self._multibeam, self._descanner, self._detector,
@@ -287,6 +321,20 @@ class CalibrationTask(object):
             d_offset = image_translation.run_image_translation(self._scanner, self._multibeam, self._descanner,
                                                                self._detector, self._dataflow, self._ccd)
             self.asm_config["descanner"]["scanOffset"] = d_offset
+            configure_asm(self._multibeam, self._descanner, self._detector, self._dataflow, self.asm_config,
+                          upload=False)
+
+        elif calibration == Calibrations.DARK_OFFSET:
+            dark_offset = dark_offset_correction.run_dark_offset(self._scanner, self._multibeam, self._descanner,
+                                                                 self._detector, self._dataflow)
+            self.asm_config["mppc"]["cellDarkOffset"] = dark_offset
+            configure_asm(self._multibeam, self._descanner, self._detector, self._dataflow, self.asm_config,
+                          upload=False)
+
+        elif calibration == Calibrations.DIGITAL_GAIN:
+            digital_gain = digital_gain_correction.run_digital_gain(self._scanner, self._multibeam, self._descanner,
+                                                                    self._detector, self._dataflow)
+            self.asm_config["mppc"]["cellDigitalGain"] = digital_gain
             configure_asm(self._multibeam, self._descanner, self._detector, self._dataflow, self.asm_config,
                           upload=False)
 

--- a/src/odemis/acq/fastem.py
+++ b/src/odemis/acq/fastem.py
@@ -31,8 +31,11 @@ from concurrent.futures import CancelledError
 import numpy
 
 try:
-    from fastem_calibrations import autofocus_multiprobe, image_translation_pre_align, configure_hw
-
+    from fastem_calibrations import (
+        autofocus_multiprobe,
+        image_translation_pre_align,
+        configure_hw
+    )
     fastem_calibrations = True
 except ImportError:
     logging.info("fastem_calibrations package not found")
@@ -185,8 +188,6 @@ class FastEMROA(object):
         return field_indices
 
 
-# TODO add ROC acquisition to acquisition task
-
 class FastEMROC(object):
     """
     Representation of a FastEM ROC (region of calibration).
@@ -210,8 +211,6 @@ class FastEMROC(object):
                                                  cls=(int, float),
                                                  unit='m')
         self.parameters = None  # calibration object with all relevant parameters
-        # TODO parameters are the darkOffset and digitalGain values for mppc VAs; set before starting acquisition
-        # if None -> acquire, if not None, don't acquire again
 
 
 def acquire(roa, path, scanner, multibeam, descanner, detector, stage, ccd, beamshift, lens):
@@ -373,6 +372,7 @@ class AcquisitionTask(object):
                           self._roa.field_indices[-1][0] + 1, self._roa.field_indices[-1][1] + 1)
             # configure the HW settings
             fastem_conf.configure_scanner(self._scanner, fastem_conf.MEGAFIELD_MODE)
+            fastem_conf.configure_detector(self._detector, self._roc)
 
             dataflow.subscribe(self.image_received)
 

--- a/src/odemis/acq/fastem_conf.py
+++ b/src/odemis/acq/fastem_conf.py
@@ -143,3 +143,22 @@ def configure_scanner(scanner, mode):
                             scanner.rotation.value)
     else:  # code should never be reached
         raise ValueError("Invalid mode %s." % mode)
+
+
+def configure_detector(detector, roc):
+    """
+    Configure the detector by setting the calibrated parameters as stored for
+    the provided region of calibration (ROC). If calibrated parameters are not
+    available, the current settings on the detector will stay as is.
+    :param detector: (technolution.MPPC) The detector to be configured.
+    :param roc: (FASTEMROC) The region of calibration as selected on the scintillator,
+                which stores the calibrated settings if calibration was performed.
+    """
+    if "cellDarkOffset" in roc.value.parameters:
+        detector.cellDarkOffset.value = roc.value.parameters["cellDarkOffset"]
+    else:
+        logging.warning("Region of calibration doesn't have dark offset parameters.")
+    if "cellDigitalGain" in roc.value.parameters:
+        detector.cellDigitalGain.value = roc.value.parameters["cellDigitalGain"]
+    else:
+        logging.warning("Region of calibration doesn't have digital gain parameters.")

--- a/src/odemis/gui/__init__.py
+++ b/src/odemis/gui/__init__.py
@@ -54,7 +54,7 @@ BORDER_COLOUR_UNFOCUS = "#000000"
 # Colours for special warnings
 ALERT_COLOUR = "#DD3939"
 
-# Colours for overlay selection selection boxes
+# Colours for overlay selection boxes
 SELECTION_COLOUR = FG_COLOUR_EDIT
 SELECTION_COLOUR_2ND = FG_COLOUR_2ND
 

--- a/src/odemis/gui/comp/miccanvas.py
+++ b/src/odemis/gui/comp/miccanvas.py
@@ -656,6 +656,9 @@ class DblMicroscopeCanvas(canvas.DraggableCanvas):
           but with explicit bounding box, so we can zoom to a specific position.
         bbox (4 floats): bounding box to be shown, defined as minx, miny, maxx,
           maxy positions in m.
+
+        Note: Should be called from main GUI thread. Make sure caller of this method
+        is running in the main GUI thread.
         """
         # compute mpp so that the bbox fits exactly the visible part
         w, h = abs(bbox[2] - bbox[0]), abs(bbox[3] - bbox[1])  # m
@@ -676,7 +679,7 @@ class DblMicroscopeCanvas(canvas.DraggableCanvas):
             self.view.mpp.value = self.view.mpp.clip(1 / self.scale)
             self.view.view_pos.value = c
 
-        wx.CallAfter(self.request_drawing_update)
+        self.request_drawing_update()
 
     def _on_view_mpp(self, mpp):
         """ Called when the view.mpp is updated """
@@ -1859,6 +1862,9 @@ class FastEMAcquisitionCanvas(DblMicroscopeCanvas):
         """
         Zoom out to show all scintillators.
         raises ValueError, IndexError: in case it's called too early during GUI startup
+
+        Note: Should be called from main GUI thread. Make sure caller of this method
+        is running in the main GUI thread.
         """
         logging.debug("Zooming out to show all scintillators.")
         if self._tab_data_model:

--- a/src/odemis/gui/comp/miccanvas.py
+++ b/src/odemis/gui/comp/miccanvas.py
@@ -1836,9 +1836,9 @@ class FastEMAcquisitionCanvas(DblMicroscopeCanvas):
         overlay.active.value = True
         return overlay
 
-    def remove_roa_overlay(self, overlay):
+    def remove_overlay(self, overlay):
         """
-        overlay (FastEMROAOverlay): overlay to be deleted
+        overlay (FastEMROAOverlay or FastEMROAOverlay): overlay to be deleted
         """
         overlay.active.value = False  # deactivating the overlay avoids weird behaviour
         self.remove_world_overlay(overlay)

--- a/src/odemis/gui/comp/stream.py
+++ b/src/odemis/gui/comp/stream.py
@@ -1667,7 +1667,7 @@ class FastEMProjectPanelHeader(wx.Control):
         )
 
 
-class FastEMProjectBar(wx.Panel):
+class FastEMProjectList(wx.Panel):
     """
     The whole panel containing project panels and a button to add more projects.
     """
@@ -1800,7 +1800,7 @@ class FastEMProjectPanel(wx.Panel):
                  wid=wx.ID_ANY, pos=wx.DefaultPosition, size=wx.DefaultSize,
                  style=wx.CP_DEFAULT_STYLE, name="ProjectPanel", collapsed=False):
 
-        assert(isinstance(parent, FastEMProjectBar))
+        assert(isinstance(parent, FastEMProjectList))
         wx.Panel.__init__(self, parent, wid, pos, size, style, name)
 
         # Appearance
@@ -2034,7 +2034,7 @@ class FastEMROAPanel(wx.Panel):
         event.Skip()
 
 
-class FastEMCalibrationBar(wx.Panel):
+class FastEMCalibrationPanelHeader(wx.Panel):
     """
     The whole panel containing the panel with the calibration buttons.
     """
@@ -2051,8 +2051,8 @@ class FastEMCalibrationBar(wx.Panel):
 
     def add_calibration_panel(self, panel):
         """
-        This method adds the calibration panel to the calibration bar. Should only be called once.
-        panel (FastEMCalibrationPanel): the calibration panel
+        This method adds the calibration panel to the calibration header. Should only be called once.
+        :param panel: (FastEMCalibrationPanel) The calibration panel to be added.
         """
         self._sz.Insert(0, panel, flag=self.DEFAULT_STYLE, border=self.DEFAULT_BORDER)
         panel.Layout()
@@ -2067,10 +2067,10 @@ class FastEMCalibrationPanel(wx.Panel):
                  wid=wx.ID_ANY, pos=wx.DefaultPosition, size=wx.DefaultSize,
                  style=wx.CP_DEFAULT_STYLE, name="CalibrationPanel"):
         """
-        layout (list of lists of int): layout of scintillator grid, given as 2D list of scintillator positions,
+        :param layout: (list of lists of int) Layout of scintillator grid, given as 2D list of scintillator positions,
         e.g. [[6, 5, 4], [3, 2, 1]]
         """
-        assert(isinstance(parent, FastEMCalibrationBar))
+        assert(isinstance(parent, FastEMCalibrationPanelHeader))
         wx.Panel.__init__(self, parent, wid, pos, size, style, name)
 
         self.buttons = {}  # int --> wx.Button
@@ -2085,7 +2085,7 @@ class FastEMCalibrationPanel(wx.Panel):
         for row_idx, row in enumerate(layout):
             for col_idx, elem in enumerate(row):
                 subsz = wx.BoxSizer(wx.HORIZONTAL)
-                btn = wx.Button(self, wx.ALL | wx.ALIGN_CENTER, label="?", size=(30, 30))
+                btn = wx.ToggleButton(self, wx.ALL | wx.ALIGN_CENTER, label="?", size=(30, 30))
                 btn.SetBackgroundColour(FG_COLOUR_BUTTON)
                 subsz.Add(btn)
                 subsz.AddSpacer(8)

--- a/src/odemis/gui/cont/fastem_acq.py
+++ b/src/odemis/gui/cont/fastem_acq.py
@@ -280,18 +280,14 @@ class FastEMAcquiController(object):
     Takes care of the acquisition button and process in the FastEM acquisition tab.
     """
 
-    def __init__(self, tab_data, tab_panel, projectbar_ctrl, calibration_ctrl):
+    def __init__(self, tab_data, tab_panel):
         """
         tab_data (FastEMGUIData): the representation of the microscope GUI
         tab_panel: (wx.Frame): the frame which contains the viewport
-        projectbar_ctrl (FastEMProjectBarController): project bar controller
-        calibration_ctrl (FastEMCalibrationController): calibration controller
         """
         self._tab_data_model = tab_data
         self._main_data_model = tab_data.main
         self._tab_panel = tab_panel
-        self._projectbar_ctrl = projectbar_ctrl
-        self._calibration_ctrl = calibration_ctrl
 
         # Path to the acquisition
         self.path = datetime.today().strftime('%Y-%m-%d')
@@ -420,9 +416,6 @@ class FastEMAcquiController(object):
         """
         self.btn_cancel.Hide()
         self.btn_acquire.Enable()
-        self._projectbar_ctrl._project_bar.Enable(True)
-        self._calibration_ctrl._calibration_bar.Enable(True)
-        self._tab_panel.btn_align.Enable(True)
         self._tab_panel.Layout()
 
         if text is not None:
@@ -441,11 +434,6 @@ class FastEMAcquiController(object):
         self.btn_cancel.Show()
         self.gauge_acq.Show()
         self._show_status_icons(None)
-
-        # Don't allow changes to acquisition/calibration ROIs during acquisition
-        self._projectbar_ctrl._project_bar.Enable(False)
-        self._calibration_ctrl._calibration_bar.Enable(False)
-        self._tab_panel.btn_align.Enable(False)
 
         self.gauge_acq.Range = self.roa_count
         self.gauge_acq.Value = 0
@@ -502,39 +490,37 @@ class FastEMAcquiController(object):
 
 class FastEMCalibrationController:
     """
-    Controls the calibration button and process in the calibration panel in the FastEM
-    overview and acquisition tab.
+    Controls the calibration button to start the calibration and the process in the calibration panel
+    in the FastEM overview and acquisition tab.
     """
-    def __init__(self, tab_data, tab_panel, calibrations):
+    def __init__(self, tab_data, tab_panel, calib_prefix, calibrations):
         """
-        tab_data: (FastEMAcquisitionGUIData) The representation of the microscope GUI.
-        tab_panel: (wx.Frame) The calibration panel, which contains the calibration button,
-                    the gauge and the label of the gauge.
-        calibrations: (list[Calibrations]) List of calibrations that should be run.
+        :param tab_data: (FastEMAcquisitionGUIData) The representation of the microscope GUI.
+        :param tab_panel: (wx.Frame) The calibration panel, which contains the calibration button to start
+                          the calibration, and the gauge and the label of the gauge to indicate the progress.
+        :param calib_prefix: (str) A prefix, which can indicate the order/type of the calibration (e.g. "calib_1").
+        :param calibrations: (list[Calibrations]) List of calibrations that should be run.
         """
         self._tab_data = tab_data
         self._main_data_model = tab_data.main
         self._panel = tab_panel
+        self._calib_prefix = calib_prefix
         self.calibrations = calibrations
 
-        self.btn_align = tab_panel.btn_align
-        self.gauge_progress = tab_panel.align_gauge_progress  # progress bar
-        self.gauge_label = tab_panel.align_lbl_gauge  # progress bar label
+        self.button = getattr(tab_panel, calib_prefix + "_btn")
+        self.gauge = getattr(tab_panel, calib_prefix + "_gauge")
+        self.label = getattr(tab_panel, calib_prefix + "_label")
+
         self.is_aligned = tab_data.main.is_aligned
+        tab_data.main.is_acquiring.subscribe(self._on_is_acquiring)  # enable/disable button
 
-        self.gauge_progress.Hide()  # hide progress bar
-        self._panel.Parent.Layout()
-        self.btn_align.Bind(wx.EVT_BUTTON, self.on_align)
+        self.button.Bind(wx.EVT_BUTTON, self.on_calibrate)
 
-        # check calibration state of system
-        # TODO If backend was not restarted, but only GUI, then the system is in principle still calibrated.
-        #   However, so far when closing the GUI the system is also not calibrated anymore.
-        if not self.is_aligned.value:
-            self._reset_calibration_gui()  # display estimated calibration time
+        self._on_calibration_state()  # display estimated calibration time
 
         self._future_connector = None  # attribute to store the ProgressiveFutureConnector
 
-    def on_align(self, evt):
+    def on_calibrate(self, evt):
         """
         Start or cancel the calibration when the button is triggered.
         :param evt: (GenButtonEvent) Button triggered.
@@ -546,16 +532,13 @@ class FastEMCalibrationController:
             return
 
         # calibrate
+        self._tab_data.main.is_acquiring.unsubscribe(self._on_is_acquiring)
+        # Don't catch this event (is_acquiring = True) - this would disable the button,
+        # but it should be still enabled in order to be able to cancel the calibration
         self._tab_data.main.is_acquiring.value = True  # make sure the acquire/tab buttons are disabled
+        self._tab_data.main.is_acquiring.subscribe(self._on_is_acquiring)
 
-        self.gauge_progress.Show()  # show progress bar
-        # Label is displayed on the right, but during the calibration, we want the gauge bar to occupy the
-        # full available space --> use a panel instead of a spacer which can be hidden (spacers cannot) to
-        # make it look nice.
-        # self._panel.align_lbl_gauge.Hide()  # hide label progress bar TODO put below gauge instead of hide?
-        self._panel.align_spacer_panel.Hide()  # hide space progress bar and progress bar label
-        self._panel.btn_align.SetLabel("Cancel")  # change button label
-        self._panel.Layout()
+        self._on_calibration_state()  # update the controls in the panel
 
         # Start alignment
         f = align.fastem.align(self._main_data_model.ebeam, self._main_data_model.multibeam,
@@ -564,12 +547,11 @@ class FastEMCalibrationController:
                                self._main_data_model.beamshift, self._main_data_model.det_rotator,
                                calibrations=self.calibrations)
 
-        f.add_done_callback(self._on_alignment_done)  # also handles cancelling and exceptions
+        f.add_done_callback(self._on_calibration_done)  # also handles cancelling and exceptions
         # connect the future to the progress bar and its label
-        self._future_connector = ProgressiveFutureConnector(f, self.gauge_progress, self.gauge_label)
+        self._future_connector = ProgressiveFutureConnector(f, self.gauge, self.label, full=False)
 
-    @call_in_wx_main
-    def _on_alignment_done(self, future):
+    def _on_calibration_done(self, future, _=None):
         """
         Called when the calibration is finished (either successfully, cancelled or failed).
         :param future: (ProgressiveFuture) Calibration future object, which can be cancelled.
@@ -581,32 +563,224 @@ class FastEMCalibrationController:
         try:
             future.result()  # wait until the calibration is done
             self.is_aligned.value = True  # allow acquiring ROAs
-            self._reset_calibration_gui("Calibration successful")
+            self._update_calibration_controls("Calibration successful")
         except CancelledError:
             self.is_aligned.value = False  # don't enable ROA acquisition
-            self._reset_calibration_gui("Calibration cancelled")  # update label to indicate cancelling
-            return
+            self._update_calibration_controls("Calibration cancelled")  # update label to indicate cancelling
         except Exception as ex:
             self.is_aligned.value = False  # don't enable ROA acquisition
             logging.exception("Calibration failed with %s.", ex)
-            self._reset_calibration_gui("Calibration failed")
-            return
+            self._update_calibration_controls("Calibration failed")
 
-    def _reset_calibration_gui(self, text=None):
+    def _on_calibration_state(self, _=None):
         """
-        Set back every element in the calibration panel to be ready for the next calibration.
-        :param text (None or str): A (error) message to display instead of the estimated acquisition time.
+        Updates the calibration state by updating the calibration controls in the panel.
         """
-        self.btn_align.Enable(True)  # enable button again
-        self.btn_align.SetLabel("Calibrate")  # change button label back to ready for calibration
-        self.gauge_progress.Hide()  # hide progress bar
-        self._panel.align_spacer_panel.Show()  # show space progress bar and progress bar label
-        self.gauge_label.Show()  # show label progress bar
+        self._update_calibration_controls()
+
+    @wxlimit_invocation(1)  # max 1/s; called in main GUI thread
+    def _update_calibration_controls(self, text=None, button_state=True):
+        """
+        Update the calibration panel controls to be ready for the next calibration.
+        :param text: (None or str) A (error) message to display instead of the estimated acquisition time.
+        :param button_state: (bool) Enabled or disable button depending on state. Default is enabled.
+        """
+        self.button.Enable(button_state)  # enable/disable button
+
+        if self._tab_data.main.is_acquiring.value:
+            self.button.SetLabel("Cancel")  # indicate canceling is possible
+            self.gauge.Show()  # show progress bar
+        else:
+            self.button.SetLabel("Calibrate")  # change button label back to ready for calibration
+            self.gauge.Hide()  # hide progress bar
 
         if text is not None:
-            self.gauge_label.SetLabel(text)
+            self.label.SetLabel(text)
         else:
-            duration = align.fastem.estimate_calibration_time(self.calibrations)
-            self.gauge_label.SetLabel(str(duration) + " seconds")
+            duration = self.estimate_calibration_time()
+            self.label.SetLabel(units.readable_time(duration, full=False))
 
-        self._panel.Layout()
+        self.button.Parent.Layout()
+
+    def estimate_calibration_time(self):
+        """
+        Calculate the estimated calibration time based on the calibrations that need to be run.
+        :return (float): The estimated calibration time in seconds.
+        """
+        return align.fastem.estimate_calibration_time(self.calibrations)
+
+    @call_in_wx_main  # call in main thread as changes in GUI are triggered
+    def _on_is_acquiring(self, mode):
+        """
+        Enable or disable the button to start a calibration depending on whether
+        a calibration or acquisition is already ongoing or not.
+        :param mode: (bool) Whether the system is currently acquiring or not acquiring.
+        """
+        self.button.Enable(not mode)
+
+
+class FastEMScintillatorCalibrationController(FastEMCalibrationController):
+    """
+    Controls the selection panel for the individual scintillators, the calibration button to start the
+    calibration and the process in the calibration panel in the FastEM acquisition tab.
+    """
+    def __init__(self, tab_data, tab_panel, calib_prefix, calibrations):
+        """
+        :param tab_data: (FastEMAcquisitionGUIData) The representation of the microscope GUI.
+        :param tab_panel: (wx.Frame) The calibration panel, which contains the selection buttons
+                          for the individual scintillators, the calibration button to start the
+                          calibration, and the gauge and the label of the gauge to indicate the progress.
+        :param calib_prefix: (str) A prefix, which can indicate the order/type of the calibration (e.g. "calib_1").
+        :param calibrations: (list[Calibrations]) List of calibrations that should be run.
+        """
+        super().__init__(tab_data, tab_panel, calib_prefix, calibrations)
+
+        # listen to calibration regions selected/deselected and update estimated calibration time accordingly
+        for roc in tab_data.calibration_regions.value.values():
+            roc.coordinates.subscribe(self._on_calibration_state)
+
+        self._main_data_model.active_scintillators.subscribe(self._on_calibration_state)
+
+    def on_calibrate(self, evt):
+        """
+        Start or cancel the calibrations for all set regions of calibrations (ROC) when the calibration
+        button is triggered. A progressive future for all rocs is created.
+        :param evt: (GenButtonEvent) Button triggered.
+        """
+        # check if cancelled
+        if self._tab_data.main.is_acquiring.value:
+            logging.debug("Calibration was cancelled.")
+            align_fastem._executor.cancel()  # all the rest will be handled by on_alignment_done()
+            # FIXME cancelling does not yet display the correct label in the gui
+            return
+
+        # calibrate
+        self._tab_data.main.is_acquiring.unsubscribe(self._on_is_acquiring)
+        # Briefly unsubscribe as don't need to know about this event (is_acquiring = True):
+        # It  would disable the calibration button, but want to be able to still cancel calibration.
+        self._tab_data.main.is_acquiring.value = True  # make sure the acquire/tab buttons are disabled
+        self._tab_data.main.is_acquiring.subscribe(self._on_is_acquiring)
+
+        self._on_calibration_state()  # update the controls in the panel
+
+        futures = {}
+        try:
+            for roc_num in sorted(self._tab_data.calibration_regions.value.keys()):
+                # check if calibration region (ROC) on scintillator is set (undefined = not set)
+                roc = self._tab_data.calibration_regions.value[roc_num]
+                if roc.coordinates.value != stream.UNDEFINED_ROI:
+
+                    # calculate the center position of the ROC (half field right/bottom
+                    # compared to top/left corner in view)
+                    xmin, ymin, _, _ = roc.coordinates.value
+                    field_size = (self._tab_data.main.multibeam.resolution.value[0]
+                                  * self._tab_data.main.multibeam.pixelSize.value[0],
+                                  self._tab_data.main.multibeam.resolution.value[1]
+                                  * self._tab_data.main.multibeam.pixelSize.value[1])
+                    roc_center = (xmin + field_size[0] / 2, ymin + field_size[1] / 2)
+
+                    # start calibration
+                    f = align.fastem.align(self._main_data_model.ebeam, self._main_data_model.multibeam,
+                                           self._main_data_model.descanner, self._main_data_model.mppc,
+                                           self._main_data_model.stage, self._main_data_model.ccd,
+                                           self._main_data_model.beamshift, self._main_data_model.det_rotator,
+                                           calibrations=self.calibrations, stage_pos=roc_center)
+                    t = align.fastem.estimate_calibration_time(self.calibrations)
+                    # also handles cancelling and exceptions
+                    f.add_done_callback(partial(self._on_calibration_done, roc_num=roc_num))
+                    futures[f] = t
+
+            calib_future = model.ProgressiveBatchFuture(futures)
+            # also handles cancelling and exceptions
+            calib_future.add_done_callback(self._on_batch_calibrations_done)
+            # connect the future to the progress bar and its label
+            self._future_connector = ProgressiveFutureConnector(calib_future, self.gauge, self.label, full=False)
+        except Exception as ex:  # In case all calibrations failed to start
+            logging.warning("Calibration failed with %s", ex)
+            for f in futures.keys():
+                f.cancel()  # cancel all sub-futures
+            self._main_data_model.is_acquiring.value = False
+            self._update_calibration_controls("Calibrations failed.")
+
+    def _on_calibration_done(self, future, roc_num):
+        """
+        Called when the calibrations for one region of calibration (ROC) are finished
+        (either successfully, cancelled or failed).
+        It stores the calibrated parameters on the ROC object.
+        :param future: (ProgressiveFuture) Calibration future object, which can be cancelled.
+        :param roc_num: (int) The number of the region of calibration.
+        """
+
+        try:
+            config = future.result()  # wait until the calibration is done
+            self.save_calibrated_settings(roc_num, config)  # save calibrated
+        except CancelledError:
+            pass  # nothing to do here, callback of batch future takes care of everything
+        except Exception as ex:
+            logging.exception("Calibration failed with %s.", ex)  # callback of batch future takes care of the rest
+
+    def _on_batch_calibrations_done(self, batch_future):
+        """
+        Called when all calibrations are finished (either successfully, cancelled or failed).
+        :param batch_future: (ProgressiveFuture) Calibration future object, which can be cancelled.
+        """
+
+        self._tab_data.main.is_acquiring.value = False
+        self._future_connector = None  # reset connection to the progress bar
+
+        try:
+            batch_future.result()  # wait until the calibration is done
+            self.is_aligned.value = True  # allow acquiring ROAs
+            self._update_calibration_controls("Calibration successful")
+        except CancelledError:
+            self.is_aligned.value = False  # don't enable ROA acquisition
+            self._update_calibration_controls("Calibration cancelled")  # update label to indicate cancelling
+        except Exception:
+            self.is_aligned.value = False  # don't enable ROA acquisition
+            self._update_calibration_controls("Calibration failed")
+
+    def _on_calibration_state(self, _=None):
+        """
+        Updates the calibration state based on the active (loaded) scintillators and whether
+        any regions of calibration (ROC) are selected.
+        """
+        # check if any scintillators loaded
+        if not self._main_data_model.active_scintillators.value:
+            self._update_calibration_controls("No scintillator loaded (go to Chamber tab).", False)
+        else:
+            # check if at least one roc was selected (undefined = not set)
+            if any(roc.coordinates.value != stream.UNDEFINED_ROI
+                   for roc in self._tab_data.calibration_regions.value.values()):
+                self._update_calibration_controls()
+            else:
+                self._update_calibration_controls("No calibration region selected.", False)
+
+    def save_calibrated_settings(self, roc_num, config):
+        """
+        Save the calibrated settings on the region of calibration (ROC) object.
+        :param roc_num: (int) The number of the region of calibration.
+        :param config: (nested dict) Dictionary containing various calibrated settings.
+        """
+        # FIXME this is not generic if we want to reuse code for field corrections
+        #  -> make 2 classes and overwrite this method here
+        # FIXME this now happens outside of future, so it could be that next calibration is already running
+        #  -> still save to do? Or pass the self._tab_data.calibration_regions to the calibration manager?
+        dark_offset = config["mppc"]["cellDarkOffset"]
+        digital_gain = config["mppc"]["cellDigitalGain"]
+        self._tab_data.calibration_regions.value[roc_num].parameters = {"cellDarkOffset": dark_offset,
+                                                                        "cellDigitalGain": digital_gain}
+
+    def estimate_calibration_time(self):
+        """
+        Calculate the estimated calibration time based on the calibrations that need to be run and the
+        number of region of calibrations (ROC) selected.
+        :return (float): The estimated calibration time in seconds.
+        """
+        # get number of rocs set
+        nroc = len([roc for roc in self._tab_data.calibration_regions.value.values()
+                   if roc.coordinates.value != stream.UNDEFINED_ROI])  # (undefined = not set)
+
+        # TODO take dwell time into account during calibration?
+
+        return nroc * align.fastem.estimate_calibration_time(self.calibrations)
+

--- a/src/odemis/gui/cont/project.py
+++ b/src/odemis/gui/cont/project.py
@@ -35,7 +35,7 @@ import wx
 import odemis.acq.fastem
 import odemis.acq.stream as acqstream
 import odemis.gui.model as guimodel
-from odemis.gui import conf
+from odemis.gui import conf, FG_COLOUR_WARNING
 from odemis.gui.comp.stream import FastEMProjectPanel, FastEMROAPanel, FastEMCalibrationPanel
 from odemis.gui.util import call_in_wx_main
 from odemis.util.filename import make_unique_name
@@ -45,27 +45,29 @@ FASTEM_PROJECT_COLOURS = ["#0000ff", "#00ff00", "#00ffff", "#ffff00", "#ff00ff",
                           "#ff00bf", "#ff0000"]
 
 
-class FastEMProjectBarController(object):
+class FastEMProjectListController(object):
     """
-    Creates/removes new the FastEM projects.
+    Creates/removes new FastEM projects.
     """
 
-    def __init__(self, tab_data, project_bar, view_ctrl):
+    def __init__(self, tab_data, project_list, view_ctrl):
         """
-        project_bar (FastEMProjectBar): top-level panel containing all project panels
-        tab_data (FastEMAcquisitionGUIData): tab data model
-        view_ctrl (FastEMAcquisitionViewport): viewport controller
+        :param tab_data: (FastEMAcquisitionGUIData) The tab data model.
+        :param project_list: (FastEMProjectList) The top-level panel containing all project panels.
+        :param view_ctrl: (FastEMAcquisitionViewport) The viewport controller. TODO replace with view only.
         """
         self._tab_data_model = tab_data
         self._main_data_model = tab_data.main
-        self._project_bar = project_bar
+        self._project_list = project_list
         self._view_ctrl = view_ctrl
 
         self.project_ctrls = {}  # dict int --> FastEMProjectController
-        self._project_bar.btn_add_project.Bind(wx.EVT_BUTTON, self._add_project)
+        self._project_list.btn_add_project.Bind(wx.EVT_BUTTON, self._add_project)
 
         # Always show one project by default
         self._add_project(None)
+
+        tab_data.main.is_acquiring.subscribe(self._on_is_acquiring)  # enable/disable project panel
 
     def _add_project(self, _):
         # Get the smallest number that is not already in use. It's a bit challenging because projects can be
@@ -75,7 +77,7 @@ class FastEMProjectBarController(object):
         name = "Project-%s" % num
         logging.debug("Creating new project %s.", name)
         colour = FASTEM_PROJECT_COLOURS[(num - 1) % len(FASTEM_PROJECT_COLOURS)]
-        project_ctrl = FastEMProjectController(name, colour, self._tab_data_model, self._project_bar, self._view_ctrl)
+        project_ctrl = FastEMProjectController(name, colour, self._tab_data_model, self._project_list, self._view_ctrl)
 
         # Add the project model to tab_data
         self.project_ctrls[num] = project_ctrl
@@ -93,7 +95,7 @@ class FastEMProjectBarController(object):
             project_ctrl.remove_roa_ctrl(next(iter(project_ctrl.roa_ctrls.values())))
 
         # Remove panel
-        self._project_bar.remove_project_panel(project_ctrl.panel)
+        self._project_list.remove_project_panel(project_ctrl.panel)
 
         # Remove controller from .project_ctrls list
         self.project_ctrls = {key: val for key, val in self.project_ctrls.items() if val != project_ctrl}
@@ -104,33 +106,43 @@ class FastEMProjectBarController(object):
         # Destroy ROAController object
         del project_ctrl
 
+    @call_in_wx_main
+    def _on_is_acquiring(self, mode):
+        """
+        Enable or disable the project list with all the ROAs depending on whether
+        a calibration or acquisition is already ongoing or not.
+        :param mode: (bool) Whether the system is currently acquiring or not acquiring.
+        """
+        # TODO only disable while an acquisition is ongoing. During calibration it is fine to enable.
+        self._project_list.Enable(not mode)
+
 
 class FastEMProjectController(object):
     """
     Controller for a FastEM project. This class is responsible for the creation and maintenance
-    of ROIs belonging to the project.
-    During initialization, a panel is created and added to the project bar.
+    of ROAs belonging to the same project.
+    During initialization, a panel is created and added to the project list.
     """
 
-    def __init__(self, name, colour, tab_data, project_bar, view_ctrl):
+    def __init__(self, name, colour, tab_data, project_list, view_ctrl):
         """
-        name (str): default name for the project
-        colour (str): hexadecimal colour code for the bounding box of the roas in the viewport
-        tab_data (FastEMAcquisitionGUIData): tab data model
-        project_bar (FastEMProjectBar): top-level panel containing all project panels
-        view_ctrl (FastEMAcquisitionViewport): viewport controller
+        :param name: (str) The default name for the project.
+        :param colour: (str) Hexadecimal colour code for the bounding box of the roas in the viewport
+        :param tab_data: (FastEMAcquisitionGUIData) The tab data model.
+        :param project_list: (FastEMProjectList) The top-level panel containing all project panels.
+        :param view_ctrl: (FastEMAcquisitionViewport) The viewport controller. TODO replace with view only
         """
         self._tab_data = tab_data
-        self._project_bar = project_bar
+        self._project_bar = project_list
         self._view_ctrl = view_ctrl
 
         self.roa_ctrls = {}  # dict int --> FastEMROAController
         self.colour = colour
         self.model = guimodel.FastEMProject(name)
 
-        # Create the panel and add it to the project bar. Subscribe to controls.
-        self.panel = FastEMProjectPanel(project_bar, name=name)
-        project_bar.add_project_panel(self.panel)
+        # Create the panel and add it to the project list. Subscribe to the controls.
+        self.panel = FastEMProjectPanel(project_list, name=name)
+        project_list.add_project_panel(self.panel)
         self.panel.btn_add_roa.Bind(wx.EVT_BUTTON, self._on_btn_roa)
         # Listen to both enter and kill focus event to make sure the text is really updated
         self.panel.txt_ctrl.Bind(wx.EVT_KILL_FOCUS, self._on_text)
@@ -184,7 +196,7 @@ class FastEMProjectController(object):
         # Abort ROI creation if nothing was selected
         if coords == acqstream.UNDEFINED_ROI:
             logging.debug("Aborting ROA creation.")
-            self._view_ctrl.viewports[0].canvas.remove_roa_overlay(roa_ctrl.overlay)
+            self._view_ctrl.viewports[0].canvas.remove_overlay(roa_ctrl.overlay)
             self.roa_ctrls = {key: val for key, val in self.roa_ctrls.items() if val != roa_ctrl}
         else:
             # Create the panel
@@ -215,7 +227,7 @@ class FastEMProjectController(object):
         self.roa_ctrls = {key: val for key, val in self.roa_ctrls.items() if val != roa_ctrl}
 
         # Remove overlay
-        self._view_ctrl.viewports[0].canvas.remove_roa_overlay(roa_ctrl.overlay)
+        self._view_ctrl.viewports[0].canvas.remove_overlay(roa_ctrl.overlay)
 
         # Remove model
         self.model.roas.value.remove(roa_ctrl.model)
@@ -225,9 +237,10 @@ class FastEMProjectController(object):
 
     def _find_closest_scintillator(self, coordinates):
         """
-        Given coordinates coords, find the closest scintillator.
-        coordinates (float, float, float, float): l, t, r, b coordinates in m
-        return (int): name (key) of closest scintillator in ._tab_data.scintillator_positions dict
+        Find the closest scintillator for the provided region of acquisition (ROA) coordinates.
+        :param coordinates: (float, float, float, float) xmin (left), ymin (top), xmax (right), ymax (bottom)
+                            coordinates in m.
+        :return: (int) Name (key) of closest scintillator in the ._tab_data.scintillator_positions dictionary.
         """
         roi_x, roi_y = (coordinates[2] + coordinates[0]) / 2, (coordinates[1] + coordinates[3]) / 2
         mindist = 1  # distances always lower 1
@@ -243,21 +256,22 @@ class FastEMProjectController(object):
 
 class FastEMROAController(object):
     """
-    Controller for a single region of acquisition.
+    Controller for a single region of acquisition (ROA).
     """
 
     def __init__(self, name, roc, colour, tab_data, project_panel, view_ctrl):
         """
-        name (str): default name for the ROA
-        roc (FastEMROC): region of calibration
-        colour (str): hexadecimal colour code for the bounding box of the roas in the viewport
-        tab_data (FastEMAcquisitionGUIData): tab data model
-        project_panel (FastEMProjectPanel): project panel
-        view_ctrl (FastEMAcquisitionViewport): viewport controller
+        :param name: (str) The default name for the ROA.
+        :param roc: (FastEMROC): The region of calibration corresponding to the ROA.
+        :param colour: (str) Hexadecimal colour code for the bounding box of the roas in the viewport.
+        :param tab_data: (FastEMAcquisitionGUIData) The tab data model.
+        :param project_panel: (FastEMProjectPanel) The corresponding project panel.
+        :param view_ctrl: (FastEMAcquisitionViewport) The viewport controller. TODO replace with view only.
         """
         self._tab_data = tab_data
         self._project_panel = project_panel
         self._view_ctrl = view_ctrl
+
         # Read the overlap from the acquisition configuration
         acqui_conf = conf.get_acqui_conf()
 
@@ -279,7 +293,7 @@ class FastEMROAController(object):
 
     def create_panel(self):
         """
-        Create a panel, add it to the project panel and subscribe to controls. Should only be called once.
+        Create a panel, add it to the project panel and subscribe to the controls. Should only be called once.
         """
         logging.debug("Creating panel for ROA %s.", self.model.name.value)
         self.panel = FastEMROAPanel(self._project_panel, self.model.name.value,
@@ -336,51 +350,55 @@ class FastEMROAController(object):
 
 class FastEMROCController(object):
     """
-    Controller for a single region of calibration.
+    Controller for a single region of calibration (ROC).
     """
 
     def __init__(self, number, tab_data, view_ctrl):
         """
-        number (int): number of the calibration region
-        tab_data (FastEMAcquisitionGUIData): tab data model
-        view_ctrl (FastEMAcquisitionViewport): viewport controller
+        :param number: (int) The number of the calibration region.
+        :param tab_data: (FastEMAcquisitionGUIData) The tab data model.
+        :param view_ctrl (FastEMAcquisitionViewport) The viewport controller. TODO replace with view only.
         """
         self._view_ctrl = view_ctrl
         self._tab_data = tab_data
 
-        # By default, the calibration region is in the center of the scintillator. The size is given by
-        # the ebeam resolution.
-        pos = tab_data.main.scintillator_positions[number]
-        sz = (tab_data.main.ebeam.resolution.value[0] * tab_data.main.ebeam.pixelSize.value[0],
-              tab_data.main.ebeam.resolution.value[1] * tab_data.main.ebeam.pixelSize.value[1])
-
-        l = pos[0] - 0.5 * sz[0]
-        t = pos[1] + 0.5 * sz[1]
-        r = pos[0] + 0.5 * sz[0]
-        b = pos[1] - 0.5 * sz[1]
-
         # Get ROC model (exists already in tab data) and change coordinates
-        self.model = tab_data.calibration_regions.value[number]
-        self.model.coordinates.value = (l, t, r, b)
-        self.model.coordinates.subscribe(self._on_coordinates)
+        self.calib_model = tab_data.calibration_regions.value[number]
+        self.calib_model.coordinates.subscribe(self._on_coordinates)
 
-        # Add overlay
-        self.overlay = view_ctrl.viewports[0].canvas.add_calibration_overlay(self.model.coordinates, number)
+        self.overlay = None
 
     def fit_view_to_bbox(self):
         """
-        Zoom in to calibration region. Calibration region is in the center and takes up 1/100 of viewport area.
+        Zoom in on calibration region (ROC). Calibration region is centered in the scintillator with the
+        corresponding number and takes up approximately 1/100 of the viewport area.
         """
-        logging.debug("Zooming in to calibration region %s.", self.model.name.value)
+        logging.debug("Zooming in on calibration region %s.", self.calib_model.name.value)
         cnvs = self._view_ctrl.viewports[0].canvas
-        l, t, r, b = self.model.coordinates.value
-        sz = (self._tab_data.main.ebeam.resolution.value[0] * self._tab_data.main.ebeam.pixelSize.value[0],
-              self._tab_data.main.ebeam.resolution.value[1] * self._tab_data.main.ebeam.pixelSize.value[1])
-        cnvs.fit_to_bbox([l - 5 * sz[0], t - 5 * sz[1], r + 5 * sz[0], b + 5 * sz[1]])
+        xmin, ymin, xmax, ymax = self.calib_model.coordinates.value
+        size = (self._tab_data.main.multibeam.resolution.value[0] * self._tab_data.main.multibeam.pixelSize.value[0],
+                self._tab_data.main.multibeam.resolution.value[1] * self._tab_data.main.multibeam.pixelSize.value[1])
+        # zoom in on ROC; add some space around ROC (factor 5 defines zoom level)
+        # wx.callAfter: then don't need decorator to run it in main GUI thread
+        wx.CallAfter(cnvs.fit_to_bbox, [xmin - 5 * size[0], ymin - 5 * size[1], xmax + 5 * size[0], ymax + 5 * size[1]])
 
-    def _on_coordinates(self, coords):
-        # Purely for logging
-        logging.debug("ROC '%s' coordinates changed to %s.", self.model.name.value, coords)
+    def _on_coordinates(self, coordinates):
+        """
+        Called when the coordinates of a region of calibration (ROC) object are changed.
+        This can be by either adding, removing or dragging a ROC.
+        :param coordinates: (UNDEFINED_ROI or tuple of 4 floats) Coordinates of the region of calibration (l, t, r, b).
+        """
+        logging.debug("ROC '%s' coordinates changed to %s.", self.calib_model.name.value, coordinates)
+        if coordinates == acqstream.UNDEFINED_ROI:
+            # remove the ROC overlay in the viewport
+            if self.overlay is not None:
+                self._view_ctrl.viewports[0].canvas.remove_overlay(self.overlay)
+                self.overlay = None  # needed so it can be added again to viewport
+        else:
+            # add ROC overlay if not there yet (e.g. do not add when just moving the overlay)
+            if self.overlay is None:
+                self.overlay = self._view_ctrl.viewports[0].canvas.add_calibration_overlay(self.calib_model.coordinates,
+                                                                                           self.calib_model.name.value)
 
 
 class FastEMCalibrationRegionsController(object):
@@ -388,48 +406,120 @@ class FastEMCalibrationRegionsController(object):
     Listens to the calibration buttons and creates the FastEMROCControllers accordingly.
     """
 
-    def __init__(self, tab_data, calibration_bar, view_ctrl):
+    def __init__(self, tab_data, calibration_panel, view_ctrl):
         """
-        tab_data (FastEMAcquisitionGUIData): tab data model
-        calibration_bar (FastEMCalibrationBar): main calibration panel
-        view_ctrl (FastEMAcquisitionViewport): viewport controller
+        :param tab_data (FastEMAcquisitionGUIData): The tab data model.
+        :param calibration_panel (FastEMCalibrationPanelHeader): The main calibration panel including the 9 regions
+                of calibration (ROC) buttons, the calibrate button, the gauge and the label.
+        :param view_ctrl (FastEMAcquisitionViewport): The viewport controller. TODO replace with just view
         """
-        self._view_ctrl = view_ctrl
-        self._calibration_bar = calibration_bar
         self._tab_data = tab_data
+        self._data_model = self._tab_data.main
+        self._calibration_panel = calibration_panel
+        self._view_ctrl = view_ctrl
 
-        self.panel = FastEMCalibrationPanel(calibration_bar, tab_data.main.scintillator_layout)
-        calibration_bar.add_calibration_panel(self.panel)
-
-        self.roc_ctrls = {}  # int --> FastEMROCController
+        self.panel = FastEMCalibrationPanel(calibration_panel, tab_data.main.scintillator_layout)
+        calibration_panel.add_calibration_panel(self.panel)
 
         for btn in self.panel.buttons.values():
-            btn.Bind(wx.EVT_BUTTON, self._on_button)
+            btn.Bind(wx.EVT_TOGGLEBUTTON, self._on_button)
             btn.Enable(False)  # disabled by default, need to select scintillator in chamber tab first
+
+        # create calibration controller for each scintillator
+        self.roc_ctrls = {}
+        for roc_num, roc in self._tab_data.calibration_regions.value.items():
+            self.roc_ctrls[roc_num] = FastEMROCController(roc_num, self._tab_data, self._view_ctrl)
+            roc.coordinates.subscribe(self._on_coordinates)
 
         # Only enable buttons for scintillators which have been selected in the chamber tab
         tab_data.main.active_scintillators.subscribe(self._on_active_scintillators)
 
-    def _on_button(self, evt):
-        btn = evt.GetEventObject()
-        btn.SetLabel("OK")
-        btn.SetForegroundColour(wx.GREEN)
+        tab_data.main.is_acquiring.subscribe(self._on_is_acquiring)  # enable/disable button
 
+    def _on_button(self, evt):
+        """
+        Called when one of the 9 single region of calibration (ROC) buttons is triggered.
+        An ROC can be added or removed by clicking again. If a ROC is added, an overlay will be
+        created in the center of the corresponding viewport. Size of the ROC is one single field.
+        If a ROC is removed, the coordinates are reset to undefined.
+        :param evt: (CommandEvent) Button triggered.
+        """
+
+        btn = evt.GetEventObject()
         num = [num for num, b in self.panel.buttons.items() if b == btn][0]
-        if num not in self.roc_ctrls:
-            # Create new calibration controller
-            logging.debug("Adding ROC controller %s.", num)
-            roc_ctrl = FastEMROCController(num, self._tab_data, self._view_ctrl)
-            self.roc_ctrls[num] = roc_ctrl
+
+        if btn.GetValue():
+            # update the coordinates
+            # By default, the calibration region is in the center of the scintillator.
+            # It is a single field image and thus its size is defined by the
+            # multibeam resolution and pixel size.
+            pos = self._data_model.scintillator_positions[num]
+            sz = (self._data_model.multibeam.resolution.value[0] * self._data_model.multibeam.pixelSize.value[0],
+                  self._data_model.multibeam.resolution.value[1] * self._data_model.multibeam.pixelSize.value[1])
+
+            xmin = pos[0] - 0.5 * sz[0]
+            ymin = pos[1] + 0.5 * sz[1]
+            xmax = pos[0] + 0.5 * sz[0]
+            ymax = pos[1] - 0.5 * sz[1]
+
+            self.roc_ctrls[num].calib_model.coordinates.value = (xmin, ymin, xmax, ymax)
+            self.roc_ctrls[num].fit_view_to_bbox()  # Zoom to calibration region
         else:
-            # Zoom to existing calibration region
-            roc_ctrl = self.roc_ctrls[num]
-        roc_ctrl.fit_view_to_bbox()
+            # reset coordinates for ROC to undefined
+            self.roc_ctrls[num].calib_model.coordinates.value = acqstream.UNDEFINED_ROI
 
     @call_in_wx_main
-    def _on_active_scintillators(self, scintillators):
+    def _on_coordinates(self, _=None):
+        """
+        Checks that the region of calibration (ROC) buttons are up-to-date (synchronize model with GUI).
+        Whenever the list of active scintillators changes and or a roc is selected/deselected, the
+        buttons are updated/enabled/disabled accordingly.
+        """
+        rocs = self._tab_data.calibration_regions.value
+        active_scintillators = self._tab_data.main.active_scintillators.value
+
         for num, b in self.panel.buttons.items():
-            if num in scintillators:
+            roc = rocs[num]
+
+            # scintillator selected, but undefined roc
+            if num in active_scintillators and roc.coordinates.value == acqstream.UNDEFINED_ROI:
                 b.Enable(True)
+                b.SetLabel("?")
+                b.SetForegroundColour(odemis.gui.FG_COLOUR_RADIO_INACTIVE)
+            # scintillator selected, defined roc
+            elif num in active_scintillators and roc.coordinates.value != acqstream.UNDEFINED_ROI:
+                b.Enable(True)
+                b.SetLabel("OK")
+                b.SetForegroundColour(FG_COLOUR_WARNING)
+            # scintillator unselected
             else:
                 b.Enable(False)
+                b.SetLabel("?")
+                b.SetForegroundColour(odemis.gui.FG_COLOUR_BUTTON)
+
+    def _on_active_scintillators(self, scintillators):
+        """
+        Called when the list of active scintillators has changed. If a scintillator becomes inactive,
+        the coordinates of the corresponding region of calibration (ROC) are reset. The calibration
+        panel containing the roc buttons are updated.
+        :param scintillators: (list of int) A list of active (loaded) scintillators as indicated in the chamber tab.
+        """
+        for num, b in self.panel.buttons.items():
+            if num not in scintillators:
+                # reset coordinates for ROC to undefined
+                self.roc_ctrls[num].calib_model.coordinates.value = acqstream.UNDEFINED_ROI
+
+        # update ROC buttons
+        self._on_coordinates()
+
+    def _update(self):
+        pass
+
+    @call_in_wx_main
+    def _on_is_acquiring(self, mode):
+        """
+        Enable or disable the calibration panel depending on whether
+        a calibration or acquisition is already ongoing or not.
+        :param mode: (bool) Whether the system is currently acquiring or not acquiring.
+        """
+        self._calibration_panel.Enable(not mode)

--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -1781,20 +1781,6 @@ class FastEMAcquisitionTab(Tab):
                                                                       view_ctrl=self.view_controller,
                                                                       )
 
-        # Project bar controller
-        self._projectbar_controller = project.FastEMProjectBarController(
-            tab_data,
-            panel.pnl_fastem_projects,
-            view_ctrl=self.view_controller,
-        )
-
-        # Controller for calibration panel 2
-        self._calibrationbar_controller = project.FastEMCalibrationRegionsController(
-            tab_data,
-            panel.pnl_fastem_calibration_2,
-            view_ctrl=self.view_controller,
-        )
-
         # Check if we deal with a real or simulated microscope. If it is a simulator,
         # we cannot run all calibrations yet.
         # HACK warning: we don't have an official way to detect a component is simulated, but here, we really
@@ -1810,13 +1796,32 @@ class FastEMAcquisitionTab(Tab):
             # IMAGE_TRANSLATION_FINAL FIXME: add when we can update the good mp position and fix for max amplitude
 
         # Controller for calibration panel 1
-        self._alignment_controller = fastem_acq.FastEMCalibrationController(
+        self._calib_1_controller = fastem_acq.FastEMCalibrationController(
             tab_data,
             panel,
-            calibrations
+            calib_prefix="calib_1",
+            calibrations=calibrations
         )
 
-        # Controller for acquistion settings panel
+        # FIXME instantiate FastEMCalibrationRegionsController in FastEMScintillatorCalibrationController and
+        #  not here as a separate controller -> will reduce it here to only one calibration 2 controller
+        # Controller for regions of calibration 2
+        self._calib_2_region_controller = project.FastEMCalibrationRegionsController(
+            tab_data,
+            panel.calib_2_pnl_regions,
+            view_ctrl=self.view_controller,  # TODO pass only viewport (panel.vp_fastem_acqui)
+        )
+
+        # Controller for calibration panel 2
+        self._calib_2_controller = fastem_acq.FastEMScintillatorCalibrationController(
+            tab_data,
+            panel,
+            calib_prefix="calib_2",
+            calibrations=[Calibrations.OPTICAL_AUTOFOCUS, Calibrations.IMAGE_TRANSLATION_PREALIGN,
+                          Calibrations.DARK_OFFSET, Calibrations.DIGITAL_GAIN]
+        )
+
+        # Controller for acquisition settings panel
         self._acq_settings_controller = settings.SettingsController(
             panel.pnl_acq_settings,
             ""  # default message, which is shown if no setting is available
@@ -1825,29 +1830,18 @@ class FastEMAcquisitionTab(Tab):
         self._acq_settings_controller.add_setting_entry(
             "dwellTime", tab_data.main.multibeam.dwellTime, tab_data.main.multibeam, dt_conf)
 
+        # Controller for the list of projects
+        self._project_list_controller = project.FastEMProjectListController(
+            tab_data,
+            panel.pnl_fastem_projects,
+            view_ctrl=self.view_controller,
+        )
+
         # Acquisition controller
         self._acquisition_controller = fastem_acq.FastEMAcquiController(
             tab_data,
             panel,
-            self._projectbar_controller,
-            self._calibrationbar_controller
         )
-
-    @property
-    def streams_controller(self):
-        return self._streams_controller
-
-    @property
-    def projectbar_controller(self):
-        return self._projectbar_controller
-
-    @property
-    def acquisition_controller(self):
-        return self._acquisition_controller
-
-    @property
-    def calibrationbar_controller(self):
-        return self._calibrationbar_controller
 
     def Show(self, show=True):
         super(FastEMAcquisitionTab, self).Show(show)
@@ -1929,10 +1923,11 @@ class FastEMOverviewTab(Tab):
         sem_stream_cont = self._stream_controller.addStream(sem_stream, add_to_view=True)
         sem_stream_cont.stream_panel.show_remove_btn(False)
 
-        # Controller for calibration panel 1
-        self._alignment_controller = fastem_acq.FastEMCalibrationController(
+        # Controller for calibration panel
+        self._calib_controller = fastem_acq.FastEMCalibrationController(
             tab_data,
             panel,
+            calib_prefix="calib",
             calibrations=[Calibrations.OPTICAL_AUTOFOCUS]
         )
 
@@ -1948,14 +1943,6 @@ class FastEMOverviewTab(Tab):
         # Add fit view to content to toolbar
         self.tb.add_tool(TOOL_ACT_ZOOM_FIT, self.view_controller.fitViewToContent)
         # TODO: add tool to zoom out (ie, all the scintillators, calling canvas.zoom_out())
-
-    @property
-    def streambar_controller(self):
-        return self._stream_controller
-
-    @property
-    def acquisition_controller(self):
-        return self._acquisition_controller
 
     def on_acquisition(self, is_acquiring):
         # Don't allow changes to acquisition/calibration ROIs during acquisition

--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -1810,7 +1810,7 @@ class FastEMAcquisitionTab(Tab):
         self._calib_2_region_controller = project.FastEMCalibrationRegionsController(
             tab_data,
             panel.calib_2_pnl_regions,
-            view_ctrl=self.view_controller,  # TODO pass only viewport (panel.vp_fastem_acqui)
+            viewport=vp,
         )
 
         # Controller for calibration panel 2
@@ -1835,7 +1835,7 @@ class FastEMAcquisitionTab(Tab):
         self._project_list_controller = project.FastEMProjectListController(
             tab_data,
             panel.pnl_fastem_projects,
-            view_ctrl=self.view_controller,
+            viewport=vp,
         )
 
         # Acquisition controller

--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -520,6 +520,7 @@ class LocalizationTab(Tab):
 
         return vpv
 
+    @call_in_wx_main
     def load_overview_data(self, data):
         # Create streams from data
         streams = data_to_static_streams(data)

--- a/src/odemis/gui/main.xrc
+++ b/src/odemis/gui/main.xrc
@@ -4547,12 +4547,12 @@
                             <bg>#555555</bg>
                         </object>
                       <object class="FoldPanelItem">
-                        <object class="wxPanel" name="pnl_fastem_calibration_1">
+                        <object class="wxPanel" name="calib_1_pnl_fastem">
                           <fg>#7F7F7F</fg>
                           <bg>#333333</bg>
                           <object class="wxBoxSizer">
                             <object class="sizeritem">
-                              <object class="ImageTextButton" name="btn_align">
+                              <object class="ImageTextButton" name="calib_1_btn">
                                 <height>24</height>
                                 <face_colour>def</face_colour>
                                 <label>Calibrate</label>
@@ -4561,12 +4561,13 @@
                                   <assign_var>1</assign_var>
                                 </XRCED>
                               </object>
+                              <option>0</option>
                               <flag>wxALL</flag>
                               <border>10</border>
                             </object>
                             <object class="sizeritem">
-                              <object class="wxGauge" name="align_gauge_progress">
-                                <size>-1,10</size>
+                              <object class="wxGauge" name="calib_1_gauge">
+                                <size>160,10</size>
                                 <range>100</range>
                                 <value>0</value>
                                 <hidden>1</hidden>
@@ -4575,25 +4576,18 @@
                                   <assign_var>1</assign_var>
                                 </XRCED>
                               </object>
-                              <option>1</option>
-                              <flag>wxTOP|wxBOTTOM|wxRIGHT</flag>
+                              <option>0</option>
+                              <flag>wxTOP|wxBOTTOM|wxRIGHT|wxFIXED_MINSIZE</flag>
                               <border>18</border>
                             </object>
                             <object class="sizeritem">
-                              <object class="wxPanel" name="align_spacer_panel">
-                              </object>
-                              <option>1</option>
-                              <flag>wxTOP</flag>
-                              <border>18</border>
-                            </object>
-                            <object class="sizeritem">
-                              <object class="wxStaticText" name="align_lbl_gauge">
+                              <object class="wxStaticText" name="calib_1_label">
                                 <style>wxALIGN_RIGHT</style>
                                 <XRCED>
                                   <assign_var>1</assign_var>
                                 </XRCED>
                               </object>
-                              <style>wxALIGN_RIGHT</style>
+                              <option>1</option>
                               <flag>wxTOP|wxBOTTOM|wxRIGHT</flag>
                               <border>14</border>
                             </object>
@@ -4605,7 +4599,54 @@
                         <bg>#555555</bg>
                       </object>
                       <object class="FoldPanelItem">
-                        <object class="FastEMCalibrationBar" name="pnl_fastem_calibration_2">
+                        <object class="wxPanel">
+                          <fg>#7F7F7F</fg>
+                          <bg>#333333</bg>
+                          <object class="wxBoxSizer">
+                            <object class="sizeritem">
+                              <object class="ImageTextButton" name="calib_2_btn">
+                                <height>24</height>
+                                <face_colour>def</face_colour>
+                                <label>Calibrate</label>
+                                <style>wxALIGN_CENTRE</style>
+                                <XRCED>
+                                  <assign_var>1</assign_var>
+                                </XRCED>
+                              </object>
+                              <option>0</option>
+                              <flag>wxALL</flag>
+                              <border>10</border>
+                            </object>
+                            <object class="sizeritem">
+                              <object class="wxGauge" name="calib_2_gauge">
+                                <size>160,10</size>
+                                <range>100</range>
+                                <value>0</value>
+                                <hidden>1</hidden>
+                                <style>wxGA_SMOOTH</style>
+                                <XRCED>
+                                  <assign_var>1</assign_var>
+                                </XRCED>
+                              </object>
+                              <option>0</option>
+                              <flag>wxTOP|wxBOTTOM|wxRIGHT|wxFIXED_MINSIZE</flag>
+                              <border>18</border>
+                            </object>
+                            <object class="sizeritem">
+                              <object class="wxStaticText" name="calib_2_label">
+                                <style>wxALIGN_RIGHT</style>
+                                <XRCED>
+                                  <assign_var>1</assign_var>
+                                </XRCED>
+                              </object>
+                              <option>1</option>
+                              <flag>wxTOP|wxBOTTOM|wxRIGHT</flag>
+                              <border>14</border>
+                            </object>
+                            <orient>wxHORIZONTAL</orient>
+                          </object>
+                        </object>
+                        <object class="FastEMCalibrationPanelHeader" name="calib_2_pnl_regions">
                           <size>300,-1</size>
                           <add_button>1</add_button>
                           <fg>#7F7F7F</fg>
@@ -4619,7 +4660,7 @@
                         <bg>#555555</bg>
                       </object>
                       <object class="FoldPanelItem">
-                        <object class="FastEMProjectBar" name="pnl_fastem_projects">
+                        <object class="FastEMProjectList" name="pnl_fastem_projects">
                           <size>300,-1</size>
                           <add_button>1</add_button>
                           <fg>#7F7F7F</fg>
@@ -4908,26 +4949,26 @@
                   <object class="sizeritem">
                     <object class="FoldPanelBar" name="fpb_settings">
                       <object class="FoldPanelItem">
-                        <object class="wxPanel" name="pnl_fastem_optical_autofocus">
+                        <object class="wxPanel" name="calib_pnl_fastem">
                           <fg>#7F7F7F</fg>
                           <bg>#333333</bg>
                           <object class="wxBoxSizer">
                             <object class="sizeritem">
-                              <object class="ImageTextButton" name="btn_align">
+                              <object class="ImageTextButton" name="calib_btn">
                                 <height>24</height>
                                 <face_colour>def</face_colour>
-                                <label>Optical Autofocus</label>
                                 <style>wxALIGN_CENTRE</style>
                                 <XRCED>
                                   <assign_var>1</assign_var>
                                 </XRCED>
                               </object>
+                              <option>0</option>
                               <flag>wxALL</flag>
                               <border>10</border>
                             </object>
                             <object class="sizeritem">
-                              <object class="wxGauge" name="align_gauge_progress">
-                                <size>-1,10</size>
+                              <object class="wxGauge" name="calib_gauge">
+                                <size>160,10</size>
                                 <range>100</range>
                                 <value>0</value>
                                 <hidden>1</hidden>
@@ -4936,25 +4977,18 @@
                                   <assign_var>1</assign_var>
                                 </XRCED>
                               </object>
-                              <option>1</option>
-                              <flag>wxTOP|wxBOTTOM|wxRIGHT</flag>
+                              <option>0</option>
+                              <flag>wxTOP|wxBOTTOM|wxRIGHT|wxFIXED_MINSIZE</flag>
                               <border>18</border>
                             </object>
                             <object class="sizeritem">
-                              <object class="wxPanel" name="align_spacer_panel">
-                              </object>
-                              <option>1</option>
-                              <flag>wxTOP</flag>
-                              <border>18</border>
-                            </object>
-                            <object class="sizeritem">
-                              <object class="wxStaticText" name="align_lbl_gauge">
+                              <object class="wxStaticText" name="calib_label">
                                 <style>wxALIGN_RIGHT</style>
                                 <XRCED>
                                   <assign_var>1</assign_var>
                                 </XRCED>
                               </object>
-                              <style>wxALIGN_RIGHT</style>
+                              <option>1</option>
                               <flag>wxTOP|wxBOTTOM|wxRIGHT</flag>
                               <border>14</border>
                             </object>

--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -509,12 +509,14 @@ class xrcpnl_tab_fastem_acqui(wx.Panel):
         self.scr_win_right = xrc.XRCCTRL(self, "scr_win_right")
         self.fpb_settings = xrc.XRCCTRL(self, "fpb_settings")
         self.pnl_acq_settings = xrc.XRCCTRL(self, "pnl_acq_settings")
-        self.pnl_fastem_calibration_1 = xrc.XRCCTRL(self, "pnl_fastem_calibration_1")
-        self.btn_align = xrc.XRCCTRL(self, "btn_align")
-        self.align_gauge_progress = xrc.XRCCTRL(self, "align_gauge_progress")
-        self.align_spacer_panel = xrc.XRCCTRL(self, "align_spacer_panel")
-        self.align_lbl_gauge = xrc.XRCCTRL(self, "align_lbl_gauge")
-        self.pnl_fastem_calibration_2 = xrc.XRCCTRL(self, "pnl_fastem_calibration_2")
+        self.calib_1_pnl_fastem = xrc.XRCCTRL(self, "calib_1_pnl_fastem")
+        self.calib_1_btn = xrc.XRCCTRL(self, "calib_1_btn")
+        self.calib_1_gauge = xrc.XRCCTRL(self, "calib_1_gauge")
+        self.calib_1_label = xrc.XRCCTRL(self, "calib_1_label")
+        self.calib_2_btn = xrc.XRCCTRL(self, "calib_2_btn")
+        self.calib_2_gauge = xrc.XRCCTRL(self, "calib_2_gauge")
+        self.calib_2_label = xrc.XRCCTRL(self, "calib_2_label")
+        self.calib_2_pnl_regions = xrc.XRCCTRL(self, "calib_2_pnl_regions")
         self.pnl_fastem_projects = xrc.XRCCTRL(self, "pnl_fastem_projects")
         self.txt_num_rois = xrc.XRCCTRL(self, "txt_num_rois")
         self.txt_destination = xrc.XRCCTRL(self, "txt_destination")
@@ -558,11 +560,10 @@ class xrcpnl_tab_fastem_overview(wx.Panel):
         self.vp_fastem_overview = xrc.XRCCTRL(self, "vp_fastem_overview")
         self.scr_win_right = xrc.XRCCTRL(self, "scr_win_right")
         self.fpb_settings = xrc.XRCCTRL(self, "fpb_settings")
-        self.pnl_fastem_optical_autofocus = xrc.XRCCTRL(self, "pnl_fastem_optical_autofocus")
-        self.btn_align = xrc.XRCCTRL(self, "btn_align")
-        self.align_gauge_progress = xrc.XRCCTRL(self, "align_gauge_progress")
-        self.align_spacer_panel = xrc.XRCCTRL(self, "align_spacer_panel")
-        self.align_lbl_gauge = xrc.XRCCTRL(self, "align_lbl_gauge")
+        self.calib_pnl_fastem = xrc.XRCCTRL(self, "calib_pnl_fastem")
+        self.calib_btn = xrc.XRCCTRL(self, "calib_btn")
+        self.calib_gauge = xrc.XRCCTRL(self, "calib_gauge")
+        self.calib_label = xrc.XRCCTRL(self, "calib_label")
         self.pnl_fastem_overview_streams = xrc.XRCCTRL(self, "pnl_fastem_overview_streams")
         self.selection_panel = xrc.XRCCTRL(self, "selection_panel")
         self.bmp_acq_status_info = xrc.XRCCTRL(self, "bmp_acq_status_info")
@@ -5458,12 +5459,12 @@ def __init_resources():
                             <bg>#555555</bg>
                         </object>
                       <object class="FoldPanelItem">
-                        <object class="wxPanel" name="pnl_fastem_calibration_1">
+                        <object class="wxPanel" name="calib_1_pnl_fastem">
                           <fg>#7F7F7F</fg>
                           <bg>#333333</bg>
                           <object class="wxBoxSizer">
                             <object class="sizeritem">
-                              <object class="ImageTextButton" name="btn_align">
+                              <object class="ImageTextButton" name="calib_1_btn">
                                 <height>24</height>
                                 <face_colour>def</face_colour>
                                 <label>Calibrate</label>
@@ -5472,12 +5473,13 @@ def __init_resources():
                                   <assign_var>1</assign_var>
                                 </XRCED>
                               </object>
+                              <option>0</option>
                               <flag>wxALL</flag>
                               <border>10</border>
                             </object>
                             <object class="sizeritem">
-                              <object class="wxGauge" name="align_gauge_progress">
-                                <size>-1,10</size>
+                              <object class="wxGauge" name="calib_1_gauge">
+                                <size>160,10</size>
                                 <range>100</range>
                                 <value>0</value>
                                 <hidden>1</hidden>
@@ -5486,25 +5488,18 @@ def __init_resources():
                                   <assign_var>1</assign_var>
                                 </XRCED>
                               </object>
-                              <option>1</option>
-                              <flag>wxTOP|wxBOTTOM|wxRIGHT</flag>
+                              <option>0</option>
+                              <flag>wxTOP|wxBOTTOM|wxRIGHT|wxFIXED_MINSIZE</flag>
                               <border>18</border>
                             </object>
                             <object class="sizeritem">
-                              <object class="wxPanel" name="align_spacer_panel">
-                              </object>
-                              <option>1</option>
-                              <flag>wxTOP</flag>
-                              <border>18</border>
-                            </object>
-                            <object class="sizeritem">
-                              <object class="wxStaticText" name="align_lbl_gauge">
+                              <object class="wxStaticText" name="calib_1_label">
                                 <style>wxALIGN_RIGHT</style>
                                 <XRCED>
                                   <assign_var>1</assign_var>
                                 </XRCED>
                               </object>
-                              <style>wxALIGN_RIGHT</style>
+                              <option>1</option>
                               <flag>wxTOP|wxBOTTOM|wxRIGHT</flag>
                               <border>14</border>
                             </object>
@@ -5516,7 +5511,54 @@ def __init_resources():
                         <bg>#555555</bg>
                       </object>
                       <object class="FoldPanelItem">
-                        <object class="FastEMCalibrationBar" name="pnl_fastem_calibration_2">
+                        <object class="wxPanel">
+                          <fg>#7F7F7F</fg>
+                          <bg>#333333</bg>
+                          <object class="wxBoxSizer">
+                            <object class="sizeritem">
+                              <object class="ImageTextButton" name="calib_2_btn">
+                                <height>24</height>
+                                <face_colour>def</face_colour>
+                                <label>Calibrate</label>
+                                <style>wxALIGN_CENTRE</style>
+                                <XRCED>
+                                  <assign_var>1</assign_var>
+                                </XRCED>
+                              </object>
+                              <option>0</option>
+                              <flag>wxALL</flag>
+                              <border>10</border>
+                            </object>
+                            <object class="sizeritem">
+                              <object class="wxGauge" name="calib_2_gauge">
+                                <size>160,10</size>
+                                <range>100</range>
+                                <value>0</value>
+                                <hidden>1</hidden>
+                                <style>wxGA_SMOOTH</style>
+                                <XRCED>
+                                  <assign_var>1</assign_var>
+                                </XRCED>
+                              </object>
+                              <option>0</option>
+                              <flag>wxTOP|wxBOTTOM|wxRIGHT|wxFIXED_MINSIZE</flag>
+                              <border>18</border>
+                            </object>
+                            <object class="sizeritem">
+                              <object class="wxStaticText" name="calib_2_label">
+                                <style>wxALIGN_RIGHT</style>
+                                <XRCED>
+                                  <assign_var>1</assign_var>
+                                </XRCED>
+                              </object>
+                              <option>1</option>
+                              <flag>wxTOP|wxBOTTOM|wxRIGHT</flag>
+                              <border>14</border>
+                            </object>
+                            <orient>wxHORIZONTAL</orient>
+                          </object>
+                        </object>
+                        <object class="FastEMCalibrationPanelHeader" name="calib_2_pnl_regions">
                           <size>300,-1</size>
                           <add_button>1</add_button>
                           <fg>#7F7F7F</fg>
@@ -5530,7 +5572,7 @@ def __init_resources():
                         <bg>#555555</bg>
                       </object>
                       <object class="FoldPanelItem">
-                        <object class="FastEMProjectBar" name="pnl_fastem_projects">
+                        <object class="FastEMProjectList" name="pnl_fastem_projects">
                           <size>300,-1</size>
                           <add_button>1</add_button>
                           <fg>#7F7F7F</fg>
@@ -5819,26 +5861,26 @@ def __init_resources():
                   <object class="sizeritem">
                     <object class="FoldPanelBar" name="fpb_settings">
                       <object class="FoldPanelItem">
-                        <object class="wxPanel" name="pnl_fastem_optical_autofocus">
+                        <object class="wxPanel" name="calib_pnl_fastem">
                           <fg>#7F7F7F</fg>
                           <bg>#333333</bg>
                           <object class="wxBoxSizer">
                             <object class="sizeritem">
-                              <object class="ImageTextButton" name="btn_align">
+                              <object class="ImageTextButton" name="calib_btn">
                                 <height>24</height>
                                 <face_colour>def</face_colour>
-                                <label>Optical Autofocus</label>
                                 <style>wxALIGN_CENTRE</style>
                                 <XRCED>
                                   <assign_var>1</assign_var>
                                 </XRCED>
                               </object>
+                              <option>0</option>
                               <flag>wxALL</flag>
                               <border>10</border>
                             </object>
                             <object class="sizeritem">
-                              <object class="wxGauge" name="align_gauge_progress">
-                                <size>-1,10</size>
+                              <object class="wxGauge" name="calib_gauge">
+                                <size>160,10</size>
                                 <range>100</range>
                                 <value>0</value>
                                 <hidden>1</hidden>
@@ -5847,25 +5889,18 @@ def __init_resources():
                                   <assign_var>1</assign_var>
                                 </XRCED>
                               </object>
-                              <option>1</option>
-                              <flag>wxTOP|wxBOTTOM|wxRIGHT</flag>
+                              <option>0</option>
+                              <flag>wxTOP|wxBOTTOM|wxRIGHT|wxFIXED_MINSIZE</flag>
                               <border>18</border>
                             </object>
                             <object class="sizeritem">
-                              <object class="wxPanel" name="align_spacer_panel">
-                              </object>
-                              <option>1</option>
-                              <flag>wxTOP</flag>
-                              <border>18</border>
-                            </object>
-                            <object class="sizeritem">
-                              <object class="wxStaticText" name="align_lbl_gauge">
+                              <object class="wxStaticText" name="calib_label">
                                 <style>wxALIGN_RIGHT</style>
                                 <XRCED>
                                   <assign_var>1</assign_var>
                                 </XRCED>
                               </object>
-                              <style>wxALIGN_RIGHT</style>
+                              <option>1</option>
                               <flag>wxTOP|wxBOTTOM|wxRIGHT</flag>
                               <border>14</border>
                             </object>

--- a/src/odemis/gui/model/__init__.py
+++ b/src/odemis/gui/model/__init__.py
@@ -1281,6 +1281,9 @@ class FastEMAcquisitionGUIData(MicroscopyGUIData):
         assert main.microscope is not None
         super(FastEMAcquisitionGUIData, self).__init__(main)
 
+        # TODO duplicate for calibration step 3
+        #  regions_calib_2
+        #  regions_calib_3
         self.calibration_regions = model.VigilantAttribute({})  # dict, number --> FastEMROC
         for i in main.scintillator_positions:
             self.calibration_regions.value[i] = fastem.FastEMROC(str(i), acqstream.UNDEFINED_ROI)

--- a/src/odemis/gui/xmlh/xh_delmic.py
+++ b/src/odemis/gui/xmlh/xh_delmic.py
@@ -231,19 +231,19 @@ class FastEMProjectBarXmlHandler(xrc.XmlResourceHandler):
         # Custom styles
 
     def CanHandle(self, node):
-        return self.IsOfClass(node, 'FastEMProjectBar')
+        return self.IsOfClass(node, 'FastEMProjectList')
 
     # Process XML parameters and create the object
     def DoCreateResource(self):
 
-        if self.GetClass() == 'FastEMProjectBar':
+        if self.GetClass() == 'FastEMProjectList':
             parent = self.GetParentAsWindow()
-            w = strm.FastEMProjectBar(parent,
-                                      self.GetID(),
-                                      self.GetPosition(),
-                                      self.GetSize(),
-                                      self.GetStyle(),
-                                      add_button=self.GetBool('add_button'))
+            w = strm.FastEMProjectList(parent,
+                                       self.GetID(),
+                                       self.GetPosition(),
+                                       self.GetSize(),
+                                       self.GetStyle(),
+                                       add_button=self.GetBool('add_button'))
             self.SetupWindow(w)
             # 'Dirty' fix for the hard coded 'add stream' child button
             if self.GetBool('add_button'):
@@ -261,19 +261,19 @@ class FastEMCalibrationBarXmlHandler(xrc.XmlResourceHandler):
         # Custom styles
 
     def CanHandle(self, node):
-        return self.IsOfClass(node, 'FastEMCalibrationBar')
+        return self.IsOfClass(node, 'FastEMCalibrationPanelHeader')
 
     # Process XML parameters and create the object
     def DoCreateResource(self):
 
-        if self.GetClass() == 'FastEMCalibrationBar':
+        if self.GetClass() == 'FastEMCalibrationPanelHeader':
             parent = self.GetParentAsWindow()
-            w = strm.FastEMCalibrationBar(parent,
-                                          self.GetID(),
-                                          self.GetPosition(),
-                                          self.GetSize(),
-                                          self.GetStyle(),
-                                          add_button=self.GetBool('add_button'))
+            w = strm.FastEMCalibrationPanelHeader(parent,
+                                                  self.GetID(),
+                                                  self.GetPosition(),
+                                                  self.GetSize(),
+                                                  self.GetStyle(),
+                                                  add_button=self.GetBool('add_button'))
             self.SetupWindow(w)
             parent.add_item(w)
             return w


### PR DESCRIPTION
* add dark/gain to calibration manager
* make controller independent of each other
* make calibration controller using a prefix argument to be able to use same class for all calibration steps
* make the gauge having a fixed size in the GUI
* use short version for text label showing the progress
* fix: ROC size should be calculated based on multibeam resolution and pixelsize
* allow adding/removing ROCs
* synchronize gui with main model (active scintillators and calibration regions defined)
* remove unnecessary properties in tabs