### PR TITLE
gui model meteor: move stage range check

### DIFF
--- a/install/linux/usr/share/odemis/sim/meteor-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/meteor-sim.odm.yaml
@@ -103,7 +103,8 @@ METEOR-Sim: {
     },
     affects: ["Camera", "EBeam"],
     metadata: {
-        POS_ACTIVE_RANGE: {"x":[0.040, 0.054], "y": [-5.e-3, 10.e-3]}
+        # Typically, x range is the same as FM_IMAGING_RANGE, and Y has to be converted
+        POS_ACTIVE_RANGE: {"x": [0.040, 0.054], "y": [-10.e-3, 20.e-3]}
     },
 }
 

--- a/src/odemis/gui/model/__init__.py
+++ b/src/odemis/gui/model/__init__.py
@@ -902,21 +902,6 @@ class CryoChamberGUIData(CryoGUIData):
         self.stage_align_slider_va = model.FloatVA(1e-6)
         self.show_advaned = model.BooleanVA(False)
 
-        # Some extra checks on the METEOR about the microscope config.
-        # The active range (on stage) should be within the FM range (on stage-bare).
-        # The difference between the two stages is only that Y is rotated (so a move
-        # on stage.Y could move less on stage-bare.Y) but typically stage-bare has a
-        # much wider range. So we assume it should always be at least as big, and
-        # this allows to detect when the user updated one metadata and not the other one.
-        if main.role == "meteor":
-            stage_fm_imaging_rng = main.stage_bare.getMetadata()[model.MD_FM_IMAGING_RANGE]
-            stage_rng = main.stage.getMetadata()[model.MD_POS_ACTIVE_RANGE]
-            for axis in ("x", "y"):
-                fm_rng = stage_fm_imaging_rng[axis]
-                if not all(fm_rng[0] <= r <= fm_rng[1] for r in stage_rng[axis]):
-                    raise ValueError(f"stage.POS_ACTIVE_RANGE should be within stage-bare.FM_IMAGING_RANGE "
-                                     f"but got axis {axis} with range {stage_rng[axis]} out of {fm_rng}")
-
 
 class AnalysisGUIData(MicroscopyGUIData):
     """


### PR DESCRIPTION
We had requirement that stage.ACTIVE_RANGE is within
stage-bare.IMAGING_RANGE, but that doesn't really make sense as the
stages are in different referentials. In practice, on many systems, that
was fine because the change of referential didn't affect the value too
much, and IMAGING_RANGE can be quite wide.... but on some systems that
just doesn't work.

=> Move the check to when moving the stage to FM. At least, the first
position reached in FM should be a legal position!