### PR TITLE
csv export: fix bug with unknown acquisition type.

### DIFF
--- a/src/odemis/dataio/csv.py
+++ b/src/odemis/dataio/csv.py
@@ -24,7 +24,6 @@ import numpy
 from odemis import model
 from odemis.util import spectrum
 
-
 FORMAT = "CSV"
 # list of file-name extensions possible, the first one is the default when saving a file
 EXTENSIONS = [u".csv"]
@@ -130,7 +129,7 @@ def export(filename, data):
             first_row = ['theta\\phi[rad]'] + [d for d in data[0, 1:]]
             csv_writer.writerow(first_row)
             # dump the array
-            csv_writer.writerows(data[1:,:])
+            csv_writer.writerows(data[1:, :])
 
     elif data.ndim == 2 and dims == "XC":
         logging.debug("Exporting spectrum-line data to CSV")
@@ -155,7 +154,7 @@ def export(filename, data):
             csv_writer.writerow(first_row)
             # dump the array
             csv_writer.writerows(data)
-        
+
     elif data.ndim == 2 and dims == "TC":
         logging.debug("Exporting temporal spectrum data to CSV")
         if acq_type != model.MD_AT_TEMPSPECTRUM:
@@ -203,4 +202,4 @@ def export(filename, data):
             csv_writer.writerows(rows)
 
     else:
-        raise ValueError(f"Unknown acquisition type {acq_types} of data (dims = {dims}) to be exported as CSV")
+        raise ValueError(f"Unknown acquisition type {acq_type} of data (dims = {dims}) to be exported as CSV")

--- a/src/odemis/dataio/test/csv_test.py
+++ b/src/odemis/dataio/test/csv_test.py
@@ -286,6 +286,15 @@ class TestCSVIO(unittest.TestCase):
             raised = True
         self.assertFalse(raised, 'Failed to read csv file')
 
+    def test_unknown_acquisition_type(self):
+        """Test that a ValueError is raised for an unknown acquisition type."""
+        size = (10, 10)
+        md = {model.MD_ACQ_TYPE: "FAKE",
+              model.MD_DIMS: "FAKE"}
+        data = model.DataArray(numpy.zeros(size), md)
+        with self.assertRaises(ValueError):
+            csv.export(FILENAME, data)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
In commit 1dc62698 the last line of the export function was adjust and it called the variable acq_types, but this doesn't exist, it should be acq_type. This commit fixes that and adds a test cases to check a value error is raised when an unknown acquisition type is passed.