### PR TITLE
dataio tiff: numpy.int -> numpy.int32

### DIFF
--- a/src/odemis/dataio/tiff.py
+++ b/src/odemis/dataio/tiff.py
@@ -1031,7 +1031,7 @@ def _getIFDsFromOME(pxe, offset=0):
         logging.warning("All dims concidered high dims (%s = %s), but still not enough to use all %d IFDs referenced",
                         hdims, hdshape, nbifds)
 
-    imsetn = numpy.empty(hdshape, dtype=numpy.int)
+    imsetn = numpy.empty(hdshape, dtype=numpy.int32)
     imsetn[:] = -1
     for tfe in pxe.findall("TiffData"):
         # UUID: can indicate data from a different file. For now, we only load


### PR DESCRIPTION
numpy.int is deprecated (and will stop working with newer versions of
numpy).
Let's be specific, and use int32 (it should be more than enough for the
TIFF image ID).