### PR TITLE
gui test: avoid segfaults if multiple test app created in a row

### DIFF
--- a/src/odemis/gui/test/__init__.py
+++ b/src/odemis/gui/test/__init__.py
@@ -173,12 +173,12 @@ class GuiTestCase(unittest.TestCase):
     def tearDownClass(cls):
         if not MANUAL:
             cls.app.test_frame.Destroy()
-            # see fixme in runall.py. Is this needed in Phoenix?
-            # wx.CallAfter(cls.app.Exit)
         elif INSPECT:
             from wx.lib import inspection
             inspection.InspectionTool().Show()
+
         cls.app.MainLoop()
+        del cls.app  # Makes sure everything is cleaned up (before starting a new app)
 
     def setUp(self):
         self.app.test_frame.SetTitle(


### PR DESCRIPTION
Each test case class creates its own app. Sometimes that seems to cause
segfaults at the end of the test cases.

Explicitly deleting the App, to force some clean-ups early fixes the
issue.