### PR TITLE
driver xt_client: use the relative move call for relative moves

### DIFF
--- a/src/odemis/driver/test/xt_client_test.py
+++ b/src/odemis/driver/test/xt_client_test.py
@@ -200,13 +200,14 @@ class TestMicroscope(unittest.TestCase):
         self.assertAlmostEqual(self.stage.position.value["rx"],
                                (abs_pos["rx"] + rel_pos["rx"]), places=4)
 
-        # Relative move in R < 0
+        # Relative move in rz < 0 => it should "wrap around" and report a value near 2pi.
+        # (rx doesn't support full rotation, so we don't use it)
         f = self.stage.moveAbs({"rz": 0})
         rel_pos = {"rz": -0.5} # rad
         f = self.stage.moveRel(rel_pos)
         f.result()
         self.assertAlmostEqual(self.stage.position.value["rz"] % (2 * math.pi),
-                               (0 + rel_pos["rz"]) % (2 * math.pi), places=4)
+                               rel_pos["rz"] % (2 * math.pi), places=4)
 
         self.stage.moveAbs(init_pos)
 

--- a/src/odemis/driver/test/xt_client_test.py
+++ b/src/odemis/driver/test/xt_client_test.py
@@ -199,6 +199,15 @@ class TestMicroscope(unittest.TestCase):
                                (abs_pos["rz"] + rel_pos["rz"]) % (2 * math.pi), places=4)
         self.assertAlmostEqual(self.stage.position.value["rx"],
                                (abs_pos["rx"] + rel_pos["rx"]), places=4)
+
+        # Relative move in R < 0
+        f = self.stage.moveAbs({"rz": 0})
+        rel_pos = {"rz": -0.5} # rad
+        f = self.stage.moveRel(rel_pos)
+        f.result()
+        self.assertAlmostEqual(self.stage.position.value["rz"] % (2 * math.pi),
+                               (0 + rel_pos["rz"]) % (2 * math.pi), places=4)
+
         self.stage.moveAbs(init_pos)
 
     def test_hfov(self):

--- a/src/odemis/driver/xt_client.py
+++ b/src/odemis/driver/xt_client.py
@@ -2051,8 +2051,11 @@ class Stage(model.Actuator):
         # actually allows rotation in both directions)
         for an in ("rx", "rz"):
             rng = self.axes[an].range
+            # To handle both rotations 0->2pi and inverted: -2pi -> 0.
+            # TODO: for inverted rotations of 2pi, it would probably be more
+            # user-friendly to still report 0->2pi as range.
             if util.almost_equal(rng[1] - rng[0], 2 * math.pi):
-                pos[an] = pos[an] % (2 * math.pi) - rng[0]
+                pos[an] = (pos[an] - rng[0]) % (2 * math.pi) + rng[0]
         return pos
 
     def _moveTo(self, future, pos, rel=False, timeout=60):
@@ -2107,7 +2110,8 @@ class Stage(model.Actuator):
 
     def _doMoveRel(self, future, shift):
         """
-        shift (dict): position in internal coordinates
+        shift (dict): position in internal coordinates (ie, axes in the same
+           direction as the hardware expects)
         """
         # We don't check the target position fit the range, the xt-adapter will take care of that
         self._moveTo(future, shift, rel=True)

--- a/src/odemis/driver/xt_client.py
+++ b/src/odemis/driver/xt_client.py
@@ -2047,19 +2047,29 @@ class Stage(model.Actuator):
         pos = self.parent.get_stage_position()
         pos["rx"] = pos.pop("t")
         pos["rz"] = pos.pop("r")
+        # Make sure the full rotations are within the range (because the SEM
+        # actually allows rotation in both directions)
+        for an in ("rx", "rz"):
+            rng = self.axes[an].range
+            if util.almost_equal(rng[1] - rng[0], 2 * math.pi):
+                pos[an] = pos[an] % (2 * math.pi) - rng[0]
         return pos
 
-    def _moveTo(self, future, pos, timeout=60):
+    def _moveTo(self, future, pos, rel=False, timeout=60):
         with future._moving_lock:
             try:
                 if future._must_stop.is_set():
                     raise CancelledError()
-                logging.debug("Moving to position {}".format(pos))
+                if rel:
+                    logging.debug("Moving by shift {}".format(pos))
+                else:
+                    logging.debug("Moving to position {}".format(pos))
+
                 if "rx" in pos.keys():
                     pos["t"] = pos.pop("rx")
                 if "rz" in pos.keys():
                     pos["r"] = pos.pop("rz")
-                self.parent.move_stage(pos, rel=False)
+                self.parent.move_stage(pos, rel=rel)
                 time.sleep(0.5)
 
                 # Wait until the move is over.
@@ -2069,10 +2079,8 @@ class Stage(model.Actuator):
                 moving = True
                 tstart = time.time()
                 while moving:
-                    pos = self._getPosition()
-                    moving = self.parent.stage_is_moving()
                     # Take the opportunity to update .position
-                    self._updatePosition(pos)
+                    self._updatePosition()
 
                     if time.time() > tstart + timeout:
                         self.parent.stop_stage_movement()
@@ -2081,6 +2089,7 @@ class Stage(model.Actuator):
 
                     # Wait for 50ms so that we do not keep using the CPU all the time.
                     time.sleep(50e-3)
+                    moving = self.parent.stage_is_moving()
 
                 # If it was cancelled, Abort() has stopped the stage before, and
                 # we still have waited until the stage stopped moving. Now let
@@ -2097,22 +2106,11 @@ class Stage(model.Actuator):
                 self._updatePosition()
 
     def _doMoveRel(self, future, shift):
-        pos = self._getPosition()
-        for k, v in shift.items():
-            pos[k] += v
-
-        target_pos = self._applyInversion(pos)
-        # Check range (for the axes we are moving)
-        for an in shift.keys():
-            rng = self.axes[an].range
-            if rng == (0, 2 * math.pi) and an in ("rx", "rz"):
-                pos[an] = pos[an] % (2 * math.pi)
-                target_pos[an] = target_pos[an] % (2 * math.pi)
-            p = target_pos[an]
-            if not rng[0] <= p <= rng[1]:
-                raise ValueError("Relative move would cause axis %s out of bound (%g m)" % (an, p))
-
-        self._moveTo(future, pos)
+        """
+        shift (dict): position in internal coordinates
+        """
+        # We don't check the target position fit the range, the xt-adapter will take care of that
+        self._moveTo(future, shift, rel=True)
 
     @isasync
     def moveRel(self, shift):
@@ -2136,7 +2134,7 @@ class Stage(model.Actuator):
         return f
 
     def _doMoveAbs(self, future, pos):
-        self._moveTo(future, pos)
+        self._moveTo(future, pos, rel=False)
 
     @isasync
     def moveAbs(self, pos):


### PR DESCRIPTION
Don't convert relatives moves directly to absolute moves. Let the SEM
do that. This has a couple of advantages:
* for rotation moves, less complexity with dealing with (fake) out of range,
   and handling cases where going a small negative turn could be
   converted  to a large positive turn.
* No need to read the current position first (and mistakenly force the
move to each axis).
* Simplify the code with range checking, by letting the xtadapter do
that.