### PR TITLE
Sdev 1181 implement updating xtadapter from ubuntu to windows

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -64,6 +64,8 @@ Depends: ${shlibs:Depends},
 # On Linux, uses GObject Interaction to map the GUI to the desktop launcher. It will run if it's not present.
          python3-gi,
          python3-requests,
+# Needed for xtadapter update notification feature
+         notification-daemon,
 Suggests: imagej
 Description: Open Delmic Microscope Software
  Odemis is the acquisition software for the Delmic microscopes. In particular,

--- a/src/odemis/driver/test/xt_client_test.py
+++ b/src/odemis/driver/test/xt_client_test.py
@@ -615,20 +615,6 @@ class TestMicroscopeInternal(unittest.TestCase):
             self.skipTest("Chamber needs to be in vacuum, please pump.")
         self.xt_type = "xttoolkit" if "xttoolkit" in self.microscope.swVersion.lower() else "xtlib"
 
-    def test_get_value_from_software_version(self):
-        """Test get current adapter version from software version"""
-        sw_version = "xt: 1.1.1; xtadapter: 1.2.1; bitness: 32bit"
-        version = self.microscope.get_value_from_software_version("xtadapter", sw_version)
-        self.assertEqual(version, "1.2.1")
-
-        sw_version = "xt: 1.1.1; xtadapter: 11.2.1; bitness: 32bit; xttoolkit"
-        version = self.microscope.get_value_from_software_version("xtadapter", sw_version)
-        self.assertEqual(version, "11.2.1")
-
-        sw_version = "xt: 1.1.1; xtadapter: 11.2.1; bitness: 32bit; xttoolkit"
-        bitness = self.microscope.get_value_from_software_version("bitness", sw_version)
-        self.assertEqual(bitness, "32bit")
-
     def test_acquisition(self):
         """Test acquiring an image."""
         image = self.microscope.get_latest_image(channel_name='electron1')

--- a/src/odemis/driver/test/xt_client_test.py
+++ b/src/odemis/driver/test/xt_client_test.py
@@ -1490,6 +1490,8 @@ class TestCheckLatestPackage(unittest.TestCase):
 
     def setUp(self):
         self.dir = "/tmp/"
+        # check_latest_package() expects a package folder to contain only one exe file
+        # Create the below list to test the correctness
         self.dir_names = [
             "delmic-fastem-xtadapter-64bit-v1.11.2",    # has 1 .exe file
             "delmic-xtadapter-32bit-v1.11.2",           # has 1 .exe file
@@ -1499,12 +1501,11 @@ class TestCheckLatestPackage(unittest.TestCase):
             "delmic-xtadapter-32bit-v3.11.2",           # has 2 .exe file
         ]
         for dir_name in self.dir_names:
-            if not os.path.isdir(os.path.join(self.dir, dir_name)):
-                os.makedirs(os.path.join(self.dir, dir_name))
-            if "2.11.2" not in dir_name:
+            os.makedirs(os.path.join(self.dir, dir_name), exist_ok=True)
+            if "2.11.2" not in dir_name:    # create one exe for packages without version 2.11.2
                 f1 = open(os.path.join(self.dir, dir_name, "test1.exe"), "w")
                 f1.close()
-                if "3.11.2" in dir_name:
+                if "3.11.2" in dir_name:    # create second exe only for packages having version 3.11.2
                     f2 = open(os.path.join(self.dir, dir_name, "test2.exe"), "w")
                     f2.close()
 

--- a/src/odemis/driver/test/xt_client_test.py
+++ b/src/odemis/driver/test/xt_client_test.py
@@ -1491,18 +1491,29 @@ class TestCheckLatestPackage(unittest.TestCase):
     def setUp(self):
         self.dir = "/tmp/"
         self.dir_names = [
-            "delmic-fastem-xtadapter-64bit-v1.11.2",
-            "delmic-xtadapter-32bit-v1.11.2",
+            "delmic-fastem-xtadapter-64bit-v1.11.2",    # has 1 .exe file
+            "delmic-xtadapter-32bit-v1.11.2",           # has 1 .exe file
+            "delmic-fastem-xtadapter-64bit-v2.11.2",    # has 0 .exe file
+            "delmic-xtadapter-32bit-v2.11.2",           # has 0 .exe file
+            "delmic-fastem-xtadapter-64bit-v3.11.2",    # has 2 .exe file
+            "delmic-xtadapter-32bit-v3.11.2",           # has 2 .exe file
         ]
         for dir_name in self.dir_names:
             if not os.path.isdir(os.path.join(self.dir, dir_name)):
                 os.makedirs(os.path.join(self.dir, dir_name))
