### PR TITLE
driver smaract: fix 5DoF ref_on_init failure

### DIFF
--- a/src/odemis/driver/smaract.py
+++ b/src/odemis/driver/smaract.py
@@ -1521,7 +1521,7 @@ class MC_5DOF(model.Actuator):
         if referenced:
             logging.debug("SA_MC is referenced")
         elif ref_on_init:
-            self.reference()  # will reference now in background.
+            self.reference(self.axes.keys())  # will reference now in background.
 
         # Use a default actuator speed
         self.linear_speed = linear_speed


### PR DESCRIPTION
Now .reference() has to take an argument, to follow the standard API.
So need to update the internal caller too.