### PR TITLE
Add fastem support for non-rectangular in the acquisition manager.

### DIFF
--- a/src/odemis/acq/test/fastem_test.py
+++ b/src/odemis/acq/test/fastem_test.py
@@ -202,7 +202,7 @@ class TestFastEMROA(unittest.TestCase):
 
     def test_get_square_field_indices(self):
         """Check that the correct number and order of field indices is returned and that row and column are in the
-                correct order."""
+        correct order."""
         x_fields = 3
         y_fields = 2
         self.multibeam.resolution.value = (6400, 6400)  # don't change

--- a/src/odemis/acq/test/fastem_test.py
+++ b/src/odemis/acq/test/fastem_test.py
@@ -31,15 +31,15 @@ from datetime import datetime
 from unittest.mock import Mock
 
 import numpy
-from odemis.acq.acqmng import SettingsObserver
 
 import odemis
 from fastem_calibrations import configure_hw
 from odemis import model
 from odemis.acq import fastem, stream
+from odemis.acq.acqmng import SettingsObserver
 from odemis.acq.align.fastem import Calibrations
 from odemis.acq.fastem import estimate_acquisition_time, SETTINGS_SELECTION
-from odemis.util import driver, img, is_point_in_rect, testing
+from odemis.util import driver, get_polygon_bbox, img, is_point_in_rect, testing
 
 # * TEST_NOHW = 1: connected to the simulator or not connected to anything
 # * TEST_NOHW = 0: connected to the real hardware, the backend should be running
@@ -200,9 +200,9 @@ class TestFastEMROA(unittest.TestCase):
 
             self.assertAlmostEqual(estimated_roa_acq_time, roa_acq_time)
 
-    def test_calculate_field_indices(self):
+    def test_get_square_field_indices(self):
         """Check that the correct number and order of field indices is returned and that row and column are in the
-        correct order."""
+                correct order."""
         x_fields = 3
         y_fields = 2
         self.multibeam.resolution.value = (6400, 6400)  # don't change
@@ -221,13 +221,14 @@ class TestFastEMROA(unittest.TestCase):
                                self.descanner,
                                self.mppc)
 
-        expected_indices = [(0, 0), (1, 0), (2, 0), (0, 1), (1, 1), (2, 1)]  # (col, row)
+        expected_indices = [(0, 0), (1, 0), (2, 0),
+                            (0, 1), (1, 1), (2, 1)]  # (col, row)
 
-        field_indices = roa._calculate_field_indices()
+        field_indices = roa.get_square_field_indices(coordinates)
 
         self.assertListEqual(expected_indices, field_indices)
 
-    def test_calculate_field_indices_overlap(self):
+    def test_get_square_field_indices_overlap(self):
         """Check that the correct number of field indices are calculated when there is overlap between the fields."""
         x_fields = 3
         y_fields = 2
@@ -252,7 +253,7 @@ class TestFastEMROA(unittest.TestCase):
             # There are 3 fields of 8 '-' and the overlap is 2, therefore the total size is 3 * (8-2) + 2
             xmax, ymax = (field_size_x * x_fields * (1 - overlap) + field_size_x * overlap,
                           field_size_y * y_fields * (1 - overlap) + field_size_y * overlap)
-            coordinates = (xmin, ymin, xmax, ymax)  # in m
+            coordinates = (xmin, ymin, xmax - px_size_x, ymax - px_size_y)  # in m
             roa = fastem.FastEMROA(roa_name,
                                    coordinates,
                                    None,
@@ -264,17 +265,21 @@ class TestFastEMROA(unittest.TestCase):
                                    overlap)
 
             expected_indices = [(0, 0), (1, 0), (2, 0), (0, 1), (1, 1), (2, 1)]  # (col, row)
-            field_indices = roa._calculate_field_indices()
+            field_indices = roa.get_square_field_indices(coordinates)
 
             # Floating point errors can result in an extra field, which is fine.
             # Check that maximum 1 extra field index in x and 1 in y is calculated and that there are not fewer fields
             # calculated than expected.
