### PR TITLE
driver FixedPositionActuator method improvement and addition of testcase

### DIFF
--- a/src/odemis/driver/actuator.py
+++ b/src/odemis/driver/actuator.py
@@ -29,6 +29,8 @@ import numbers
 import threading
 from concurrent.futures._base import CancelledError, FINISHED
 from concurrent import futures
+from typing import Dict, Union, Set
+
 import numpy
 from past.builtins import basestring
 
@@ -1307,13 +1309,14 @@ class FixedPositionsActuator(model.Actuator):
 
         self._cycle = cycle
         self._move_sum = 0
-        self._position = {}
-        self._referenced = {}
+        self._position: Dict[str, float] = {}
+        self._referenced: Dict[str, bool] = {}
         axis, dep = list(dependencies.items())[0]
         self._axis = axis
         self._dependency = dep
         self._caxis = axis_name
-        self._positions = positions
+        self._positions: Union[Set[float], Dict[float, str]] = positions
+        self._actual_positions: Dict[float, float] = {}  # one choice position -> dependency position
         # Executor used to reference and move to nearest position
         self._executor = CancellableThreadPoolExecutor(max_workers=1)  # one task at a time
 
@@ -1333,7 +1336,7 @@ class FixedPositionsActuator(model.Actuator):
 
         model.Actuator.__init__(self, name, role, axes=axes, dependencies=dependencies, **kwargs)
 
-        self._position = {}
+        # self._position = {}  # isn't this a double declaration of empty dict?
         self.position = model.VigilantAttribute({}, readonly=True)
 
         logging.debug("Subscribing to position of dependency %s", dep.name)
@@ -1399,7 +1402,7 @@ class FixedPositionsActuator(model.Actuator):
     def moveRel(self, shift):
         if not shift:
             return model.InstantaneousFuture()
-        self._checkMoveRel(shift)
+        # self._checkMoveRel(shift)
         raise NotImplementedError("Relative move on fixed positions axis not supported")
 
     @isasync
