### PR TITLE
Driver ueye crop image data

### DIFF
--- a/src/odemis/driver/test/cam_test_abs.py
+++ b/src/odemis/driver/test/cam_test_abs.py
@@ -448,7 +448,8 @@ class VirtualTestCam(with_metaclass(ABCMeta, object)):
 
         # ask for the whole image
         self.size = (self.camera.shape[0] // 2, self.camera.shape[1] // 2)
-        self.camera.resolution.value = self.size
+        if not self.camera.resolution.readonly:
+            self.camera.resolution.value = self.size
         exposure = 0.1
         self.camera.exposureTime.value = exposure
 
@@ -456,7 +457,7 @@ class VirtualTestCam(with_metaclass(ABCMeta, object)):
         im = self.camera.data.get()
         duration = time.time() - start
 
-        self.assertEqual(im.shape, self.size[::-1]) # TODO a small size diff is fine if bigger than requested
+        self.assertEqual(im.shape, self.size[::-1])  # TODO a small size diff is fine if bigger than requested
         self.assertGreaterEqual(duration, exposure, "Error execution took %f s, less than exposure time %f." % (duration, exposure))
         self.assertIn(model.MD_EXP_TIME, im.metadata)
         self.assertEqual(im.metadata[model.MD_BINNING], new_binning)
@@ -469,7 +470,8 @@ class VirtualTestCam(with_metaclass(ABCMeta, object)):
         self.size = (self.camera.shape[0] // 2, self.camera.shape[1] // 2)
         exposure = 0.1
 
-        if (self.camera.resolution.range[0][0] > self.size[0] or
+        if (self.camera.resolution.readonly or
+            self.camera.resolution.range[0][0] > self.size[0] or
             self.camera.resolution.range[0][1] > self.size[1]):
             # cannot divide the size by 2? Then it probably doesn't support AOI
             self.skipTest("Camera doesn't support area of interest")

--- a/src/odemis/driver/test/ueye_test.py
+++ b/src/odemis/driver/test/ueye_test.py
@@ -24,6 +24,7 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 
 import logging
 from odemis.driver import ueye
+from odemis import model
 import os
 import unittest
 from unittest.case import skip
@@ -37,7 +38,7 @@ logging.getLogger().setLevel(logging.DEBUG)
 TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 CLASS = ueye.Camera
-KWARGS = dict(name="camera", role="ccd", device=None, transp=[2, -1])
+KWARGS = dict(name="camera", role="ccd", device=None, max_res=None, transp=[2, -1])
 
 
 class StaticTestUEye(VirtualStaticTestCam, unittest.TestCase):
@@ -95,6 +96,55 @@ class TestSynchronized(VirtualTestSynchronized, unittest.TestCase):
         if TEST_NOHW:
             self.skipTest("No simulator available")
         VirtualTestCam.setUp(self)
+
+
+class TestUEyeCroppingTranspose(VirtualTestCam, unittest.TestCase):
+    """
+    Test setting up the UEye class with a transposed image and a set resolution to force cropping.
+    """
+    camera_type = CLASS
+    camera_kwargs = KWARGS
+
+    @classmethod
+    def setUpClass(cls):
+        if TEST_NOHW:
+            raise unittest.SkipTest('No camera HW present. Skipping tests.')
+
+        # set a fixed max_res smaller than the maximum supported camera resolution
+        cls.camera_kwargs['max_res'] = (768, 1000)
+
+        super(TestUEyeCroppingTranspose, cls).setUpClass()
+
+    def test_set_resolution(self):
+        """
+        Test if the max resolution and the transpose argument are passed and applied.
+        Also test if an acquired image is of the correct dimensions and the axes are right also with binning active.
+        """
+        # assign the right resolutions after initialization of the camera class
+        sensor_res_raw = self.camera._sensor_res
+        expected_res = self.camera_kwargs['max_res']
+        sensor_res_user = self.camera.getMetadata()[model.MD_SENSOR_SIZE]
+
+        # check if the set camera resolution matches the expected resolution
+        self.assertEqual(expected_res, self.camera.resolution.value)
+
+        # check if the resolution is not the same, own cam res should be higher
+        self.assertNotEqual(self.camera_kwargs['max_res'], sensor_res_raw)
+
+        # check if the transpose parameter is applied and axes are switched
+        self.assertEqual(sensor_res_raw, sensor_res_user[::-1])
+
+        # be sure to have binning set to base value
+        self.camera.binning.value = (1, 1)
+        # check if the acquired image is of the right size
+        im = self.camera.data.get()
+        self.assertEqual(im.shape, expected_res[::-1])
+
+        # check if the acquired image is of the right size with higher binning
+        self.camera.binning.value = (2, 4)
+        binned_resolution = (expected_res[0] // 2, expected_res[1] / 4)
+        im = self.camera.data.get()
+        self.assertEqual(im.shape, binned_resolution[::-1])
 
 
 if __name__ == '__main__':

--- a/src/odemis/driver/ueye.py
+++ b/src/odemis/driver/ueye.py
@@ -725,14 +725,17 @@ class Camera(model.DigitalCamera):
             sensor_res_user = self._transposeSizeToUser(self._sensor_res)
             if max_res is None:
                 max_res = sensor_res_user
+                forced_max_res = False
             else:
                 max_res = tuple(max_res)
-                # force image cropping of max_res is specified in the configuration of the camera
-                self._set_aoi(self._sensor_res, max_res)
+                forced_max_res = True
             if not all(1 <= mr <= r for mr, r in zip(max_res, sensor_res_user)):
-                raise ValueError("max_res has to be between 1, 1 and %s, but got %s", sensor_res_user, max_res)
+                raise ValueError(f"max_res has to be between (1, 1) and {sensor_res_user}, but got {max_res}")
             max_res_hw = self._transposeSizeFromUser(max_res)
 
+            # force image cropping of max_res is specified in the configuration of the camera
+            if forced_max_res:
+                self._set_aoi(self._sensor_res, max_res)
             self._metadata[model.MD_SENSOR_SIZE] = sensor_res_user
 
             # old
@@ -1157,7 +1160,7 @@ class Camera(model.DigitalCamera):
 
         # TODO use the return value to see if the command was successful??
         self._dll.is_AOI(self._hcam, AOI_IMAGE_SET_AOI, byref(rect_aoi), sizeof(rect_aoi))
-        logging.debug("Updated area of interest from %s to %s", sensor_res, max_res)
+        logging.debug("Updated area of interest from %s to %s" % (sensor_res, max_res))
 
         # the use of SetFrameRate and SetExposure afterwards is recommended by the programmer's guide
 


### PR DESCRIPTION
The sensor of the uEye is sometimes too big compared to the image received. That means that on the border, there is no image. While on the live image it’s not a big issue, for tiling, it causes black line between each tile. 

To avoid this, we should have a way to crop the image. Probably the best is to use the same as for the andorcam3 (Zyla): add a max_res parameter to the component that restrict the maximum resolution reported by the driver. It’s always centered.

=> Extend ueye.Camera to support max_res (int, int).
This can be done by using the is_AOI() function.

See specification here: Technology Development/Software/Odemis/Specification uEye max_res argument.docx

https://docs.google.com/document/d/1iTjxhw3LBRfkOiASk4N_D_p9gXiU_BSG/edit?pli=1
