### PR TITLE
gui test: fix tests using MirrorArcOverlay

### DIFF
--- a/src/odemis/gui/test/comp_overlay_test.py
+++ b/src/odemis/gui/test/comp_overlay_test.py
@@ -35,6 +35,8 @@ from odemis.driver.tmcm import TMCLController
 from odemis.gui.comp.overlay import view as vol
 from odemis.gui.comp.overlay import world as wol
 from odemis.gui.comp.overlay.view import HORIZONTAL_LINE, VERTICAL_LINE, CROSSHAIR
+from odemis.gui.comp.overlay.world import EKOverlay
+from odemis.gui.comp.viewport import ARLiveViewport
 from odemis.gui.model import TOOL_POINT, TOOL_LINE, TOOL_RULER, TOOL_LABEL, FeatureOverviewView
 from odemis.gui.util.img import wxImage2NDImage
 from odemis.util import mock
@@ -50,7 +52,6 @@ import odemis.gui.comp.canvas as canvas
 import odemis.gui.comp.miccanvas as miccanvas
 import odemis.gui.model as guimodel
 import odemis.gui.test as test
-from odemis.gui.comp.overlay.world import EKOverlay
 
 test.goto_manual()
 logging.getLogger().setLevel(logging.DEBUG)
@@ -1190,10 +1191,12 @@ class OverlayTestCase(test.GuiTestCase):
         test.gui_loop()
 
     def test_mirror_arc_overlay(self):
-        cnvs = miccanvas.SparcARCanvas(self.panel)
-        cnvs.scale = 20000
-        self.add_control(cnvs, wx.EXPAND, proportion=1, clear=True)
+        vp = ARLiveViewport(self.panel)
+        vp.show_mirror_overlay()
+        self.add_control(vp, wx.EXPAND, proportion=1, clear=True)
 
+        cnvs = vp.canvas
+        cnvs.scale = 20000
         cnvs.flip = 0
         cnvs.update_drawing()
 

--- a/src/odemis/gui/test/dev_rotknob_test.py
+++ b/src/odemis/gui/test/dev_rotknob_test.py
@@ -27,6 +27,7 @@ import unittest
 import wx
 
 import odemis.gui.comp.miccanvas as miccanvas
+from odemis.gui.comp.viewport import ARLiveViewport
 from odemis.gui.dev.powermate import Powermate
 from odemis.gui.evt import EVT_KNOB_ROTATE
 import odemis.gui.test as test
@@ -42,11 +43,12 @@ class RotationKnobTestCase(test.GuiTestCase):
     frame_class = test.test_gui.xrccanvas_frame
 
     def test_mirror_arc_overlay(self):
-        cnvs = miccanvas.SparcARCanvas(self.panel)
+        vp = ARLiveViewport(self.panel)
+        vp.show_mirror_overlay()
+        self.add_control(vp, wx.EXPAND, proportion=1, clear=True)
+
+        cnvs = vp.canvas
         cnvs.scale = 20000
-        cnvs.add_world_overlay(cnvs.mirror_ol)
-        cnvs.mirror_ol.active.value = True
-        self.add_control(cnvs, wx.EXPAND, proportion=1, clear=True)
 
         def zoom(evt):
             mi, ma = 1000, 80000


### PR DESCRIPTION
They expected that the SparcARCanvas provides the overlay. However, it
doesn't do that anymore. In the GUI it's now created by the viewport ARLiveViewport.

=> instantiate a ARLiveViewport, and use the canvas + overlay created
there.