### PR TITLE
fix input arguments for stream_test.py::SPARC2PolAnalyzerTestCase::test_arpol_ss

### DIFF
--- a/src/odemis/acq/test/stream_test.py
+++ b/src/odemis/acq/test/stream_test.py
@@ -3211,7 +3211,7 @@ class SPARC2PolAnalyzerTestCase(unittest.TestCase):
         """ Test ARSettingsStream """
         # Create the stream
         ars = stream.ARSettingsStream("test",
-                      self.ccd, self.ccd.data, self.ebeam, self.analyzer,
+                      self.ccd, self.ccd.data, self.ebeam, analyzer=self.analyzer,
                       detvas={"exposureTime", "readoutRate", "binning", "resolution"})
 
         # shouldn't affect


### PR DESCRIPTION
One test case i.e  test_arpol_ss in [SWM-61](https://delmic.atlassian.net/browse/SWM-61?atlOrigin=eyJpIjoiMDliOTk1ZGU3OWZkNDRkNmE0OWIwZjc2NzY2YTZiN2YiLCJwIjoiaiJ9) fixed. 
