### PR TITLE
[fix] remove blocking function which keeps gui open after the test ca…

### DIFF
--- a/src/odemis/gui/test/comp_legend_test.py
+++ b/src/odemis/gui/test/comp_legend_test.py
@@ -43,7 +43,6 @@ class LegendTestCase(test.GuiTestCase):
     frame_class = test.test_gui.xrccanvas_frame
 
     def test_legend(self):
-        test.goto_manual()
         self.frame.SetSize((400, 60))
         leg = legend.AxisLegend(self.panel)
         leg.SetBackgroundColour(wx.RED)


### PR DESCRIPTION
```
Running /home/testing/development/odemis/src/odemis/gui/test/comp_legend_test.py:
FAIL comp_legend_test.py::LegendTestCase::test_legend
```

remove blocking function