### PR TITLE
dataio hdf5: read/write MD_HW_NAME and MD_HW_VERSION

### DIFF
--- a/src/odemis/dataio/hdf5.py
+++ b/src/odemis/dataio/hdf5.py
@@ -698,6 +698,10 @@ def _parse_physical_data(pdgroup, da):
         read_metadata(pdgroup, i, md, "EmissionCurrentOverTime", model.MD_EBEAM_CURRENT_TIME,
                       converter=numpy.ndarray.tolist,
                       bad_states=(ST_INVALID, ST_DEFAULT))
+
+        read_metadata(pdgroup, i, md, "HardwareName", model.MD_HW_NAME, converter=read_str)
+        read_metadata(pdgroup, i, md, "HardwareVersion", model.MD_HW_VERSION, converter=read_str)
+
         # angle resolved
         read_metadata(pdgroup, i, md, "PolePosition", model.MD_AR_POLE, converter=tuple)
         read_metadata(pdgroup, i, md, "XMax", model.MD_AR_XMAX, converter=float)
@@ -1042,6 +1046,10 @@ def _add_image_metadata(group, image, mds):
     # (only meaningful for AR/SPARC)
     pf, st_pf = [], []
 
+    # Hardware info
+    hw_name, st_hw_name = [], []
+    hw_version, st_hw_version = [], []
+
     # Polarization: position (string) of polarization analyzer
     # (only meaningful for AR/SPARC with polarization analyzer)
     pol, st_pol = [], []
@@ -1076,6 +1084,10 @@ def _add_image_metadata(group, image, mds):
         append_metadata(st_hd, hd, md, model.MD_AR_HOLE_DIAMETER, default_value=0)
         append_metadata(st_fd, fd, md, model.MD_AR_FOCUS_DISTANCE, default_value=0)
         append_metadata(st_pf, pf, md, model.MD_AR_PARABOLA_F, default_value=0)
+
+        append_metadata(st_hw_name, hw_name, md, model.MD_HW_NAME)
+        append_metadata(st_hw_version, hw_version, md, model.MD_HW_VERSION)
+
         # polarization analyzer
         append_metadata(st_pol, pol, md, model.MD_POL_MODE)
         append_metadata(st_posqwp, posqwp, md, model.MD_POL_POS_QWP, default_value=0)
@@ -1097,6 +1109,10 @@ def _add_image_metadata(group, image, mds):
     set_metadata(gp, "HoleDiameter", st_hd, hd)
     set_metadata(gp, "FocusDistance", st_fd, fd)
     set_metadata(gp, "ParabolaF", st_pf, pf)
+    # Hardware info
+    set_metadata(gp, "HardwareName", st_hw_name, hw_name)
+    set_metadata(gp, "HardwareVersion", st_hw_version, hw_version)
+
     # polarization analyzer
     set_metadata(gp, "Polarization", st_pol, pol)
     set_metadata(gp, "QuarterWavePlate", st_posqwp, posqwp)

--- a/src/odemis/dataio/test/hdf5_test.py
+++ b/src/odemis/dataio/test/hdf5_test.py
@@ -262,6 +262,7 @@ class TestHDF5IO(unittest.TestCase):
         size = (512, 256)
         metadata3d = {model.MD_SW_VERSION: "1.0-test",
                     model.MD_HW_NAME: "fake spec",
+                    model.MD_HW_VERSION: "Spec v3",
                     model.MD_DESCRIPTION: "test3d",
                     model.MD_ACQ_DATE: time.time(),
                     model.MD_BPP: 12,
@@ -272,7 +273,8 @@ class TestHDF5IO(unittest.TestCase):
                     model.MD_IN_WL: (500e-9, 520e-9),  # m
                     }
         metadata = {model.MD_SW_VERSION: "1.0-test",
-                    model.MD_HW_NAME: "",  # check empty unicode strings
+                    model.MD_HW_NAME: "",  # check empty strings
+                    model.MD_HW_NAME: "vÉ",  # check unicode
                     model.MD_DESCRIPTION: "test",
                     model.MD_ACQ_DATE: time.time(),
                     model.MD_BPP: 12,
@@ -312,6 +314,8 @@ class TestHDF5IO(unittest.TestCase):
         self.assertEqual(imr.metadata[model.MD_POS], metadata3d[model.MD_POS])
         self.assertEqual(imr.metadata[model.MD_PIXEL_SIZE], metadata3d[model.MD_PIXEL_SIZE])
         self.assertEqual(imr.metadata[model.MD_ACQ_DATE], metadata3d[model.MD_ACQ_DATE])
+        self.assertEqual(imr.metadata[model.MD_HW_NAME], metadata3d[model.MD_HW_NAME])
+        self.assertEqual(imr.metadata[model.MD_HW_VERSION], metadata3d[model.MD_HW_VERSION])
 
         self.assertEqual(imr[0, 0, 0], 0)
         self.assertEqual(imr[-1, 0, 0], end)
@@ -324,7 +328,8 @@ class TestHDF5IO(unittest.TestCase):
         dtype = numpy.uint8
         size = (3, 512, 256) # C, X, Y
         metadata = {model.MD_SW_VERSION: "1.0-test",
-                    model.MD_DESCRIPTION: u"test",
+                    model.MD_HW_NAME: "",  # check empty strings
+                    model.MD_HW_VERSION: "vÉ",  # check unicode
                     model.MD_ACQ_DATE: time.time(),
                     model.MD_BINNING: (1, 2), # px, px
                     model.MD_PIXEL_SIZE: (1e-6, 1e-6), # m/px
@@ -359,6 +364,8 @@ class TestHDF5IO(unittest.TestCase):
         self.assertEqual(im.metadata[model.MD_POS], md[model.MD_POS])
         self.assertEqual(im.metadata[model.MD_PIXEL_SIZE], md[model.MD_PIXEL_SIZE])
         self.assertEqual(im.metadata[model.MD_ACQ_DATE], md[model.MD_ACQ_DATE])
+        self.assertEqual(im.metadata[model.MD_HW_NAME], md[model.MD_HW_NAME])
+        self.assertEqual(im.metadata[model.MD_HW_VERSION], md[model.MD_HW_VERSION])
 
     def testMetadata(self):
         """


### PR DESCRIPTION
It's quite handy metadata, to know which camera was used for imaging.
Of course we also store this info in MD_EXTRA_SETTINGS, but on systems
with multiple cameras, you have to guess which camera was used.