### PR TITLE
driver simcam: store binning in metadata

### DIFF
--- a/src/odemis/driver/simcam.py
+++ b/src/odemis/driver/simcam.py
@@ -183,6 +183,8 @@ class Camera(model.DigitalCamera):
 
         # fit
         self.resolution.value = self.resolution.clip(new_res)
+
+        self._metadata[model.MD_BINNING] = self._binning
         return self._binning
 
     def _setResolution(self, value):


### PR DESCRIPTION
Like all other CCD components.