### PR TITLE
Renaming ContrastBrightness

### DIFF
--- a/install/linux/etc/odemis.conf
+++ b/install/linux/etc/odemis.conf
@@ -1,7 +1,7 @@
 
 # Use these values during development
-#DEVPATH="$HOME/development"
-#PYTHONPATH="$DEVPATH/odemis/src/:$DEVPATH/Pyro4/src/:$PYTHONPATH"
+DEVPATH="$HOME/development"
+PYTHONPATH="$DEVPATH/odemis/src/:$DEVPATH/Pyro4/src/:$PYTHONPATH"
 LOGFILE="/var/log/odemis.log"
 LOGLEVEL=2 # 0=Warning+, 1=Info+, 2=Debug+
 

--- a/install/linux/etc/odemis.conf
+++ b/install/linux/etc/odemis.conf
@@ -1,7 +1,7 @@
 
 # Use these values during development
-DEVPATH="$HOME/development"
-PYTHONPATH="$DEVPATH/odemis/src/:$DEVPATH/Pyro4/src/:$PYTHONPATH"
+#DEVPATH="$HOME/development"
+#PYTHONPATH="$DEVPATH/odemis/src/:$DEVPATH/Pyro4/src/:$PYTHONPATH"
 LOGFILE="/var/log/odemis.log"
 LOGLEVEL=2 # 0=Warning+, 1=Info+, 2=Debug+
 

