### PR TITLE
Bugfix in odemis.acq.align.FindGridSpots

### DIFF
--- a/src/odemis/acq/align/spot.py
+++ b/src/odemis/acq/align/spot.py
@@ -409,9 +409,11 @@ def FindGridSpots(image, repetition, spot_size=18, method=GRID_AFFINE):
     # Find the transformation from a grid centered around the origin to the sorted positions.
     if method == GRID_AFFINE:
         transformation = AffineTransform.from_pointset(grid, pos_sorted)
+        translation = transformation.translation
         scale, rotation, shear = alt_transformation_matrix_to_implicit(transformation.matrix, "RSU")
     elif method == GRID_SIMILARITY:
         transformation = SimilarityTransform.from_pointset(grid, pos_sorted)
+        translation = transformation.translation
         scale, rotation, _ = alt_transformation_matrix_to_implicit(transformation.matrix, "RSU")
         shear = None  # The similarity transform does not have a shear component.
     else:


### PR DESCRIPTION
Returned translation value was the initial estimation, not the refined value.