### PR TITLE
fix syntax errors in errors being raised in andorcam3 and xt_client

### DIFF
--- a/src/odemis/driver/andorcam3.py
+++ b/src/odemis/driver/andorcam3.py
@@ -270,7 +270,7 @@ class AndorCam3(model.DigitalCamera):
         else:
             max_res = tuple(max_res)
         if not all(1 <= mr <= r for mr, r in zip(max_res, sensor_res_user)):
-            raise ValueError("max_res has to be between 1, 1 and %s, but got %s", sensor_res_user, max_res)
+            raise ValueError("max_res has to be between 1, 1 and %s, but got %s" % sensor_res_user, max_res)
         max_res_hw = self._transposeSizeFromUser(max_res)
 
         self._metadata[model.MD_SENSOR_SIZE] = sensor_res_user

--- a/src/odemis/driver/xt_client.py
+++ b/src/odemis/driver/xt_client.py
@@ -1551,7 +1551,7 @@ class FibScanner(model.Emitter):
             self.parent.set_scan_mode("full_frame")
             current_mode = self.parent.get_scan_mode()
             if current_mode != "full_frame":
-                raise HwError("Couldn't set full_frame as scan mode on the XT client mode. Current mode is: %s",
+                raise HwError("Couldn't set full_frame as scan mode on the XT client mode. Current mode is: %s" %
                               current_mode)
 
     def finishScan(self):


### PR DESCRIPTION
In two places the errors were raised with a comment like this raise Error("comment %s", value), however this is not the correct syntax for raising errors and will not put the value after the comment.