### PR TITLE
fastem-update-acq-time

### DIFF
--- a/src/odemis/gui/cont/fastem_acq.py
+++ b/src/odemis/gui/cont/fastem_acq.py
@@ -346,6 +346,16 @@ class FastEMAcquiController(object):
         self._tab_data_model.is_calib_3_done.subscribe(self._on_va_change, init=True)
         self._main_data_model.is_acquiring.subscribe(self._on_va_change)
 
+        # update the estimated acquisition time when the dwell time changes
+        self._main_data_model.multibeam.dwellTime.subscribe(self._on_update_acquisition_time)
+
+    def _on_update_acquisition_time(self, _=None):
+        """
+        Callback that listens to changes that influence the estimated acquisition time
+        and updates the displayed acquisition time in the GUI accordingly.
+        """
+        self.update_acquisition_time()
+
     def _on_projects(self, projects):
         for p in projects:
             p.roas.subscribe(self._on_roas)

--- a/src/odemis/gui/cont/fastem_acq.py
+++ b/src/odemis/gui/cont/fastem_acq.py
@@ -367,6 +367,8 @@ class FastEMAcquiController(object):
                 # when roa.roc_2 and/or roa.roc_3 are changed, call on_va_changed to update GUI
                 roa.roc_2.subscribe(self._on_va_change)
                 roa.roc_3.subscribe(self._on_va_change)
+                # update the estimated acquisition time when the roa is resized
+                roa.coordinates.subscribe(self._on_update_acquisition_time)
                 self.subscribed_roas.add(roa)
         self._update_roa_count()
         self.check_acquire_button()


### PR DESCRIPTION
Update the estimated acquisition time displayed in the GUI when the ROA is resized or when the dwell time is changed.