### PR TITLE
progressive batch future: fix start time in progress update

### DIFF
--- a/src/odemis/model/_futures.py
+++ b/src/odemis/model/_futures.py
@@ -509,35 +509,56 @@ class ProgressiveBatchFuture(ProgressiveFuture):
         start = time.time()  # start time of the batch future
         super().__init__(start=start, end=start + sum(self.futures.values()))
         self.set_running_or_notify_cancel()
+        self.task_canceller = self._cancel_all  # takes care of cancelling the task (=all sub-futures)
 
         for f in self.futures:
-            f.add_update_callback(self._on_future_update)  # called whenever set_progress of any single future is called
-            f.add_done_callback(self._on_future_done)  # called when future is done
+            f.add_update_callback(self._on_future_update)  # called whenever set_progress of a sub-future is called
+            f.add_done_callback(self._on_future_done)  # called when a sub-future is done
 
     def _on_future_update(self, f, start, end):
         """
-        Whenever progress on the single future is reported, the progress (or end) for the batch future
+        Whenever progress on the single sub-future is reported, the progress (or end) for the batch future
         is updated accordingly.
 
+        :param f: (ProgressiveFuture) A single sub-future.
         :param start: (float) Start time of a single future in the batch future in seconds.
         :param end: (float) End of a single future in the batch future in seconds.
         """
         if f.running():  # only care about the future which is currently running
-            self.futures[f] = end - start  # update the time estimation of the time left of that future
-            self.set_progress(end=self._estimate_end())  # set the progress for batch future
+            # For a running future it is of interest how much time is still needed for execution until finished.
+            # If the future is running, it is no longer of interest when the future has started (which is now in the
+            # past), but how much time is still needed between now and the estimated end.
+            now = time.time()
+            # Update the time estimation for the running future with the time still needed to finish this future
+            self.futures[f] = end - max(start, now)
+            self.set_progress(end=self._estimate_end())  # set the progress for batch future (all futures not done yet)
 
     def _on_future_done(self, f):
-        self.set_progress(end=self._estimate_end())
+        """
+        Called whenever a single sub-future is finished.
+        If all sub-futures are finished, the result on the batch future will be set (None).
+        If an exception occurred during the execution of the sub-future or the sub-future was cancelled,
+        the exception/cancellation will be propagated towards the batch future and handled there.
 
-        # Set exception if future failed and cancel all other futures
+        :param f: (ProgressiveFuture) A single sub-future.
+        """
+        self.set_progress(end=self._estimate_end())  # set the progress for batch future (all futures not done yet)
+
+        # Set exception if future failed and cancel all other sub-futures
         try:
             ex = f.exception()  # raises CancelledError if cancelled, otherwise returns error
             if ex:
                 self.cancel()
                 self.set_exception(ex)
+                return
         except CancelledError:
-            pass
+            if self.cancel():  # if cancelling works
+                return
+            else:
+                self.set_exception(CancelledError())  # if cancelling fails
+                return
 
+        # If everything is fine:
         # Set result if all futures are done
         if all(f.done() for f in self.futures):
             # always return None, it's not clear what the return value of a batch of tasks should be
@@ -551,19 +572,25 @@ class ProgressiveBatchFuture(ProgressiveFuture):
         run the remaining futures. Calculates the new end time based on the current
         time plus the estimated time for all futures that still need to be executed.
 
-        returns: (float) Newly estimated end time for the batch future.
+        :returns: (float) Newly estimated end time for the batch future.
         """
         # with f.done() only futures are taken into account that are not executed (finished) yet
         time_left = sum(t for f, t in self.futures.items() if not f.done())
 
         return time.time() + time_left
 
-    def cancel(self):
-        super().cancel()
-        fs = [f for f in self.futures if not f.done()]
+    def _cancel_all(self, f):
+        """
+        Cancel all sub-futures in the batch future, which are not finish yet.
+        :param f: (dict: ProgressiveFuture --> float) The batch future containing the sub-futures.
+        :returns: (boolean)
+            True: If all sub-futures, that were not yet finished, are successfully cancelled.
+            False: If no sub-future was left that could be cancelled.
+        """
+        fs = [f for f in self.futures if not f.done()]  # get all futures not finished yet
         logging.debug("Canceling %s futures.", len(fs))
         if not fs:
             return False  # nothing to cancel
         for f in fs:
-            f.cancel()
+            f.cancel()  # cancel all sub-futures
         return True

--- a/src/odemis/model/_futures.py
+++ b/src/odemis/model/_futures.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 Created on 10 Dec 2013

--- a/src/odemis/model/_futures.py
+++ b/src/odemis/model/_futures.py
@@ -1,19 +1,26 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 Created on 10 Dec 2013
 
-@author: Éric Piel
+@author: Éric Piel, Philip Winkler, Sabrina Rossberger
 
 Copyright © 2013-2022 Éric Piel, Delmic
 
 This file is part of Odemis.
 
-Odemis is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License version 2 as published by the Free Software Foundation.
+Odemis is free software: you can redistribute it and/or modify it under the terms
+of the GNU General Public License version 2 as published by the Free Software
+Foundation.
 
-Odemis is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+Odemis is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+PURPOSE. See the GNU General Public License for more details.
 
-You should have received a copy of the GNU General Public License along with Odemis. If not, see http://www.gnu.org/licenses/.
+You should have received a copy of the GNU General Public License along with
+Odemis. If not, see http://www.gnu.org/licenses/.
 """
