### PR TITLE
GUI fastem: comment autofocus and autostigmation buttons.

### DIFF
--- a/src/odemis/gui/cont/streams.py
+++ b/src/odemis/gui/cont/streams.py
@@ -1356,13 +1356,15 @@ class StreamController(object):
 
     def _add_fastem_ctrls(self):
         self.stream_panel.add_divider()
-        _, btn_autofocus = self.stream_panel.add_run_btn("Autofocus")
-        _, btn_autobc = self.stream_panel.add_run_btn("Auto-brightness/contrast")
-        _, btn_autostigmation = self.stream_panel.add_run_btn("Autostigmation")
 
-        btn_autofocus.Bind(wx.EVT_BUTTON, self._on_btn_autofocus)
+        # FIXME uncomment autofocus and autostigmation, when the functionality is working correctly.
+        # _, btn_autofocus = self.stream_panel.add_run_btn("Autofocus")
+        _, btn_autobc = self.stream_panel.add_run_btn("Auto-brightness/contrast")
+        # _, btn_autostigmation = self.stream_panel.add_run_btn("Autostigmation")
+
+        # btn_autofocus.Bind(wx.EVT_BUTTON, self._on_btn_autofocus)
         btn_autobc.Bind(wx.EVT_BUTTON, self._on_btn_autobc)
-        btn_autostigmation.Bind(wx.EVT_BUTTON, self._on_btn_autostigmation)
+        # btn_autostigmation.Bind(wx.EVT_BUTTON, self._on_btn_autostigmation)
 
     @call_in_wx_main
     def _on_btn_autofocus(self, _):


### PR DESCRIPTION
Autofocus and autostigmation is not working correctly yet, the functionality should be updated on the xtadapter side. Once that is done the buttons can be added again.