-            self.assertLessEqual(max(field_indices)[0] - max(expected_indices)[0], 1)
-            self.assertGreaterEqual(max(field_indices)[0] - max(expected_indices)[0], 0)
-            self.assertLessEqual(max(field_indices)[1] - max(expected_indices)[1], 1)
-            self.assertGreaterEqual(max(field_indices)[1] - max(expected_indices)[1], 0)
+            exp_x_min, exp_y_min, exp_x_max, exp_y_max = get_polygon_bbox(expected_indices)
+            res_x_min, res_y_min, res_x_max, res_y_max = get_polygon_bbox(field_indices)
+            self.assertEqual(exp_x_min, res_x_min)
+            self.assertEqual(exp_y_min, res_y_min)
+            self.assertLessEqual(res_x_max - exp_x_max, 1)
+            self.assertLessEqual(res_y_max - exp_y_max, 1)
+            self.assertGreaterEqual(res_x_max - exp_x_max, 0)
+            self.assertGreaterEqual(res_y_max - exp_y_max, 0)
 
-    def test_calculate_field_indices_overlap_small_roa(self):
+    def test_get_square_field_indices_overlap_small_roa(self):
         """Check that the correct number of field indices are calculated for ROA's that are smaller than the overlap."""
         res_x, res_y = self.multibeam.resolution.value  # single field size
         px_size_x, px_size_y = self.multibeam.pixelSize.value
@@ -302,7 +307,117 @@ class TestFastEMROA(unittest.TestCase):
 
         # For very small ROA's we expect at least a single field.
         expected_indices = [(0, 0)]  # (col, row)
-        field_indices = roa._calculate_field_indices()
+        field_indices = roa.get_square_field_indices(coordinates)
+        self.assertListEqual(field_indices, expected_indices)
+
+    def test_get_poly_field_indices(self):
+        """Test that the correct indices are returned and that they are in the right order."""
+        x_fields = 5
+        y_fields = 4
+        self.multibeam.resolution.value = (6400, 6400)  # don't change
+        res_x, res_y = self.multibeam.resolution.value  # single field size
+        px_size_x, px_size_y = self.multibeam.pixelSize.value
+        xmax = res_x * px_size_x * x_fields
+        ymax = res_y * px_size_y * y_fields
+        coordinates = (0, 0, xmax, ymax)  # in m, don't change
+        polygon = [(0, 0), (ymax - px_size_y, xmax - px_size_x), (ymax - px_size_y, 0)]
+        roc_2 = fastem.FastEMROC("roc_2", coordinates)
+        roc_3 = fastem.FastEMROC("roc_3", coordinates)
+        roa_name = time.strftime("test_megafield_id-%Y-%m-%d-%H-%M-%S")
+        roa = fastem.FastEMROA(roa_name,
+                               coordinates,
+                               roc_2,
+                               roc_3,
+                               self.asm,
+                               self.multibeam,
+                               self.descanner,
+                               self.mppc)
+
+        expected_indices = [(0, 0), (1, 0),
+                            (0, 1), (1, 1), (2, 1),
+                            (0, 2), (1, 2), (2, 2), (3, 2),
+                            (0, 3), (1, 3), (2, 3), (3, 3), (4, 3)]  # (col, row)
+
+        field_indices = roa.get_poly_field_indices(polygon)
+        self.assertListEqual(expected_indices, field_indices)
+
+    def test_get_poly_field_indices_overlap(self):
+        """Test that the correct indices are returned and are in the right order with different sizes of overlap."""
+        x_fields = 5
+        y_fields = 4
+        self.multibeam.resolution.value = (6400, 6400)  # don't change
+        res_x, res_y = self.multibeam.resolution.value  # single field size
+        px_size_x, px_size_y = self.multibeam.pixelSize.value
+
+        roa_name = time.strftime("test_megafield_id-%Y-%m-%d-%H-%M-%S")
+
+        field_size_x = res_x * px_size_x
+        field_size_y = res_y * px_size_y
+
+        expected_indices = [(0, 0), (1, 0),
+                            (0, 1), (1, 1), (2, 1),
+                            (0, 2), (1, 2), (2, 2), (3, 2),
+                            (0, 3), (1, 3), (2, 3), (3, 3), (4, 3)]
+
+        for overlap in (0, 0.0625, 0.2, 0.5, 0.7):
+            xmin, ymin = (0, 0)
+            xmax, ymax = (field_size_x * x_fields * (1 - overlap) + field_size_x * overlap,
+                          field_size_y * y_fields * (1 - overlap) + field_size_y * overlap)
+            coordinates = (xmin, ymin, xmax - px_size_x, ymax - px_size_y)  # in m
+            polygon = [(ymin, xmin), (ymax - px_size_y, xmax - px_size_x), (ymax - px_size_y, xmin)]
+            roa = fastem.FastEMROA(roa_name,
+                                   coordinates,
+                                   None,
+                                   None,
+                                   self.asm,
+                                   self.multibeam,
+                                   self.descanner,
+                                   self.mppc,
+                                   overlap)
+
+            res_field_indices = roa.get_poly_field_indices(polygon)
+
+            max_extra_fields = int(1/(1-overlap))
+
+            exp_x_min, exp_y_min, exp_x_max, exp_y_max = get_polygon_bbox(expected_indices)
+            res_x_min, res_y_min, res_x_max, res_y_max = get_polygon_bbox(res_field_indices)
+            self.assertEqual(exp_x_min, res_x_min)
+            self.assertEqual(exp_y_min, res_y_min)
+            self.assertLessEqual(res_x_max - exp_x_max, max_extra_fields)
+            self.assertLessEqual(res_y_max - exp_y_max, max_extra_fields)
+            self.assertGreaterEqual(res_x_max - exp_x_max, 0)
+            self.assertGreaterEqual(res_y_max - exp_y_max, 0)
+
+    def test_get_poly_field_indices_overlap_small_roa(self):
+        """Check that the correct number of field indices are calculated for ROA's that are smaller than the overlap."""
+        res_x, res_y = self.multibeam.resolution.value  # single field size
+        px_size_x, px_size_y = self.multibeam.pixelSize.value
+        overlap = 0.2
+
+        roa_name = time.strftime("test_megafield_id-%Y-%m-%d-%H-%M-%S")
+
+        field_size_x = res_x * px_size_x
+        field_size_y = res_y * px_size_y
+        # The coordinates of the ROA in meters.
+        xmin, ymin = (0, 0)
+        # Create xmax and ymax such that they are smaller than the field_size * overlap.
+        xmax, ymax = (0.8 * field_size_x * overlap,
+                      0.8 * field_size_y * overlap)
+        coordinates = (xmin, ymin, xmax, ymax)  # in m
+        polygon = [(0, 0), (ymax - px_size_y, xmax - px_size_x), (ymax - px_size_y, 0)]
+        roa = fastem.FastEMROA(roa_name,
+                               coordinates,
+                               None,
+                               None,
+                               self.asm,
+                               self.multibeam,
+                               self.descanner,
+                               self.mppc,
+                               overlap)
+
+        # For very a small ROA only single field is expected.
+        expected_indices = [(0, 0)]  # (col, row)
+        field_indices = roa.get_poly_field_indices(polygon)
         self.assertListEqual(field_indices, expected_indices)
 
 

