### PR TITLE
acq path: distinguish "ek" path and "ek-align" paths

### DIFF
--- a/install/linux/usr/share/odemis/sim/sparc2-ek-polarizer-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/sparc2-ek-polarizer-sim.odm.yaml
@@ -240,7 +240,7 @@ SPARC2: {
         # Default position of the lens (can be improved by user)
         FAV_POS_ACTIVE: {"x": 0.0045} # m
     },
-    affects: ["Camera", "Spectrometer 1", "Spectral Camera", "Spectrometer 2"],
+    affects: ["Lens2 Switch"],
 }
 
 # The second lens of Plate 1, either to working or parking position
@@ -259,7 +259,7 @@ SPARC2: {
         FAV_POS_ACTIVE: {"x": 4.0e-3}, # m
         POS_ACTIVE_RANGE: {"x": [-1.e-3, 1.e-3]},  # relative min/max from the active position when doing EK-scanning
     },
-    affects: ["Camera", "Spectrometer Vis-NIR", "Spectral Camera", "Spectrometer IR", "CL Detector"],
+    affects: ["Camera", "Spectrometer 1", "Spectral Camera", "Spectrometer 2"],
 }
 
 # Control the slit position to either fully-open or small (dependent on the spectrometer slit-in)

--- a/install/linux/usr/share/odemis/sim/sparc2-polarizer-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/sparc2-polarizer-sim.odm.yaml
@@ -238,7 +238,7 @@ SPARC2: {
         # Default position of the lens (can be improved by user)
         FAV_POS_ACTIVE: {"x": 0.0045} # m
     },
-    affects: ["Camera", "Spectrometer 1", "Spectral Camera", "Spectrometer 2"],
+    affects: ["Lens2 Switch"],
 }
 
 # The second lens of Plate 1, either to working or parking position

--- a/src/odemis/acq/path.py
+++ b/src/odemis/acq/path.py
@@ -101,11 +101,7 @@ SPARC2_MODES = {
                 {'lens-switch': {'x': "MD:" + model.MD_FAV_POS_ACTIVE},  # ek mode available only if MD_FAV_POS_ACTIVE
                  'lens-mover': {'x': "MD:" + model.MD_FAV_POS_ACTIVE},
                  'slit-in-big': {'x': 'off'},  # closed
-                 'spectrograph': {'grating': GRATING_NOT_MIRROR},
                  # Typically the grating should be non-mirror but we leave it up to the user/GUI.
-                 # 'cl-det-selector': {'x': 'off'},
-                 # 'spec-selector': {'x': "MD:" + model.MD_FAV_POS_DEACTIVE},
-                 # 'spec-det-selector': {'rx': 0},
                  'chamber-light': {'power': 'off'},
                 }),
             'cli': ("cl-detector",
@@ -191,6 +187,14 @@ SPARC2_MODES = {
                  'chamber-light': {'power': 'off'},
                  'pol-analyzer': {'pol': MD_POL_NONE},
                  }),
+            'ek-align': (r"ccd.*",  # Same as "ek", but with grating and filter explicitly set by default
+                {'lens-switch': {'x': "MD:" + model.MD_FAV_POS_ACTIVE},  # ek mode available only if MD_FAV_POS_ACTIVE
+                 'lens-mover': {'x': "MD:" + model.MD_FAV_POS_ACTIVE},
+                 'slit-in-big': {'x': 'off'},  # closed
+                 'spectrograph': {'grating': GRATING_NOT_MIRROR},
+                 'filter': {'band': BAND_PASS_THROUGH},
+                 'chamber-light': {'power': 'off'},
+                }),
             'chamber-view': (r"ccd.*",  # Same as AR but SEM is disabled and a light may be used
                 {'lens-switch': {'x': ("MD:" + model.MD_FAV_POS_ACTIVE, 'on')},
                  'lens-mover': {'x': "MD:" + model.MD_FAV_POS_ACTIVE},

--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -5946,7 +5946,7 @@ class Sparc2AlignTab(Tab):
             "lens-align": "mirror-align",  # if autofocus is needed: spec-focus (first)
             "lens2-align": "lens2-align",  # if autofocus is needed: spec-focus (first)
             "center-align": "ar",
-            "ek-align": "ek",
+            "ek-align": "ek-align",
             "fiber-align": "fiber-align",
             "streak-align": "streak-align",
         }


### PR DESCRIPTION
For ek-align, we used to just use the "ek" path. However, we want to
force the grating and the filter to be in "good" positions.
That'd be ugly to do in the GUI, so explicitly place it in the OPM.
It will force the axes everytime the stream starts. The GUI still allows
the user to change to different (and odd) positions while playing the
stream.

For the standard EK streams, the GUI takes care of setting the default
position of these streams when it's added by the user (and the user can
later override it).

Also extend the path test cases, to actually test a EK simulator.

Also found a bug in the Sparc EK polarizer simulator.