### PR TITLE
driver tmcm: add support for 1211

### DIFF
--- a/src/odemis/driver/tmcm.py
+++ b/src/odemis/driver/tmcm.py
@@ -98,7 +98,7 @@ REFPROC_STD = "Standard"  # Use the standard reference search built in the contr
 REFPROC_FAKE = "FakeReferencing"  # was used for simulator when it didn't support referencing
 
 # Model number (int) of devices tested
-KNOWN_MODELS = {1140, 3110, 6110, 3214}
+KNOWN_MODELS = {1140, 3110, 6110, 3214, 1211}
 KNOWN_MODELS_CAN = {'PD-1240', 'PD-1240-fake'}
 # These models report the velocity/accel in internal units of the TMC429
 USE_INTERNAL_UNIT_429 = {1110, 1140, 3110, 6110}

--- a/util/tmcmconfig
+++ b/util/tmcmconfig
@@ -44,12 +44,15 @@ import time
 AXIS_PARAMS = {
     4: "Maximum positioning speed",
     5: "Maximum acceleration",
-    # Note: some versions of the documentation state params 6 & 7 cannot be
+    # Note: some versions of the TMCM-6110 documentation state params 6 & 7 cannot be
     # stored in EEPROM, but that is an error, they are stored fine.
     6: "Absolute max current",
     7: "Standby current",
     12: "Right limit switch disable",
     13: "Left limit switch disable",
+    17: "Maximum deceleration",
+    24: "Right limit switch polarity",
+    25: "Left limit switch polarity",
     140: "Microstep resolution",
     149: "Soft stop flag",
     153: "Ramp divisor",
@@ -57,7 +60,7 @@ AXIS_PARAMS = {
     193: "Reference search mode",
     194: "Reference search speed",
     195: "Reference switch speed",
-    204: "Free wheeling delay (in 10ms)",  # Free wheeling mode on 3214
+    204: "Free wheeling delay (in 10ms)",  # Free wheeling mode on 1211/3214
     214: "Power down delay (in 10ms)",
 
     # These ones are not saved in EEPROM (but save in user config)
@@ -82,6 +85,7 @@ GLOBAL_PARAMS = {
 #     (0, 64): "EEPROM reset",  # Anything different from 228 (or 66?) will cause reset on next reboot
 #     (0, 73): "EEPROM locked",  # Reads 0/1, but needs to be written either 1234 or 4321
 
+    (0, 66): "Serial address",
     (0, 77): "Autostart mode (on main power supply)",
     (0, 79): "End switch polarity",
     (0, 84): "Coordinate storage",
@@ -95,22 +99,24 @@ OUT_CONFIG = {  # Saved in user config
 
 # (port/add) -> val (int)
 OUT_CONFIG_DEFAULT = {
-    (0, 0): 3,
+    (0, 0): 3,  # All pull-ups on (true for the 6110)
 }
 
 # Models which don't support axis param storage
-NO_AXIS_STORAGE = {3214}
+NO_AXIS_STORAGE = {1211, 3214}
 
 # List of axis params which are _not_ present (per model)
 MISSING_AXIS_PARAMS = {
+    1211: {149, 153, 154},
     3214: {149, 153, 154},
-    1410: {26, 31, 251},
-    3110: {26, 31, 201, 212, 251},
-    6110: {26, 31, 201, 212, 251},
+    1410: {17, 24, 25, 26, 31, 251},
+    3110: {17, 24, 25, 26, 31, 201, 212, 251},
+    6110: {17, 24, 25, 26, 31, 201, 212, 251},
 }
 
 # List of global params which are _not_ present (per model)
 MISSING_GLOBAL_PARAMS = {
+    1211: {(0, 79), (0, 90)},
     3214: {(0, 79), (0, 90)},
     1410: {},
     3110: {},
@@ -123,10 +129,13 @@ def _get_naxes(ctrl):
     Count the number of axes that the device supports
     return (0 < int)
     """
-    if ctrl._modl == 3214:  # v1.09 has a bug: return 1 for any axis
-        return 3
+    if ctrl._modl in tmcm.KNOWN_MODELS:
+        return ctrl._modl // 1000  # The first number correspond to the number of axes
 
+    logging.info("Unknown model, will try to guess the number of axes")
     # Try to read an simple axis param and see if the device complains
+    # TODO: this doesn't work on all boards, as some board happily return values
+    # for all axes... or crash and stop answering completely.
     for i in range(64):
         try:
             ctrl.GetAxisParam(i, 1)  # current pos


### PR DESCRIPTION
Mostly the same as the 3210, but with a single axis.