### PR TITLE
gui cont streams: fix display order of HW Detector VAs

### DIFF
--- a/src/odemis/gui/cont/streams.py
+++ b/src/odemis/gui/cont/streams.py
@@ -347,7 +347,8 @@ class StreamController(object):
 
         # Process the hardware VAs first (emitter and detector hardware VAs are combined into one
         # attribute called 'hw_vas'
-        vas_names = util.sorted_according_to(list(self.stream.hw_vas.keys()), list(emitter_conf.keys()))
+        vas_names = util.sorted_according_to(list(self.stream.hw_vas.keys()),
+                                             list(emitter_conf.keys()) + list(detector_conf.keys()))
 
         for name in vas_names:
             va = self.stream.hw_vas[name]


### PR DESCRIPTION
HW VAs are mixed for the emitter and detector, but until now we only
used the emitter order. That meant that if the VAs came from the
detector, the order would be roughly random (except for the VAs who
share the same name).
=> use both orders, one after the other. It's not an issue if a VA is
listed several times, the first occurence will be used.