### PR TITLE
Smaract driver parameter file update and testcases

### DIFF
--- a/src/odemis/driver/smaract.py
+++ b/src/odemis/driver/smaract.py
@@ -23,19 +23,22 @@ This driver supports SmarAct and SmarPod actuators, which are accessed via a C D
 provided by SmarAct. This must be installed on the system for this actuator to run. Please
 refer to the SmarAct readme for Linux installation instructions.
 '''
-from concurrent.futures import CancelledError, TimeoutError
+
 import copy
-from ctypes import *
 import logging
 import math
+import os
+import threading
+import time
+import re
+
+from ctypes import *
+from typing import Optional, Dict
 from odemis import model
 from odemis import util
 from odemis.model import CancellableFuture, CancellableThreadPoolExecutor, isasync, VigilantAttribute, roattribute
 from odemis.util import driver, RepeatingTimer, almost_equal
-import os
-import threading
-import time
-from typing import Optional, Dict
+from concurrent.futures import CancelledError, TimeoutError
 
 
 def add_coord(pos1, pos2):
@@ -2770,7 +2773,7 @@ class SA_CTLError(IOError):
 class MCS2(model.Actuator):
 
     def __init__(self, name, role, locator, ref_on_init=False, axes=None, speed=1e-3, accel=1e-3,
-                 hold_time=float('inf'), pos_deactive_after_ref=False, **kwargs):
+                 hold_time=float('inf'), pos_deactive_after_ref=False, param_file=None, **kwargs):
         """
         A driver for a SmarAct MCS2 Actuator.
         This driver uses a DLL provided by SmarAct which connects via
@@ -2849,6 +2852,19 @@ class MCS2(model.Actuator):
             raise
         logging.debug("Connected to SA_CTL Controller ID %d with %d channels", self._id.value, self._get_number_of_channels())
         model.Actuator.__init__(self, name, role, axes=axes_def, **kwargs)
+
+        # Read param_file
+        if param_file:
+            try:
+                filestream = open(param_file)
+            except Exception as ex:
+                raise ValueError("Failed to open file %s: %s" % (param_file, ex))
+            try:
+                prop_params_i32, prop_params_i64, prop_params_str = self.parse_tsv_config(filestream)
+            except Exception as ex:
+                raise ValueError("Failed to parse file %s: %s" % (param_file, ex))
+            logging.debug("Extracted param file config: %s, %s, %s", prop_params_i32, prop_params_i64, prop_params_str)
+            self.apply_config(prop_params_i32, prop_params_i64, prop_params_str)
 
         # Add metadata
         self._swVersion = self.GetFullVersionString()
@@ -2930,6 +2946,74 @@ class MCS2(model.Actuator):
                 raise ValueError("Invalid metadata, should be a coordinate dictionary but got %s." % (deactive_pos,))
         super(MCS2, self).updateMetadata(md)
 
+    # Methods below are for using and applying additional parameters through a param_file
+    def apply_config(self, prop_params_i32, prop_params_i64, prop_params_str):
+        """
+        Configure the device according to the given 'user configuration' from a specified param_file.
+        :param prop_params_i32 (dict (int, int) -> int): channel index/property code -> value of type int32
+        :param prop_params_i64 (dict (int, int) -> int): channel index/property code -> value of type int64
+        :param prop_params_str (dict (int, int) -> int): channel index/property code -> value of type str
+        """
+
+        # if type is int32 run this method for every dict item
+        for (ch, p), v in prop_params_i32.items():
+            self.SetProperty_i32(p, ch, v)
+        # if type is int64 run this method for every dict item
+        for (ch, p), v in prop_params_i64.items():
+            self.SetProperty_i64(p, ch, v)
+        # if type is str run this method for every dict item
+        for (ch, p), v in prop_params_str.items():
+            self.SetProperty_s(p, ch, v)
+
+    @staticmethod
+    def parse_tsv_config(filestream):
+        """
+        Parse a tab-separated value (.mcs2.tsv) file in the following format:
+            file header > channel_index property value # description
+            channel_index can be a (Ch) number starting from 0 this also refers to a defined channel type
+            property is a hexadecimal code representing a specific property
+            value is a hexadecimal code representing independent property ﬂags
+        filestream (File): opened filestream
+        return:
+            prop_params_i32 (dict (int, int) -> int): channel index/property code -> value (int32)
+            prop_params_i64 (dict (int, int) -> int): channel index/property code -> value (int64)
+            prop_params_str (dict (int, int) -> int): channel index/property code -> value (str)
+        """
+
+        # MCS2 property types dedicated dicts:
+        prop_params_i32 = {}
+        prop_params_i64 = {}
+        prop_params_str = {}
+
+        # read the parameters "database" the file
+        for readline in filestream:
+            # comment or empty line?
+            mc = re.match(r"\s*(#|$)", readline)
+
+            if mc:
+                logging.debug("Comment line skipped: '%s'", readline.rstrip("\n\r"))
+                continue
+            # check for a match of subsequent [number, hex, hex, str, hashed str]
+            m = re.match(r"(?P<num>[0-9]+)\t(?P<code>0x[0-9A-F]+)\t(?P<value>0x[0-9A-F]+)\t(?P<type>(I32|I64|Str))\s*(#.*)?$", readline)
+            if not m:
+                # read line is not in the correct format
+                raise ValueError("Failed to parse line '%s'" % readline.rstrip("\n\r"))
+
+            # assigned the read str value to the appropriate variables (hex will be cast to int)
+            ch_num, prop_code, set_val, typ = int(m.group("num")), int(m.group("code"), 0), int(m.group("value"), 0), m.group("type")
+
+            # check the read type and append values to the right dicts
+            if typ == "I32":
+                prop_params_i32[(ch_num, prop_code)] = set_val
+            elif typ == "I64":
+                prop_params_i64[(ch_num, prop_code)] = set_val
+            elif typ == "Str":
+                prop_params_str[(ch_num, prop_code)] = set_val
+            else:
+                raise ValueError("Unexpected line '%s'" % readline.rstrip("\n\r"))
+
+        return prop_params_i32, prop_params_i64, prop_params_str
+
     @staticmethod
     def scan():
         """
@@ -2979,6 +3063,14 @@ class MCS2(model.Actuator):
         value (int64): value to set
         """
         self.core.SA_CTL_SetProperty_i64(self._id, c_int8(idx), c_uint32(property_key), c_int64(value))
+
+    def SetProperty_s(self, property_key, idx, value):
+        """
+        property_key (int32): property key symbol
+        idx (int): channel
+        value (str): value to set
+        """
+        self.core.SA_CTL_SetProperty_s(self._id, c_int8(idx), c_uint32(property_key), value)
 
     def GetProperty_f64(self, property_key, idx):
         """
@@ -3540,6 +3632,11 @@ class FakeMCS2_DLL(object):
         self.properties[property_key.value][ch.value] = value.value
 
     def SA_CTL_SetProperty_i64(self, handle, ch, property_key, value):
+        if not property_key.value in self.properties:
+            raise SA_CTLError(SA_CTLDLL.SA_CTL_ERROR_INVALID_KEY, "error")
+        self.properties[property_key.value][ch.value] = value.value
+
+    def SA_CTL_SetProperty_s(self, handle, ch, property_key, value):
         if not property_key.value in self.properties:
             raise SA_CTLError(SA_CTLDLL.SA_CTL_ERROR_INVALID_KEY, "error")
         self.properties[property_key.value][ch.value] = value.value


### PR DESCRIPTION
The default behaviour of the SmarAct is to search for a reference mark in the positive direction, which is down (towards the sample). If the lens is in focus, this will reach very near the sample (there is a physical limit switch right before). It’s dangerous for the hardware.

=> change the referencing to start with negative direction.

Similarly to the tmcm.TMCLController, accept a (new) parameter param_file, which takes a filename as value. This file contains a list of parameters, their channel and their value.

The file extension should be .mcs2.tsv.  Similar format as for  the TMCM. Preferably, the values can be either decimal or hexadecimal (starts with 0x).

This file is read at init, and all the values are immediately set on the device. If setting some values fails, the initialisation of the driver should fail with ValueError.

Extend the code in driver/smaract.py/MCS2 . Copy as much as possible from tmcm.py/TMCLController. (see parse_tsv_config et al.)

Add a small .mcs2.tsv file to the test cases, and check they are properly applied (by adding it to the param_file option in the test cases).