### PR TITLE
acq move: concidered ENZEL alignement position also part of the THREE_BEAMS position

### DIFF
--- a/src/odemis/acq/move.py
+++ b/src/odemis/acq/move.py
@@ -256,6 +256,7 @@ def getCurrentAlignerPositionLabel(current_pos, align):
     # exactly at POS_ACTIVE.
     # TODO: should have a POS_ACTIVE_RANGE to define the whole region
     if (_isNearPosition(current_pos, align_active, align.axes) or
+        _isNearPosition(current_pos, align_alignment, align.axes) or
         _isNearPosition(current_pos, three_beams, align.axes)
        ):
         return THREE_BEAMS


### PR DESCRIPTION
It's all very near, we cannot really distinguish the positions.
So concider them equivalent.

Also fix some test cases.