--- a/src/odemis/util/__init__.py
+++ b/src/odemis/util/__init__.py
@@ -397,6 +397,13 @@ def get_polygon_bbox(coordinates):
     :param coordinates: (list of nested tuples (a,b))
     :return: a_min, b_min, a_max, b_max
     """
+    if len(coordinates) <= 1:
+        raise ValueError(f"Coordinates contains {len(coordinates)} elements, two or more are required.")
+
+    for coordinate in coordinates:
+        if len(coordinate) != 2:
+            raise ValueError(f"The function only works for 2D coordinates, coordinate: {coordinate} has {len(coordinate)} dimensions.")
+
     maximum = list(map(max, zip(*coordinates)))
     minimum = list(map(min, zip(*coordinates)))
 

--- a/src/odemis/util/__init__.py
+++ b/src/odemis/util/__init__.py
@@ -389,6 +389,20 @@ def expand_rect(rect, margin):
     return minx - margin, miny - margin, maxx + margin, maxy + margin
 
 
+def get_polygon_bbox(coordinates):
+    """
+    Get the maximum and minimum values for a and b from a list of tuples
+    with shape: [(a1,b1), (a2,b2), ....., (an,bn)]
+
+    :param coordinates: (list of nested tuples (a,b))
+    :return: a_min, b_min, a_max, b_max
+    """
+    maximum = list(map(max, zip(*coordinates)))
+    minimum = list(map(min, zip(*coordinates)))
+
+    return minimum[0], minimum[1], maximum[0], maximum[1]
+
+
 def find_plot_content(xd, yd):
     """
     Locate the first leftmost non-zero value and the first rightmost non-zero

--- a/src/odemis/util/img.py
+++ b/src/odemis/util/img.py
@@ -1203,39 +1203,58 @@ def assembleZCube(images, zlevels):
         return ret
 
 
