### PR TITLE
driver xt_client: allow to set the brightness and contrast

### DIFF
--- a/src/odemis/driver/test/xt_client_test.py
+++ b/src/odemis/driver/test/xt_client_test.py
@@ -545,6 +545,38 @@ class TestMicroscope(unittest.TestCase):
         self.assertEqual(self.detector.brightness.value, init_brightness + 0.01)
         self.detector.brightness.value = init_brightness
 
+    @unittest.skipIf(TEST_NOHW, 'Contrast and brightness do not change on the simulated hardware.')
+    def test_brightness_contrast(self):
+        """Test that changing the contrast and brightness updates the image correctly."""
+        # Test that for brightness and contrast 1 all values in the image are equal to 255
+        init_brightness = self.detector.brightness.value
+        init_contrast = self.detector.contrast.value
+        self.detector.brightness = 1
+        self.detector.contrast = 1
+        image = self.microscope.get_latest_image(self.scanner.channel)
+        numpy.testing.assert_array_equal(image, 255)
+
+        # Test that decreasing the brightness results in a darker image
+        self.detector.brightness = 0.5
+        darker_image = self.microscope.get_latest_image(self.scanner.channel)
+        self.assertGreater(numpy.sum(image), numpy.sum(darker_image))
+
+        # Test that for brightness and contrast 0 all values in the image are equal to 0
+        self.detector.brightness = 0
+        self.detector.contrast = 0
+        image = self.microscope.get_latest_image(self.scanner.channel)
+        numpy.testing.assert_array_equal(image, 0)
+
+        # Test that increasing the brightness and contrast results in a lighter image
+        self.detector.brightness = 0.5
+        self.detector.contrast = 0.5
+        lighter_image = self.microscope.get_latest_image(self.scanner.channel)
+        self.assertGreater(numpy.sum(lighter_image), numpy.sum(image))
+
+        # Set back initial values
+        self.detector.brightness.value = init_brightness
+        self.detector.contrast.value = init_contrast
+
 
 class TestMicroscopeInternal(unittest.TestCase):
     """

--- a/src/odemis/driver/test/xt_client_test.py
+++ b/src/odemis/driver/test/xt_client_test.py
@@ -478,7 +478,7 @@ class TestMicroscope(unittest.TestCase):
         """
         self.scanner.blanker = False
         # Start auto focus and check if it is running.
-        autofocus_future = self.efocus.applyAutofocus()
+        autofocus_future = self.efocus.applyAutofocus(self.detector)
         autofocus_state = self.microscope.is_autofocusing(self.scanner.channel)
         self.assertEqual(autofocus_state, True)
         self.assertIsInstance(autofocus_future, ProgressiveFuture)
@@ -491,7 +491,7 @@ class TestMicroscope(unittest.TestCase):
         self.assertIsInstance(autofocus_future, ProgressiveFuture)
 
         # Test starting auto focus and cancelling directly
-        autofocus_future = self.efocus.applyAutofocus()
+        autofocus_future = self.efocus.applyAutofocus(self.detector)
         autofocus_future.cancel()
         time.sleep(1.0)  # Give microscope/simulator the time to update the state
         autofocus_state = self.microscope.is_autofocusing(self.scanner.channel)
@@ -501,7 +501,7 @@ class TestMicroscope(unittest.TestCase):
         # Start autofocus
         max_execution_time = 40  # Approximately 3 times the normal expected execution time (s)
         starting_time = time.time()
-        autofocus_future = self.efocus.applyAutofocus()
+        autofocus_future = self.efocus.applyAutofocus(self.detector)
         time.sleep(0.5)  # Give microscope/simulator the time to update the state
         autofocus_future.result(timeout=max_execution_time)  # Wait until the autofocus is finished
 
@@ -533,17 +533,17 @@ class TestMicroscope(unittest.TestCase):
 
     def test_contrast(self):
         """Test setting the contrast."""
-        init_contrast = self.scanner.contrast.value
-        self.scanner.contrast.value += 0.01
-        self.assertEqual(self.scanner.contrast.value, init_contrast + 0.01)
-        self.scanner.contrast.value = init_contrast
+        init_contrast = self.detector.contrast.value
+        self.detector.contrast.value += 0.01
+        self.assertEqual(self.detector.contrast.value, init_contrast + 0.01)
+        self.detector.contrast.value = init_contrast
 
     def test_brightness(self):
         """Test setting the brightness."""
