### PR TITLE
 fix warning of wxPyDeprecationWarning in wxPython module

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -64,6 +64,8 @@ Depends: ${shlibs:Depends},
 # On Linux, uses GObject Interaction to map the GUI to the desktop launcher. It will run if it's not present.
          python3-gi,
          python3-requests,
+# wx.lib.pubsub is now based on PyPubSub package
+         python3-pubsub,
 Suggests: imagej
 Description: Open Delmic Microscope Software
  Odemis is the acquisition software for the Delmic microscopes. In particular,

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ Pillow>=3.2.0
 pycairo>=1.10.0
 PyInstaller>=3.6
 psutil>=4.3.0
+Pypubsub<=4.0.3
 PyYAML>=3.11
 pyzmq>=15.2.0
 scipy>=0.15.1,<1.5

--- a/src/odemis/gui/comp/stream.py
+++ b/src/odemis/gui/comp/stream.py
@@ -43,9 +43,9 @@ from odemis.gui.comp.text import SuggestTextCtrl, UnitFloatCtrl, FloatTextCtrl, 
 from odemis.gui.util import call_in_wx_main
 from odemis.gui.util.widgets import VigilantAttributeConnector
 from odemis.model import TINT_FIT_TO_RGB, TINT_RGB_AS_IS
+from pubsub import pub
 import wx
 import wx.lib.newevent
-from wx.lib.pubsub import pub
 from odemis.gui.conf.data import COLORMAPS
 import matplotlib.colors as colors
 

--- a/src/odemis/gui/cont/streams.py
+++ b/src/odemis/gui/cont/streams.py
@@ -34,7 +34,7 @@ from builtins import str
 import numpy
 import wx
 from past.builtins import basestring, long
-from wx.lib.pubsub import pub
+from pubsub import pub
 
 import odemis.acq.stream as acqstream
 import odemis.gui.model as guimodel

--- a/src/odemis/gui/cont/streams.py
+++ b/src/odemis/gui/cont/streams.py
@@ -258,6 +258,10 @@ class StreamController(object):
 
         self.entries = []
 
+        # Tell control bar to also discard all references to the stream
+        if self._sb_ctrl:
+             self._sb_ctrl.remove_stream(self.stream)
+
         gc.collect()
 
     def _display_metadata(self):

--- a/src/odemis/gui/main.py
+++ b/src/odemis/gui/main.py
@@ -31,11 +31,11 @@ from odemis.gui.cont.menu import MenuController
 from odemis.gui.cont.temperature import TemperatureController
 from odemis.gui.util import call_in_wx_main
 from odemis.gui.xmlh import odemis_get_resources
+from pubsub import pub
 import sys
 import threading
 import traceback
 import wx
-from wx.lib.pubsub import pub
 import warnings
 
 import odemis.gui.cont.tabs as tabs


### PR DESCRIPTION
Resolves wxPython warning ([SWM-73](https://delmic.atlassian.net/browse/SWM-73?atlOrigin=eyJpIjoiMmYwZGM1YjgwMGRmNGRlNjljNjE1MjljZTUyNDM3YTAiLCJwIjoiaiJ9)). The warnings were from the tests in odemis/src/odemeis/gui/test

Solution:-
Install PyPubSub package which is actually what wx.lib.pubsub was based on
Then replace 
`from wx.lib.pubsub import pub with from pubsub import pub`

Warning Message:-
`/usr/lib/python3/dist-packages/wx/lib/pubsub/__init__.py:23
  /usr/lib/python3/dist-packages/wx/lib/pubsub/__init__.py:23: wxPyDeprecationWarning: wx.lib.pubsub has been deprecated, plese migrate your code to use pypubsub, available on PyPI.
    warnings.warn('wx.lib.pubsub has been deprecated, plese migrate your '`


