### PR TITLE
Sdev 1161 rename xt client beamshift to shift

### DIFF
--- a/src/odemis/driver/scanner.py
+++ b/src/odemis/driver/scanner.py
@@ -87,7 +87,7 @@ class CompositedScanner(model.Emitter):
             self.magnification = self._external_scanner.magnification
 
         # TODO: just pick every VAs which are not yet on self?
-        for vaname in ("accelVoltage", "probeCurrent", "depthOfField", "spotSize", "beamShift"):
+        for vaname in ("accelVoltage", "probeCurrent", "depthOfField", "spotSize", "shift"):
             if model.hasVA(self._internal_scanner, vaname):
                 va = getattr(self._internal_scanner, vaname)
                 setattr(self, vaname, va)

--- a/src/odemis/driver/test/xt_client_test.py
+++ b/src/odemis/driver/test/xt_client_test.py
@@ -531,20 +531,20 @@ class TestMicroscope(unittest.TestCase):
 
     def test_set_beam_shift(self):
         """Setting the beam shift."""
-        init_beam_shift = self.scanner.beamShift.value
-        beam_shift_range = self.scanner.beamShift.range
+        init_beam_shift = self.scanner.shift.value
+        beam_shift_range = self.scanner.shift.range
         new_beam_shift_x = beam_shift_range[1][0] - 1e-6
         new_beam_shift_y = beam_shift_range[0][1] + 1e-6
-        self.scanner.beamShift.value = (new_beam_shift_x, new_beam_shift_y)
+        self.scanner.shift.value = (new_beam_shift_x, new_beam_shift_y)
         time.sleep(0.1)
-        testing.assert_tuple_almost_equal((new_beam_shift_x, new_beam_shift_y), self.scanner.beamShift.value)
+        testing.assert_tuple_almost_equal((new_beam_shift_x, new_beam_shift_y), self.scanner.shift.value)
         # Test it still works for different values.
         new_beam_shift_x = beam_shift_range[0][0] + 1e-6
         new_beam_shift_y = beam_shift_range[1][1] - 1e-6
-        self.scanner.beamShift.value = (new_beam_shift_x, new_beam_shift_y)
-        testing.assert_tuple_almost_equal((new_beam_shift_x, new_beam_shift_y), self.scanner.beamShift.value)
-        # set beamShift back to initial value
-        self.scanner.beamShift.value = init_beam_shift
+        self.scanner.shift.value = (new_beam_shift_x, new_beam_shift_y)
+        testing.assert_tuple_almost_equal((new_beam_shift_x, new_beam_shift_y), self.scanner.shift.value)
+        # set shift back to initial value
+        self.scanner.shift.value = init_beam_shift
 
     def test_contrast(self):
         """Test setting the contrast."""

--- a/src/odemis/driver/xt_client.py
+++ b/src/odemis/driver/xt_client.py
@@ -1231,7 +1231,7 @@ class Scanner(model.Emitter):
         beam_shift_info = self.parent.beam_shift_info()
         range_x = beam_shift_info["range"]["x"]
         range_y = beam_shift_info["range"]["y"]
