### PR TITLE
acq stream sync SEMAngularSpectrumMDStream: if multiple polarizations, store them separately

### DIFF
--- a/src/odemis/acq/stream/_sync.py
+++ b/src/odemis/acq/stream/_sync.py
@@ -2453,7 +2453,7 @@ class SEMAngularSpectrumMDStream(SEMCCDMDStream):
          live update overlay and can be converted by _assembleFinalData into the final ._raw.
         """
         if n != self._ccd_idx:
-            return super(SEMAngularSpectrumMDStream, self)._assembleLiveData(n, raw_data, px_idx, rep, pol_idx)
+            return super()._assembleLiveData(n, raw_data, px_idx, rep, pol_idx)
 
         # Raw data format is AC
         # Final data format is CAZYX with spec_res, angle_res, 1 , X , Y with X, Y = 1 at one ebeam position
@@ -2497,6 +2497,21 @@ class SEMAngularSpectrumMDStream(SEMCCDMDStream):
             raw_data = raw_data[::-1, ...]  # invert C
         self._live_data[n][pol_idx][:,:, 0, px_idx[0], px_idx[1]] = raw_data.reshape(spec_res, angle_res)
 
+    def _assembleFinalData(self, n, data):
+        """
+        :param n: (int) number of the current stream which is assembled into ._raw
+        :param data: all acquired data of the stream
+        This function post-processes/organizes the data for a stream and exports it into ._raw.
+        """
+        if n != self._ccd_idx:
+            return super()._assembleFinalData(n, data)
+
+        if len(data) > 1:  # Multiple polarizations => keep them separated, and add the polarization name to the description
+            for d in data:
+                d.metadata[model.MD_DESCRIPTION] += " " + d.metadata[model.MD_POL_MODE]
+
+        self._raw.extend(data)
+
 
 class SEMTemporalSpectrumMDStream(SEMCCDMDStream):
     """
@@ -2516,7 +2531,7 @@ class SEMTemporalSpectrumMDStream(SEMCCDMDStream):
          live update overlay and can be converted by _assembleFinalData into the final ._raw.
         """
         if n != self._ccd_idx:
-            return super(SEMTemporalSpectrumMDStream, self)._assembleLiveData(n, raw_data, px_idx, rep, pol_idx)
+            return super()._assembleLiveData(n, raw_data, px_idx, rep, pol_idx)
 
         # Data format is CTZYX with spec_res, temp_res, 1 , X , Y with X, Y = 1 at one ebeam position
         temp_res = raw_data.shape[0]


### PR DESCRIPTION
The default behaviour when there are multiple polarizations is to store
the average. That's not handy here, we want to store each one
individually.

The analysis tab doesn't show it in a great way, but it works. That's
enough for now.