### PR TITLE
gui comp: increase the text fields in height to ensure all characters are shown

### DIFF
--- a/src/odemis/gui/comp/file.py
+++ b/src/odemis/gui/comp/file.py
@@ -94,6 +94,7 @@ class FileBrowser(wx.Panel):
         box = wx.BoxSizer(wx.HORIZONTAL)
 
         self.text_ctrl = wx.TextCtrl(self, style=wx.BORDER_NONE | wx.TE_READONLY)
+        self.text_ctrl.MinSize = (-1, 20)
         self.text_ctrl.SetForegroundColour(odemis.gui.FG_COLOUR_EDIT)
         self.text_ctrl.SetBackgroundColour(odemis.gui.BG_COLOUR_MAIN)
         self.text_ctrl.Bind(wx.EVT_TEXT, self.on_changed)

--- a/src/odemis/gui/comp/settings.py
+++ b/src/odemis/gui/comp/settings.py
@@ -150,14 +150,16 @@ class SettingsPanel(wx.Panel):
             if selectable:
                 value_ctrl = wx.TextCtrl(self, value=value,
                                          style=wx.BORDER_NONE | wx.TE_READONLY)
+                value_ctrl.MinSize = (-1, 20)
                 value_ctrl.SetForegroundColour(gui.FG_COLOUR_DIS)
                 value_ctrl.SetBackgroundColour(gui.BG_COLOUR_MAIN)
                 self.gb_sizer.Add(value_ctrl, (self.num_rows, 1),
-                                  flag=wx.ALL | wx.EXPAND | wx.ALIGN_CENTER_VERTICAL, border=5)
+                                  flag=wx.EXPAND | wx.ALIGN_CENTER_VERTICAL, border=5)
             else:
                 value_ctrl = wx.StaticText(self, label=value)
                 value_ctrl.SetForegroundColour(gui.FG_COLOUR_DIS)
-                self.gb_sizer.Add(value_ctrl, (self.num_rows, 1), flag=wx.ALL, border=5)
+                self.gb_sizer.Add(value_ctrl, (self.num_rows, 1),
+                                  flag=wx.BOTTOM | wx.TOP, border=5)
         else:
             value_ctrl = None
 
@@ -178,13 +180,15 @@ class SettingsPanel(wx.Panel):
         lbl_ctrl = self._add_side_label(label_text)
         value_ctrl = wx.TextCtrl(self, value=str(value or ""),
                                  style=wx.TE_PROCESS_ENTER | wx.BORDER_NONE | (wx.TE_READONLY if readonly else 0))
+        value_ctrl.MinSize = (-1, 20)
+
         if readonly:
             value_ctrl.SetForegroundColour(gui.FG_COLOUR_DIS)
         else:
             value_ctrl.SetForegroundColour(gui.FG_COLOUR_EDIT)
         value_ctrl.SetBackgroundColour(gui.BG_COLOUR_MAIN)
         self.gb_sizer.Add(value_ctrl, (self.num_rows, 1),
-                          flag=wx.ALL | wx.EXPAND | wx.ALIGN_CENTER_VERTICAL, border=5)
+                          flag=wx.EXPAND | wx.ALIGN_CENTER_VERTICAL, border=5)
 
         return lbl_ctrl, value_ctrl
 
@@ -351,7 +355,7 @@ class SettingsPanel(wx.Panel):
 
         self.gb_sizer.Add(value_ctrl,
                           (self.num_rows, 1),
-                          flag=wx.ALL | wx.EXPAND | wx.ALIGN_CENTER_VERTICAL,
+                          flag=wx.EXPAND | wx.ALIGN_CENTER_VERTICAL,
                           border=5)
 
         return lbl_ctrl, value_ctrl

--- a/src/odemis/gui/comp/stream.py
+++ b/src/odemis/gui/comp/stream.py
@@ -1056,14 +1056,16 @@ class StreamPanel(wx.Panel):
             if selectable:
                 value_ctrl = wx.TextCtrl(self._panel, value=value,
                                          style=wx.BORDER_NONE | wx.TE_READONLY)
+                value_ctrl.MinSize = (-1, 20)
                 value_ctrl.SetForegroundColour(gui.FG_COLOUR_DIS)
                 value_ctrl.SetBackgroundColour(gui.BG_COLOUR_MAIN)
                 self.gb_sizer.Add(value_ctrl, (self.num_rows, 1),
-                                  flag=wx.ALL | wx.EXPAND | wx.ALIGN_CENTER_VERTICAL, border=5)
+                                  flag=wx.EXPAND | wx.ALIGN_CENTER_VERTICAL, border=5)
             else:
                 value_ctrl = wx.StaticText(self._panel, label=value)
                 value_ctrl.SetForegroundColour(gui.FG_COLOUR_DIS)
-                self.gb_sizer.Add(value_ctrl, (self.num_rows, 1), flag=wx.ALL, border=5)
+                self.gb_sizer.Add(value_ctrl, (self.num_rows, 1),
+                                  flag=wx.BOTTOM | wx.TOP | wx.ALIGN_CENTER_VERTICAL, border=5)
         else:
             value_ctrl = None
 
@@ -1131,13 +1133,14 @@ class StreamPanel(wx.Panel):
         lbl_ctrl = self._add_side_label(label_text)
         value_ctrl = wx.TextCtrl(self._panel, value=str(value or ""),
                                  style=wx.TE_PROCESS_ENTER | wx.BORDER_NONE | (wx.TE_READONLY if readonly else 0))
+        value_ctrl.MinSize = (-1, 20)
         if readonly:
             value_ctrl.SetForegroundColour(gui.FG_COLOUR_DIS)
         else:
             value_ctrl.SetForegroundColour(gui.FG_COLOUR_EDIT)
         value_ctrl.SetBackgroundColour(gui.BG_COLOUR_MAIN)
         self.gb_sizer.Add(value_ctrl, (self.num_rows, 1),
-                          flag=wx.ALL | wx.EXPAND | wx.ALIGN_CENTER_VERTICAL, border=5)
+                          flag=wx.EXPAND | wx.ALIGN_CENTER_VERTICAL, border=5)
 
         return lbl_ctrl, value_ctrl
 


### PR DESCRIPTION
By default the text fields are too small, at least with the default
Ubuntu theme. The bottom of letters like p or µ was hidden.

So reduce the margin and increase the text height. It
should actually take a few pixels *less* in total now.