-def apply_flood_fill(array, start):
+def apply_flood_fill(input_array, start):
     """
     Flood fills a 2-Dimensional numpy array with truth values from a given start position with the 4-connected method.
     The input array contains a shape represented with truth values for the borders of the shape.
 
-    :param array: (ndarray(bool)) binary array of size mxn containing the shape to be filled
+    Example
+    --------
+    >>> input_array = numpy.array(
+        [[0, 0, 0, 0, 0, 0,],
+         [0, 0, 1, 1, 0, 0,],
+         [0, 1, 0, 0, 1, 0,],
+         [0, 1, 0, 0, 1, 0,],
+         [0, 0, 1, 1, 1, 0,],
+         [0, 0, 0, 0, 0, 0,]])
+
+    >>> apply_flood_fill(input_array, (2, 2))
+    array([[0, 0, 0, 0, 0, 0],
+           [0, 0, 1, 1, 0, 0],
+           [0, 1, 1, 1, 1, 0],
+           [0, 1, 1, 1, 1, 0],
+           [0, 0, 1, 1, 1, 0],
+           [0, 0, 0, 0, 0, 0]])
+
+
+    :param input_array: (ndarray(bool)) binary array of size MxN containing the shape to be filled
     :param start: (tuple(int, int)) position from which to start flood fill
-    :return: (ndarray(bool)) array of size mxn containing the filled shape, with filled values True
+    :return: (ndarray(bool)) array of size MxN containing the filled shape, with filled values True
     """
-    if start >= array.shape:
+    if start >= input_array.shape:
         raise ValueError(f"Start position of {start} does not lie within the array.")
 
-    array = array.copy()
-    max_area = array.shape[0] * array.shape[1]
-    queue = [start]
+    input_array = input_array.copy()
+    max_area = input_array.shape[0] * input_array.shape[1]
+    pixel_queue = [start]
     overflow_counter = 0
-    while len(queue) > 0:
+    while len(pixel_queue) > 0:
         # To prevent the possibility of an infinite loop count the number of iterations. If it is larger than the
         # total number of values in the array raise an error since this should not be possible.
         if overflow_counter > max_area:
             raise ValueError(f"Number of loop iterations is higher than maximum iterations possible ({max_area}) in "
-                             f"array of shape: {array.shape}")
-
-        row, col = queue.pop(0)  # Set the current pixel to the first element of the queue and remove it from the queue
-        if not array[row, col]:
-            array[row, col] = True  # Fill current pixel
-            if not array[max(row - 1, 0), col]:  # Check north of pixel
-                queue.append((max(row - 1, 0), col))
-            if not array[row, max(col - 1, 0)]:  # Check west of pixel
-                queue.append((row, max(col - 1, 0)))
-            if not array[min(row + 1, array.shape[0] - 1), col]:  # Check south of pixel
-                queue.append((min(row + 1, array.shape[0] - 1), col))
-            if not array[row, min(col + 1, array.shape[1] - 1)]:  # Check east of pixel
-                queue.append((row, min(col + 1, array.shape[1] - 1)))
+                             f"array of shape: {input_array.shape}")
+        # Set the current pixel to the first element of the queue and remove it from the queue
+        row, col = pixel_queue.pop(0)
+        if not input_array[row, col]:
+            input_array[row, col] = True  # Fill current pixel
+            if not input_array[max(row - 1, 0), col]:  # Check north of pixel
+                pixel_queue.append((max(row - 1, 0), col))
+            if not input_array[row, max(col - 1, 0)]:  # Check west of pixel
+                pixel_queue.append((row, max(col - 1, 0)))
+            if not input_array[min(row + 1, input_array.shape[0] - 1), col]:  # Check south of pixel
+                pixel_queue.append((min(row + 1, input_array.shape[0] - 1), col))
+            if not input_array[row, min(col + 1, input_array.shape[1] - 1)]:  # Check east of pixel
+                pixel_queue.append((row, min(col + 1, input_array.shape[1] - 1)))
         overflow_counter += 1
-    return array
+    return input_array

--- a/src/odemis/util/img.py
+++ b/src/odemis/util/img.py
@@ -1201,3 +1201,41 @@ def assembleZCube(images, zlevels):
         ret = DataArray(ret, metadata3d)
 
         return ret
