### PR TITLE
driver andorcam2: rename framePeriod -> frameDuration

### DIFF
--- a/plugins/ext_spec_map.py
+++ b/plugins/ext_spec_map.py
@@ -89,10 +89,10 @@ class ExternalAcquisition:
         self.expectedDuration = model.VigilantAttribute(1, unit="s", readonly=True)
 
         self.frameOverhead = model.FloatContinuous(0, range=(0, 1000), unit="s", readonly=True)
-        if model.hasVA(spec, "framePeriod"):
-            self.frameDuration = spec.framePeriod
+        if model.hasVA(spec, "frameDuration"):
+            self.frameDuration = spec.frameDuration
         else:
-            logging.warning("Spectrometer doesn't provide framePeriod, frame duration will not be precise")
+            logging.warning("Spectrometer doesn't provide frameDuration, frame duration will not be precise")
             # TODO: if not present, fall back to exposure time + readout rate * resolution
             self.frameDuration = model.FloatContinuous(0, range=(0, 1000), unit="s", readonly=True)
             # self.stream.exposureTime.subscribe(self._update_exp_dur)
@@ -136,10 +136,10 @@ class ExternalAcquisition:
         """
         Shows how long the acquisition takes.
         """
-        frame_p = self.spectrometer.framePeriod.value
+        frame_p = self.spectrometer.frameDuration.value
         overhead = frame_p - self.stream.exposureTime.value
-        if overhead < 0:  # it's wrong, probably because the framePeriod hasn't been updated
-            logging.warning("Frame period probably incorrect, play the stream to update it")
+        if overhead < 0:  # it's wrong, probably because the frameDuration hasn't been updated
+            logging.warning("Frame duration probably incorrect, play the stream to update it")
             overhead = 0
         overhead = math.ceil(overhead * 1e3) * 1e-3  # round-up to the ms
 

--- a/src/odemis/driver/andorcam2.py
+++ b/src/odemis/driver/andorcam2.py
@@ -663,7 +663,7 @@ class AndorCam2(model.DigitalCamera):
             # WARNING: for now it's only updated when the camera is acquiring.
             # TODO: We probably could do better by having the acquisition thread still
             # updating the camera settings when not acquiring (ie, idle).
-            self.framePeriod = model.FloatVA(self._exposure_time, unit="s", readonly=True)
+            self.frameDuration = model.FloatVA(self._exposure_time, unit="s", readonly=True)
 
             # To control the acquisition thread behaviour when several new frames
             # are available (because the driver is slower than the hardware).
@@ -2069,7 +2069,7 @@ class AndorCam2(model.DigitalCamera):
         readout = im_res[0] * im_res[1] * self._metadata[model.MD_READOUT_TIME] # s
         # accumulate should be approximately same as exposure + readout => play safe
         duration = max(accumulate, exposure + readout)
-        self.framePeriod._set_value(duration, force_write=True)
+        self.frameDuration._set_value(duration, force_write=True)
 
         logging.debug("Exposure time = %f s (asked %f s), readout = %f, accumulate time = %f, kinetic = %f, expecting duration = %f",
                       exposure, self._exposure_time, readout, accumulate, kinetic, duration)

--- a/src/odemis/driver/test/andorcam2_test.py
+++ b/src/odemis/driver/test/andorcam2_test.py
@@ -165,7 +165,7 @@ class TestAndorCam2HwTrigger(unittest.TestCase):
         # Check frame_period is shorter than the trigger, otherwise some triggers
         # will be missed.
         time.sleep(0.1)
-        self.assertGreater(trigger_period, self.camera.framePeriod.value)
+        self.assertGreater(trigger_period, self.camera.frameDuration.value)
 
         while self.left > 0:
             time.sleep(exp / 10)

--- a/src/odemis/gui/conf/data.py
+++ b/src/odemis/gui/conf/data.py
@@ -120,7 +120,7 @@ HW_SETTINGS_CONFIG = {
             ("dropOldFrames", {
                 "control_type": odemis.gui.CONTROL_NONE,
             }),
-            ("framePeriod", {
+            ("frameDuration", {
                 "control_type": odemis.gui.CONTROL_NONE,
             }),
             # Advanced settings for andorcam2
@@ -339,7 +339,7 @@ HW_SETTINGS_CONFIG = {
             ("dropOldFrames", {
                 "control_type": odemis.gui.CONTROL_NONE,
             }),
-            ("framePeriod", {
+            ("frameDuration", {
                 "control_type": odemis.gui.CONTROL_NONE,
             }),
             # Advanced settings for andorcam2
@@ -449,7 +449,7 @@ HW_SETTINGS_CONFIG = {
             ("dropOldFrames", {
                 "control_type": odemis.gui.CONTROL_NONE,
             }),
-            ("framePeriod", {
+            ("frameDuration", {
                 "control_type": odemis.gui.CONTROL_NONE,
             }),
             # Advanced settings for andorcam2


### PR DESCRIPTION
We already had a VA with the same meaning in the technolution driver.
Let's use the same name.