### PR TITLE
Add warning to the unreliable FindTransform func, add expectedFailure…

### DIFF
--- a/src/odemis/acq/align/keypoint.py
+++ b/src/odemis/acq/align/keypoint.py
@@ -21,6 +21,8 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 '''
 
 import logging
+import warnings
+
 import numpy
 import cv2
 from scipy import ndimage
@@ -58,6 +60,8 @@ def FindTransform(ima, imb, fd_type=None):
     raises:
     ValueError: if no good transformation is found.
     """
+
+    warnings.warn("Please be aware that the FindTransform function does not work reliably at the moment.")
 
     # Instantiate the feature detector and the matcher
     # TODO: try BRISK, AZAKE and other detectors?

--- a/src/odemis/acq/align/test/keypoint_test.py
+++ b/src/odemis/acq/align/test/keypoint_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-'''
+"""
 Created on 04 Mar 2017
 
 @author: Guilherme Stiebler
@@ -19,7 +19,7 @@ PURPOSE. See the GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License along with
 Odemis. If not, see http://www.gnu.org/licenses/.
-'''
+"""
 import cairo
 import logging
 import math
@@ -42,14 +42,14 @@ IMG_PATH = os.path.join(os.path.dirname(__file__), "images")
 
 class TestKeypoint(unittest.TestCase):
 
+    @unittest.expectedFailure
     def test_image_pair(self):
-        ''' Testing a pair of images
-        '''
+        """Testing a pair of images"""
         # WARNING: if opencv is not compiled with SIFT support (ie, only ORB
         # available), then this test case will fail.
         # FIXME: these two images are very hard, and any tiny change in the
-        # algorithm or settings can cause the alignment to fail => not a good
-        # test case
+        #  algorithm or settings can cause the alignment to fail => not a good
+        #  test case
         # only one image will be used, but this structure helps to test
         # different images
         image_pairs = [
@@ -64,7 +64,7 @@ class TestKeypoint(unittest.TestCase):
 #             (
 #                 ('t3 DELPHI.tiff', False, (False, False), (0, 200, 0, 0), 3),
 #                 ('t3 testoutA3.tif', False, (False, False), (0, 420, 0, 0), 3)
-#             )
+#             ),
         ]
         image_pair = image_pairs[0]
         # open the images
@@ -75,6 +75,7 @@ class TestKeypoint(unittest.TestCase):
                              image_pair[0][3], image_pair[0][4], True)
         sem_img = preprocess(sem_img, image_pair[1][1], image_pair[1][2],
                              image_pair[1][3], image_pair[1][4], True)
+
         # execute the algorithm to find the transform between the images
         try:
             tmat, _, _, _, _ = keypoint.FindTransform(tem_img, sem_img)
@@ -121,10 +122,10 @@ class TestKeypoint(unittest.TestCase):
             self.assertEqual(tmetadatan, tmetadata)
 
     def test_synthetic_images(self):
-        ''' Testing the matching of a synthetic image. The image is generated with
+        """ Testing the matching of a synthetic image. The image is generated with
         a rotation and scale, and then it checks if the matching algorithm
         came up with the same result
-        '''
+        """
         # generate a syntyetic image
         image = numpy.zeros((1000, 1000, 4), dtype=numpy.uint8)
         surface = cairo.ImageSurface.create_for_data(image, cairo.FORMAT_ARGB32, 1000, 1000)
@@ -228,7 +229,7 @@ class TestKeypoint(unittest.TestCase):
         cv2.imwrite(IMG_PATH + 'rotated_opencv.jpg', warped_im)'''
 
     def test_no_match(self):
-        '''Testing the matching of two feature-less images'''
+        """Testing the matching of two feature-less images"""
         image = numpy.zeros((1000, 1000), dtype=numpy.uint8) + 86
         timg = numpy.zeros((2000, 1000), dtype=numpy.uint16) + 2563
 


### PR DESCRIPTION
Added a warning message to the unreliable FindTransform function,
Added a @unittest.expectedFailure to test_image_pair test case as the failure is expected. That way it will be easier to spot and update the test case once the FindTransform function starts working reliably.