@@ -1408,6 +1411,7 @@ class FixedPositionsActuator(model.Actuator):
         Move the actuator to the defined position in m for each axis given.
         pos dict(string-> float): name of the axis and position in m
         """
+
         if not pos:
             return model.InstantaneousFuture()
         self._checkMoveAbs(pos)
@@ -1417,8 +1421,18 @@ class FixedPositionsActuator(model.Actuator):
         return f
 
     def _doMoveAbs(self, pos):
-        axis, distance = list(pos.items())[0]
-        logging.debug("Moving axis %s (-> %s) to %g", self._axis, self._caxis, distance)
+        axis, req_pos = list(pos.items())[0]
+
+        # if the actuator is already at the requested position skip movement
+        # this to prevent the actuator to move due to difference dep pos and requested pos
+        # and en up in the same place again. For instance, this is typical when anti-backlash is used.
+        if req_pos in self._actual_positions:
+            cur_pos = self._dependency.position.value[self._caxis]
+            if cur_pos == self._actual_positions[req_pos]:
+                logging.debug("Dependency actuator is already at the right position (pos: %s cur_pos: %s)", pos, cur_pos)
+                return
+
+        logging.debug("Moving axis %s (-> %s) to %g", self._axis, self._caxis, req_pos)
 
         try:
             # While it's moving, don't listen to the intermediary positions,
@@ -1426,14 +1440,14 @@ class FixedPositionsActuator(model.Actuator):
             self._dependency.position.unsubscribe(self._update_dep_position)
 
             if self._cycle is None:
-                move = {self._caxis: distance}
+                move = {self._caxis: req_pos}
                 self._dependency.moveAbs(move).result()
             else:
                 # Optimize by moving through the closest way
                 cur_pos = self._dependency.position.value[self._caxis]
-                vector1 = distance - cur_pos
+                vector1 = req_pos - cur_pos
                 mod1 = vector1 % self._cycle
-                vector2 = cur_pos - distance
+                vector2 = cur_pos - req_pos
                 mod2 = vector2 % self._cycle
                 if abs(mod1) < abs(mod2):
                     self._move_sum += mod1
@@ -1445,7 +1459,7 @@ class FixedPositionsActuator(model.Actuator):
                         move_to_ref = (self._cycle - cur_pos) % self._cycle + self._offset
                         self._dependency.moveRel({self._caxis: move_to_ref}).result()
                         self._dependency.reference({self._caxis}).result()
-                        move = {self._caxis: distance}
+                        move = {self._caxis: req_pos}
                     else:
                         move = {self._caxis: mod1}
                 else:
@@ -1453,6 +1467,10 @@ class FixedPositionsActuator(model.Actuator):
                     self._move_sum -= mod2
 
                 self._dependency.moveRel(move).result()
+
+            # after successful movement store the actual position reached by the dependency
+            cur_pos = self._dependency.position.value[self._caxis]
+            self._actual_positions[req_pos] = cur_pos
         finally:
             self._dependency.position.subscribe(self._update_dep_position, init=True)
 

--- a/src/odemis/driver/test/actuator_test.py
+++ b/src/odemis/driver/test/actuator_test.py
@@ -44,8 +44,8 @@ logging.basicConfig(format="%(asctime)s  %(levelname)-7s %(module)s:%(lineno)d %
 CONFIG_PATH = os.path.dirname(odemis.__file__) + "/../../install/linux/usr/share/odemis/"
 DELPHI_CONFIG = CONFIG_PATH + "sim/delphi-sim.odm.yaml"
 
-class MultiplexTest(unittest.TestCase, simulated_test.ActuatorTest):
 
+class MultiplexTest(unittest.TestCase, simulated_test.ActuatorTest):
     actuator_type = MultiplexActuator
 
     def setUp(self):
@@ -68,27 +68,25 @@ class MultiplexTest(unittest.TestCase, simulated_test.ActuatorTest):
 
 
 class MultiplexOneTest(unittest.TestCase, simulated_test.ActuatorTest):
-
     actuator_type = MultiplexActuator
 
     def setUp(self):
         self.dependency = tmcm.TMCLController(name="test", role="test",
-                                         port="/dev/fake3",
-                                         axes=["a", "b"],
-                                         ustepsize=[5.9e-9, 5.8e-9],
-                                         rng=[[-1e-3, 1e-3], [0, 1e-3]],
-                                         refproc="Standard")
+                                              port="/dev/fake3",
+                                              axes=["a", "b"],
+                                              ustepsize=[5.9e-9, 5.8e-9],
+                                              rng=[[-1e-3, 1e-3], [0, 1e-3]],
+                                              refproc="Standard")
         self.dev = self.actuator_type("stage", "stage",
                                       dependencies={"x": self.dependency, "y": self.dependency},
                                       axes_map={"x": "a", "y": "b"},
                                       ref_on_init={"x": 0.0001},
-                                    )
+                                      )
         # Wait for the init move to be over
         self.dev.moveRel({"x": 1e-8, "y": 1e-8}).result()
 
 
 class LinearActuatorTest(unittest.TestCase):
-
     actuator_type = LinearActuator
 
     def setUp(self):
@@ -134,7 +132,6 @@ class LinearActuatorTest(unittest.TestCase):
 
 
 class FixedPositionsTest(unittest.TestCase):
-
     actuator_type = FixedPositionsActuator
 
     def setUp(self):
@@ -142,12 +139,12 @@ class FixedPositionsTest(unittest.TestCase):
         self.dependency1 = simulated.Stage("sstage1", "test", {"a"})
         self.dev_normal = self.actuator_type("stage", "stage",
                                              {"x": self.dependency1}, "a", {0: "pos0", 0.01: "pos1",
-                                                                       0.02: "pos2", 0.03: "pos3",
-                                                                       0.04: "pos4", 0.05: "pos5"})
+                                                                            0.02: "pos2", 0.03: "pos3",
+                                                                            0.04: "pos4", 0.05: "pos5"})
         self.dev_cycle = self.actuator_type("stage", "stage",
                                             {"x": self.dependency1}, "a", {0: "pos0", 0.01: "pos1",
-                                                                      0.02: "pos2", 0.03: "pos3",
-                                                                      0.04: "pos4", 0.05: "pos5"}, cycle=0.06)
+                                                                           0.02: "pos2", 0.03: "pos3",
+                                                                           0.04: "pos4", 0.05: "pos5"}, cycle=0.06)
 
     def test_normal_moveAbs(self):
         # It's optional
@@ -202,28 +199,26 @@ class FixedPositionsTestAntibacklash(unittest.TestCase):
     def setUp(self):
         # create a dependency as a standard TMCL controller
         self.dependency = tmcm.TMCLController(name="test", role="test",
-                                         port="/dev/fake3",
-                                         axes=["x"],
-                                         ustepsize=[10e-6],
-                                         rng=[[-10e-3, 10e-3]],
-                                         refproc="Standard")
+                                              port="/dev/fake3",
+                                              axes=["x"],
+                                              ustepsize=[10e-6],
+                                              rng=[[-10e-3, 10e-3]],
+                                              refproc="Standard")
 
         # create a stage with a backlash value
         self.ab_stage = AntiBacklashActuator("absact", "align", {"orig": self.dependency},
-                                     backlash={"x": 100e-6})
+                                             backlash={"x": 100e-6})
 
         # create a normal device FixedPositionActuator with positions that are 'slightly off' rounded numbers
-        self.dev_normal = FixedPositionsActuator("stage", "stage",
-                                                 {"x": self.ab_stage},
-                                                 "x",
-                                                 # Fixed positions, which cannot be reached exactly with the ustepsize
-                                                 {0 + 2e-6: "pos0", 0.001 + 3e-6: "pos1",
-                                                  0.002 - 2e-6: "pos2", 0.003 - 6e-6: "pos3"}
-                                                 )
-        self.dev_cycle = FixedPositionsActuator("stage", "stage",
-                                                {"x": self.ab_stage}, "x", {0: "pos0", 0.01: "pos1",
-                                                                      0.02: "pos2", 0.03: "pos3",
-                                                                      0.04: "pos4", 0.05: "pos5"}, cycle=0.06)
+        self.dev = FixedPositionsActuator("stage", "stage",
+                                          {"x": self.ab_stage},
+                                          "x",
+                                          # Fixed positions, which cannot be reached exactly with the ustepsize
+                                          {0 + 2e-6: "pos0",
+                                           0.001 + 3e-6: "pos1",
+                                           0.002 - 2e-6: "pos2",
+                                           0.003 - 6e-6: "pos3"}
+                                          )
 
     def test_same_position(self):
         # fixed_pos = 0.001 + 3e-6
@@ -233,7 +228,7 @@ class FixedPositionsTestAntibacklash(unittest.TestCase):
         fixed_pos = 0.002 - 2e-6
         rounded_pos = 0.002
 
-        f = self.dev_normal.moveAbs({'x': fixed_pos})
+        f = self.dev.moveAbs({'x': fixed_pos})
         f.result()
 
         self.assertEqual(self.dependency.position.value['x'], rounded_pos)
@@ -244,7 +239,7 @@ class FixedPositionsTestAntibacklash(unittest.TestCase):
 
         # There should be no move (even with backlash), as it's already at the right place
         # (although it reports a slightly different position).
-        f = self.dev_normal.moveAbs({'x': fixed_pos})
+        f = self.dev.moveAbs({'x': fixed_pos})
         f.result()
 
         self.assertEqual(self._dep_positions, [])  # empty list == no move
@@ -305,7 +300,7 @@ class TestCoupledStage(unittest.TestCase):
         f.result()
         testing.assert_pos_almost_equal(align.position.value, {"x": 1e-06, "y": 2e-06}, atol=1e-7)
         testing.assert_pos_almost_equal(sem_stage.position.value, {"x": 1e-06, "y": 2e-06}, atol=1e-7)
-        self.assertXYAlmostEqual(tmcm.position.value, {"x":-1e-06, "y":-2e-06}, atol=1e-7)
+        self.assertXYAlmostEqual(tmcm.position.value, {"x": -1e-06, "y": -2e-06}, atol=1e-7)
         f = stage.moveRel({"x": -1e-06, "y": -2e-06})
         f.result()
         testing.assert_pos_almost_equal(align.position.value, {"x": 0, "y": 0}, atol=1e-7)
@@ -322,7 +317,7 @@ class TestCoupledStage(unittest.TestCase):
         f.result()
         testing.assert_pos_almost_equal(align.position.value, {"x": 1e-06, "y": 2e-06}, atol=1e-7)
         testing.assert_pos_almost_equal(sem_stage.position.value, {"x": 1e-05, "y": 2e-05}, atol=1e-7)
-        self.assertXYAlmostEqual(tmcm.position.value, {"x":-1e-06, "y":-2e-06}, atol=1e-7)
+        self.assertXYAlmostEqual(tmcm.position.value, {"x": -1e-06, "y": -2e-06}, atol=1e-7)
         f = stage.moveRel({"x": -1e-06, "y": -2e-06})
         f.result()
         testing.assert_pos_almost_equal(align.position.value, {"x": 0, "y": 0}, atol=1e-7)
@@ -338,8 +333,8 @@ class TestCoupledStage(unittest.TestCase):
         f = stage.moveRel({"x": 1e-06, "y": 2e-06})
         f.result()
         testing.assert_pos_almost_equal(align.position.value, {"x": 1e-06, "y": 2e-06}, atol=1e-7)
-        testing.assert_pos_almost_equal(sem_stage.position.value, {"x":-2e-06, "y": 1e-06}, atol=1e-7)
-        self.assertXYAlmostEqual(tmcm.position.value, {"x":-1e-06, "y":-2e-06}, atol=1e-7)
+        testing.assert_pos_almost_equal(sem_stage.position.value, {"x": -2e-06, "y": 1e-06}, atol=1e-7)
+        self.assertXYAlmostEqual(tmcm.position.value, {"x": -1e-06, "y": -2e-06}, atol=1e-7)
         f = stage.moveRel({"x": -1e-06, "y": -2e-06})
         f.result()
         testing.assert_pos_almost_equal(align.position.value, {"x": 0, "y": 0}, atol=1e-7)
@@ -355,17 +350,17 @@ class TestCoupledStage(unittest.TestCase):
         f = stage.moveRel({"x": 0, "y": 0})  # synchronize stages again
         f.result()
         testing.assert_pos_almost_equal(align.position.value, {"x": 0, "y": 0}, atol=1e-7)
-        testing.assert_pos_almost_equal(sem_stage.position.value, {"x":-1e-06, "y":-2e-06}, atol=1e-7)
+        testing.assert_pos_almost_equal(sem_stage.position.value, {"x": -1e-06, "y": -2e-06}, atol=1e-7)
         self.assertXYAlmostEqual(tmcm.position.value, {"x": 0, "y": 0}, atol=1e-7)
         f = stage.moveRel({"x": 1e-06, "y": 2e-06})
         f.result()
         testing.assert_pos_almost_equal(align.position.value, {"x": 1e-06, "y": 2e-06}, atol=1e-7)
         testing.assert_pos_almost_equal(sem_stage.position.value, {"x": 0, "y": 0}, atol=1e-7)
-        self.assertXYAlmostEqual(tmcm.position.value, {"x":-1e-06, "y":-2e-06}, atol=1e-7)
+        self.assertXYAlmostEqual(tmcm.position.value, {"x": -1e-06, "y": -2e-06}, atol=1e-7)
         f = stage.moveRel({"x": -1e-06, "y": -2e-06})
         f.result()
         testing.assert_pos_almost_equal(align.position.value, {"x": 0, "y": 0}, atol=1e-7)
-        testing.assert_pos_almost_equal(sem_stage.position.value, {"x":-1e-06, "y":-2e-06}, atol=1e-7)
+        testing.assert_pos_almost_equal(sem_stage.position.value, {"x": -1e-06, "y": -2e-06}, atol=1e-7)
         self.assertXYAlmostEqual(tmcm.position.value, {"x": 0, "y": 0}, atol=1e-7)
         f = stage.moveAbs({"x": 0, "y": 0})
         f.result()
@@ -378,11 +373,11 @@ class TestCoupledStage(unittest.TestCase):
         f.result()
         testing.assert_pos_almost_equal(align.position.value, {"x": 1e-06, "y": 2e-06}, atol=1e-7)
         testing.assert_pos_almost_equal(sem_stage.position.value, {"x": 0, "y": 0}, atol=1e-7)
-        self.assertXYAlmostEqual(tmcm.position.value, {"x":-1e-06, "y":-2e-06}, atol=1e-7)
+        self.assertXYAlmostEqual(tmcm.position.value, {"x": -1e-06, "y": -2e-06}, atol=1e-7)
         f = stage.moveRel({"x": -1e-06, "y": -2e-06})
         f.result()
         testing.assert_pos_almost_equal(align.position.value, {"x": 0, "y": 0}, atol=1e-7)
-        testing.assert_pos_almost_equal(sem_stage.position.value, {"x":-1e-05, "y":-2e-05}, atol=1e-7)
+        testing.assert_pos_almost_equal(sem_stage.position.value, {"x": -1e-05, "y": -2e-05}, atol=1e-7)
         self.assertXYAlmostEqual(tmcm.position.value, {"x": 0, "y": 0}, atol=1e-7)
         f = stage.moveAbs({"x": 0, "y": 0})
         f.result()
@@ -406,7 +401,7 @@ class TestCoupledStage(unittest.TestCase):
         f.result()
         testing.assert_pos_almost_equal(align.position.value, {"x": 1e-06, "y": 2e-06}, atol=1e-7)
         testing.assert_pos_almost_equal(sem_stage.position.value, {"x": 1e-06, "y": 2e-06}, atol=1e-7)
-        self.assertXYAlmostEqual(tmcm.position.value, {"x":-1e-06, "y":-2e-06}, atol=1e-7)
+        self.assertXYAlmostEqual(tmcm.position.value, {"x": -1e-06, "y": -2e-06}, atol=1e-7)
 
         # scaling
         stage.updateMetadata({model.MD_ROTATION_COR: 0})
@@ -416,7 +411,7 @@ class TestCoupledStage(unittest.TestCase):
         f.result()
         testing.assert_pos_almost_equal(align.position.value, {"x": 1e-06, "y": 2e-06}, atol=1e-7)
         testing.assert_pos_almost_equal(sem_stage.position.value, {"x": 1e-05, "y": 2e-05}, atol=1e-7)
-        self.assertXYAlmostEqual(tmcm.position.value, {"x":-1e-06, "y":-2e-06}, atol=1e-7)
+        self.assertXYAlmostEqual(tmcm.position.value, {"x": -1e-06, "y": -2e-06}, atol=1e-7)
 
         # rotation
         stage.updateMetadata({model.MD_ROTATION_COR: math.pi / 2})
@@ -425,8 +420,8 @@ class TestCoupledStage(unittest.TestCase):
         f = stage.moveAbs({"x": 1e-06, "y": 2e-06})
         f.result()
         testing.assert_pos_almost_equal(align.position.value, {"x": 1e-06, "y": 2e-06}, atol=1e-7)
-        testing.assert_pos_almost_equal(sem_stage.position.value, {"x":-2e-06, "y": 1e-06}, atol=1e-7)
-        self.assertXYAlmostEqual(tmcm.position.value, {"x":-1e-06, "y":-2e-06}, atol=1e-7)
+        testing.assert_pos_almost_equal(sem_stage.position.value, {"x": -2e-06, "y": 1e-06}, atol=1e-7)
+        self.assertXYAlmostEqual(tmcm.position.value, {"x": -1e-06, "y": -2e-06}, atol=1e-7)
 
         # offset
         stage.updateMetadata({model.MD_ROTATION_COR: 0})
@@ -436,7 +431,7 @@ class TestCoupledStage(unittest.TestCase):
         f.result()
         testing.assert_pos_almost_equal(align.position.value, {"x": 1e-06, "y": 2e-06}, atol=1e-7)
         testing.assert_pos_almost_equal(sem_stage.position.value, {"x": 0, "y": 0}, atol=1e-7)
-        self.assertXYAlmostEqual(tmcm.position.value, {"x":-1e-06, "y":-2e-06}, atol=1e-7)
+        self.assertXYAlmostEqual(tmcm.position.value, {"x": -1e-06, "y": -2e-06}, atol=1e-7)
 
         # offset + scaling
         stage.updateMetadata({model.MD_ROTATION_COR: 0})
@@ -446,7 +441,7 @@ class TestCoupledStage(unittest.TestCase):
         f.result()
         testing.assert_pos_almost_equal(align.position.value, {"x": 1e-06, "y": 2e-06}, atol=1e-7)
         testing.assert_pos_almost_equal(sem_stage.position.value, {"x": 0, "y": 0}, atol=1e-7)
-        self.assertXYAlmostEqual(tmcm.position.value, {"x":-1e-06, "y":-2e-06}, atol=1e-7)
+        self.assertXYAlmostEqual(tmcm.position.value, {"x": -1e-06, "y": -2e-06}, atol=1e-7)
         f = stage.moveAbs({"x": 0, "y": 0})
         f.result()
 
@@ -493,8 +488,8 @@ class TestConvertStage(unittest.TestCase):
         f = stage.moveRel({"x": 1e-06, "y": 2e-06})
         f.result()
         testing.assert_pos_almost_equal(stage.position.value, {"x": 1e-06, "y": 2e-06})
-        testing.assert_pos_almost_equal(dependency.position.value, {"a":-2.1213203435596424e-06,
-                                                         "b": 7.071067811865477e-07})
+        testing.assert_pos_almost_equal(dependency.position.value, {"a": -2.1213203435596424e-06,
+                                                                    "b": 7.071067811865477e-07})
         f = stage.moveRel({"x": -1e-06, "y": -2e-06})
         f.result()
         testing.assert_pos_almost_equal(stage.position.value, {"x": 0, "y": 0})
@@ -590,7 +585,7 @@ class TestConvertStage(unittest.TestCase):
         f.result()
         testing.assert_pos_almost_equal(stage.position.value, {"x": 1e-06, "y": 2e-06})
         testing.assert_pos_almost_equal(dependency.position.value, {"x": 10e-06, "y": 20e-06})
-        f = stage.moveRel({"x":-1e-06, "y":-2e-06})
+        f = stage.moveRel({"x": -1e-06, "y": -2e-06})
         f.result()
         testing.assert_pos_almost_equal(stage.position.value, {"x": 0, "y": 0})
         testing.assert_pos_almost_equal(dependency.position.value, {"x": 0, "y": 0})
@@ -602,7 +597,7 @@ class TestConvertStage(unittest.TestCase):
         f = stage.moveRel({"x": 1e-06, "y": 2e-06})
         f.result()
         self.assertEqual(stage.position.value, {"x": 1e-06, "y": 2e-06})
-        testing.assert_pos_almost_equal(dependency.position.value, {"x":-2e-06, "y": 1e-06})
+        testing.assert_pos_almost_equal(dependency.position.value, {"x": -2e-06, "y": 1e-06})
         f = stage.moveRel({"x": -1e-06, "y": -2e-06})
         f.result()
         testing.assert_pos_almost_equal(stage.position.value, {"x": 0, "y": 0})
@@ -611,28 +606,28 @@ class TestConvertStage(unittest.TestCase):
         # offset
         stage = ConvertStage("conv", "align", {"orig": dependency}, axes=["x", "y"],
                              translation=(1e-06, 2e-06))
-        testing.assert_pos_almost_equal(stage.position.value, {"x":-1e-06, "y":-2e-06})
+        testing.assert_pos_almost_equal(stage.position.value, {"x": -1e-06, "y": -2e-06})
         f = stage.moveRel({"x": 1e-06, "y": 2e-06})
         f.result()
         testing.assert_pos_almost_equal(stage.position.value, {"x": 0, "y": 0})
         testing.assert_pos_almost_equal(dependency.position.value, {"x": 1e-06, "y": 2e-06})
         f = stage.moveRel({"x": -1e-06, "y": -2e-06})
         f.result()
-        testing.assert_pos_almost_equal(stage.position.value, {"x":-1e-06, "y":-2e-06})
+        testing.assert_pos_almost_equal(stage.position.value, {"x": -1e-06, "y": -2e-06})
         testing.assert_pos_almost_equal(dependency.position.value, {"x": 0, "y": 0})
 
         # offset + scaling
         stage = ConvertStage("conv", "align", {"orig": dependency}, axes=["x", "y"],
                              translation=(1e-06, 2e-06),
                              scale=(10, 10))
-        testing.assert_pos_almost_equal(stage.position.value, {"x":-1e-06, "y":-2e-06})
+        testing.assert_pos_almost_equal(stage.position.value, {"x": -1e-06, "y": -2e-06})
         f = stage.moveRel({"x": 1e-06, "y": 2e-06})
         f.result()
         testing.assert_pos_almost_equal(stage.position.value, {"x": 0, "y": 0})
         testing.assert_pos_almost_equal(dependency.position.value, {"x": 10e-06, "y": 20e-06})
         f = stage.moveRel({"x": -1e-06, "y": -2e-06})
         f.result()
-        testing.assert_pos_almost_equal(stage.position.value, {"x":-1e-06, "y":-2e-06})
+        testing.assert_pos_almost_equal(stage.position.value, {"x": -1e-06, "y": -2e-06})
         testing.assert_pos_almost_equal(dependency.position.value, {"x": 0, "y": 0})
 
     # @skip("skip")
@@ -688,11 +683,11 @@ class TestConvertStage(unittest.TestCase):
         f = stage.moveAbs({"x": 1e-06, "y": 2e-06})
         f.result()
         testing.assert_pos_almost_equal(stage.position.value, {"x": 1e-06, "y": 2e-06})
-        testing.assert_pos_almost_equal(dependency.position.value, {"x":-2e-06, "y": 1e-06})
+        testing.assert_pos_almost_equal(dependency.position.value, {"x": -2e-06, "y": 1e-06})
         f = stage.moveAbs({"x": 1e-06})  # Test only move only one axis
         f.result()
         testing.assert_pos_almost_equal(stage.position.value, {"x": 1e-06, "y": 2e-06})
-        testing.assert_pos_almost_equal(dependency.position.value, {"x":-2e-06, "y": 1e-06})
+        testing.assert_pos_almost_equal(dependency.position.value, {"x": -2e-06, "y": 1e-06})
         f = stage.moveAbs({"x": 0, "y": 0})
         f.result()
         testing.assert_pos_almost_equal(stage.position.value, {"x": 0, "y": 0})
@@ -701,7 +696,7 @@ class TestConvertStage(unittest.TestCase):
         # offset
         stage = ConvertStage("conv", "align", {"orig": dependency}, axes=["x", "y"],
                              translation=(1e-06, 2e-06))
-        testing.assert_pos_almost_equal(stage.position.value, {"x":-1e-06, "y":-2e-06})
+        testing.assert_pos_almost_equal(stage.position.value, {"x": -1e-06, "y": -2e-06})
         # Speed should not be affected by offset
         testing.assert_pos_almost_equal(stage.speed.value, {"x": 2e-6, "y": 5e-6})
 
@@ -711,18 +706,19 @@ class TestConvertStage(unittest.TestCase):
         testing.assert_pos_almost_equal(dependency.position.value, {"x": 1e-06, "y": 2e-06})
         f = stage.moveAbs({"x": -1e-06, "y": -2e-06})
         f.result()
-        testing.assert_pos_almost_equal(stage.position.value, {"x":-1e-06, "y":-2e-06})
+        testing.assert_pos_almost_equal(stage.position.value, {"x": -1e-06, "y": -2e-06})
         testing.assert_pos_almost_equal(dependency.position.value, {"x": 0, "y": 0})
 
         # offset + scaling
         stage = ConvertStage("conv", "align", {"orig": dependency}, axes=["x", "y"],
                              translation=(1e-06, 2e-06),
                              scale=(10, 10))
-        testing.assert_pos_almost_equal(stage.position.value, {"x":-1e-06, "y":-2e-06})
+        testing.assert_pos_almost_equal(stage.position.value, {"x": -1e-06, "y": -2e-06})
         f = stage.moveAbs({"x": 0, "y": 0})
         f.result()
         testing.assert_pos_almost_equal(stage.position.value, {"x": 0, "y": 0})
         testing.assert_pos_almost_equal(dependency.position.value, {"x": 1e-05, "y": 2e-05})
+
 
 class TestConvert3DStage(unittest.TestCase):
     # @skip("skip")
@@ -903,7 +899,7 @@ class TestConvert3DStage(unittest.TestCase):
         f.result()
         testing.assert_pos_almost_equal(stage.position.value, {"x": 1e-06, "y": 2e-06, "z": 0})
         testing.assert_pos_almost_equal(dependency.position.value, {"a": 7.071067811865477e-07,
-                                                                 "b": -2.1213203435596424e-06, "c": 0})
+                                                                    "b": -2.1213203435596424e-06, "c": 0})
         f = stage.moveRel({"x": -1e-06, "y": -2e-06, "z": 0})
         f.result()
         testing.assert_pos_almost_equal(stage.position.value, {"x": 0, "y": 0, "z": 0})
@@ -915,7 +911,7 @@ class TestConvert3DStage(unittest.TestCase):
         f.result()
         testing.assert_pos_almost_equal(stage.position.value, {"x": 1e-06, "y": 0, "z": 2e-06})
         testing.assert_pos_almost_equal(dependency.position.value, {"a": -2.1213203435596424e-06,
-                                                                 "b": 0, "c": -7.071067811865477e-07})
+                                                                    "b": 0, "c": -7.071067811865477e-07})
         f = stage.moveRel({"x": -1e-06, "y": 0, "z": -2e-06})
         f.result()
         testing.assert_pos_almost_equal(stage.position.value, {"x": 0, "y": 0, "z": 0})
@@ -927,7 +923,7 @@ class TestConvert3DStage(unittest.TestCase):
         f.result()
         testing.assert_pos_almost_equal(stage.position.value, {"x": 0, "y": 1e-06, "z": 2e-06})
         testing.assert_pos_almost_equal(dependency.position.value,
-                                     {"a": 0, "b": 7.071067811865477e-07, "c": -2.1213203435596424e-06})
+                                        {"a": 0, "b": 7.071067811865477e-07, "c": -2.1213203435596424e-06})
         f = stage.moveRel({"x": 0, "y": -1e-06, "z": -2e-06})
         f.result()
         testing.assert_pos_almost_equal(stage.position.value, {"x": 0, "y": 0, "z": 0})
@@ -986,6 +982,7 @@ class TestConvert3DStage(unittest.TestCase):
 
         testing.assert_pos_almost_equal(stage.speed.value, {"x": 10e-6, "y": 20e-6, "z": 30e-6})
 
+
 class TestAntiBacklashActuator(unittest.TestCase):
 
     def test_simple(self):
@@ -1006,8 +1003,8 @@ class TestAntiBacklashActuator(unittest.TestCase):
         testing.assert_pos_almost_equal(dependency.position.value, {"x": 0, "y": 0})
         f = stage.moveAbs({"x": -23e-06, "y": -15e-06})
         f.result()
-        testing.assert_pos_almost_equal(stage.position.value, {"x":-23e-06, "y":-15e-06})
-        testing.assert_pos_almost_equal(dependency.position.value, {"x":-23e-06, "y":-15e-06})
+        testing.assert_pos_almost_equal(stage.position.value, {"x": -23e-06, "y": -15e-06})
+        testing.assert_pos_almost_equal(dependency.position.value, {"x": -23e-06, "y": -15e-06})
 
         # rel
         f = stage.moveAbs({"x": 0, "y": 0})
@@ -1045,12 +1042,12 @@ class TestAntiBacklashActuator(unittest.TestCase):
         testing.assert_pos_almost_equal(dependency.position.value, {"a": 1e-06, "b": 0})
         f = stage.moveAbs({"a": -23e-06, "b": -15e-06})
         f.result()
-        testing.assert_pos_almost_equal(stage.position.value, {"a":-23e-06, "b":-15e-06})
-        testing.assert_pos_almost_equal(dependency.position.value, {"a":-23e-06, "b":-15e-06})
-        f = stage.moveAbs({"a": -20e-06}) # negative position but positive move
+        testing.assert_pos_almost_equal(stage.position.value, {"a": -23e-06, "b": -15e-06})
+        testing.assert_pos_almost_equal(dependency.position.value, {"a": -23e-06, "b": -15e-06})
+        f = stage.moveAbs({"a": -20e-06})  # negative position but positive move
         f.result()
-        testing.assert_pos_almost_equal(stage.position.value, {"a":-20e-06, "b":-15e-06})
-        testing.assert_pos_almost_equal(dependency.position.value, {"a":-20e-06, "b":-15e-06})
+        testing.assert_pos_almost_equal(stage.position.value, {"a": -20e-06, "b": -15e-06})
+        testing.assert_pos_almost_equal(dependency.position.value, {"a": -20e-06, "b": -15e-06})
 
         # rel
         f = stage.moveAbs({"a": 0})
@@ -1123,14 +1120,14 @@ class TestCombinedSensorActuator(unittest.TestCase):
     def setUp(self):
         self.cact = simulated.Stage("sstage1", "test", {"a"})
         self.csensor = simulated.Stage("sstage2", "test", {"b"})
-        self.csensor.moveAbs({"b":-1e-3}).result()  # simulate
+        self.csensor.moveAbs({"b": -1e-3}).result()  # simulate
         self.dev = CombinedSensorActuator("stage", "stage",
                                           dependencies={"actuator": self.cact,
-                                                    "sensor": self.csensor},
+                                                        "sensor": self.csensor},
                                           axis_actuator="a",
                                           axis_sensor="b",
                                           positions={0: "pos0", 0.01: "pos1"},
-                                          to_sensor={0:-1e-3, 0.01: 1e-3},
+                                          to_sensor={0: -1e-3, 0.01: 1e-3},
                                           )
 
     def test_moveAbs(self):
@@ -1151,7 +1148,7 @@ class TestCombinedSensorActuator(unittest.TestCase):
         # Move to a known position
         move = {"a": 0.00}
         f = self.dev.moveAbs(move)
-        self.csensor.moveAbs({"b":-1e-3}).result()  # simulate successful move
+        self.csensor.moveAbs({"b": -1e-3}).result()  # simulate successful move
         f.result()  # wait
         self.assertDictEqual(move, self.dev.position.value,
                              "Actuator didn't move to the requested position")
@@ -1173,25 +1170,25 @@ class TestCombinedFixedPositionActuator(unittest.TestCase):
         self.cycle = None
         self.fallback = "unspecified"
         self.positions = {
-                         # [qwp, linear]
-                         # pos (str) -> list(pos (float), pos (float))
-                         "horizontal": [0.1, 0.1],  # use value different from [0.0, 0.0] to test some
-                                                    # allowed position is reached after referencing
-                         "vertical": [1.570796, 1.570796],  # (pi/2, pi/2)
-                         "posdiag": [0.785398, 0.785398],  # (pi/4, pi/4)
-                         "negdiag": [2.356194, 2.356194],  # (3pi/4, 3pi/4)
-                         "rhc": [0.0, 0.785398],  # (0, pi/4)
-                         "lhc": [0.0, 2.356194],  # (0, 3pi/4)
-                         "pass-through": [1.6, 1.6],  # 91.67 degree: choose something close to vertical
-                                                      # as it will fit most real samples best
-                        }
+            # [qwp, linear]
+            # pos (str) -> list(pos (float), pos (float))
+            "horizontal": [0.1, 0.1],  # use value different from [0.0, 0.0] to test some
+            # allowed position is reached after referencing
+            "vertical": [1.570796, 1.570796],  # (pi/2, pi/2)
+            "posdiag": [0.785398, 0.785398],  # (pi/4, pi/4)
+            "negdiag": [2.356194, 2.356194],  # (3pi/4, 3pi/4)
+            "rhc": [0.0, 0.785398],  # (0, pi/4)
+            "lhc": [0.0, 2.356194],  # (0, 3pi/4)
+            "pass-through": [1.6, 1.6],  # 91.67 degree: choose something close to vertical
+            # as it will fit most real samples best
+        }
 
         # create one dependency
         self.dependency1 = tmcm.TMCLController("rotstage1", "test", port="/dev/fake6",
-                                          axes=[self.axis1, self.axis2], ustepsize=[3.392e-5, 3.392e-5],
-                                          unit=["rad", "rad"],
-                                          refproc="Standard",
-                                          )
+                                               axes=[self.axis1, self.axis2], ustepsize=[3.392e-5, 3.392e-5],
+                                               unit=["rad", "rad"],
+                                               refproc="Standard",
+                                               )
 
         self.dev = CombinedFixedPositionActuator("combinedstage", "stage",
                                                  dependencies={"bla": self.dependency1, "blub": self.dependency1},
@@ -1355,23 +1352,23 @@ class TestCombinedFixedPositionActuatorCycle(unittest.TestCase):
         self.cycle = [math.pi * 2, math.pi * 2]
         self.fallback = "unspecified"
         self.positions = {
-                         # [qwp, linear]
-                         # pos (str) -> list(pos (float), pos (float))
-                         "horizontal": [0.0, 0.0],
-                         "vertical": [1.570796, 1.570796],  # (pi/2, pi/2)
-                         "posdiag": [0.785398, 0.785398],  # (pi/4, pi/4)
-                         "negdiag": [2.356194, 2.356194],  # (3pi/4, 3pi/4)
-                         "rhc": [0.0, 0.785398],  # (0, pi/4)
-                         "lhc": [0.0, 2.356194],  # (0, 3pi/4)
-                         "pass-through": [1.6, 1.6],  # 91.67 degree: choose something close to vertical
-                                                      # as it will fit most real samples best
-                        }
+            # [qwp, linear]
+            # pos (str) -> list(pos (float), pos (float))
+            "horizontal": [0.0, 0.0],
+            "vertical": [1.570796, 1.570796],  # (pi/2, pi/2)
+            "posdiag": [0.785398, 0.785398],  # (pi/4, pi/4)
+            "negdiag": [2.356194, 2.356194],  # (3pi/4, 3pi/4)
+            "rhc": [0.0, 0.785398],  # (0, pi/4)
+            "lhc": [0.0, 2.356194],  # (0, 3pi/4)
+            "pass-through": [1.6, 1.6],  # 91.67 degree: choose something close to vertical
+            # as it will fit most real samples best
+        }
 
         # create one dependency
         self.dependency1 = tmcm.TMCLController("rotstage1", "test", port="/dev/fake6",
-                                          axes=[self.axis1, self.axis2], ustepsize=[3.392e-5, 3.392e-5],
-                                          unit=["rad", "rad"],
-                                          refproc="Standard")
+                                               axes=[self.axis1, self.axis2], ustepsize=[3.392e-5, 3.392e-5],
+                                               unit=["rad", "rad"],
+                                               refproc="Standard")
 
         self.dev = CombinedFixedPositionActuator("combinedstage", "stage",
                                                  dependencies={"axis1": self.dependency1, "axis2": self.dependency1},
@@ -1421,17 +1418,17 @@ class TestRotationActuator(unittest.TestCase):
 
         # # create 1 dependency
         self.dependency1 = tmcm.TMCLController("rotstage1", "test", port="/dev/fake6",
-                                          axes=[self.axis], ustepsize=[3.392e-5],
-                                          unit=["rad"],
-                                          refproc="Standard",
-                                          )
+                                               axes=[self.axis], ustepsize=[3.392e-5],
+                                               unit=["rad"],
+                                               refproc="Standard",
+                                               )
 
         self.dev_cycle = RotationActuator("stage", "stage",
                                           dependencies={self.axis_name: self.dependency1},
                                           axis_name=self.axis,
                                           ref_start=1,
                                           ref_frequency=self.ref_freq
-                                         )
+                                          )
 
         # TODO write test case for args ref_start=... monitor dependency position -> pass zero?
 
@@ -1447,7 +1444,7 @@ class TestRotationActuator(unittest.TestCase):
             self.skipTest("Actuator doesn't support absolute move")
 
         # generate random pos > 2pi
-        new_pos = random.uniform(2*math.pi, 10) + 0.0001  # to exclude 2pi
+        new_pos = random.uniform(2 * math.pi, 10) + 0.0001  # to exclude 2pi
         with self.assertRaises(ValueError):
             f = self.dev_cycle.moveAbs({axis_name: new_pos})  # move
             f.result()  # wait
@@ -1467,7 +1464,7 @@ class TestRotationActuator(unittest.TestCase):
         self.assertEqual(self.dev_cycle.position.value[axis_name], cur_pos)
 
         # test new position
-        new_pos = random.uniform(0, 2*math.pi)
+        new_pos = random.uniform(0, 2 * math.pi)
         f = self.dev_cycle.moveAbs({axis_name: new_pos})
         f.result()
         # check absolute difference is smaller half the ustepsize
@@ -1488,7 +1485,7 @@ class TestRotationActuator(unittest.TestCase):
         self.assertEqual(self.dev_cycle.position.value[axis_name], cur_pos)
 
         # test shift position
-        shift = random.uniform(0, 2*math.pi)
+        shift = random.uniform(0, 2 * math.pi)
         f = self.dev_cycle.moveRel({axis_name: shift})
         f.result()
         # check absolute difference is smaller half the ustepsize
@@ -1547,10 +1544,10 @@ class TestRotationActuator(unittest.TestCase):
         # Overrun 2pi after 4 moves in counter-clockwise direction
         # The 5th move should be started again from 0
         for i in range(5):
-            f = self.dev_cycle.moveRel({axis_name:-shift})
+            f = self.dev_cycle.moveRel({axis_name: -shift})
             f.result()
 
-        exp_pos = (-shift * 5) % (2 * math.pi)  #  = 3/2 pi ~= 4.712
+        exp_pos = (-shift * 5) % (2 * math.pi)  # = 3/2 pi ~= 4.712
         exp_pos_dep = -shift  # Expected position of the dependent device
 
         # Check position reported by rotational axis is within cycle
@@ -1579,7 +1576,6 @@ class TestRotationActuator(unittest.TestCase):
         # test a positive and negative offset
         offsets = [1, -1]
         for offset in offsets:
-
             _pos = self.dev_cycle.position.value[axis_name]
 
             # set mounting offset
@@ -1601,7 +1597,7 @@ class TestRotationActuator(unittest.TestCase):
                                    % self.dev_cycle._cycle, 4)
 
             # move to any position in range allowed + offset: report position without offset
-            new_pos = random.uniform(0, 2*math.pi)
+            new_pos = random.uniform(0, 2 * math.pi)
             f = self.dev_cycle.moveAbs({axis_name: new_pos})
             f.result()
             # check if position of actuator minus position requested is almost equal to mounting offset
@@ -1612,7 +1608,7 @@ class TestRotationActuator(unittest.TestCase):
 
             # supported position + offset overrunning cycle: report position without offset
             # check that position is mapped back correctly when cycle is overrun
-            new_pos = 2*math.pi
+            new_pos = 2 * math.pi
             f = self.dev_cycle.moveAbs({axis_name: new_pos})
             f.result()
             # check if position of actuator minus position requested is almost equal to mounting offset
@@ -1622,7 +1618,7 @@ class TestRotationActuator(unittest.TestCase):
                                    % self.dev_cycle._cycle, 4)
 
             # move to unsupported position: report position without offset
-            new_pos = random.uniform(2*math.pi, 7) + 0.00001  # to select pos > 2pi
+            new_pos = random.uniform(2 * math.pi, 7) + 0.00001  # to select pos > 2pi
             with self.assertRaises(ValueError):
                 f = self.dev_cycle.moveAbs({axis_name: new_pos})  # move
                 f.result()  # wait
@@ -1653,9 +1649,9 @@ class TestRotationActuator(unittest.TestCase):
         axis_name = list(self.dev_cycle.axes.keys())[0]
 
         # request to move to 3 different positions, stop after some time
-        i=1
+        i = 1
         while i <= 3:
-            pos = random.uniform(0, 2*math.pi) % self.dev_cycle._cycle
+            pos = random.uniform(0, 2 * math.pi) % self.dev_cycle._cycle
             f = self.dev_cycle.moveAbs({axis_name: pos})  # move
             i += 1
 
@@ -1679,7 +1675,7 @@ class TestRotationActuator(unittest.TestCase):
         axis_name = list(self.dev_cycle.axes.keys())[0]
 
         # move to random position, check if axis was referenced
-        new_pos = random.uniform(0, 2*math.pi)
+        new_pos = random.uniform(0, 2 * math.pi)
         f = self.dev_cycle.moveAbs({axis_name: new_pos})
         f.result()
 
@@ -1823,7 +1819,8 @@ class TestLinkedHeightActuator(unittest.TestCase):
         testing.assert_pos_almost_equal(focus.position.value, initial_foc, atol=ATOL_LENS)
 
         # Move all axes (focus won't be moved)
-        target_pos = {'x': self.target_value, 'y': self.target_value, 'z': self.target_value, 'rx': self.target_value, 'rz': self.target_value}
+        target_pos = {'x': self.target_value, 'y': self.target_value, 'z': self.target_value, 'rx': self.target_value,
+                      'rz': self.target_value}
         # Put focus in deactive, so no exception would be thrown
         f = focus.moveAbs(focus.getMetadata()[model.MD_FAV_POS_DEACTIVE])
         f.result()
@@ -2021,7 +2018,7 @@ class TestLinkedHeightActuator(unittest.TestCase):
             focus.updateMetadata({model.MD_FAV_POS_DEACTIVE: {'z': -1 * self.target_value}})
 
         with self.assertRaises(ValueError):
-            focus.updateMetadata({model.MD_FAV_POS_ACTIVE: {'z':-1 * self.target_value}})
+            focus.updateMetadata({model.MD_FAV_POS_ACTIVE: {'z': -1 * self.target_value}})
 
         focus.updateMetadata({model.MD_FAV_POS_ACTIVE: {'z': self.target_value}})
 
@@ -2167,7 +2164,8 @@ class TestLinkedAxesActuator(unittest.TestCase):
         linked_axes = self.linked_axes
         linked_axes.updateMetadata({model.MD_POS_COR: [0, 0, 0]})
         linked_axes.updateMetadata({model.MD_CALIB: [[1, 0], [0, 1], [0, 0]]})
-        testing.assert_pos_almost_equal(self.dep_stage.position.value, linked_axes.position.value,  atol=ATOL_STAGE, match_all=False)
+        testing.assert_pos_almost_equal(self.dep_stage.position.value, linked_axes.position.value, atol=ATOL_STAGE,
+                                        match_all=False)
 
     def test_move_abs(self):
         """
