### PR TITLE
`to_physical_space` and `to_pixel_index` to accept GeometricTransform

### DIFF
--- a/src/odemis/util/test/registration_test.py
+++ b/src/odemis/util/test/registration_test.py
@@ -40,6 +40,8 @@ from odemis.util.registration import (
 )
 from odemis.util.transform import AffineTransform
 
+from transform_test import random_transform
+
 
 class BijectiveMatchingTest(unittest.TestCase):
     """Unit tests for `bijective_matching()`."""
@@ -184,32 +186,6 @@ class UnitGridPointsTest(unittest.TestCase):
         numpy.testing.assert_array_almost_equal(ji, _ji)
 
 
-def random_affine_transform(seed=None):
-    """
-    Return a randomized affine transform.
-
-    Parameters
-    ----------
-    rng : numpy.random.Generator, optional
-        Random number generator
-
-    Returns
-    -------
-    tform : AffineTransform
-        Randomized affine transform.
-
-    """
-    rng = check_random_state(seed)
-    params = {
-        "scale": 1 + 0.5 * rng.uniform(-1, 1),
-        "rotation": 0.25 * numpy.pi * rng.uniform(-1, 1),
-        "squeeze": 1 + 0.1 * rng.uniform(-1, 1),
-        "shear": 0.1 * rng.uniform(-1, 1),
-        "translation": rng.uniform(-1, 1, (2,)),
-    }
-    return AffineTransform(**params)
-
-
 def unit_gridpoints_graph(shape, tform, index):
     """
     Return the known good graph of the unit grid.
@@ -259,7 +235,7 @@ class NearestNeighborGraphTest(unittest.TestCase):
                     n, m = shape
                     shuffle = self._rng.permutation(n * m)
                     index = numpy.argsort(shuffle)
-                    tform = random_affine_transform(self._rng)
+                    tform = random_transform(AffineTransform, self._rng)
                     xy = tform.apply(unit_gridpoints(shape, mode="xy")[shuffle])
                     graph = unit_gridpoints_graph(shape, tform, index)
                     out = nearest_neighbor_graph(xy)
@@ -279,7 +255,7 @@ class NearestNeighborGraphTest(unittest.TestCase):
                     n, m = shape
                     shuffle = self._rng.permutation(n * m)
                     index = numpy.argsort(shuffle)
-                    tform = random_affine_transform(self._rng)
+                    tform = random_transform(AffineTransform, self._rng)
                     xy = tform.apply(unit_gridpoints(shape, mode="xy")[shuffle])[:-1]
                     _graph = unit_gridpoints_graph(shape, tform, index)
                     vertex = n * m - 1
@@ -372,7 +348,7 @@ class EstimateGridOrientationTest(unittest.TestCase):
                 with self.subTest(shape=shape, i=i):
                     n, m = shape
                     shuffle = self._rng.permutation(n * m)
-                    tform = random_affine_transform(self._rng)
+                    tform = random_transform(AffineTransform, self._rng)
                     xy = tform.apply(unit_gridpoints(shape, mode="xy")[shuffle])
                     out = estimate_grid_orientation(xy, shape, AffineTransform)
                     numpy.testing.assert_array_almost_equal(tform.matrix, out.matrix)
@@ -391,7 +367,7 @@ class EstimateGridOrientationTest(unittest.TestCase):
                 with self.subTest(shape=shape, i=i):
                     n, m = shape
                     shuffle = self._rng.permutation(n * m)
-                    tform = random_affine_transform(self._rng)
+                    tform = random_transform(AffineTransform, self._rng)
                     xy = tform.apply(unit_gridpoints(shape, mode="xy")[shuffle])[:-1]
                     out = estimate_grid_orientation(xy, shape, AffineTransform)
                     numpy.testing.assert_array_almost_equal(tform.matrix, out.matrix)


### PR DESCRIPTION
When [PR-2325](https://github.com/delmic/odemis/pull/2325) is merged, the updated `estimate_grid_orientation` and `estimate_grid_orientation_from_img` now return a GeometricTransform that works on image pixel coordinates. It is desirable to be able to convert this returned transform to work on physical coordinates. This pull request adds this functionality to `to_physical_space` and `to_pixel_index` in `odemis.util.transform`.