+
 from __future__ import division
 
 import collections
@@ -521,8 +528,8 @@ class ProgressiveBatchFuture(ProgressiveFuture):
         is updated accordingly.
 
         :param f: (ProgressiveFuture) A single sub-future.
-        :param start: (float) Start time of a single future in the batch future in seconds.
-        :param end: (float) End of a single future in the batch future in seconds.
+        :param start: (float) Start time of a single future in the batch future in seconds since epoch.
+        :param end: (float) End of a single future in the batch future in seconds since epoch.
         """
         if f.running():  # only care about the future which is currently running
             # For a running future it is of interest how much time is still needed for execution until finished.

--- a/src/odemis/model/test/futures_test.py
+++ b/src/odemis/model/test/futures_test.py
@@ -1,25 +1,31 @@
 # -*- coding: utf-8 -*-
-'''
+"""
 Created on 10 Dec 2013
 
 @author: Éric Piel
 
-Copyright © 2013 Éric Piel, Delmic
+Copyright © 2013-2022 Éric Piel, Delmic
 
 This file is part of Odemis.
 
-Odemis is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License version 2 as published by the Free Software Foundation.
+Odemis is free software: you can redistribute it and/or modify it under the terms
+of the GNU General Public License version 2 as published by the Free Software
+Foundation.
 
-Odemis is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+Odemis is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+PURPOSE. See the GNU General Public License for more details.
 