+            if "2.11.2" not in dir_name:
+                f1 = open(os.path.join(self.dir, dir_name, "test1.exe"), "w")
+                f1.close()
+                if "3.11.2" in dir_name:
+                    f2 = open(os.path.join(self.dir, dir_name, "test2.exe"), "w")
+                    f2.close()
+
         self.file_names = [
             "delmic-xtadapter-32bit-v1.11.2-dev.zip",
             "delmic-xtadapter-32bit-v1.11.2-dev.exe",
         ]
         for file_name in self.file_names:
-            f = open(self.dir + file_name, "w")
+            f = open(os.path.join(self.dir, file_name), "w")
             f.close()
 
     def tearDown(self):
@@ -1526,7 +1537,7 @@ class TestCheckLatestPackage(unittest.TestCase):
             bitness=bitness,
             is_zip=is_zip,
         )
-        self.assertIsNone(pkg.version)
+        self.assertIsNone(pkg)
 
         # current_version < latest version
         current_version = "1.11.1"
@@ -1554,7 +1565,7 @@ class TestCheckLatestPackage(unittest.TestCase):
             bitness=bitness,
             is_zip=is_zip,
         )
-        self.assertIsNone(pkg.version)
+        self.assertIsNone(pkg)
 
     def test_check_latest_package_adapter_parameter(self):
 
@@ -1598,7 +1609,7 @@ class TestCheckLatestPackage(unittest.TestCase):
             bitness=bitness,
             is_zip=is_zip,
         )
-        self.assertIsNone(pkg.adapter)
+        self.assertIsNone(pkg)
 
     def test_check_latest_package_bitness_parameter(self):
 
@@ -1642,7 +1653,7 @@ class TestCheckLatestPackage(unittest.TestCase):
             bitness=bitness,
             is_zip=is_zip,
         )
-        self.assertIsNone(pkg.bitness)
+        self.assertIsNone(pkg)
 
         # adapter: fastem-xtadapter, bitness: 32bit (not available)
         current_version = "1.11.1"
@@ -1656,7 +1667,7 @@ class TestCheckLatestPackage(unittest.TestCase):
             bitness=bitness,
             is_zip=is_zip,
         )
-        self.assertIsNone(pkg.bitness)
+        self.assertIsNone(pkg)
 
     def test_check_latest_package_zip_parameter(self):
 
@@ -1714,7 +1725,7 @@ class TestCheckLatestPackage(unittest.TestCase):
             bitness=bitness,
             is_zip=is_zip,
         )
-        self.assertIsNone(pkg.name)
+        self.assertIsNone(pkg)
 
 
 if __name__ == '__main__':

--- a/src/odemis/driver/test/xt_client_test.py
+++ b/src/odemis/driver/test/xt_client_test.py
@@ -615,15 +615,19 @@ class TestMicroscopeInternal(unittest.TestCase):
             self.skipTest("Chamber needs to be in vacuum, please pump.")
         self.xt_type = "xttoolkit" if "xttoolkit" in self.microscope.swVersion.lower() else "xtlib"
 
-    def test_get_current_version(self):
+    def test_get_value_from_software_version(self):
         """Test get current adapter version from software version"""
-        sw_version = "xt: 1.1.1; xtadapter: 1.2.1"
-        version = self.microscope.get_current_version(sw_version)
+        sw_version = "xt: 1.1.1; xtadapter: 1.2.1; bitness: 32bit"
+        version = self.microscope.get_value_from_software_version("xtadapter", sw_version)
         self.assertEqual(version, "1.2.1")
 
-        sw_version = "xt: 1.1.1; xtadapter: 11.2.1; xttoolkit"
-        version = self.microscope.get_current_version(sw_version)
+        sw_version = "xt: 1.1.1; xtadapter: 11.2.1; bitness: 32bit; xttoolkit"
+        version = self.microscope.get_value_from_software_version("xtadapter", sw_version)
         self.assertEqual(version, "11.2.1")
+
+        sw_version = "xt: 1.1.1; xtadapter: 11.2.1; bitness: 32bit; xttoolkit"
+        bitness = self.microscope.get_value_from_software_version("bitness", sw_version)
+        self.assertEqual(bitness, "32bit")
 
     def test_acquisition(self):
         """Test acquiring an image."""
