### PR TITLE
runtests update to only show the short test summary info in the test …

### DIFF
--- a/util/pytest_log_filter.py
+++ b/util/pytest_log_filter.py
@@ -34,7 +34,9 @@ def filter_test_log(log_txt, filter_type='summary'):
     If the output log is too long the middle part of the logged is not returned.
 
     :param log_txt: (str) String with the log of a single test file.
-    :return (str): filtered log, returns None if there is nothing interesting in log_txt
+    :param filter_type: (str) The type of message that we want to filter out. Optional, default 'summary'.
+        'summary' returns the short test summary output, and 'warning' returns the warnings summary.
+    :return: (str) filtered log, returns None if there is nothing interesting in log_txt
 
     Example of filtering:
     This function expects a pytest test report of single test file as input, a string such as the example below:

--- a/util/pytest_log_filter.py
+++ b/util/pytest_log_filter.py
@@ -27,7 +27,7 @@ import re
 import sys
 
 
-def filter_test_log(log_txt):
+def filter_test_log(log_txt, filter_type='summary'):
     """
     Filters a log file to only include the parts with a failure warning etc.
     Text regarding progress and passed tests are excluded.
@@ -68,33 +68,26 @@ def filter_test_log(log_txt):
     For a full test report only the short summary, failures, errors etc. are of interest, therefore only this part is
     outputted, the rest is filtered. An example of such an output string is the following example:
 
-        =========================== short test summary info ============================
+        Running /home/testing/development/odemis/src/odemis/gui/test/comp_canvas_test.py:
         FAIL comp_canvas_test.py::TestDblMicroscopeCanvas::test_pyramidal_3x2
         FAIL comp_canvas_test.py::TestDblMicroscopeCanvas::test_pyramidal_one_tile
         FAIL comp_canvas_test.py::TestDblMicroscopeCanvas::test_pyramidal_zoom
 
-        =================================== FAILURES ===================================
-        /home/kleijwegt/development/odemis/src/odemis/gui/test/comp_canvas_test.py:742: AssertionError: Tuples differ: (0, 128, 127) != (0, 76, 179)
-        /home/kleijwegt/development/odemis/src/odemis/gui/test/comp_canvas_test.py:501: AssertionError: Tuples differ: (0, 128, 127) != (0, 76, 179)
-        /home/kleijwegt/development/odemis/src/odemis/gui/test/comp_canvas_test.py:604: AssertionError: Tuples differ: (0, 127, 128) != (0, 179, 76)
-        ====================== 3 failed, 6 passed in 7.43 seconds ======================
-
     """
+    if filter_type not in ['summary', 'warning']:
+        raise ValueError(f"filter_type must be 'summary' or 'warning' not {filter_type}")
+    filter_types = {"summary": "short test summary info",
+                    "warning": "warnings summary"}
+
     # Filter to only get the usefull parts of the test report
-    test_results = re.search("\n===.*(short test|FAILURES|ERRORS|warnings)(.+?)((.|\n)*)==", log_txt)
+    test_results = re.search("(?s)(?<=" + re.escape(filter_types[filter_type]) + ").+?(?=\n{1,2}=)", log_txt)
     test_results = test_results.group() if test_results else ""  # Can only group if there is something to group
     test_results = test_results.lstrip("\n")  # Remove preceding empty lines
     # Only display when there is more to tell than just passed test cases (meaning failures, warning etc.)
     if "\n" in test_results:  # Only a message with multiple lines contains interesting information.
-        if len(test_results) > 2000:
-            test_results = test_results.split("\n")
-            # Cut out the middle part of the log and leave the first and last 20 lines.
-            test_results = "\n".join(test_results[:20]) + \
-                           "\n\n \t--The middle part of the logging message is not displayed," \
-                           " because it is too long for the default summary report. -- \n\n" + \
-                           "\n".join(test_results[-20:]) + \
-                           "\n \t--Logging message is too long for the default summary report, " \
-                           "the middle part is not displayed -- \n\n"
+        test_results = test_results.split("\n")[1:]  # skip the first line
+        test_results.insert(0, log_txt.split("\n")[0])  # start with the full test path
+        test_results = "\n".join(test_results) + "\n"  # join the results into a single string and add an empty line
     else:
         test_results = None
     return test_results
