### PR TITLE
model: do not automatically fallback to a different BASE_DIRECTORY

### DIFF
--- a/src/odemis/model/_core.py
+++ b/src/odemis/model/_core.py
@@ -22,7 +22,6 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 import logging
 import multiprocessing
 import os
-import tempfile
 import threading
 from collections.abc import Mapping
 from urllib.parse import quote
@@ -58,15 +57,9 @@ CALL_TIMEOUT = 30  # s
 
 # Set the base directory
 BASE_DIRECTORY = "/var/run/odemisd"
-path_exists = os.path.exists(BASE_DIRECTORY)
-if not path_exists:
-    logging.info(f"{BASE_DIRECTORY} could not be found. Creating new temporary folder.")
-    BASE_DIRECTORY = os.path.join(tempfile.gettempdir(), "odemisd")
-    os.makedirs(BASE_DIRECTORY, exist_ok=True)
-
 BASE_GROUP = "odemis"  # user group that is allowed to access the backend
-BACKEND_FILE = os.path.join(BASE_DIRECTORY, "backend.ipc")  # the official ipc file for backend (just to detect status)
 BACKEND_NAME = "backend"  # the official name for the backend container
+BACKEND_FILE = os.path.join(BASE_DIRECTORY, BACKEND_NAME + ".ipc")  # the official ipc file for backend (just to detect status)
 
 _microscope = None
 