--- a/src/odemis/acq/align/delphi.py
+++ b/src/odemis/acq/align/delphi.py
@@ -1044,7 +1044,7 @@ def _DoHoleDetection(future, detector, escan, sem_stage, ebeam_focus, manual=Fal
             escan.scale.value = (1, 1)
             escan.dwellTime.value = 5.2e-06  # good enough for clear SEM image
             detector.data.subscribe(_discard_data)  # unblank the beam
-            f = detector.applyAutoContrast()
+            f = detector.applyAutoContrastBrightness()
             f.result()
             detector.data.unsubscribe(_discard_data)
             image = detector.data.get(asap=False)
@@ -1064,7 +1064,7 @@ def _DoHoleDetection(future, detector, escan, sem_stage, ebeam_focus, manual=Fal
             escan.horizontalFoV.value = 250e-06  # m
             escan.scale.value = (4, 4)
             detector.data.subscribe(_discard_data)  # unblank the beam
-            f = detector.applyAutoContrast()
+            f = detector.applyAutoContrastBrightness()
             f.result()
             detector.data.unsubscribe(_discard_data)
             future._autofocus_f = autofocus.AutoFocus(detector, escan, ebeam_focus)
@@ -1435,7 +1435,7 @@ def _DoHFWShiftFactor(future, detector, escan, logpath=None):
         zoom_f = 2  # zoom factor
 
         detector.data.subscribe(_discard_data)  # unblank the beam
-        f = detector.applyAutoContrast()
+        f = detector.applyAutoContrastBrightness()
         f.result()
         detector.data.unsubscribe(_discard_data)
 
@@ -1571,7 +1571,7 @@ def _DoResolutionShiftFactor(future, detector, escan, logpath):
         resolution_values = []
 
         detector.data.subscribe(_discard_data)  # unblank the beam
-        f = detector.applyAutoContrast()
+        f = detector.applyAutoContrastBrightness()
         f.result()
         detector.data.unsubscribe(_discard_data)
 
@@ -1744,7 +1744,7 @@ def _DoScaleShiftFactor(future, detector, escan, logpath=None):
         zoom_f = 2  # zoom factor
 
         detector.data.subscribe(_discard_data)  # unblank the beam
-        f = detector.applyAutoContrast()
+        f = detector.applyAutoContrastBrightness()
         f.result()
         detector.data.unsubscribe(_discard_data)
 

--- a/src/odemis/driver/phenom.py
+++ b/src/odemis/driver/phenom.py
@@ -756,16 +756,16 @@ class Detector(model.Detector):
         self.updateMetadata({model.MD_DET_TYPE: model.MD_DT_NORMAL})
 
     @isasync
-    def applyAutoContrast(self):
+    def applyAutoContrastBrightness(self):
         # Create ProgressiveFuture and update its state to RUNNING
         est_start = time.time() + 0.1
         f = model.ProgressiveFuture(start=est_start,
                                     end=est_start + 2)  # rough time estimation
         f._move_lock = threading.Lock()
 
-        return self._executor.submitf(f, self._applyAutoContrast, f)
+        return self._executor.submitf(f, self._applyAutoContrastBrightness, f)
 
-    def _applyAutoContrast(self, future):
+    def _applyAutoContrastBrightness(self, future):
         """
         Trigger Phenom's AutoContrast
         """

--- a/src/odemis/driver/simsem.py
+++ b/src/odemis/driver/simsem.py
@@ -379,7 +379,7 @@ class Detector(model.Detector):
         self.stop_acquire()
 
     @isasync
-    def applyAutoContrast(self):
+    def applyAutoContrastBrightness(self):
         """
         (Simulation of) run the calibration for the brightness/contrast.
         (Identical interface as the phenom driver)

--- a/src/odemis/driver/test/phenom_test.py
+++ b/src/odemis/driver/test/phenom_test.py
@@ -31,6 +31,7 @@ import threading
 import time
 import unittest
 from unittest.case import skip
+
 logging.getLogger().setLevel(logging.DEBUG)
 logging.basicConfig(format="%(asctime)s  %(levelname)-7s %(module)-15s: %(message)s")
 

--- a/src/odemis/driver/test/phenom_test.py
+++ b/src/odemis/driver/test/phenom_test.py
@@ -31,7 +31,6 @@ import threading
 import time
 import unittest
 from unittest.case import skip
-
 logging.getLogger().setLevel(logging.DEBUG)
 logging.basicConfig(format="%(asctime)s  %(levelname)-7s %(module)-15s: %(message)s")
 
@@ -514,7 +513,7 @@ class TestSEM(unittest.TestCase):
         """
         Check it's possible to apply AutoContrast
         """
-        f = self.sed.applyAutoContrast()
+        f = self.sed.applyAutoContrastBrightness()
         f.result()
 
 

--- a/src/odemis/gui/cont/settings.py
+++ b/src/odemis/gui/cont/settings.py
@@ -308,7 +308,7 @@ class SettingsController(with_metaclass(ABCMeta, object)):
         def auto_adjust(_):
             """ Call the auto contrast method on the detector if it's not already running """
             if not btn_autoadjust.up:
-                f = detector.applyAutoContrast() # TODO renaming required here?
+                f = detector.applyAutoContrastBrightness()
                 btn_autoadjust.SetLabel("Adjusting...")
                 btn_autoadjust.Disable()
                 brightness_entry.value_ctrl.Disable()

--- a/src/odemis/gui/cont/settings.py
+++ b/src/odemis/gui/cont/settings.py
@@ -308,7 +308,7 @@ class SettingsController(with_metaclass(ABCMeta, object)):
         def auto_adjust(_):
             """ Call the auto contrast method on the detector if it's not already running """
             if not btn_autoadjust.up:
-                f = detector.applyAutoContrast()
+                f = detector.applyAutoContrast() # TODO renaming required here?
                 btn_autoadjust.SetLabel("Adjusting...")
                 btn_autoadjust.Disable()
                 brightness_entry.value_ctrl.Disable()

--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -1068,7 +1068,7 @@ class SecomStreamsTab(Tab):
                 if self.curr_s.focuser.role == "ebeam-focus" and self.main_data.role == "delphi":
                     self.orig_hfw = emt.horizontalFoV.value
                     emt.horizontalFoV.value = min(self.orig_hfw, AUTOFOCUS_HFW)
-                    f = det.applyAutoContrast()
+                    f = det.applyAutoContrast() #TODO renaming required here?
                     f.result()
                     # Use the good initial focus value if known
                     init_focus = self._state_controller.good_focus

--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -1068,7 +1068,7 @@ class SecomStreamsTab(Tab):
                 if self.curr_s.focuser.role == "ebeam-focus" and self.main_data.role == "delphi":
                     self.orig_hfw = emt.horizontalFoV.value
                     emt.horizontalFoV.value = min(self.orig_hfw, AUTOFOCUS_HFW)
-                    f = det.applyAutoContrast() #TODO renaming required here?
+                    f = det.applyAutoContrastBrightness()
                     f.result()
                     # Use the good initial focus value if known
                     init_focus = self._state_controller.good_focus


### PR DESCRIPTION
The contrast brightness function is renamed to align functions in simsem and phenom with xt_client. 

Please check the two questions added as TODOs in the code.

Testing Method - Respective unit tests were run for all three of them. 
Output               - Tests ran properly for phenom and simsm(passed, ignored)
                          - one test in xt_client failed - TestMBScanner 
                          `    raise TypeError("XTtoolkit must be running to instantiate the multi-beam scanner child.")
TypeError: XTtoolkit must be running to instantiate the multi-beam scanner child.`
