### PR TITLE
gui: fix display of colourmap combo-box on Windows

### DIFF
--- a/src/odemis/gui/comp/combo.py
+++ b/src/odemis/gui/comp/combo.py
@@ -33,6 +33,7 @@ from odemis.gui.comp.buttons import ImageButton, darken_image
 import wx
 import wx.adv
 from odemis.util.img import getColorbar, tintToColormap
+from odemis.gui.util.img import NDImage2wxBitmap
 
 
 class ComboBox(wx.adv.OwnerDrawnComboBox):
@@ -214,8 +215,7 @@ class ColorMapComboBox(ComboBox):
             h = r.height
 
             gradient = getColorbar(color_map, w, h)
-            bmp = wx.Bitmap(*gradient.shape[1::-1])
-            bmp.CopyFromBuffer(gradient, format=wx.BitmapBufferFormat_RGB)
+            bmp = NDImage2wxBitmap(gradient)
             dc.DrawBitmap(bmp, 0, 0)
             return
         else:
@@ -223,9 +223,7 @@ class ColorMapComboBox(ComboBox):
             # Draw color map
             colorbar_width = int(round(r.width * COLOBAR_WITH_RATIO))
             gradient = getColorbar(color_map, colorbar_width, r.height)
-            bmp = wx.Bitmap(*gradient.shape[1::-1])
-            bmp.CopyFromBuffer(gradient, format=wx.BitmapBufferFormat_RGB)
-            # image = wx.ImageFromBuffer(*gradient.shape[1::-1], gradient)
+            bmp = NDImage2wxBitmap(gradient)
             dc.DrawBitmap(bmp, 0, item * r.height)
             item_name = self.Strings[item]
             dc.DrawText(item_name.title(), colorbar_width + 5, item * r.height + 5)

--- a/src/odemis/gui/util/img.py
+++ b/src/odemis/gui/util/img.py
@@ -2791,9 +2791,9 @@ def NDImage2wxBitmap(image):
     assert(len(image.shape) == 3)
     size = image.shape[1::-1]
     if image.shape[2] == 3: # RGB
-        bim = wx.Bitmap(size[0], size[1], 24)
-        bim.CopyFromBuffer(image, wx.BitmapBufferFormat_RGB)
-        # bim = wx.Bitmap.FromBuffer(size[0], size[1], image)
+        # Note that creating a empty Bitmap and then using CopyFromBuffer()
+        # doesn't work on Windows (with wxPython 4.0.7).
+        bim = wx.Bitmap.FromBuffer(size[0], size[1], image)
     elif image.shape[2] == 4: # RGBA
         bim = wx.Bitmap.FromBufferRGBA(size[0], size[1], image)
     else:


### PR DESCRIPTION
On Windows, Bitmap.CopyFromBuffer() doesn't work. It generates an error
like:
RuntimeError: Failed to gain raw access to bitmap data.

Anyway, there is actually a better function for what we need: FromBuffer().
So let's use it. Actually use the code from gui.util.img, to avoid
duplicating code.

This fixes the display of the colourmaps in Windows.