### PR TITLE
acq align fastem: fix import when fastem_calibration is missing

### DIFF
--- a/src/odemis/acq/align/fastem.py
+++ b/src/odemis/acq/align/fastem.py
@@ -56,6 +56,8 @@ except ImportError:
     image_translation_pre_align = None
     image_rotation = None
     image_translation = None
+    dark_offset_correction = None
+    digital_gain_correction = None
 
     fastem_calibrations = False
 


### PR DESCRIPTION
It's supposed to be fine to import even if fastem_calibration is not
available. However due to extra functions loaded, that wasn't the case
anymore.