### PR TITLE
gui cont menu: fix "Reset overview image" when not on SECOM live tab

### DIFF
--- a/src/odemis/gui/cont/menu.py
+++ b/src/odemis/gui/cont/menu.py
@@ -183,7 +183,11 @@ class MenuController(object):
         self._main_frame.menu_item_reset_finealign.Enable(False)
 
     def _on_reset_overview(self, _):
-        self._main_data.tab.value.overview_controller.reset_ovv()
+        """
+        Empty the overview view (on SECOM)
+        """
+        live_tab = self._main_data.getTabByName("secom_live")
+        live_tab.overview_controller.reset_ovv()
 
     def _get_current_stream(self):
         """


### PR DESCRIPTION
It was trying to reset the overview image on the current tab... but that
only works on the live tab. So just explicitly retrieve the live tab.