### PR TITLE
Fastem test cases: raise an error when trying to run the test cases w…

### DIFF
--- a/install/linux/usr/share/odemis/sim/fastem-sim-asm.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/fastem-sim-asm.odm.yaml
@@ -211,11 +211,12 @@ FASTEM-sim: {
 "Beam Shift Controller": {
     class: tfsbc.BeamShiftController,
     role: ebeam-shift,
+    dependencies: {"scanner": "MultiBeam Scanner XT"},
     init: {
         port: "/dev/fake",
         serialnum: FT43FD2D,
     },
-    affects: ["EBeam Scanner", "MultiBeam Scanner"],
+    affects: ["MultiBeam Scanner XT", "MultiBeam Scanner"],
 }
 
 "Focus Tracker": {

--- a/install/linux/usr/share/odemis/sim/fastem-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/fastem-sim.odm.yaml
@@ -209,11 +209,15 @@ FASTEM-sim: {
 "Beam Shift Controller": {
     class: tfsbc.BeamShiftController,
     role: ebeam-shift,
+    # The Multibeam Scanner XT can be set as a dependency to automatically retrieve
+    # the calibration data from the scanner, however this is not possible here,
+    # because the SimSem does not contain calibration data.
+    # dependencies: {"scanner": "MultiBeam Scanner XT"},
     init: {
         port: "/dev/fake",
         serialnum: FT43FD2D,
     },
-    affects: ["EBeam Scanner", "MultiBeam Scanner"],
+    affects: ["MultiBeam Scanner XT", "MultiBeam Scanner"],
 }
 
 "Focus Tracker": {

--- a/src/odemis/acq/align/test/fastem_test.py
+++ b/src/odemis/acq/align/test/fastem_test.py
@@ -34,7 +34,7 @@ import odemis
 from odemis import model
 from odemis.acq.align import fastem
 from odemis.acq.align.fastem import Calibrations
-from odemis.util import test
+from odemis.util import driver, test
 
 # * TEST_NOHW = 1: use simulator (asm/sam and xt adapter simulators need to be running)
 # technolution_asm_simulator/simulator2/run_the_simulator.py
@@ -55,6 +55,8 @@ class TestFastEMCalibration(unittest.TestCase):
     def setUpClass(cls):
         if TEST_NOHW:
             test.start_backend(FASTEM_CONFIG)
+        elif driver.get_backend_status() != driver.BACKEND_RUNNING:
+            raise IOError("Backend controlling a real hardware should be started before running this test case")
 
         # get the hardware components
         cls.scanner = model.getComponent(role='e-beam')

--- a/src/odemis/acq/test/fastem_test.py
+++ b/src/odemis/acq/test/fastem_test.py
@@ -548,9 +548,6 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
         cls.beamshift = model.getComponent(role="ebeam-shift")
         cls.lens = model.getComponent(role="lens")
 
-        # Normally the beamshift MD_CALIB is set when running the calibrations.
-        # Set it here explicitly because we do not run the calibrations in these test cases.
-        cls.beamshift.updateMetadata({model.MD_CALIB: cls.scanner.beamShiftTransformationMatrix.value})
         cls.beamshift.shift.value = (0, 0)
         cls.stage.reference({"x", "y"}).result()
 

--- a/src/odemis/acq/test/fastem_test.py
+++ b/src/odemis/acq/test/fastem_test.py
@@ -37,7 +37,7 @@ import odemis
 from fastem_calibrations import configure_hw
 from odemis import model
 from odemis.acq import fastem, stream
-from odemis.util import test, img, is_point_in_rect
+from odemis.util import driver, img, is_point_in_rect, test
 
 # * TEST_NOHW = 1: connected to the simulator or not connected to anything
 # * TEST_NOHW = 0: connected to the real hardware, the backend should be running
@@ -59,6 +59,8 @@ class TestFASTEMOverviewAcquisition(unittest.TestCase):
     def setUpClass(cls):
         if TEST_NOHW:
             test.start_backend(FASTEM_CONFIG)
+        elif driver.get_backend_status() != driver.BACKEND_RUNNING:
+            raise IOError("Backend controlling a real hardware should be started before running this test case")
 
         cls.ebeam = model.getComponent(role="e-beam")
         cls.efocuser = model.getComponent(role="ebeam-focus")
@@ -134,6 +136,8 @@ class TestFastEMROA(unittest.TestCase):
     def setUpClass(cls):
         if TEST_NOHW:
             test.start_backend(FASTEM_CONFIG_ASM)
+        elif driver.get_backend_status() != driver.BACKEND_RUNNING:
+            raise IOError("Backend controlling a real hardware should be started before running this test case")
 
         # get the hardware components
         cls.asm = model.getComponent(role="asm")
@@ -300,6 +304,8 @@ class TestFastEMAcquisition(unittest.TestCase):
     def setUpClass(cls):
         if TEST_NOHW:
             test.start_backend(FASTEM_CONFIG_ASM)
+        elif driver.get_backend_status() != driver.BACKEND_RUNNING:
+            raise IOError("Backend controlling a real hardware should be started before running this test case")
 
         # get the hardware components
         cls.scanner = model.getComponent(role='e-beam')
@@ -527,6 +533,8 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
     def setUpClass(cls):
         if TEST_NOHW:
             test.start_backend(FASTEM_CONFIG_ASM)
+        elif driver.get_backend_status() != driver.BACKEND_RUNNING:
+            raise IOError("Backend controlling a real hardware should be started before running this test case")
 
         # Get the hardware components from the simulators or hardware
         cls.scanner = model.getComponent(role='e-beam')


### PR DESCRIPTION
…ith hardware and no backend running.

Previously when trying to run the test cases with TEST_NOHW=False and no backend running it would try to get the different components, and fail with a non descriptive error.
Raise a more informative error when there is no backend running, and thus it is impossible to get the components.