@@ -2337,17 +2335,17 @@ class TestDualChannelPositionSensorWithStage(unittest.TestCase):
         Construct DualChannelPositionSensor object and its dependencies.
         """
         cls.sensor = smaract.Picoscale(name="Stage Metrology",
-                                   role="metrology",
-                                   ref_on_init=False,
-                                   locator="fake",
-                                   channels={'x1': 0, 'x2': 1, 'y1': 2},
-                                   )
+                                       role="metrology",
+                                       ref_on_init=False,
+                                       locator="fake",
+                                       channels={'x1': 0, 'x2': 1, 'y1': 2},
+                                       )
         cls.stage = tmcm.TMCLController(name="test", role="test",
-                                    port="/dev/fake3",
-                                    axes=["x", "y"],
-                                    ustepsize=[5.9e-9, 5.8e-9],
-                                    rng=[[-1e-3, 1e-3], [0, 1e-3]],
-                                    refproc="Standard")
+                                        port="/dev/fake3",
+                                        axes=["x", "y"],
+                                        ustepsize=[5.9e-9, 5.8e-9],
+                                        rng=[[-1e-3, 1e-3], [0, 1e-3]],
+                                        refproc="Standard")
         cls.dev = DualChannelPositionSensor(name="TestDualChannelPositionSensor",
                                             role="stage-position",
                                             dependencies={"sensor": cls.sensor,


### PR DESCRIPTION
After moving to a position, the actual reported position might not be exactly the position requested. It’s can be because the stage has a quantized position (ie, number of steps) like the TMCM, or the stage has an encoder which keeps updating to positions very near-by.

When asking to move again to the “same” position, the FixedPositionActuator passes on the request. Usually, it has little effect, because it causes a very tiny move, which is either discarded, or very quick. However, in case of anti-backlash under it, there is 50% chance that it it thinks it’s in the “bad” direction, and causes a small step back, followed by a small step forward. That can be quite long.

=> In FixedPositionActuator, after moving to a position, remember where it arrived. Later on, when requested to move to a position, if the dependency is already at either the requested position, or the previous position, don’t do anything.