### PR TITLE
init: handle better git error

### DIFF
--- a/src/odemis/__init__.py
+++ b/src/odemis/__init__.py
@@ -45,8 +45,12 @@ def _get_version_git():
         if ver.startswith("v"):
             ver = ver[1:]
         return ver
-    except EnvironmentError:
+    except OSError:
         raise LookupError("Unable to run git")
+    except subprocess.CalledProcessError as ex:
+        logging.warning("Failed to run git: %s", ex)
+        raise LookupError("Execution of git failed")
+
 
 def _get_version_setuptools():
     """


### PR DESCRIPTION
We use git just to check the version number in case we are running from
the development branch (and so git repo).

If "git describe" returns an error, we used to completely fail.
Now just fallback to the standard way to detect the version number.
It might be not exactly the right version, but it's much better than not
starting at all.

Useful with the changes to git that prevents running it as a different
user. So running git as root (which is the case when staring the
backend) failed if the git repo was owned by the user.