### PR TITLE
FASTEM: use calibration manager also during acquisition

### DIFF
--- a/src/odemis/acq/align/fastem.py
+++ b/src/odemis/acq/align/fastem.py
@@ -160,7 +160,7 @@ class CalibrationTask(object):
         :param beamshift: (tfsbc.BeamShiftController) Component that controls the beamshift deflection.
         :param det_rotator: (actuator) K-mirror controller. Must have a rotational (rz) axis.
         :param calibrations: (list[Calibrations]) List of calibrations that should be run.
-        :param stage_pos: (float, float) Stage position where the calibration should be run. If None,
+        :param stage_pos: (float, float) Stage position where the calibration should be run in meter. If None,
                       the calibration is run at the current stage position.
         """
         self.asm_config = None

--- a/src/odemis/acq/fastem_conf.py
+++ b/src/odemis/acq/fastem_conf.py
@@ -154,6 +154,7 @@ def configure_detector(detector, rocs):
     :param rocs: (list of FastEMROC) The region of calibration as selected on the scintillator,
                  which stores the calibrated settings if calibration was performed.
     """
+
     # check all parameters are available
     if not any(roc.parameters and "cellDarkOffset" in roc.parameters for roc in rocs):
         logging.warning("Region of calibration doesn't have dark offset parameters.")

--- a/src/odemis/gui/cont/fastem_acq.py
+++ b/src/odemis/gui/cont/fastem_acq.py
@@ -42,6 +42,8 @@ import wx
 from odemis import model, dataio
 from odemis.acq import align, stream, fastem
 from odemis.acq.align import fastem as align_fastem
+from odemis.acq.align.fastem import Calibrations
+from odemis.acq.fastem import estimate_acquisition_time
 from odemis.acq.stream import FastEMOverviewStream
 from odemis.gui import FG_COLOUR_BUTTON
 from odemis.gui.util import get_picture_folder, call_in_wx_main, \
@@ -407,7 +409,8 @@ class FastEMAcquiController(object):
             acq_time = 0
             for p in projects:
                 for roa in p.roas.value:
-                    acq_time += roa.estimate_acquisition_time()
+                    acq_time += estimate_acquisition_time(roa, [Calibrations.OPTICAL_AUTOFOCUS,
+                                                                Calibrations.IMAGE_TRANSLATION_PREALIGN])
             acq_time = math.ceil(acq_time)  # round a bit pessimistic
             txt = u"Estimated time is {}."
             txt = txt.format(units.readable_time(acq_time))
@@ -488,14 +491,16 @@ class FastEMAcquiController(object):
 
         # Acquire ROAs for all projects
         fs = {}
+        pre_calibrations = [Calibrations.OPTICAL_AUTOFOCUS, Calibrations.IMAGE_TRANSLATION_PREALIGN]
         for p in self._tab_data_model.projects.value:
             ppath = os.path.join(self.path, p.name.value)  # <acquisition date>/<project name>
             for roa in p.roas.value:
                 f = fastem.acquire(roa, ppath, self._main_data_model.ebeam, self._main_data_model.multibeam,
                                    self._main_data_model.descanner, self._main_data_model.mppc,
                                    self._main_data_model.stage, self._main_data_model.ccd,
-                                   self._main_data_model.beamshift, self._main_data_model.lens)
-                t = roa.estimate_acquisition_time()
+                                   self._main_data_model.beamshift, self._main_data_model.det_rotator,
+                                   self._main_data_model.lens, pre_calibrations=pre_calibrations)
+                t = estimate_acquisition_time(roa, pre_calibrations)
                 fs[f] = t
 
         self.acq_future = model.ProgressiveBatchFuture(fs)

--- a/src/odemis/gui/cont/project.py
+++ b/src/odemis/gui/cont/project.py
@@ -289,7 +289,7 @@ class FastEMROAController(object):
         self.model = odemis.acq.fastem.FastEMROA(name, acqstream.UNDEFINED_ROI, roc_2, roc_3,
                                                  self._tab_data.main.asm, self._tab_data.main.multibeam,
                                                  self._tab_data.main.descanner, self._tab_data.main.mppc,
-                                                 acqui_conf.overlap, pre_calibrate=True)
+                                                 acqui_conf.overlap)
         self.model.coordinates.subscribe(self._on_coordinates)
         self.model.roc_2.subscribe(self._on_roc)
         self.model.roc_3.subscribe(self._on_roc)


### PR DESCRIPTION
When acquiring an ROA we run a set of calibrations before each ROA. So far there was own code for this in the acquisition manager. However, now that we have the calibration manager, make use of it.