@@ -1493,7 +1497,10 @@ class TestCheckLatestPackage(unittest.TestCase):
         for dir_name in self.dir_names:
             if not os.path.isdir(os.path.join(self.dir, dir_name)):
                 os.makedirs(os.path.join(self.dir, dir_name))
-        self.file_names = ["delmic-xtadapter-32bit-v1.11.2-dev.zip"]
+        self.file_names = [
+            "delmic-xtadapter-32bit-v1.11.2-dev.zip",
+            "delmic-xtadapter-32bit-v1.11.2-dev.exe",
+        ]
         for file_name in self.file_names:
             f = open(self.dir + file_name, "w")
             f.close()

--- a/src/odemis/driver/xt_client.py
+++ b/src/odemis/driver/xt_client.py
@@ -254,12 +254,13 @@ class SEM(model.HwComponent):
                     data = f.read()
                     self.transfer_latest_package(data)
                     f.close()
-                    notify2.init("odemis:driver:xt_client")
+                    notify2.init("odemis.driver.xt_client")
                     update = notify2.Notification(
-                        "Update Delmic XT Adapter", "Newer version {} is available on Thermo Fisher Windows PC."
-                        " Please first safety close Odemis and Delmic XT Adapter and then restart the Delmic XT"
-                        " Adapter to install it.".format(package.version))
-                    update.set_urgency(notify2.URGENCY_CRITICAL)
+                        "Update Delmic XT Adapter", "Newer version {} is available on Thermo Fisher Windows PC.\n\n"
+                        "How to update?\n\n1. Safety close Odemis and Delmic XT Adapter.\n2. Restart the Delmic XT Adapter "
+                        "to install it.".format(package.version))
+                    update.set_urgency(notify2.URGENCY_NORMAL)
+                    update.set_timeout(10000)    # 10 seconds
                     update.show()
         except Exception as err:
             logging.exception(err)

--- a/src/odemis/driver/xt_client.py
+++ b/src/odemis/driver/xt_client.py
@@ -255,6 +255,7 @@ class SEM(model.HwComponent):
             if package is not None:
                 zip_file = zipfile.ZipFile(package.path)
                 ret = zip_file.testzip()
+                zip_file.close()
                 if ret is None:
                     # Open the package's zip file as bytes and transfer them
                     with open(package.path, mode="rb") as f:

--- a/src/odemis/driver/xt_client.py
+++ b/src/odemis/driver/xt_client.py
@@ -344,7 +344,7 @@ class SEM(model.HwComponent):
                     notify2.init(__name__)
                     update = notify2.Notification(
                         "Update Delmic XT Adapter", "Newer version {} is available on ThermoFisher Support PC.\n\n"
-                        "How to update?\n\n1. Safely close Odemis (full stop) and Delmic XT Adapter.\n2. Restart the Delmic XT Adapter "
+                        "How to update?\n\n1. Full stop Odemis and close Delmic XT Adapter.\n2. Restart the Delmic XT Adapter "
                         "to install it.".format(package.version))
                     update.set_urgency(notify2.URGENCY_NORMAL)
                     update.set_timeout(10000)    # 10 seconds

--- a/src/odemis/driver/xt_client.py
+++ b/src/odemis/driver/xt_client.py
@@ -266,7 +266,7 @@ class SEM(model.HwComponent):
                         notify2.init("odemis.driver.xt_client")
                         update = notify2.Notification(
                             "Update Delmic XT Adapter", "Newer version {} is available on Thermo Fisher Windows PC.\n\n"
-                            "How to update?\n\n1. Safety close Odemis and Delmic XT Adapter.\n2. Restart the Delmic XT Adapter "
+                            "How to update?\n\n1. Safely close Odemis and Delmic XT Adapter.\n2. Restart the Delmic XT Adapter "
                             "to install it.".format(package.version))
                         update.set_urgency(notify2.URGENCY_NORMAL)
                         update.set_timeout(10000)    # 10 seconds

