### PR TITLE
gui conf: fallback to default project dir if impossible to create a new project folder

### DIFF
--- a/src/odemis/gui/conf/file.py
+++ b/src/odemis/gui/conf/file.py
@@ -258,7 +258,7 @@ class AcquisitionConfig(Config):
 
         # Define the default settings for the project parameters
         self.default.add_section("project")
-        self.default.set("project", "pj_last_path", ACQUI_PATH)
+        self.default.set("project", "pj_last_path", ACQUI_PATH + "/")
         self.default.set("project", "pj_ptn", u"{datelng}-{timelng}")
         self.default.set("project", "pj_count", "0")
 
@@ -342,7 +342,7 @@ class AcquisitionConfig(Config):
         lp = self.get("project", "pj_last_path")
         # Check that it (still) exists, and if not, fallback to the default
         if not os.path.isdir(lp):
-            lp = ACQUI_PATH
+            lp = ACQUI_PATH + "/"
         return lp
 
     @pj_last_path.setter

--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -2742,7 +2742,20 @@ class CryoChamberTab(Tab):
         """
         root_dir = os.path.dirname(self.conf.pj_last_path)
         np = create_projectname(root_dir, self.conf.pj_ptn, count=self.conf.pj_count)
-        os.mkdir(np)
+        try:
+            os.mkdir(np)
+        except OSError:
+            # If for some reason it's not possible to create the new folder, for
+            # example because it's on a remote folder which is not connected anymore,
+            # don't completely fail, but just try something safe.
+            logging.exception("Failed to create expected project folder %s, will fallback to default folder", np)
+            pj_last_path = self.conf.default.get("project", "pj_last_path")
+            root_dir = os.path.dirname(pj_last_path)
+            pj_ptn = self.conf.default.get("project", "pj_ptn")
+            pj_count = self.conf.default.get("project", "pj_count")
+            np = create_projectname(root_dir, pj_ptn, count=pj_count)
+            os.mkdir(np)
+
         self._change_project_conf(np)
 
     def _reset_project_data(self):


### PR DESCRIPTION
It can happen that the default project dir cannot be created, for
instance, it got unmounted, or permissions changed. Let's not completely
fail to start the GUI in such case.
=> fall back to the default project directory.

Also, add a "/" after the root project dir because it's actually supposed to
contain the *previous* project directory, and then the parent folder is
used. As it's directly the parent folder, we need to indicate that with
an extra "/".