### PR TITLE
config: fix secom-pretty sim to match the images again

### DIFF
--- a/install/linux/usr/share/odemis/sim/secom-sim-pretty.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/secom-sim-pretty.odm.yaml
@@ -61,7 +61,7 @@ Spectra: {
 "Nikon Super Duper": {
     class: static.OpticalLens,
     role: lens,
-    init: {mag: 192.31}, # ratio to get the sim-ccd image to the right size
+    init: {mag: 60},
     affects: ["Andor SimCam"]
 }
 


### PR DESCRIPTION
Some time ago the CCD simulator must have adjusted the metadata, and
this caused the images to not overlay properly anymore.

It's now easier, we just put the original lens magnification.