### PR TITLE
SDEV-1247 fix calibration region overlay appearing when the button was deselected

### DIFF
--- a/src/odemis/gui/cont/project.py
+++ b/src/odemis/gui/cont/project.py
@@ -523,7 +523,7 @@ class FastEMCalibrationRegionsController(object):
                         b.SetForegroundColour(FG_COLOUR_WARNING)
                     else:
                         b.SetForegroundColour(wx.GREEN)  # default to green
-                elif not self.roc_ctrls[num].is_selected:
+                else:
                     b.SetLabel("?")
                     b.SetForegroundColour(odemis.gui.FG_COLOUR_RADIO_INACTIVE)
             else:  # scintillator unselected


### PR DESCRIPTION
When selecting and deselecting a region of calibration the coordinates of active but deselected scintillators can update unexpectedly. When the coordinates change all active scintllators are checked and re-drawn based on the coordinates. Because the coordinates had updated even the deselected boxes would be re-drawn. This fix makes sure that boxes are only drawn based on whether the calibration region box has been selected or de-selected.