-        init_brightness = self.scanner.brightness.value
-        self.scanner.brightness.value += 0.01
-        self.assertEqual(self.scanner.brightness.value, init_brightness + 0.01)
-        self.scanner.brightness.value = init_brightness
+        init_brightness = self.detector.brightness.value
+        self.detector.brightness.value += 0.01
+        self.assertEqual(self.detector.brightness.value, init_brightness + 0.01)
+        self.detector.brightness.value = init_brightness
 
 
 class TestMicroscopeInternal(unittest.TestCase):

--- a/src/odemis/driver/xt_client.py
+++ b/src/odemis/driver/xt_client.py
@@ -2221,7 +2221,8 @@ class Focus(model.Actuator):
         out of focus, an incorrect focus can be found using the autofocus functionality.
         This call is non-blocking.
 
-        :param detector (str): Role of the detector.
+        :param detector: (model.Detector)
+            Detector component that stores information about which channel to use for autofocusing.
         :return: Future object
         """
         # Create ProgressiveFuture and update its state
@@ -2700,6 +2701,10 @@ class XTTKFocus(Focus):
     def applyAutofocus(self, detector):
         """
         Wrapper for autofocus flash function, non-blocking.
+
+        :param detector: (model.Detector)
+            The detector is unused for XTTK focusing, because it is not possible to select a channel for flash focusing.
+        :return: Future object
         """
         est_start = time.time() + 0.1
         f = ProgressiveFuture(start=est_start,

--- a/src/odemis/driver/xt_client.py
+++ b/src/odemis/driver/xt_client.py
@@ -1093,6 +1093,84 @@ class SEM(model.HwComponent):
             self.server._pyroClaimOwnership()
             return self.server.start_auto_lens_centering_flash()
 
+    def set_contrast(self, contrast, channel_name='electron1'):
+        """
+        Set the contrast of the scanned image to a specified factor.
+
+        Parameters
+        ----------
+        contrast: float
+            Value the brightness should be set to as a factor between 0 and 1.
+        channel_name: str
+            Name of one of the electron channels.
+        """
+        with self._proxy_access:
+            self.server._pyroClaimOwnership()
+            return self.server.set_contrast(contrast, channel_name)
+
+    def get_contrast(self, channel_name='electron1'):
+        """
+        Get the contrast of the scanned image.
+
+        Parameters
+        ----------
+        channel_name: str
+            Name of one of the electron channels.
+
+        Returns
+        -------
+        contrast: float
+            Returns value of current contrast as a factor between 0 and 1.
+        """
+        with self._proxy_access:
+            self.server._pyroClaimOwnership()
+            return self.server.get_contrast(channel_name)
+
+    def contrast_info(self):
+        """Returns the contrast unit [-] and range [0, 1]."""
+        with self._proxy_access:
+            self.server._pyroClaimOwnership()
+            return self.server.contrast_info()
+
+    def set_brightness(self, brightness, channel_name='electron1'):
+        """
+        Set the brightness of the scanned image to a specified factor.
+
+        Parameters
+        ----------
+        brightness: float
+            Value the brightness should be set to as a factor between 0 and 1.
+        channel_name: str
+            Name of one of the electron channels.
+        """
+        with self._proxy_access:
+            self.server._pyroClaimOwnership()
+            return self.server.set_brightness(brightness, channel_name)
+
+    def get_brightness(self, channel_name='electron1'):
+        """
+        Get the brightness of the scanned image.
+
+        Parameters
+        ----------
+        channel_name: str
+            Name of one of the electron channels.
+
+        Returns
+        -------
+        brightness: float
+            Returns value of current brightness as a factor between 0 and 1.
+        """
+        with self._proxy_access:
+            self.server._pyroClaimOwnership()
+            return self.server.get_brightness(channel_name)
+
+    def brightness_info(self):
+        """Returns the brightness unit [-] and range [0, 1]."""
+        with self._proxy_access:
+            self.server._pyroClaimOwnership()
+            return self.server.brightness_info()
+
 
 class Scanner(model.Emitter):
     """
@@ -1417,66 +1495,6 @@ class Scanner(model.Emitter):
         self.parent.set_scan_mode(scan_mode)
         return external
 
