### PR TITLE
util units: add also µsec display to the time display

### DIFF
--- a/src/odemis/util/test/units_test.py
+++ b/src/odemis/util/test/units_test.py
@@ -117,8 +117,14 @@ class TestUnits(unittest.TestCase):
         values = [((1.0,), "1 second"),
                   ((0,), "0 second"),
                   ((3601,), "1 hour and 1 second"),
-                  ((12.350,), "12 seconds and 350 ms"),
+                  ((12.350,), "12 seconds and 350 milliseconds"),
+                  ((12.3501,), "12 seconds, 350 milliseconds and 100 microseconds"),
+                  ((1e-6,), "1 microsecond"),
+                  ((12 + 50e-6,), "12 seconds and 50 microseconds"),
                   ((3 * 24 * 60 * 60 + 12 * 60,), "3 days and 12 minutes"),
+                  ((12 + 50e-6, False), "12 s and 50 µs"),
+                  ((3 * 24 * 60 * 60 + 12 * 60, False), "3 d and 12 min"),
+                  ((1e-6, False), "1 µs"),
                   ]
         for (i, eo) in values:
             o = units.readable_time(*i)

--- a/src/odemis/util/units.py
+++ b/src/odemis/util/units.py
@@ -324,11 +324,16 @@ def readable_time(seconds, full=True):
         logging.debug("Converting time longer than a month.")
 
     second, subsec = divmod(seconds, 1)
-    msec = round(subsec * 1e3)
-    if msec == 1000:
-        msec = 0
+    msec, submsec = divmod(subsec, 1e-3)
+    usec = round(submsec * 1e6)
+    if usec >= 1000:
+        usec -= 1000
+        msec += 1
+    if msec >= 1000:
+        msec -= 1000
         second += 1
-    if second == 0 and msec == 0:
+
+    if second == 0 and msec == 0 and usec == 0:
         # exactly 0 => special case
         if full:
             return u"0 second"
@@ -364,7 +369,16 @@ def readable_time(seconds, full=True):
             result.append(u"%d s" % (second,))
 
     if msec:
-        result.append(u"%d ms" % msec)
+        if full:
+            result.append(u"%d millisecond%s" % (msec, u"" if msec == 1 else u"s"))
+        else:
+            result.append(u"%d ms" % msec)
+
+    if usec:
+        if full:
+            result.append(u"%d microsecond%s" % (usec, u"" if usec == 1 else u"s"))
+        else:
+            result.append(u"%d µs" % usec)
 
     if len(result) == 1:
         # simple case


### PR DESCRIPTION
Avoids having values < 1ms represented as "0 s". The µs can still matter
a lot, depending on which time frame we care about.