@@ -104,6 +97,7 @@ if __name__ == "__main__":
     # Run with as first argument the path to a log txt file of a single test file.
     with open(sys.argv[1]) as f:
         log_txt = f.read()
-    output = filter_test_log(log_txt)
+
+    output = filter_test_log(log_txt, sys.argv[2])
     if output:
         print(output)

--- a/util/test/test_input_pytest_log_filter_18_04.txt
+++ b/util/test/test_input_pytest_log_filter_18_04.txt
@@ -133,5 +133,15 @@ fastem_conf_test.py:54: in setUpClass
 ../../util/test.py:108: in run_backend
     raise IOError("Backend still starting after %d s" % (timeout,))
 E   OSError: Backend still starting after 30 s
+=============================== warnings summary ===============================
+src/odemis/acq/align/test/delphi_test.py::TestCalibration::test_align_offset
+  /usr/lib/python3/dist-packages/numpy/core/_methods.py:135: RuntimeWarning: Degrees of freedom <= 0 for slice
+    keepdims=keepdims)
+  /usr/lib/python3/dist-packages/numpy/core/_methods.py:105: RuntimeWarning: invalid value encountered in true_divide
+    arrmean, rcount, out=arrmean, casting='unsafe', subok=False)
+  /usr/lib/python3/dist-packages/numpy/core/_methods.py:125: RuntimeWarning: invalid value encountered in true_divide
+    ret, rcount, out=ret, casting='unsafe', subok=False)
+
+-- Docs: http://doc.pytest.org/en/latest/warnings.html
 =========================== 3 error in 34.80 seconds ===========================
 /home/testing/development/odemis/src/odemis/acq/test/fastem_conf_test.py returned 1

--- a/util/test/test_input_pytest_log_filter_20_04.txt
+++ b/util/test/test_input_pytest_log_filter_20_04.txt
@@ -1,4 +1,3 @@
-/home/testing/development/odemis/src/odemis/acq/align/test/shift_test.py returned 0
 Running /home/testing/development/odemis/src/odemis/acq/align/test/keypoint_test.py:
 ============================= test session starts ==============================
 platform linux -- Python 3.8.10, pytest-4.6.9, py-1.8.1, pluggy-0.13.0 -- /usr/bin/python3

--- a/util/test/test_input_pytest_log_filter_20_04.txt
+++ b/util/test/test_input_pytest_log_filter_20_04.txt
@@ -65,6 +65,12 @@ DEBUG    root:keypoint.py:99 Using feature detector ORB
 DEBUG    root:keypoint.py:104 Found 130 and 236 keypoints
 DEBUG    root:keypoint.py:125 Found 130 matches and 6 good ones
 DEBUG    root:keypoint_test.py:119 Computed metadata = {'Centre position': (-0.0005086268780434295, -0.00036049255362293457), 'Pixel size': (6.228309738084018e-06, 9.289514065255769e-06), 'Rotation': 0.31142635014535613, 'Shear': -1364.2415444658388}
+=============================== warnings summary ===============================
+src/odemis/odemisd/test/main_test.py::TestCommandLine::test_error_instantiate
+  /usr/lib/python3/dist-packages/Pyro4/socketserver/threadpoolserver.py:49: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
+    log.warn("error during connect: %s", x)
+
+-- Docs: https://docs.pytest.org/en/latest/warnings.html
 =========================== short test summary info ============================
 FAILED keypoint_test.py::TestKeypoint::test_image_pair - AssertionError: 
 ====================== 1 failed, 2 passed in 9.17 seconds ======================

