### PR TITLE
fastem gui: fix for pop-up of calibration regions after de-selecting …

### DIFF
--- a/src/odemis/gui/cont/project.py
+++ b/src/odemis/gui/cont/project.py
@@ -541,6 +541,7 @@ class FastEMCalibrationRegionsController(object):
             if num not in scintillators:
                 # reset coordinates for ROC to undefined
                 self.roc_ctrls[num].calib_model.coordinates.value = acqstream.UNDEFINED_ROI
+                self.roc_ctrls[num].is_selected = False
 
         # update ROC buttons
         self._on_coordinates()


### PR DESCRIPTION
…the scintillator

selecting a calibration region in the acquisition tab and afterwards deselecting the scintillator in the chamber tab, caused the calibration region to pop up randomly in the acquisition tab. With this fix, when a scintillator is removed from the list of active scintillators it will also toggle the is_selected attribute to False.