-    @isasync
-    def applyAutoContrastBrightness(self, detector):
-        """
-        Wrapper for running the automatic setting of the contrast brightness functionality asynchronously. It
-        automatically sets the contrast and the brightness via XT, the beam must be turned on and unblanked. Auto
-        contrast brightness functionality works best if there is a feature visible in the image. This call is
-        non-blocking.
-
-        :param detector (str): Role of the detector.
-        :return: Future object
-
-        """
-        # Create ProgressiveFuture and update its state
-        est_start = time.time() + 0.1
-        f = ProgressiveFuture(start=est_start,
-                              end=est_start + 20)  # Rough time estimation
-        f._auto_contrast_brighness_lock = threading.Lock()
-        f._must_stop = threading.Event()  # Cancel of the current future requested
-        f.task_canceller = self._cancelAutoContrastBrightness
-        f._channel_name = self.channel
-        return self._executor.submitf(f, self._applyAutoContrastBrightness, f)
-
-    def _applyAutoContrastBrightness(self, future):
-        """
-        Starts applying auto contrast brightness and checks if the process is finished for the ProgressiveFuture object.
-        :param future (Future): the future to start running.
-        """
-        channel_name = future._channel_name
-        with future._auto_contrast_brighness_lock:
-            if future._must_stop.is_set():
-                raise CancelledError()
-            self.parent.set_auto_contrast_brightness(channel_name, XT_RUN)
-            time.sleep(0.5)  # Wait for the auto contrast brightness to start
-
-        # Wait until the microscope is no longer performing auto contrast brightness
-        while self.parent.is_running_auto_contrast_brightness(channel_name):
-            future._must_stop.wait(0.1)
-            if future._must_stop.is_set():
-                raise CancelledError()
-
-    def _cancelAutoContrastBrightness(self, future):
-        """
-        Cancels the auto contrast brightness. Non-blocking.
-        :param future (Future): the future to stop.
-        :return (bool): True if it successfully cancelled (stopped) the move.
-        """
-        future._must_stop.set()  # Tell the thread taking care of auto contrast brightness it's over.
-
-        with future._auto_contrast_brighness_lock:
-            logging.debug("Cancelling auto contrast brightness")
-            try:
-                self.parent.set_auto_contrast_brightness(future._channel_name, XT_STOP)
-                return True
-            except OSError as error_msg:
-                logging.warning("Failed to cancel auto brightness contrast: %s", error_msg)
-                return False
-
-    def prepareForScan(self):
-        pass
-
 
 class FibScanner(model.Emitter):
     """
@@ -1547,8 +1565,27 @@ class Detector(model.Detector):
         else:
             raise ValueError("No Scanner available")
 
+        brightness_info = self.parent.brightness_info()
+        self.brightness = model.FloatContinuous(
+            self.parent.get_brightness(),
+            brightness_info["range"],
+            unit=brightness_info["unit"],
+            setter=self._setBrightness)
+
+        contrast_info = self.parent.contrast_info()
+        self.contrast = model.FloatContinuous(
+            self.parent.get_contrast(),
+            contrast_info["range"],
+            unit=contrast_info["unit"],
+            setter=self._setContrast)
+
         self._genmsg = queue.Queue()  # GEN_*
         self._generator = None
+
+        # Refresh regularly the values, from the hardware, starting from now
+        self._updateSettings()
+        self._va_poll = util.RepeatingTimer(5, self._updateSettings, "Settings polling detector")
+        self._va_poll.start()
 
     def terminate(self):
         if self._generator:
@@ -1740,6 +1777,83 @@ class Detector(model.Detector):
             self._scanner = self.parent._fib_scanner
 
         return scanner_name
+
+    def _updateSettings(self):
+        """
+        Reads all the current settings from the Detector and reflects them on the VAs
+        """
+        brightness = self.parent.get_brightness(self.channel)
+        if brightness != self.brightness.value:
+            self.brightness._value = brightness
+            self.brightness.notify(brightness)
+        contrast = self.parent.get_contrast(self.channel)
+        if contrast != self.contrast.value:
+            self.contrast._value = contrast
+            self.contrast.notify(contrast)
+
+    def _setBrightness(self, brightness):
+        self.parent.set_brightness(brightness, self.channel)
+        return self.parent.get_brightness(self.channel)
+
+    def _setContrast(self, contrast):
+        self.parent.set_contrast(contrast, self.channel)
+        return self.parent.get_contrast(self.channel)
+
+    @isasync
+    def applyAutoContrastBrightness(self):
+        """
+        Wrapper for running the automatic setting of the contrast brightness functionality asynchronously. It
+        automatically sets the contrast and the brightness via XT, the beam must be turned on and unblanked. Auto
+        contrast brightness functionality works best if there is a feature visible in the image. This call is
+        non-blocking.
+
+        :return: Future object
+
+        """
+        # Create ProgressiveFuture and update its state
+        est_start = time.time() + 0.1
+        f = ProgressiveFuture(start=est_start,
+                              end=est_start + 20)  # Rough time estimation
+        f._auto_contrast_brightness_lock = threading.Lock()
+        f._must_stop = threading.Event()  # Cancel of the current future requested
+        f.task_canceller = self._cancelAutoContrastBrightness
+        f._channel_name = self._scanner.channel
+        return self._executor.submitf(f, self._applyAutoContrastBrightness, f)
+
+    def _applyAutoContrastBrightness(self, future):
+        """
+        Starts applying auto contrast brightness and checks if the process is finished for the ProgressiveFuture object.
+        :param future (Future): the future to start running.
+        """
+        channel_name = future._channel_name
+        with future._auto_contrast_brightness_lock:
+            if future._must_stop.is_set():
+                raise CancelledError()
+            self.parent.set_auto_contrast_brightness(channel_name, XT_RUN)
+            time.sleep(0.5)  # Wait for the auto contrast brightness to start
+
+        # Wait until the microscope is no longer performing auto contrast brightness
+        while self.parent.is_running_auto_contrast_brightness(channel_name):
+            future._must_stop.wait(0.1)
+            if future._must_stop.is_set():
+                raise CancelledError()
+
+    def _cancelAutoContrastBrightness(self, future):
+        """
+        Cancels the auto contrast brightness. Non-blocking.
+        :param future (Future): the future to stop.
+        :return (bool): True if it successfully cancelled (stopped) the move.
+        """
+        future._must_stop.set()  # Tell the thread taking care of auto contrast brightness it's over.
+
+        with future._auto_contrast_brightness_lock:
+            logging.debug("Cancelling auto contrast brightness")
+            try:
+                self.parent.set_auto_contrast_brightness(future._channel_name, XT_STOP)
+                return True
+            except OSError as error_msg:
+                logging.warning("Failed to cancel auto brightness contrast: %s", error_msg)
+                return False
 
 
 # Very approximate values
@@ -2100,15 +2214,13 @@ class Focus(model.Actuator):
         self._pos_poll.start()
 
     @isasync
-    def applyAutofocus(self, detector):
+    def applyAutofocus(self):
         """
         Wrapper for running the autofocus functionality asynchronously. It sets the state of autofocus,
         the beam must be turned on and unblanked. Also a a reasonable manual focus is needed. When the image is too far
         out of focus, an incorrect focus can be found using the autofocus functionality.
         This call is non-blocking.
 
