### PR TITLE
Acquisition tests: skip test cases that require the nikonc driver.

### DIFF
--- a/src/odemis/acq/test/flim_test.py
+++ b/src/odemis/acq/test/flim_test.py
@@ -31,7 +31,6 @@ from odemis.util import test
 import os
 import time
 import unittest
-from unittest.case import skip
 
 logging.getLogger().setLevel(logging.DEBUG)
 logging.basicConfig(format="%(asctime)s  %(levelname)-7s %(module)s:%(lineno)d %(message)s")
@@ -54,6 +53,12 @@ class TestFlim(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        try:
+            # The nikonc driver needs omniorb which is not packaged in Ubuntu anymore
+            from odemis.driver import nikonc
+        except ImportError as err:
+            raise unittest.SkipTest(f"Skipping FLIM tests, cannot import nikonc driver."
+                                    f"Got error: {err}")
 
         try:
             test.start_backend(SECOM_FLIM_CONFIG)
@@ -481,4 +486,3 @@ class TestFlim(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/src/odemis/acq/test/path_test.py
+++ b/src/odemis/acq/test/path_test.py
@@ -1474,6 +1474,13 @@ class SecomFlimPathTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         try:
+            # The nikonc driver needs omniorb which is not packaged in Ubuntu anymore
+            from odemis.driver import nikonc
+        except ImportError as err:
+            raise unittest.SkipTest(f"Skipping SECOM FLIM path tests, cannot import nikonc driver."
+                                    f"Got error: {err}")
+
+        try:
             test.start_backend(SECOM_FLIM_CONFIG)
         except LookupError:
             logging.info("A running backend is already found, skipping tests")

--- a/src/odemis/acq/test/stream_test.py
+++ b/src/odemis/acq/test/stream_test.py
@@ -688,6 +688,13 @@ class SECOMConfocalTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         try:
+            # The nikonc driver needs omniorb which is not packaged in Ubuntu anymore
+            from odemis.driver import nikonc
+        except ImportError as err:
+            raise unittest.SkipTest(f"Skipping SECOM confocal tests, cannot import nikonc driver."
+                                    f"Got error: {err}")
+
+        try:
             test.start_backend(SECOM_CONFOCAL_CONFIG)
         except LookupError:
             logging.info("A running backend is already found, skipping tests")


### PR DESCRIPTION
The nikonc driver is not easily available for python3. When tests were run that required this driver the backend failed to start. In the setupclass it is now checked if the driver is available and otherwise the tests are skipped