### PR TITLE
Wait a second to listen so the slower VM on the test machine can catch up.

### DIFF
--- a/src/odemis/driver/rigol.py
+++ b/src/odemis/driver/rigol.py
@@ -338,6 +338,8 @@ class FakeDG1000Z(object):
         self._listener_thread.daemon = True
         # or listener_thread.setDaemon(True) for old versions of python
         self._listener_thread.start()
+        # Wait a second to ensure the server is running
+        time.sleep(1)
 
     def __del__(self):
         try:


### PR DESCRIPTION
The connection was sometimes timed out because the VM was too slow.