--- a/src/odemis/model/test/remote_test.py
+++ b/src/odemis/model/test/remote_test.py
@@ -20,22 +20,22 @@ PURPOSE. See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along with 
 Odemis. If not, see http://www.gnu.org/licenses/.
 '''
-import Pyro4
-from concurrent import futures
-from concurrent.futures import CancelledError
 import gc
 import logging
-import numpy
-from odemis import model
-from odemis.model import roattribute, oneway, isasync, VigilantAttributeBase
-from odemis.util import mock, timeout, executeAsyncTask
 import os
 import pickle
-import sys
 import threading
 import time
 import unittest
+from concurrent import futures
 from multiprocessing import Process
+
+import numpy
+import Pyro4
+
+from odemis import model
+from odemis.model import VigilantAttributeBase, isasync, oneway, roattribute
+from odemis.util import executeAsyncTask, mock, timeout, testing
 
 logging.basicConfig(format="%(asctime)s  %(levelname)-7s %(module)-15s: %(message)s")
 logging.getLogger().setLevel(logging.DEBUG)
@@ -157,12 +157,17 @@ class SerializerTest(unittest.TestCase):
 
 # @unittest.skip("simple")
 class ProxyOfProxyTest(unittest.TestCase):
-# Test sharing a shared component from the client
+    # Test sharing a shared component from the client
 
-#  create one remote container with an object (Component)
-#  create a second remote container with a HwComponent
-#  change .affects of HwComponent to the first object
+    # @classmethod
+    # def setUpClass(cls) -> None:
+    #     testing.use_fake_backend_directory()
+
     def test_component(self):
+        # create one remote container with an object (Component)
+        # create a second remote container with a HwComponent
+        # change .affects of HwComponent to the first object
+
         cont, comp = model.createInNewContainer("testscont", model.HwComponent,
                                           {"name":"MyHwComp", "role":"affected"})
         self.assertEqual(comp.name, "MyHwComp")
@@ -1179,5 +1184,4 @@ class SynchronizableDataFlow(model.DataFlow):
 
 
 if __name__ == "__main__":
-    # import sys;sys.argv = ['', 'Test.testName']
     unittest.main()

--- a/src/odemis/util/test/testing_test.py
+++ b/src/odemis/util/test/testing_test.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Jan 31, 2023
+
+@author: Éric Piel
+
+Copyright © 2023 Éric Piel, Delmic
+
+This file is part of Odemis.
+
+Odemis is free software: you can redistribute it and/or modify it under the terms
+of the GNU General Public License version 2 as published by the Free Software
+Foundation.
+
+Odemis is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+Odemis. If not, see http://www.gnu.org/licenses/.
+"""
+import logging
+import os
+import unittest
+
+import odemis
+from odemis import model
+from odemis.util import driver, testing
+
+logging.getLogger().setLevel(logging.DEBUG)
+
+CONFIG_PATH = os.path.dirname(odemis.__file__) + "/../../install/linux/usr/share/odemis/"
+ENZEL_CONFIG = CONFIG_PATH + "sim/enzel-sim.odm.yaml"
+SPARC_CONFIG = CONFIG_PATH + "sim/sparc-sim.odm.yaml"
+
+
+class TestBackendStarter(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        # make sure initially no backend is running.
+        if driver.get_backend_status() == driver.BACKEND_RUNNING:
+            testing.stop_backend()
+
+    @classmethod
+    def tearDownClass(cls):
+        # turn off everything when the testing finished.
+        if driver.get_backend_status() == driver.BACKEND_RUNNING:
+            testing.stop_backend()
+
+    def test_no_running_backend(self):
+        # check if there is no running backend
+        backend_status = driver.get_backend_status()
+        self.assertIn(backend_status, [driver.BACKEND_STOPPED, driver.BACKEND_DEAD])
+        # run enzel
+        testing.start_backend(ENZEL_CONFIG)
+        # now check if the role is enzel
+        role = model.getMicroscope().role
+        self.assertEqual(role, "enzel")
+
+    def test_running_backend_same_as_requested(self):
+        # run enzel backend
+        testing.start_backend(ENZEL_CONFIG)
+        # check if the role is enzel
+        role = model.getMicroscope().role
+        self.assertEqual(role, "enzel")
+        # run enzel backend again
+        testing.start_backend(ENZEL_CONFIG)
+        # it should still be enzel.
+        role = model.getMicroscope().role
+        self.assertEqual(role, "enzel")
+
+    def test_running_backend_different_from_requested(self):
+        # run sparc backend
+        testing.start_backend(SPARC_CONFIG)
+        # check if the role is sparc
+        role = model.getMicroscope().role
+        self.assertEqual(role, "sparc")
+        # now run another backend (enzel)
+        testing.start_backend(ENZEL_CONFIG)
+        # check if the role now is enzel instead of sparc
+        role = model.getMicroscope().role
+        self.assertEqual(role, "enzel")
+
+
+class TestFakeBackendDir(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        # make sure initially no backend is running.
+        if driver.get_backend_status() == driver.BACKEND_RUNNING:
+            testing.stop_backend()
+
+        cls.orig_backend_dir = model.BASE_DIRECTORY
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        # turn off everything when the testing finished.
+        if driver.get_backend_status() == driver.BACKEND_RUNNING:
+            testing.stop_backend()
+
+        model.BASE_DIRECTORY = cls.orig_backend_dir
+
+    def test_fake_dir(self):
+        testing.use_fake_backend_directory()
+        self.assertNotEqual(model.BASE_DIRECTORY, self.orig_backend_dir)
+        orig_files = os.listdir(model.BASE_DIRECTORY)  # typically, it should be empty
+        self.assertEqual(len(orig_files), 0)
+
+        # We cannot start a backend in that new directory easily, but we can check
+        # there is no backend running
+        status = driver.get_backend_status()
+        self.assertEqual(status, driver.BACKEND_STOPPED)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/odemis/util/test/util_test.py
+++ b/src/odemis/util/test/util_test.py
@@ -29,7 +29,7 @@ import logging
 import math
 from odemis.model import CancellableFuture
 from odemis.util import limit_invocation, TimeoutError, executeAsyncTask, \
-    perpendicular_distance, to_str_escape, testing, driver, timeout
+    perpendicular_distance, to_str_escape, timeout
 import time
 import unittest
 import weakref
@@ -393,60 +393,6 @@ class CanvasTestCase(unittest.TestCase):
 
         for orig, clipped in outer_to_inner:
             self.assertEqual(clipped, clip(*orig))
-
-
-CONFIG_PATH = os.path.dirname(odemis.__file__) + "/../../install/linux/usr/share/odemis/"
-ENZEL_CONFIG = CONFIG_PATH + "sim/enzel-sim.odm.yaml"
-SPARC_CONFIG = CONFIG_PATH + "sim/sparc-sim.odm.yaml"
-
-
-class TestBackendStarter(unittest.TestCase):
-
-    @classmethod
-    def setUpClass(cls):
-        # make sure initially no backend is running.
-        if driver.get_backend_status() == driver.BACKEND_RUNNING:
-            testing.stop_backend()
-
-    @classmethod
-    def tearDownClass(cls):
-        # turn off everything when the testing finished.
-        if driver.get_backend_status() == driver.BACKEND_RUNNING:
-            testing.stop_backend()
-
-    def test_no_running_backend(self):
-        # check if there is no running backend
-        backend_status = driver.get_backend_status()
-        self.assertIn(backend_status, [driver.BACKEND_STOPPED, driver.BACKEND_DEAD])
-        # run enzel
-        testing.start_backend(ENZEL_CONFIG)
-        # now check if the role is enzel
-        role = model.getMicroscope().role
-        self.assertEqual(role, "enzel")
-
-    def test_running_backend_same_as_requested(self):
-        # run enzel backend
-        testing.start_backend(ENZEL_CONFIG)
-        # check if the role is enzel
-        role = model.getMicroscope().role
-        self.assertEqual(role, "enzel")
-        # run enzel backend again
-        testing.start_backend(ENZEL_CONFIG)
-        # it should still be enzel.
-        role = model.getMicroscope().role
-        self.assertEqual(role, "enzel")
-
-    def test_running_backend_different_from_requested(self):
-        # run sparc backend
-        testing.start_backend(SPARC_CONFIG)
-        # check if the role is sparc
-        role = model.getMicroscope().role
-        self.assertEqual(role, "sparc")
-        # now run another backend (enzel)
-        testing.start_backend(ENZEL_CONFIG)
-        # check if the role now is enzel instead of sparc
-        role = model.getMicroscope().role
-        self.assertEqual(role, "enzel")
 
 
 class FindClosestTestCase(unittest.TestCase):


### PR DESCRIPTION
Commit 6064bb32afe (model: if base directory is not available use a
temporary one) changed the way BASE_DIRECTORY is set.

This introduced two issues:
* As soon as odemis.model is imported, code is run, which is not a good behaviour.
In particular, it would call logging, possibly very early at startup,
which causes some odd logging configuration (everything is displayed in
the terminal).
* The standard BASE_DIRECTORY (/var/run/odemisd) *never* exists when
starting the backend. So it would always create a temporary directory.
Normally, create that directory is handled by the backend.

=> Remove the smartness of the BASE_DIRECTORY constant.
The backend takes care of creating that directory.
=> Create a new function testing.use_fake_backend_directory() for the
cases where we need a fake base directory... However I couldn't
reproduce the issue in ProxyOfProxy test cases. So for now it's unused.