### PR TITLE
driver andorcam3: fix incorrect warning

### DIFF
--- a/src/odemis/driver/andorcam3.py
+++ b/src/odemis/driver/andorcam3.py
@@ -1336,6 +1336,7 @@ class AndorCam3(model.DigitalCamera):
                     if re.match(pattern, gs):
                         gains[gain] = gs
                         self._gain_to_idx[gain] = idx
+                        break
                 else:
                     logging.warning("Unhandled gain %s", gs)
         except ATError:


### PR DESCRIPTION
Missing break in for loop caused every gain to be reported as "unhandled",
although everything worked fine.