### PR TITLE
gui cont tabs: allows to select multiple files to open in analysis tab

### DIFF
--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -3401,7 +3401,7 @@ class AnalysisTab(Tab):
                                message="Choose a file to load",
                                defaultDir=path,
                                defaultFile="",
-                               style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST,
+                               style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST | wx.FD_MULTIPLE,
                                wildcard=wildcards)
 
         # Show the dialog and check whether is was accepted or cancelled
@@ -3409,16 +3409,17 @@ class AnalysisTab(Tab):
             return False
 
         # Detect the format to use
-        filename = os.fsdecode(dialog.GetPath())
-        if extend:
-            logging.debug("Extending the streams with file %s", filename)
-        else:
-            logging.debug("Current file set to %s", filename)
-
         fmt = formats[dialog.GetFilterIndex()]
 
-        # popup.show_message(self.main_frame, "Opening file")
-        self.load_data(filename, fmt, extend=extend)
+        for filename in dialog.GetPaths():
+            if extend:
+                logging.debug("Extending the streams with file %s", filename)
+            else:
+                logging.debug("Current file set to %s", filename)
+
+            self.load_data(filename, fmt, extend=extend)
+            extend = True  # If multiple files loaded, the first one is considered main one
+
         return True
 
     def on_file_open_button(self, _):


### PR DESCRIPTION
It's possible to open multiple files simultaneously, but until now the user had to
select each file one at a time using the "From file..." button.
Now, it's directly possible to select multiple files. Either from the
"open" button, or from the "From file...".

Handy when trying to open quite a few files at the same time, like
tiles.