--- a/src/odemis/driver/xt_client.py
+++ b/src/odemis/driver/xt_client.py
@@ -181,13 +181,14 @@ def check_latest_package(
                 # Filter using adapter type and bitness
                 if bitness == package.bitness and adapter == package.adapter:
                     version_package[package.version] = package
+        # Check if any version is newer than the current one
         versions = list(version_package)
-        if len(versions):
-            # Sort the available versions in reverse order i.e. the latest version is the first element
-            versions.sort(key=lambda s: [int(u) for u in s.split(".")], reverse=True)
-            if current_version < versions[0]:
-                logging.info("The latest version is {}.\n".format(versions[0]))
-                latest_package = version_package[versions[0]]
+        if versions:
+            # Find the latest version
+            latest_version = max(versions, key=lambda s: [int(u) for u in s.split(".")])
+            if current_version < latest_version:
+                logging.info("The latest version is {}.\n".format(latest_version))
+                latest_package = version_package[latest_version]
                 if "-dev" in latest_package.name:
                     logging.warning(
                         "{} is a development version.\n".format(latest_package.name)
@@ -341,7 +342,8 @@ class SEM(model.HwComponent):
                     with open(package.path, mode="rb") as f:
                         data = f.read()
                     self.transfer_latest_package(data)
-                    notify2.init(__name__)
+                    # Notify the user that a newer xtadpater version is available
+                    notify2.init("Odemis")
                     update = notify2.Notification(
                         "Update Delmic XT Adapter", "Newer version {} is available on ThermoFisher Support PC.\n\n"
                         "How to update?\n\n1. Full stop Odemis and close Delmic XT Adapter.\n2. Restart the Delmic XT Adapter "

--- a/src/odemis/driver/xt_client.py
+++ b/src/odemis/driver/xt_client.py
@@ -270,7 +270,7 @@ class SEM(model.HwComponent):
                         update.set_timeout(10000)    # 10 seconds
                         update.show()
                 else:
-                    logging.warning("{} is a bad file in {} not tranferring it.".format(ret, package.path))
+                    logging.warning("{} is a bad file in {} not tranferring latest package.".format(ret, package.path))
         except Exception as err:
             logging.exception(err)
 

--- a/src/odemis/driver/xt_client.py
+++ b/src/odemis/driver/xt_client.py
@@ -27,6 +27,7 @@ import queue
 import re
 import threading
 import time
+from typing import Optional
 import zipfile
 from concurrent.futures import CancelledError
 
@@ -133,7 +134,7 @@ class Package(object):
 
 def check_latest_package(
     directory: str, current_version: str, adapter: str, bitness: str, is_zip: bool
-) -> Package:
+) -> Optional[Package]:
     """
     Check if a latest xtadapter package is available.
 

--- a/src/odemis/driver/xt_client.py
+++ b/src/odemis/driver/xt_client.py
@@ -234,6 +234,7 @@ class SEM(model.HwComponent):
         # The transferred package will be a zip file in the form of bytes
         try:
             # xtadapter debian package installation directory which contains xtadapter's zip files
+            package = None
             install_dir = "/usr/share/xtadapter"
             bitness = self.get_value_from_software_version("bitness", self._swVersion)
             adapter = "xtadapter"


### PR DESCRIPTION
This PR should be reviewed together with 
- https://bitbucket.org/delmic/xtlib-adapter/pull-requests/70
- https://bitbucket.org/delmic/ubuntu-delmic/pull-requests/5

Flow (xtadapter release management):
- [xt_client line](https://github.com/nandishjpatel/odemis/blob/e864631d800198517d7aff99fc379242fbaeb095/src/odemis/driver/xt_client.py#L217): get the xtadapter version, type, bitness from the running application on Windows PC
- [xt_client line](https://github.com/nandishjpatel/odemis/blob/e864631d800198517d7aff99fc379242fbaeb095/src/odemis/driver/xt_client.py#L224): check if a newer package is available under `/usr/share/xtadapter` i.e. the directory where the zip files will be made available from the xtadapater debian package
- [xt_client line](https://github.com/nandishjpatel/odemis/blob/e864631d800198517d7aff99fc379242fbaeb095/src/odemis/driver/xt_client.py#L231): if a newer package (zip file) is available transfer it in the form of bytes
- xt_client: [Done](https://github.com/nandishjpatel/odemis/blob/8d89e80b9629ac29713b9be0358d1e3912444a58/src/odemis/driver/xt_client.py#L267) a pop-up starting a newer version in available, please safety restart the xtadapter application on the Windows PC to install it
- [xt_adapter:base_adapter](https://bitbucket.org/delmic/xtlib-adapter/src/58c99cd1ebade55e9625ebd43eda935e4890e497/xtadapter/base_adapter.py#lines-1441) : from the bytes, create a zipfile in memory and extract all contents of the zipfile in `Downloads` directory of the Windows PC
- [xt_adapter:server](https://bitbucket.org/delmic/xtlib-adapter/src/58c99cd1ebade55e9625ebd43eda935e4890e497/xtadapter/server.py#lines-195) : when the user will restart the xtadpater application, a message box pop-us. If the user would like to update the application then the latest package installer will start
 