### PR TITLE
[SWM-70] convert float type to int in legend.py

### DIFF
--- a/src/odemis/gui/comp/legend.py
+++ b/src/odemis/gui/comp/legend.py
@@ -454,7 +454,7 @@ class AxisLegend(wx.Panel):
         if self._orientation == wx.HORIZONTAL:
             self.lockBtn.SetPosition((self.ClientSize.x - 24, 0))
         else:
-            self.lockBtn.SetPosition((self.ClientSize.x - self.ClientSize.x / 2 - 12, 0))
+            self.lockBtn.SetPosition((self.ClientSize.x // 2 - 12, 0))
 
     @wxlimit_invocation(0.2)
     def Refresh(self):
@@ -536,7 +536,7 @@ class AxisLegend(wx.Panel):
 
         if self._orientation == wx.VERTICAL and max_width != self._max_tick_width:
             self._max_tick_width = max_width
-            self.SetMinSize((self._max_tick_width + 14, -1))
+            self.SetMinSize((int(self._max_tick_width + 14), -1))
             self.Parent.GetSizer().Layout()
 
 


### PR DESCRIPTION
Following Deprecation Warnings Resolved ([SWM-70](https://delmic.atlassian.net/browse/SWM-70?atlOrigin=eyJpIjoiYWM0MzEzYmYxMTdmNDUzNzg0YTMzYTBhNDE1N2IwNTQiLCJwIjoiaiJ9)):
 

```
/home/testing/development/odemis/src/odemis/gui/comp/legend.py:457: DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
    self.lockBtn.SetPosition((self.ClientSize.x - self.ClientSize.x / 2 - 12, 0))

  /home/testing/development/odemis/src/odemis/gui/comp/legend.py:539: DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
    self.SetMinSize((self._max_tick_width + 14, -1))
```