-        :param detector (str): Role of the detector.
-        :param state (str):  "run", or "stop"
         :return: Future object
         """
         # Create ProgressiveFuture and update its state

--- a/src/odemis/gui/cont/streams.py
+++ b/src/odemis/gui/cont/streams.py
@@ -1372,7 +1372,7 @@ class StreamController(object):
         self.stream_panel.Enable(False)
         self.pause()
         self.pauseStream()
-        f = self.stream.focuser.applyAutofocus()
+        f = self.stream.focuser.applyAutofocus(self.stream.detector)
         f.add_done_callback(self._on_autofunction_done)
 
     @call_in_wx_main

--- a/src/odemis/gui/cont/streams.py
+++ b/src/odemis/gui/cont/streams.py
@@ -1372,7 +1372,7 @@ class StreamController(object):
         self.stream_panel.Enable(False)
         self.pause()
         self.pauseStream()
-        f = self.stream.focuser.applyAutofocus(self.stream.detector)
+        f = self.stream.focuser.applyAutofocus()
         f.add_done_callback(self._on_autofunction_done)
 
     @call_in_wx_main
@@ -1380,7 +1380,7 @@ class StreamController(object):
         self.stream_panel.Enable(False)
         self.pause()
         self.pauseStream()
-        f = self.stream.emitter.applyAutoContrastBrightness(self.stream.detector)
+        f = self.stream.detector.applyAutoContrastBrightness()
         f.add_done_callback(self._on_autofunction_done)
 
     @call_in_wx_main


### PR DESCRIPTION
For the overview imaging it is necessary to adjust the brightness and contrast beforehand.
Add a brightness and a contrast VA to allow setting these values.