+
+
+def apply_flood_fill(array, start):
+    """
+    Flood fills a 2-Dimensional numpy array with truth values from a given start position with the 4-connected method.
+    The input array contains a shape represented with truth values for the borders of the shape.
+
+    :param array: (ndarray(bool)) binary array of size mxn containing the shape to be filled
+    :param start: (tuple(int, int)) position from which to start flood fill
+    :return: (ndarray(bool)) array of size mxn containing the filled shape, with filled values True
+    """
+    if start >= array.shape:
+        raise ValueError(f"Start position of {start} does not lie within the array.")
+
+    array = array.copy()
+    max_area = array.shape[0] * array.shape[1]
+    queue = [start]
+    overflow_counter = 0
+    while len(queue) > 0:
+        # To prevent the possibility of an infinite loop count the number of iterations. If it is larger than the
+        # total number of values in the array raise an error since this should not be possible.
+        if overflow_counter > max_area:
+            raise ValueError(f"Number of loop iterations is higher than maximum iterations possible ({max_area}) in "
+                             f"array of shape: {array.shape}")
+
+        row, col = queue.pop(0)  # Set the current pixel to the first element of the queue and remove it from the queue
+        if not array[row, col]:
+            array[row, col] = True  # Fill current pixel
+            if not array[max(row - 1, 0), col]:  # Check north of pixel
+                queue.append((max(row - 1, 0), col))
+            if not array[row, max(col - 1, 0)]:  # Check west of pixel
+                queue.append((row, max(col - 1, 0)))
+            if not array[min(row + 1, array.shape[0] - 1), col]:  # Check south of pixel
+                queue.append((min(row + 1, array.shape[0] - 1), col))
+            if not array[row, min(col + 1, array.shape[1] - 1)]:  # Check east of pixel
+                queue.append((row, min(col + 1, array.shape[1] - 1)))
+        overflow_counter += 1
+    return array

--- a/src/odemis/util/test/img_test.py
+++ b/src/odemis/util/test/img_test.py
@@ -1184,18 +1184,23 @@ class TestRotateImage(unittest.TestCase):
 class TestFloodFill(unittest.TestCase):
 
     def test_standard_fill(self):
-        """Test the flood_fill as it is expected to be used"""
+        """Test the expected use of flood fill"""
         a = numpy.zeros((7, 7), dtype=bool)
         for i in range(min(a.shape)):
             a[i, i] = True
             a[-i - 1, i] = True
 
-        filled_array = img.apply_flood_fill(a, (3, 0))
+        expected_array = numpy.array([
+            [1, 0, 0, 0, 0, 0, 1],
+            [1, 1, 0, 0, 0, 1, 0],
+            [1, 1, 1, 0, 1, 0, 0],
+            [1, 1, 1, 1, 0, 0, 0],
+            [1, 1, 1, 0, 1, 0, 0],
+            [1, 1, 0, 0, 0, 1, 0],
+            [1, 0, 0, 0, 0, 0, 1]])
 
-        self.assertTrue(filled_array[3, 1])
-        self.assertFalse(filled_array[3, -1])
-        self.assertFalse(filled_array[0, 3])
-        self.assertFalse(filled_array[-1, 3])
+        filled_array = img.apply_flood_fill(a, (3, 0))
+        numpy.testing.assert_array_equal(expected_array, filled_array)
 
     def test_start_on_filled(self):
         """Check that the array stays the same after starting on an already filled position"""

--- a/src/odemis/util/test/img_test.py
+++ b/src/odemis/util/test/img_test.py
@@ -1181,6 +1181,40 @@ class TestRotateImage(unittest.TestCase):
             numpy.testing.assert_array_equal(image, rotated_img)  # The data should not change, only the metadata.
 
 
+class TestFloodFill(unittest.TestCase):
+
+    def test_standard_fill(self):
+        """Test the flood_fill as it is expected to be used"""
+        a = numpy.zeros((7, 7), dtype=bool)
+        for i in range(min(a.shape)):
+            a[i, i] = True
+            a[-i - 1, i] = True
+
+        filled_array = img.apply_flood_fill(a, (3, 0))
+
+        self.assertTrue(filled_array[3, 1])
+        self.assertFalse(filled_array[3, -1])
+        self.assertFalse(filled_array[0, 3])
+        self.assertFalse(filled_array[-1, 3])
+
+    def test_start_on_filled(self):
+        """Check that the array stays the same after starting on an already filled position"""
+        a = numpy.zeros((7, 7), dtype=int)
+        for i in range(min(a.shape)):
+            a[i, i] = True
+            a[-i - 1, i] = True
+
+        filled_array = img.apply_flood_fill(a, (3, 3))
+        numpy.testing.assert_equal(a, filled_array)
+
+    def test_out_of_range(self):
+        """Check if the function returns an error when start is out of range"""
+        a = numpy.zeros((2, 3))
+
+        with self.assertRaises(ValueError):
+            img.apply_flood_fill(a, (2, 4))
+
+
 # TODO: test guessDRange()
 
 