-You should have received a copy of the GNU General Public License along with Odemis. If not, see http://www.gnu.org/licenses/.
-'''
+You should have received a copy of the GNU General Public License along with
+Odemis. If not, see http://www.gnu.org/licenses/.
+"""
+
 from __future__ import division
 
 from concurrent.futures._base import CancelledError
 import logging
 from odemis.model._futures import ProgressiveFuture, CancellableFuture, \
-    CancellableThreadPoolExecutor, ParallelThreadPoolExecutor
+    CancellableThreadPoolExecutor, ParallelThreadPoolExecutor, ProgressiveBatchFuture
 from odemis.util import timeout
 import random
 import threading
@@ -260,44 +266,65 @@ class TestFutures(unittest.TestCase):
 
         self.assertEqual(self.cancelled, 0)
 
-    def testProgressiveFuture(self):
+    # TODO create own class for progressive future
+    def test_progressive_future_progress(self):
         """
-        Only tests a simple ProgressiveFuture
+        Test progress update for ProgressiveFuture.
         """
-        self.cancelled = 0
-        self.start = None
-        self.end = None
-        future = ProgressiveFuture()
+        self.start = None  # for the caller
+        self.end = None  # for the caller
+        now = time.time()
+        # start is default time now if not specified
+        future = ProgressiveFuture(end=now + 1)
         future.task_canceller = self.cancel_task
 
-        now = time.time()
-        # try to update progress
-        future.set_progress(end=now + 1)
+        # caller request future to indicate change in time estimation
         future.add_update_callback(self.on_progress_update)
-        future.set_progress(end=now + 2) # should say about 2 s left
+        # update the progress
+        future.set_progress(end=now + 2)
+        # check end time was updated
         self.assertEqual(self.end, now + 2)
-        # before being started, start should always be (a bit) in the future
+        # future not running yet, so start should be after "now"
         self.assertGreaterEqual(self.start, now)
 
-        # "start" the task
+        # "start" the task (set the future running)
         future.set_running_or_notify_cancel()
+        # the progress should be updated and thus .start should be updated now with the current time
         self.assertTrue(0 <= time.time() - self.start < 0.1)
-        time.sleep(0.1)
+
+        time.sleep(0.1)  # wait a bit
 
         now = time.time()
+        # while running, update the estimated ending time
         future.set_progress(end=now + 1)
+        # the progress should be updated and thus .end should be in 1 sec from now
         self.assertTrue(0.9 <= self.end - time.time() < 1)
 
-        # try to cancel while running
+    def test_progressive_future_cancel(self):
+        """
+        Test cancelling of ProgressiveFuture while running.
+        """
+        self.cancelled = 0
+        self.start = None  # for the caller
+        self.end = None  # for the caller
+        now = time.time()
+        # start is default time now if not specified
+        future = ProgressiveFuture(end=now + 2)
+        future.task_canceller = self.cancel_task
+
+        # "start" the task (set the future running)
+        future.set_running_or_notify_cancel()
+        time.sleep(0.1)  # wait a bit
+
         future.cancel()
         self.assertTrue(future.cancelled())
-        self.assertRaises(CancelledError, future.result, 1)
-        self.assertLessEqual(self.end, time.time())
+        with self.assertRaises(CancelledError):
+            future.result(timeout=5)
         self.assertEqual(self.cancelled, 1)
 
-    def testPF_get_progress(self):
+    def test_progressive_future_get_progress(self):
         """
-        Tests set/get_progress of ProgressiveFuture
+        Tests set/get_progress of ProgressiveFuture.
         """
         f = ProgressiveFuture()
 
@@ -310,28 +337,205 @@ class TestFutures(unittest.TestCase):
         self.assertEqual(end, endf)
 
         # "start" the task
-        f.set_running_or_notify_cancel()
+        f.set_running_or_notify_cancel()  # updates start and end
         startf, endf = f.get_progress()
-        self.assertLessEqual(startf, time.time())
-        self.assertAlmostEqual(startf + 1, endf)
-        self.assertAlmostEqual(endf, time.time() + 1, delta=0.1)
+        self.assertLessEqual(startf, time.time())  # start should be a tiny bit before now
+        self.assertAlmostEqual(startf + 1, endf)  # task should take 1s, so expect duration is still 1s
+        self.assertAlmostEqual(endf, time.time() + 1, delta=0.1)  # end should be 1s in the future
         time.sleep(0.1)
 
         # "finish" the task
         f.set_result(None)
         self.assertTrue(f.done())
         startf, endf = f.get_progress()
-        self.assertLessEqual(startf, time.time())
-        self.assertLessEqual(endf, time.time())
+        self.assertLessEqual(startf, time.time())  # start should be in the past now as started future in the past
+        self.assertLessEqual(endf, time.time())  # end should be also in the past now as future finished
 
     def cancel_task(self, future):
+        """Task canceller"""
         self.cancelled += 1
         return True
 
     def on_progress_update(self, future, start, end):
+        """Called whenever some progress on the future is reported. Start and end time are updated."""
         self.start = start
         self.end = end
 
+
+class TestProgressiveBatchFuture(unittest.TestCase):
+    """Test progressive batch future."""
+
+    def test_progress_future(self):
+        """
+        Test progress update of batch future.
+        """
+        self.start = None  # for the caller
+        self.end = None  # for the caller
+        fs = {}
+        f1 = ProgressiveFuture()
+        f1.task_canceller = self.cancel_task
+        f2 = ProgressiveFuture()
+        f2.task_canceller = self.cancel_task
+        fs[f1] = 10  # estimated duration in seconds
+        fs[f2] = 15  # estimated duration in seconds
+        time_creation_batch_future = time.time()
+        batch_future = ProgressiveBatchFuture(fs)
+        batch_future.add_update_callback(self.on_progress_update)
+
+        # check estimated time for batch future is sum of estimated time for sub-futures
+        self.assertEqual(self.end - self.start, fs[f1] + fs[f2])
+
+        # "start" the sub-tasks; the batch task is already started at creation
+        f1.set_running_or_notify_cancel()
+
+        now = time.time()
+        f1.set_progress(end=now + 2)  # update the progress on one sub-future
+        # check that the estimated end time of the batch futures has been updated
+        self.assertTrue(now + fs[f2] + 1.9 <= self.end <= now + fs[f2] + 2.1)
+        # check that the start of the batch future is after creation of batch future
+        self.assertGreaterEqual(self.start, time_creation_batch_future)
+
+        now = time.time()
+        f1.set_result(None)  # set sub-future done
+
+        # check estimated time of batch future is equal to f2
+        self.assertTrue(now + fs[f2] - 0.1 <= self.end <= now + fs[f2] + 0.1)
+
+        f2.set_running_or_notify_cancel()
+        # check time of batch future is still equal to f2 as future just started
+        self.assertTrue(now + fs[f2] - 0.1 <= self.end <= now + fs[f2] + 0.1)
+
+        now = time.time()
+        f2.set_progress(end=now + 10)  # update the progress on one sub-future
+        # check that the estimated end time of the batch futures has been updated
+        self.assertTrue(now + 9.9 <= self.end <= now + 10.1)
+
+        f2.set_result(None)  # set sub-future done
+
+        # check batch future automatically finished when all sub-futures finished
+        self.assertTrue(batch_future.done())
+        self.assertIsNone(batch_future.result())  # result of successful batch future is None
+
+    def test_cancel_while_running(self):
+        """
+        Cancel batch future while running.
+        """
+        self.cancelled = 0
+        fs = {}
+        f1 = ProgressiveFuture()
+        f1.task_canceller = self.cancel_task
+        f2 = ProgressiveFuture()
+        f2.task_canceller = self.cancel_task
+        fs[f1] = 10  # estimated duration in seconds
+        fs[f2] = 15  # estimated duration in seconds
+        batch_future = ProgressiveBatchFuture(fs)
+
+        # "start" the sub-task; the batch task is already started at creation
+        f1.set_running_or_notify_cancel()
+        self.assertEqual(self.cancelled, 0)
+
+        # try to cancel while running
+        self.assertTrue(batch_future.cancel())
+
+        self.assertTrue(batch_future.cancelled())  # check batch future cancelled
+        for f in fs:  # check all sub-futures are cancelled
+            self.assertTrue(f.cancelled())
+
+        with self.assertRaises(CancelledError):  # check result batch future
+            batch_future.result(timeout=5)
+        for f in fs:  # check result for sub-futures
+            with self.assertRaises(CancelledError):
+                f.result(timeout=5)
+
+        # only one sub-future should trigger the callback (the other future is not running yet or already finished)
+        self.assertEqual(self.cancelled, 1)  # one sub-futures should be cancelled
+
+    def test_cancel_pre_start(self):
+        """
+        Check that canceller is not called if cancelled before starting.
+        """
+        self.cancelled = 0
+        fs = {}
+        f1 = ProgressiveFuture()
+        f1.task_canceller = self.cancel_task
+        f2 = ProgressiveFuture()
+        f2.task_canceller = self.cancel_task
+        fs[f1] = 10  # estimated duration in seconds
+        fs[f2] = 15  # estimated duration in seconds
+        batch_future = ProgressiveBatchFuture(fs)
+        self.assertEqual(self.cancelled, 0)
+
+        # try to cancel before running
+        self.assertTrue(batch_future.cancel())
+
+        self.assertTrue(batch_future.cancelled())  # check batch future cancelled
+        for f in fs:  # check all sub-futures are cancelled
+            self.assertTrue(f.cancelled())
+
+        with self.assertRaises(CancelledError):  # check result batch future
+            batch_future.result(timeout=5)
+        for f in fs:  # check result for sub-futures
+            with self.assertRaises(CancelledError):
+                f.result(timeout=5)
+
+        self.assertTrue(batch_future.cancel())  # it's ok to cancel twice
+
+        self.assertEqual(self.cancelled, 0)
+
+    def test_cancel_post_end(self):
+        """
+        Check that canceller is not called if cancelled after end.
+        """
+        self.cancelled = 0
+        fs = {}
+        f1 = ProgressiveFuture()
+        f1.task_canceller = self.cancel_task
+        f2 = ProgressiveFuture()
+        f2.task_canceller = self.cancel_task
+        fs[f1] = 10  # estimated duration in seconds
+        fs[f2] = 15  # estimated duration in seconds
+        batch_future = ProgressiveBatchFuture(fs)
+
+        # "start" the sub-tasks; the batch task is already started at creation
+        # (Note: typically only one sub-future is run at a time)
+        f1.set_running_or_notify_cancel()
+        f2.set_running_or_notify_cancel()
+        self.assertEqual(self.cancelled, 0)
+
+        # "end" the sub-futures
+        f1.set_result(1)
+        f2.set_result(2)
+
+        # check batch future automatically finished when all sub-futures finished
+        self.assertTrue(batch_future.done())
+        self.assertIsNone(batch_future.result())  # result of successful batch future is None
+        self.assertEqual(f1.result(), 1)
+        self.assertEqual(f2.result(), 2)
+
+        # try to cancel after end
+        self.assertFalse(batch_future.cancel())
+
+        self.assertFalse(batch_future.cancelled())  # check batch future is not cancelled
+        for f in fs:  # check all sub-futures are not cancelled
+            self.assertFalse(f.cancelled())
+
+        # The result shouldn't change
+        self.assertIsNone(batch_future.result())
+        self.assertEqual(f1.result(), 1)
+        self.assertEqual(f2.result(), 2)
+
+        self.assertEqual(self.cancelled, 0)
+
+    def cancel_task(self, future):
+        """Task canceller. Called whenever a sub-future is cancelled."""
+        self.cancelled += 1
+        return True
+
+    def on_progress_update(self, future, start, end):
+        """Whenever there is a progress update, update start and end time."""
+        self.start = start
+        self.end = end
+
+
 if __name__ == "__main__":
-    #import sys;sys.argv = ['', 'Test.testName']
     unittest.main()


### PR DESCRIPTION
When the progress was set the start time was not correctly updated.
If the sub-future was cancelled, also cancel the batch future.
Add test cases for batch future.