### PR TITLE
gui util widgets: fix error when disconnecting a AxisConnector

### DIFF
--- a/src/odemis/gui/util/widgets.py
+++ b/src/odemis/gui/util/widgets.py
@@ -254,7 +254,7 @@ class AxisConnector(object):
         logging.debug("Disconnecting AxisConnector")
         if self.value_ctrl:
             for event in self.change_events:
-                self.value_ctrl.Unbind(event, self._on_value_change)
+                self.value_ctrl.Unbind(event, handler=self._on_value_change)
         self.comp.position.unsubscribe(self._on_pos_change)
 
 


### PR DESCRIPTION
Probably we never tried (except when stopping the GUI).
Need to set the argument name explicitly, as for the VAConnector.