### PR TITLE
gui comp stream: remove "improvement" to event handler which broke closing streams

### DIFF
--- a/src/odemis/gui/comp/stream.py
+++ b/src/odemis/gui/comp/stream.py
@@ -1547,7 +1547,6 @@ class StreamBar(wx.Panel):
         self._sz.Detach(spanel)
         self.stream_panels.remove(spanel)
         spanel.Destroy()
-        spanel.Unbind(wx.EVT_WINDOW_DESTROY, source=spanel, handler=self.on_streamp_destroy)
 
     def clear(self):
         """


### PR DESCRIPTION
In commit a8fec30dee4 (move cryo acquired streams control to the streambar
controller), I tried to "clean" the event removal. However, as the
control is destroyed, the event is automatically removed. In some cases,
this would even cause an error as we were accessing dead objects.