### PR TITLE
fix picoquant_test shutter test cases

### DIFF
--- a/src/odemis/driver/test/picoquant_test.py
+++ b/src/odemis/driver/test/picoquant_test.py
@@ -154,6 +154,7 @@ class TestPH300(unittest.TestCase):
         df.unsubscribe(self._on_det)
         self.assertGreater(self._cnt, 3)
         self.assertEqual(self._lastdata.shape, exp_shape)
+        time.sleep(2)  # consider some time for resetting the shutters
 
     def _on_det(self, df, data):
         self._cnt += 1
@@ -254,6 +255,7 @@ class TestHH400(unittest.TestCase):
         df.unsubscribe(self._on_det)
         self.assertGreater(self._cnt, 3)
         self.assertEqual(self._lastdata.shape, exp_shape)
+        time.sleep(2)  # consider some time for resetting the shutters
 
     def _on_det(self, df, data):
         self._cnt += 1


### PR DESCRIPTION
TestHH400_Shutters.test_shutters and TestPH300_Shutters.test_shutters were failing when running all the test cases in a class but not when runnning the test standalone. After unsubscribing in test_acquire_sub it takes a bit of time for the shutters to reset, therefore add a time.sleep at the end of that test case.