### PR TITLE
gui win OverviewAcquisitionDialog: round up the estimated time

### DIFF
--- a/src/odemis/gui/win/acquisition.py
+++ b/src/odemis/gui/win/acquisition.py
@@ -909,7 +909,7 @@ class OverviewAcquisitionDialog(xrcfr_overview_acq):
                                                           focusing_method=focus_mtd)
 
         txt = "The estimated acquisition time is {}."
-        txt = txt.format(units.readable_time(acq_time))
+        txt = txt.format(units.readable_time(math.ceil(acq_time)))
         self.lbl_acqestimate.SetLabel(txt)
 
     def get_fov(self, s):


### PR DESCRIPTION
The estimated acquisition time is very rough. Rounding to 1s is more
than sufficient, instead of say "2 minutes, 3 seconds, 343 milliseconds,
123 microseconds".