### PR TITLE
FASTEM: Return resolution and cell size for cell translation calibration

### DIFF
--- a/src/odemis/acq/align/fastem.py
+++ b/src/odemis/acq/align/fastem.py
@@ -335,9 +335,13 @@ class CalibrationTask(object):
             self.asm_config["multibeam"]["scanAmplitude"] = s_amplitude
 
         elif calibration == Calibrations.CELL_TRANSLATION:
-            translation = calibration.value.run(self._scanner, self._multibeam, self._descanner, self._detector,
-                                                self._dataflow, plot_cell_translation=True)
+            translation, resolution, cell_complete_resolution = calibration.value.run(self._scanner, self._multibeam,
+                                                                                      self._descanner, self._detector,
+                                                                                      self._dataflow,
+                                                                                      plot_cell_translation=True)
             self.asm_config["mppc"]["cellTranslation"] = translation
+            self.asm_config["multibeam"]["resolution"] = resolution
+            self.asm_config["mppc"]["cellCompleteResolution"] = cell_complete_resolution
 
         else:
             raise ValueError(f"Unknown calibration {calibration.name}.")


### PR DESCRIPTION
The cell translation calibration is run for a specific set of values for the single field resolution and the cell complete resolution. Thus, for the acquisition it is necessary to also use this settings. As long as adjustable resolution and cell size are not supported in the calibration itself, also do not allow to use different value for the acquisition.