--- a/src/odemis/util/test/util_test.py
+++ b/src/odemis/util/test/util_test.py
@@ -543,10 +543,10 @@ class ExpandRectTestCase(unittest.TestCase):
                                                        "expanded rectangle %s" % (expanded_rect, expected_rect))
 
 
-class GetMinMaxTupleTestCase(unittest.TestCase):
+class GetPolygonBBoxTestCase(unittest.TestCase):
 
-    def test_minmax(self):
-        """Test getting the minimum and maximum values from a list of tuples"""
+    def test_poly_bbox_positive(self):
+        """Test getting the minimum and maximum values from a list of tuples with positive values"""
         values = [(2, 3), (1, 1), (2, 5), (5, 8), (0, 5), (10, 3), (0, 1)]
         min_0, min_1, max_0, max_1 = 0, 1, 10, 8
         rmin_0, rmin_1, rmax_0, rmax_1 = util.get_polygon_bbox(values)
@@ -555,6 +555,38 @@ class GetMinMaxTupleTestCase(unittest.TestCase):
         self.assertEqual(max_0, rmax_0)
         self.assertEqual(min_1, rmin_1)
         self.assertEqual(max_1, rmax_1)
+
+    def test_poly_bbox_negative(self):
+        """Test getting the minimum and maximum values from a list of tuples with negative values"""
+        values = [(-1, -3), (-1, -1), (-2, -5), (-5, -8), (0, -5), (-10, -3), (0, -1)]
+        min_0, min_1, max_0, max_1 = -10, -8, 0, -1
+        rmin_0, rmin_1, rmax_0, rmax_1 = util.get_polygon_bbox(values)
+
+        self.assertEqual(min_0, rmin_0)
+        self.assertEqual(max_0, rmax_0)
+        self.assertEqual(min_1, rmin_1)
+        self.assertEqual(max_1, rmax_1)
+
+    def test_poly_bbox_mixed(self):
+        """Test getting the minimum and maximum values from a list of tuples with positive and negative values"""
+        values = [(1, -3), (1, 1), (-2, 5), (5, 8), (0, 5), (-10, 3), (0, -1)]
+        min_0, min_1, max_0, max_1 = -10, -3, 5, 8
+        rmin_0, rmin_1, rmax_0, rmax_1 = util.get_polygon_bbox(values)
+
+        self.assertEqual(min_0, rmin_0)
+        self.assertEqual(max_0, rmax_0)
+        self.assertEqual(min_1, rmin_1)
+        self.assertEqual(max_1, rmax_1)
+
+    def test_incorrect_length(self):
+        """Test that the function raises an error when only one coordinate is given"""
+        with self.assertRaises(ValueError):
+            util.get_polygon_bbox([(0, 0)])
+
+    def test_incorrect_shape(self):
+        """Test that the function raises an error when coordinates of different shapes are given"""
+        with self.assertRaises(ValueError):
+            util.get_polygon_bbox([(0, 0), (0, 1, 2)])
 
 
 class FindPlotContentTestCase(unittest.TestCase):

--- a/src/odemis/util/test/util_test.py
+++ b/src/odemis/util/test/util_test.py
@@ -543,6 +543,20 @@ class ExpandRectTestCase(unittest.TestCase):
                                                        "expanded rectangle %s" % (expanded_rect, expected_rect))
 
 
+class GetMinMaxTupleTestCase(unittest.TestCase):
+
+    def test_minmax(self):
+        """Test getting the minimum and maximum values from a list of tuples"""
+        values = [(2, 3), (1, 1), (2, 5), (5, 8), (0, 5), (10, 3), (0, 1)]
+        min_0, min_1, max_0, max_1 = 0, 1, 10, 8
+        rmin_0, rmin_1, rmax_0, rmax_1 = util.get_polygon_bbox(values)
+
+        self.assertEqual(min_0, rmin_0)
+        self.assertEqual(max_0, rmax_0)
+        self.assertEqual(min_1, rmin_1)
+        self.assertEqual(max_1, rmax_1)
+
+
 class FindPlotContentTestCase(unittest.TestCase):
 
     def test_find_plot_content(self):


### PR DESCRIPTION
Add the functionality to be able to acquire non-rectangular or rotated rectangular regions of acquisition (ROA's). For now the previous method is still used for acquisition since the GUI still requires compatibility. Two utility functions were added for flood filling a ndarray, which is used for finding the inside of the polygonal ROA's and for finding the bounding box of a set of polygon coordinates.