### PR TITLE
logging.warn() -> logging.warning()

### DIFF
--- a/src/odemis/driver/pmtctrl.py
+++ b/src/odemis/driver/pmtctrl.py
@@ -509,7 +509,7 @@ class PMTControl(model.PowerSupplier):
             try:
                 self._serial.write(cmd)
             except IOError:
-                logging.warn("Failed to send command to PMT Control firmware, "
+                logging.warning("Failed to send command to PMT Control firmware, "
                              "trying to reconnect.")
                 if self._recovering:
                     raise
@@ -525,7 +525,7 @@ class PMTControl(model.PowerSupplier):
                 try:
                     char = self._serial.read()
                 except IOError:
-                    logging.warn("Failed to read from PMT Control firmware, "
+                    logging.warning("Failed to read from PMT Control firmware, "
                                  "trying to reconnect.")
                     if self._recovering:
                         raise

--- a/src/odemis/driver/tmcm.py
+++ b/src/odemis/driver/tmcm.py
@@ -904,7 +904,7 @@ class TMCLController(model.Actuator):
             try:
                 self._serial.write(msg)
             except IOError:
-                logging.warn("Failed to send command to TMCM, trying to reconnect.")
+                logging.warning("Failed to send command to TMCM, trying to reconnect.")
                 self._tryRecover()
                 # Failure here should mean that the device didn't get the (complete)
                 # instruction, so it's safe to send the command again.
@@ -914,7 +914,7 @@ class TMCLController(model.Actuator):
                 try:
                     res = self._serial.read(9)
                 except IOError:
-                    logging.warn("Failed to read from TMCM, trying to reconnect.")
+                    logging.warning("Failed to read from TMCM, trying to reconnect.")
                     self._tryRecover()
                     # We already sent the instruction before, so don't send it again
                     # here. Instead, raise an error and let the user decide what to do next

--- a/src/odemis/gui/comp/canvas.py
+++ b/src/odemis/gui/comp/canvas.py
@@ -544,7 +544,7 @@ class BufferedCanvas(wx.Panel):
                 self.draw_timer.Start(int(delay * 1000), oneShot=True)
         except RuntimeError:
             # This only should happen when running test cases
-            logging.warn("Drawing requested on dead canvas")
+            logging.warning("Drawing requested on dead canvas")
 
     def update_drawing(self):
         """ Redraw the buffer and display it """
@@ -1862,7 +1862,7 @@ class PlotCanvas(BufferedCanvas):
             self.unit_x = unit_x
             self.unit_y = unit_y
         else:
-            logging.warn("Trying to fill PlotCanvas with empty data!")
+            logging.warning("Trying to fill PlotCanvas with empty data!")
             self.clear()
 
         wx.CallAfter(self.request_drawing_update)
@@ -1999,7 +1999,7 @@ class PlotCanvas(BufferedCanvas):
         # It is possible that the buffer has not been initialized yet, because this method can be
         # called before the Size event handler sets it.
         # if not self._bmp_buffer:
-        #     logging.warn("No buffer created yet, ignoring draw request")
+        #     logging.warning("No buffer created yet, ignoring draw request")
         #     return
 
         if not self or 0 in self.ClientSize:

--- a/src/odemis/gui/comp/overlay/base.py
+++ b/src/odemis/gui/comp/overlay/base.py
@@ -629,10 +629,10 @@ class SelectionMixin(DragMixin):
 
             if isinstance(self.select_v_start_pos, list):
                 self.select_v_start_pos = Vec(self.select_v_start_pos)
-                logging.warn("'select_v_start_pos' is still set as a list somewhere!")
+                logging.warning("'select_v_start_pos' is still set as a list somewhere!")
             if isinstance(self.select_v_end_pos, list):
                 self.select_v_end_pos = Vec(self.select_v_end_pos)
-                logging.warn("'select_v_end_pos' is still set as a list somewhere!")
+                logging.warning("'select_v_end_pos' is still set as a list somewhere!")
 
             self._calc_edges()
             self.selection_mode = SEL_MODE_NONE

--- a/src/odemis/gui/comp/overlay/world.py
+++ b/src/odemis/gui/comp/overlay/world.py
@@ -458,7 +458,7 @@ class WorldSelectOverlay(WorldOverlay, SelectionMixin):
 
             self.update_projection(b_start_pos, b_end_pos, (shift[0], shift[1], scale))
 
-            # logging.warn("%s %s", shift, phys_to_buffer_pos(shift))
+            # logging.warning("%s %s", shift, phys_to_buffer_pos(shift))
             rect = (b_start_pos.x,
                     b_start_pos.y,
                     b_end_pos.x - b_start_pos.x,
@@ -729,7 +729,7 @@ class RepetitionSelectOverlay(WorldSelectOverlay):
                     self._roa.value = UNDEFINED_ROI
 
         else:
-            logging.warn("Expected ROA not found!")
+            logging.warning("Expected ROA not found!")
 
     def _draw_points(self, ctx):
         # Calculate the offset of the center of the buffer relative to the

--- a/src/odemis/gui/conf/file.py
+++ b/src/odemis/gui/conf/file.py
@@ -104,7 +104,7 @@ class Config(with_metaclass(ABCMeta, object)):
         value (byte string or unicode): if unicode, it's encoded as UTF-8
         """
         if not self.config.has_section(section):
-            logging.warn("Section %s not found, creating...", section)
+            logging.warning("Section %s not found, creating...", section)
             self.config.add_section(section)
         value = self._ensure_str_format(value)
         self.config.set(section, option, value)
@@ -117,7 +117,7 @@ class Config(with_metaclass(ABCMeta, object)):
           (if the value is unicode, it's encoded as UTF-8)
         """
         if not self.config.has_section(section):
-            logging.warn("Section %s not found, creating...", section)
+            logging.warning("Section %s not found, creating...", section)
             self.config.add_section(section)
         for option, value in option_value_list:
             value = self._ensure_str_format(value)

--- a/src/odemis/gui/conf/util.py
+++ b/src/odemis/gui/conf/util.py
@@ -250,7 +250,7 @@ def determine_default_control(va):
     """
 
     if not va:
-        logging.warn("No VA provided!")
+        logging.warning("No VA provided!")
         return odemis.gui.CONTROL_NONE
 
     if va.readonly:

--- a/src/odemis/gui/cont/microscope.py
+++ b/src/odemis/gui/cont/microscope.py
@@ -987,11 +987,11 @@ class DelphiStateController(SecomStateController):
         self._hole_focus = None
 
         if sht is None:
-            logging.warn("No sample holder loaded!")
+            logging.warning("No sample holder loaded!")
             return
         elif sht != PHENOM_SH_TYPE_OPTICAL:
             # Log the warning but load the calibration data
-            logging.warn("Wrong sample holder type! We will try to load the "
+            logging.warning("Wrong sample holder type! We will try to load the "
                          "calibration data anyway...")
 
         calib = self._calibconf.get_sh_calib(shid)
@@ -1143,7 +1143,7 @@ class DelphiStateController(SecomStateController):
             return
         elif sht != PHENOM_SH_TYPE_OPTICAL:
             # Hopefully it's just because the sample holder has not been correctly registered
-            logging.warn("Wrong sample holder type %d! We will try to calibrate anyway...", sht)
+            logging.warning("Wrong sample holder type %d! We will try to calibrate anyway...", sht)
 
         # Returns 'yes' for automatic, 'no' for manual
         dlg = windelphi.RecalibrationDialog(self._main_frame)

--- a/src/odemis/gui/cont/streams.py
+++ b/src/odemis/gui/cont/streams.py
@@ -2228,7 +2228,7 @@ class StreamBarController(object):
         # Remove from the views
         for v in self._tab_data_model.views.value:
             if hasattr(v, "removeStream"):
-                # logging.warn("> %s > %s", v, stream)
+                # logging.warning("> %s > %s", v, stream)
                 v.removeStream(stream)
 
         # Remove from the list of streams

--- a/src/odemis/gui/cont/views.py
+++ b/src/odemis/gui/cont/views.py
@@ -809,7 +809,7 @@ class ViewButtonController(object):
         """ Associate each button with the correct visible viewport """
 
         if not self.viewports:
-            logging.warn("Could not handle view change, viewports unknown!")
+            logging.warning("Could not handle view change, viewports unknown!")
             return
 
         self._unsubscribe()

--- a/src/odemis/gui/dev/powermate.py
+++ b/src/odemis/gui/dev/powermate.py
@@ -187,7 +187,7 @@ class Powermate(threading.Thread):
                             )
                             wx.PostEvent(self.target_viewport.canvas, knob_evt)
             except IOError:
-                logging.warn("Failed to communicate with the powermate, was unplugged?")
+                logging.warning("Failed to communicate with the powermate, was unplugged?")
                 # Sleep and after try and find the device again
                 while True:
                     time.sleep(5)

--- a/src/odemis/gui/util/__init__.py
+++ b/src/odemis/gui/util/__init__.py
@@ -94,7 +94,7 @@ def ignore_dead(f, self, *args, **kwargs):
     try:
         return f(self, *args, **kwargs)
     except RuntimeError:
-        logging.warn("Dead object %s ignored in %s", self, f.__name__)
+        logging.warning("Dead object %s ignored in %s", self, f.__name__)
 
 
 def dead_object_wrapper(f):

--- a/src/odemis/gui/util/updater.py
+++ b/src/odemis/gui/util/updater.py
@@ -90,7 +90,7 @@ class WindowsUpdater:
             web_version = web_version_file.readline().strip()
             web_version_file.close()
         except IOError as err:
-            logging.warn("Error on remote version check (%s)", err)
+            logging.warning("Error on remote version check (%s)", err)
             return None
 
         return web_version.decode('latin1')

--- a/src/odemis/gui/util/widgets.py
+++ b/src/odemis/gui/util/widgets.py
@@ -100,7 +100,7 @@ class VigilantAttributeConnector(object):
             logging.debug("Setting VA value to %s after control event %d", value, evt.Id)
             self.vigilattr.value = value
         except (ValueError, TypeError, IndexError) as exc:
-            logging.warn("VA refused value %s: %s", value, exc)
+            logging.warning("VA refused value %s: %s", value, exc)
             self.va_2_ctrl(self.vigilattr.value)
         evt.Skip()
 

--- a/src/odemis/util/__init__.py
+++ b/src/odemis/util/__init__.py
@@ -489,7 +489,7 @@ def limit_invocation(delay_s):
     """
 
     if delay_s > 5:
-        logging.warn("Warning! Long delay interval. Please consider using "
+        logging.warning("Warning! Long delay interval. Please consider using "
                      "an interval of 5 or less seconds")
 
     def li_dec(f):

--- a/src/odemis/util/img.py
+++ b/src/odemis/util/img.py
@@ -42,7 +42,7 @@ from matplotlib import cm
 try:
     from odemis.util import img_fast
 except ImportError:
-    logging.warn("Failed to load optimised functions, slow version will be used.")
+    logging.warning("Failed to load optimised functions, slow version will be used.")
     img_fast = None
 
 # This is a weave-based optimised version (but weave requires g++ installed)


### PR DESCRIPTION
This old method name has been deprecated for a long time.
Using logging.warning() works since even longer.
=> This avoids warnings about using a deprecated function, and
helps make Odemis compatible with Python 3.10