### PR TITLE
avoid warning in numpy.linalg.lstsq()

### DIFF
--- a/src/odemis/acq/align/delphi.py
+++ b/src/odemis/acq/align/delphi.py
@@ -1642,7 +1642,7 @@ def _DoResolutionShiftFactor(future, detector, escan, logpath):
         a_x, b_x = 0, 0
         if smxs:
             coef_x = array([rx, [1] * len(rx)])
-            a_nx, b_nx = linalg.lstsq(coef_x.T, smxs)[0]
+            a_nx, b_nx = linalg.lstsq(coef_x.T, smxs, rcond=None)[0]
             logger.debug("Computed linear reg NX as %s, %s", a_nx, b_nx)
             if a_nx != 0:
                 a_x = -1 / a_nx
@@ -1651,7 +1651,7 @@ def _DoResolutionShiftFactor(future, detector, escan, logpath):
         a_y, b_y = 0, 0
         if smys:
             coef_y = array([ry, [1] * len(ry)])
-            a_ny, b_ny = linalg.lstsq(coef_y.T, smys)[0]
+            a_ny, b_ny = linalg.lstsq(coef_y.T, smys, rcond=None)[0]
             logger.debug("Computed linear reg NY as %s, %s", a_ny, b_ny)
             if a_ny != 0:
                 a_y = -1 / a_ny

--- a/src/odemis/acq/align/transform.py
+++ b/src/odemis/acq/align/transform.py
@@ -59,7 +59,7 @@ def CalculateTransform(optical_coordinates, electron_coordinates, skew=False):
         u_array[list_len: 2 * list_len, 0] = electron_array[:, 1]
 
         # Calculate matrix R, R = X\U
-        r_array, resid, rank, s = numpy.linalg.lstsq(x_array, u_array)
+        r_array, resid, rank, s = numpy.linalg.lstsq(x_array, u_array, rcond=None)
         # if r_array[1][0] == 0:
         #    r_array[1][0] = 1
         translation_x = -r_array[2][0]
@@ -79,7 +79,7 @@ def CalculateTransform(optical_coordinates, electron_coordinates, skew=False):
         u_array = electron_array
 
         # We know that X*T=U
-        t_inv, resid, rank, s = numpy.linalg.lstsq(x_array, u_array)
+        t_inv, resid, rank, s = numpy.linalg.lstsq(x_array, u_array, rcond=None)
         translation_xy = t_inv[2, :]
         theta = math.atan2(t_inv[1, 0], t_inv[1, 1])
         scaling_x = t_inv[0, 0] * math.cos(theta) - t_inv[0, 1] * math.sin(theta)

--- a/src/odemis/driver/tfsbc.py
+++ b/src/odemis/driver/tfsbc.py
@@ -145,7 +145,7 @@ def transform_coordinates_reverse(register_values, xlower, xupper, ylower, yuppe
     A = numpy.array([[xupper[0], yupper[0]], [xlower[0], ylower[0]],
                      [xupper[1], yupper[1]], [xlower[1], ylower[1]]])
     b = numpy.array([dc_xupper, dc_xlower, dc_yupper, dc_ylower])
-    value, *_ = numpy.linalg.lstsq(A, b)
+    value, *_ = numpy.linalg.lstsq(A, b, rcond=None)
 
     value = (value[0] * 1e-6, value[1] * 1e-6)  # µm --> m
     return value


### PR DESCRIPTION
Since numpy 1.14, not specifying rcond causes a warning, because it
slightly changed behaviour.

I don't think we ever really cared on the "Cut-off ratio for small
singular values". So just explicitly use the new behaviour (None),
which is probably better.