### PR TITLE
odemisd: extend the file mask to include the execute bit

### DIFF
--- a/src/odemis/odemisd/main.py
+++ b/src/odemis/odemisd/main.py
@@ -518,10 +518,12 @@ class BackendRunner(object):
         try:
             os.setgid(gid_base)
         except OSError:
+            # This can happen especially when running the backend as a standard user.
             logging.warning("Not enough permissions to run in group " + model.BASE_GROUP + ", trying anyway...")
 
-        # everything created after must be rw by group
-        os.umask(~(stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP))
+        # Everything created after should be (also) accessible by the group.
+        # Need the user execute bit, to allow directory creation (with files inside)
+        os.umask(~(stat.S_IRWXU | stat.S_IRGRP | stat.S_IWGRP))
 
     def mk_base_dir(self):
         """
@@ -569,6 +571,7 @@ class BackendRunner(object):
             self.mk_base_dir()
         except Exception:
             logging.error("Failed to create back-end directory " + model.BASE_DIRECTORY)
+            raise
 
         # create the root container
         try:


### PR DESCRIPTION
The execute bit on the mask doesn't really mean much for new files.
However, when creating directories, that allows to add files to the
directory... which is a very useful feature.
No driver seemed to depend on this, however on Ubuntu 20.04, some
libraries depend on OpenMPI, which creates some directories in the
background.
This prevented the backend from being started as a normal user on Ubuntu
20.04.