### PR TITLE
gui main xrc: Increase "LOADED" button size for Delphi

### DIFF
--- a/src/odemis/gui/main.xrc
+++ b/src/odemis/gui/main.xrc
@@ -7097,7 +7097,7 @@
                     <object class="wxBoxSizer">
                       <object class="sizeritem">
                         <object class="ImageTextToggleButton" name="btn_press">
-                          <size>114,-1</size>
+                          <size>130,-1</size>
                           <icon>img/icon/ico_press.png</icon>
                           <height>48</height>
                           <face_colour>def</face_colour>

--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -8102,7 +8102,7 @@ def __init_resources():
                     <object class="wxBoxSizer">
                       <object class="sizeritem">
                         <object class="ImageTextToggleButton" name="btn_press">
-                          <size>114,-1</size>
+                          <size>130,-1</size>
                           <icon>img_icon_ico_press_png</icon>
                           <height>48</height>
                           <face_colour>def</face_colour>


### PR DESCRIPTION
The button was too small. When displaying "UNLOADED", the last letter
was hidden.

(Note sure when this started, maybe due to font change in Ubuntu 20.04?)