-        self.beamShift = model.TupleContinuous(
+        self.shift = model.TupleContinuous(
             self.parent.get_beam_shift(),
             ((range_x[0], range_y[0]), (range_x[1], range_y[1])),
             cls=(int, float),
@@ -1334,9 +1334,9 @@ class Scanner(model.Emitter):
                 self.spotSize._value = spot_size
                 self.spotSize.notify(spot_size)
             beam_shift = self.parent.get_beam_shift()
-            if beam_shift != self.beamShift.value:
-                self.beamShift._value = beam_shift
-                self.beamShift.notify(beam_shift)
+            if beam_shift != self.shift.value:
+                self.shift._value = beam_shift
+                self.shift.notify(beam_shift)
             rotation = self.parent.get_rotation()
             if rotation != self.rotation.value:
                 self.rotation._value = rotation

--- a/src/odemis/gui/conf/data.py
+++ b/src/odemis/gui/conf/data.py
@@ -234,9 +234,6 @@ HW_SETTINGS_CONFIG = {
             ("scanner", {
                 "control_type": odemis.gui.CONTROL_NONE,
             }),
-            ("beamShift", {
-                "control_type": odemis.gui.CONTROL_NONE,
-            }),
         )),
     "laser-mirror":
         OrderedDict((

--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -4898,7 +4898,7 @@ class EnzelAlignTab(Tab):
         self.panel.html_alignment_doc.LoadPage(doc_path)
 
         self.panel.controls_step_size_slider.SetRange(1e-6,
-                                                      min(50e-6, abs(self._sem_stream.emitter.beamShift.range[1][0])))
+                                                      min(50e-6, abs(self._sem_stream.emitter.shift.range[1][0])))
         self.panel.controls_step_size_slider.set_position_value(10e-6)
 
         self.panel.pnl_z_align_controls.Show(False)
@@ -4927,10 +4927,10 @@ class EnzelAlignTab(Tab):
 
         :param shift (dict --> float): Relative movement of the beam shift with the axis as keys (x/y)
         """
-        beamShiftVA = self._sem_stream.emitter.beamShift
+        shiftVA = self._sem_stream.emitter.shift
         try:
             if "x" in shift:
-                beamShiftVA.value = (beamShiftVA.value[0] + shift["x"], beamShiftVA.value[1])
+                shiftVA.value = (shiftVA.value[0] + shift["x"], shiftVA.value[1])
         except IndexError:
             show_message(wx.GetApp().main_frame,
                          "Reached the limits of the beam shift, cannot move any further in x direction.",
@@ -4939,7 +4939,7 @@ class EnzelAlignTab(Tab):
 
         try:
             if "y" in shift:
-                beamShiftVA.value = (beamShiftVA.value[0], beamShiftVA.value[1] + shift["y"])
+                shiftVA.value = (shiftVA.value[0], shiftVA.value[1] + shift["y"])
         except IndexError:
             show_message(wx.GetApp().main_frame,
                          "Reached the limits of the beam shift, cannot move any further in y direction.",


### PR DESCRIPTION
Ticket: https://delmic.atlassian.net/browse/SDEV-1161

Unit tests results (ran locally):

- For [TestMicroscope](https://github.com/nandishjpatel/odemis/blob/c1fddc9b4308851f4faa2b10dbcbf096f9685988/src/odemis/driver/test/xt_client_test.py#L103), [TestMicroscopeInternal](https://github.com/nandishjpatel/odemis/blob/c1fddc9b4308851f4faa2b10dbcbf096f9685988/src/odemis/driver/test/xt_client_test.py#L596), [TestFIBScanner](https://github.com/nandishjpatel/odemis/blob/c1fddc9b4308851f4faa2b10dbcbf096f9685988/src/odemis/driver/test/xt_client_test.py#L1088), [TestDualModeMicroscope](https://github.com/nandishjpatel/odemis/blob/c1fddc9b4308851f4faa2b10dbcbf096f9685988/src/odemis/driver/test/xt_client_test.py#L1119) using [server_sim.py](https://bitbucket.org/delmic/xtlib-adapter/src/master/xtadapter/server_sim.py)

```
----------------------------------------------------------------------
Ran 61 tests in 43.519s

OK (skipped=18)
```

- For [TestMBScanner](https://github.com/nandishjpatel/odemis/blob/c1fddc9b4308851f4faa2b10dbcbf096f9685988/src/odemis/driver/test/xt_client_test.py#L1238) using [server_sim_xttoolkit.py](https://bitbucket.org/delmic/xtlib-adapter/src/master/xtadapter/server_sim_xttoolkit.py)

```
----------------------------------------------------------------------
Ran 12 tests in 57.136s

OK
```