--- a/util/test/test_pytest_log_filter.py
+++ b/util/test/test_pytest_log_filter.py
@@ -8,21 +8,37 @@ class TestFilterTestLog(unittest.TestCase):
     Test on the filter_test_log function
     """
 
-    def test_sample_input_ubuntu_18_04(self):
+    def test_sample_input_ubuntu_18_04_summary(self):
         """Test that the logs are filtered correctly on Ubuntu 18.04"""
         with open("test_input_pytest_log_filter_18_04.txt") as f:
             log_txt = f.read()
-        filtered_log = filter_test_log(log_txt)
+        filtered_log = filter_test_log(log_txt, 'summary')
         self.assertEqual(5, len(filtered_log.split("\n")))
-        self.assertTrue(filtered_log.startswith("Running /home/testing"))
+        self.assertTrue(filtered_log.startswith("Running "))
 
-    def test_sample_input_ubuntu_20_04(self):
+    def test_sample_input_ubuntu_18_04_warning(self):
+        """Test that the logs are filtered correctly on Ubuntu 18.04"""
+        with open("test_input_pytest_log_filter_18_04.txt") as f:
+            log_txt = f.read()
+        filtered_log = filter_test_log(log_txt, 'warning')
+        self.assertEqual(11, len(filtered_log.split("\n")))
+        self.assertTrue(filtered_log.startswith("Running "))
+
+    def test_sample_input_ubuntu_20_04_summary(self):
         """Test that the logs are filtered correctly on Ubuntu 20.04"""
         with open("test_input_pytest_log_filter_20_04.txt") as f:
             log_txt = f.read()
-        filtered_log = filter_test_log(log_txt)
+        filtered_log = filter_test_log(log_txt, 'summary')
         self.assertEqual(3, len(filtered_log.split("\n")))
-        self.assertTrue(filtered_log.startswith("Running /home/testing"))
+        self.assertTrue(filtered_log.startswith("Running "))
+
+    def test_sample_input_ubuntu_20_04_warning(self):
+        """Test that the logs are filtered correctly on Ubuntu 20.04"""
+        with open("test_input_pytest_log_filter_20_04.txt") as f:
+            log_txt = f.read()
+        filtered_log = filter_test_log(log_txt, 'warning')
+        self.assertEqual(7, len(filtered_log.split("\n")))
+        self.assertTrue(filtered_log.startswith("Running "))
 
     def test_sample_empty_str(self):
         """Test that the logs are filtered correctly and the size is reduced for an empty string"""

--- a/util/test/test_pytest_log_filter.py
+++ b/util/test/test_pytest_log_filter.py
@@ -9,20 +9,20 @@ class TestFilterTestLog(unittest.TestCase):
     """
 
     def test_sample_input_ubuntu_18_04(self):
-        """Test that the logs are filtered correctly and the size is reduced for a too long message on Ubuntu 18.04"""
+        """Test that the logs are filtered correctly on Ubuntu 18.04"""
         with open("test_input_pytest_log_filter_18_04.txt") as f:
             log_txt = f.read()
         filtered_log = filter_test_log(log_txt)
-        self.assertEqual(46, len(filtered_log.split("\n")))
-        self.assertTrue("Logging message is too long" in filtered_log)
+        self.assertEqual(5, len(filtered_log.split("\n")))
+        self.assertTrue(filtered_log.startswith("Running /home/testing"))
 
     def test_sample_input_ubuntu_20_04(self):
-        """Test that the logs are filtered correctly and the size is reduced for a too long message on Ubuntu 20.04"""
+        """Test that the logs are filtered correctly on Ubuntu 20.04"""
         with open("test_input_pytest_log_filter_20_04.txt") as f:
             log_txt = f.read()
         filtered_log = filter_test_log(log_txt)
-        self.assertEqual(46, len(filtered_log.split("\n")))
-        self.assertTrue("Logging message is too long" in filtered_log)
+        self.assertEqual(3, len(filtered_log.split("\n")))
+        self.assertTrue(filtered_log.startswith("Running /home/testing"))
 
     def test_sample_empty_str(self):
         """Test that the logs are filtered correctly and the size is reduced for an empty string"""


### PR DESCRIPTION
…summary file

The test summary used to show anything accept the passed test cases. Because there are a lot of warnings and logs the test summary per module was often more than 40 lines long and then the middle part was cut out. This resulted in some of the failures being cut out of the summary as well. From now on we only show the short test summary in the summary file. This contains one line per failed test case. There is no cutting in the summary anymore, so even if there are more than 40 fails,they will still all be shown. The summary for each test module starts with 'Running ....', with the filepath of the test module on the dots.

The example test output from ubuntu 20.04 started with the wrong line, so that line was removed.