### PR TITLE
Add support for moving to defined position in MIMAS, including the optical path manager

### DIFF
--- a/install/linux/usr/share/odemis/sim/mimas-orsay-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/mimas-orsay-sim.odm.yaml
@@ -1,23 +1,21 @@
-# MIMAS, fully simulated
+# MIMAS, fully simulated, using the Orsay Physics simulator running on a dedicated Windows VM.
 
 MIMAS-Sim: {
     class: Microscope,
     role: mimas,
     children: [
-    # TODO: need to simulate all the components commented out (typically provided by the Orsay system)
-#        "Pneumatic Suspension", "Chamber", "Pumping System", "FIB Vacuum",
-#        "UPS",
-        "GIS",
-        #"GIS Reservoir",
-        "Chamber Cam",
+        "Pneumatic Suspension", "Chamber", "Pumping System", "FIB Vacuum",
+        "UPS",
+        "GIS", "GIS Reservoir",
         "Chamber Light",
-#        "Ion Source",
-#        "Ion Beam",
+        "Ion Source",
+        "Ion Beam",
         "Ion Focus",
-#        "FIB Aperture",
+        "FIB Aperture",
         "FIB Scanner",
         "ETD",
         "Sample Thermostat",
+        "Chamber Cam 1",
         "Stage",
         "Stage Focus",
         "Optical Objective",
@@ -28,85 +26,121 @@ MIMAS-Sim: {
     ],
 }
 
-# Allows to change pressure in the chamber
-"Chamber": {
-    class: simulated.Chamber,
-    role: chamber,
+# Connection to the Orsay server
+# Simulation:   192.168.56.101
+# Hardware:     192.168.30.101
+"Orsay Server": {
+    class: orsay.OrsayComponent,
+    role: null,
     init: {
-        # The Orsay component has these positions, but the simulator has different names: ["vented", "primary vacuum", "high vacuum"],
-        positions: ["vented", "low-vacuum", "vacuum"],
+        host: "192.168.56.101"
+    },
+    children: {
+        pneumatic-suspension: "Pneumatic Suspension",
+        pressure: "Chamber",
+        pumping-system: "Pumping System",
+        fib-vacuum: "FIB Vacuum",
+        ups: "UPS",
+        gis: "GIS",
+        gis-reservoir: "GIS Reservoir",
+        light: "Chamber Light",
+        fib-source: "Ion Source",
+        fib-beam: "Ion Beam",
+        fib-aperture: "FIB Aperture",
+        scanner: "FIB Scanner",
+        focus: "Ion Focus",
+        detector: "ETD",
+    }
+}
+
+"Pneumatic Suspension": {
+    role: pneumatic-suspension,
+    init: {}
+}
+
+"Chamber": {
+    role: chamber,
+    init: {}
+}
+
+"Pumping System": {
+    role: pumping-system,
+    init: {}
+}
+
+"UPS": {
+    role: ups,
+    init: {}
+}
+
+"GIS": {
+    role: gis,
+    init: {}
+}
+
+"GIS Reservoir": {
+    role: gis-reservoir,
+    init: {}
+}
+
+"Chamber Light": {
+    role: chamber-light,
+    init: {}
+}
+
+"FIB Vacuum": {
+    role: fib-vacuum,
+    init: {}
+}
+
+"Ion Source": {
+    role: ion-source,
+    init: {}
+}
+
+"Ion Beam": {
+    role: null,
+    init: {}
+}
+
+"FIB Aperture": {
+    role: fib-aperture,
+    init: {}
+}
+
+"FIB Scanner": {
+    role: ion-beam,
+    init: {}
+}
+
+"ETD": {
+    role: se-detector,
+    init: {},
+    metadata: {
+        # TODO: if we want to compensate for the tilt (as defined in ION_BEAM_TO_SAMPLE_ANGLE),
+        # we could "expand" the Y using this formula: 1/cos(90°- angle)
+        # PIXEL_SIZE_COR: [1, 5.78],  # ratio
     },
 }
 
-# Simulate the GIS needle by using a simple axis simulator
-"GIS": {
-    class: simulated.GenericComponent,
-    role: gis,
+"Ion Focus": {
+    role: ion-focus,
     init: {
-        axes: {
-            "arm": {
-                # First value is the initial value
-                choices: {False: "parked", True: "engaged"},
-            },
-            "reservoir": {
-                choices: {False: "closed", True: "open"},
-            },
-        },
+      rng: [0.0, 0.1]  # range of the focus in meter
     },
+    metadata: {
+        CALIB: 0.18e+6,  # Volt per meter. Read the driver specifications for more details on this value
+    }
 }
 
 # Currently not available on the real MIMAS
-"Chamber Cam": {
+"Chamber Cam 1": {
     class: andorcam2.AndorCam2,
     role: chamber-ccd,
     init: {
        device: "fake",
        # 8 bits greyscale
     },
-}
-
-# (IR) light for the chamber
-"Chamber Light": {
-    class: simulated.Light,
-    role: chamber-light,
-    init: {},
-    affects: ["Chamber Cam"],
-}
-
-"FIB Simulator": {
-    class: simsem.SimSEM,
-    role: null,
-    init: {
-           image: "simsem-fake-output.h5", # any large 16 bit image is fine
-#           drift_period: 5, # seconds
-    },
-    children: {
-        scanner: "FIB Scanner",
-        detector0: "ETD",
-        focus: "Ion Focus",
-    }
-}
-
-"FIB Scanner": {
-    role: ion-beam,
-    init: {
-        # TODO: check if we can provide better numbers to simulated the Orsay FIB
-        aperture: 200.e-6, # m
-        wd: 7.e-3, # m
-    },
-    properties: {
-        dwellTime: 10.e-6, # s
-    },
-    affects: ["ETD", "Camera"] # affects the CCD in case of cathodoluminescence
-}
-
-"ETD": {
-    role: se-detector,
-    init: {},
-}
-
-"Ion Focus": {
-    role: ion-focus,
 }
 
 # Lakeshore 350, which controls the temperature

--- a/src/odemis/acq/test/path_test.py
+++ b/src/odemis/acq/test/path_test.py
@@ -20,16 +20,18 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 
 # Test module for model.Stream classes
 import logging
-from odemis import model
-import odemis
-from odemis.acq import path, stream
-from odemis.acq.path import ACQ_QUALITY_BEST, ACQ_QUALITY_FAST
-from odemis.util import testing
 import os
 import time
 import unittest
 from unittest.case import skip
 
+import odemis
+from odemis import model
+from odemis.acq import path, stream
+from odemis.acq.move import (FM_IMAGING, LOADING, cryoSwitchSamplePosition,
+                             getCurrentPositionLabel)
+from odemis.acq.path import ACQ_QUALITY_BEST, ACQ_QUALITY_FAST
+from odemis.util import testing
 
 logging.getLogger().setLevel(logging.DEBUG)
 
@@ -54,6 +56,7 @@ SPARC2_EXT_SPEC_CONFIG = CONFIG_PATH + "sim/sparc2-ext-spec-sim.odm.yaml"
 SECOM_FLIM_CONFIG = CONFIG_PATH + "sim/secom-flim-sim.odm.yaml"
 SPARC2_POLARIZATIONANALYZER_CONFIG = CONFIG_PATH + "sim/sparc2-ek-polarizer-sim.odm.yaml"
 SPARC2_4SPEC_CONFIG = CONFIG_PATH + "sim/sparc2-4spec-sim.odm.yaml"
+MIMAS_CONFIG = CONFIG_PATH + "sim/mimas-sim.odm.yaml"
 
 
 def path_pos_to_phys_pos(pos, comp, axis):
@@ -1350,6 +1353,95 @@ class SecomFlimPathTestCase(unittest.TestCase):
 
         guess = self.optmngr.guessMode(helper)
         self.assertEqual(guess, "flim-setup")
+
+
+class MimasPathTestCase(unittest.TestCase):
+    """
+    Tests to be run with a MIMAS
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        testing.start_backend(MIMAS_CONFIG)
+
+        # Microscope component
+        cls.microscope = model.getComponent(role="mimas")
+        cls.optmngr = path.OpticalPathManager(cls.microscope)
+
+        # Find components
+        cls.ccd = model.getComponent(role="ccd")
+        cls.light = model.getComponent(role="light")
+        cls.filter = model.getComponent(role="filter")
+        cls.stage = model.getComponent(role="stage")
+        cls.focus = model.getComponent(role="focus")
+        cls.align = model.getComponent(role="align")
+        cls.sed = model.getComponent(role="se-detector")
+        cls.ibeam = model.getComponent(role="ion-beam")
+
+        # Move to LOADING (will reference if needed)
+        cryoSwitchSamplePosition(LOADING).result()
+        # Then move to FM_IMAGING, so that switching between optical path is allowed
+        cryoSwitchSamplePosition(FM_IMAGING).result()
+
+    def assert_pos_align(self, expected_pos_name: str):
+        """
+        Check that the aligner is positioned at the given "posture"
+        expected_pos_name: MD_FAV_POS_ACTIVE or MD_FAV_POS_DEACTIVE
+        """
+        exp_pos = self.align.getMetadata()[expected_pos_name]
+        testing.assert_pos_almost_equal(self.align.position.value, exp_pos)
+
+    def test_guess_mode(self):
+        """
+        Check that .guessMode(Stream) return the correct mode for each stream type
+        """
+        fib_stream = stream.SEMStream("test ion se", self.sed, self.sed.data, self.ibeam, opm=self.optmngr)
+        fluo_stream = stream.FluoStream("test fluo", self.ccd, self.ccd.data, self.light,
+                                        self.filter, opm=self.optmngr)
+
+        m = self.optmngr.guessMode(fib_stream)
+        self.assertEqual(m, "fib")
+
+        m = self.optmngr.guessMode(fluo_stream)
+        self.assertEqual(m, "optical")
+
+    def test_set_path_mode(self):
+        """
+        Check that .setPath(mode_name) moves the aligner according to the requested mode
+        """
+        f = self.optmngr.setPath("optical")
+        f.result()
+        self.assert_pos_align(model.MD_FAV_POS_ACTIVE)
+
+        f = self.optmngr.setPath("fib")
+        f.result()
+        self.assert_pos_align(model.MD_FAV_POS_DEACTIVE)
+
+        # check that when in LOADING position, the optical path doesn't change
+        cryoSwitchSamplePosition(LOADING).result()
+        f = self.optmngr.setPath("optical")
+        f.result()
+        pos_name = getCurrentPositionLabel(self.stage.position.value, self.stage, self.align)
+        self.assertEqual(pos_name, LOADING)
+
+        # Move it back to FM_IMAGING
+        cryoSwitchSamplePosition(FM_IMAGING).result()
+
+    def test_set_path_stream(self):
+        """
+        Check that .setPath(Stream) moves the aligner according to the stream type
+        """
+        fib_stream = stream.SEMStream("test ion se", self.sed, self.sed.data, self.ibeam, opm=self.optmngr)
+        fluo_stream = stream.FluoStream("test fluo", self.ccd, self.ccd.data, self.light,
+                                        self.filter, opm=self.optmngr)
+
+        f = self.optmngr.setPath(fluo_stream)
+        f.result()
+        self.assert_pos_align(model.MD_FAV_POS_ACTIVE)
+
+        f = self.optmngr.setPath(fib_stream)
+        f.result()
+        self.assert_pos_align(model.MD_FAV_POS_DEACTIVE)
 
 
 if __name__ == "__main__":

--- a/src/odemis/gui/model/__init__.py
+++ b/src/odemis/gui/model/__init__.py
@@ -345,6 +345,8 @@ class MainGUIData(object):
                     required_roles += ["ion-beam", "se-detector-ion"]
             elif self.role == "meteor":
                 required_roles += ["light", "stage", "focus"]
+            elif self.role == "mimas":
+                required_roles += ["light", "stage", "focus", "align", "ion-beam"]
             elif self.role in ("sparc", "sparc2"):
                 # SPARCv1 can also work without a lens
                 required_roles += ["e-beam", "mirror"]

--- a/src/odemis/util/__init__.py
+++ b/src/odemis/util/__init__.py
@@ -137,6 +137,27 @@ def wrap_to_mpi_ppi(a: float) -> float:
     return (a + math.pi) % (2 * math.pi) - math.pi
 
 
+def rot_shortest_move(a: float, b: float, cycle: float = 2 * math.pi) -> float:
+    """
+    Computes the small rotational move to go from angle a to angle b, assuming
+    that a whole cycle is possible.
+    For instance, to go from 0 rad to 1.5π, with the usual cycle of 2π, the shortest move is -0.5π.
+    :param a: an angle, in any unit, can be any value
+    :param b: an angle, in the same unit as b, can be any value
+    :param cycle (> 0): the angle corresponding to a whole rotation.
+    :return: an angle between -cycle/2 and +cycle/2, in the same unit as a and b
+    """
+    vector = b - a
+    # mod1 and mod2 are always positive as cycle is positive
+    mod1 = vector % cycle
+    mod2 = -vector % cycle
+
+    if mod1 < mod2:
+        return mod1
+    else:
+        return -mod2
+
+
 def to_str_escape(s):
     """
     Escapes the given string (or bytes) in such a way that all the

--- a/src/odemis/util/test/util_test.py
+++ b/src/odemis/util/test/util_test.py
@@ -561,6 +561,40 @@ class WrapToMpiPpiTestCase(unittest.TestCase):
                                                            "with the converted value: %s" % converted_angle)
 
 
+class RotShortestMoveTestCase(unittest.TestCase):
+
+    def test_2_pi(self):
+        """Test value with 2 pi cycle"""
+        in_out = (
+            # input -> expected output
+            ((0.1, 0.2), 0.1),
+            ((0.2, 0.1), -0.1),
+            ((0, 0), 0),
+            ((0, 2 * math.pi), 0),
+            ((2 * math.pi, 0), 0),
+            ((0, 1.5 * math.pi), -0.5 *math.pi),
+            ((-10, -10 + 20 * (2 * math.pi)), 0),
+        )
+        for args, exp in in_out:
+            res = util.rot_shortest_move(*args)
+            self.assertAlmostEqual(res, exp, msg=f"Input {args} -> {res} while expected {exp}")
+
+    def test_cycles(self):
+        """Test value with different cycles"""
+        in_out = (
+            # input -> expected output
+            ((0.1, 0.2, 5), 0.1),
+            ((0.2, 0.1, 5), -0.1),
+            ((0, 0, 10), 0),
+            ((0, 2, 2), 0),
+            ((2, 0, 2), 0),
+        )
+        for args, exp in in_out:
+            res = util.rot_shortest_move(*args)
+            self.assertAlmostEqual(res, exp, msg=f"Input {args} -> {res} while expected {exp}")
+
+
+
 class RecursiveDictUpdateTestCase(unittest.TestCase):
 
     def test_dict_update(self):


### PR DESCRIPTION
Add the 4 defined positions in MIMAS to the acq.move module, similarly to ENZEL and METEOR.
Then also add support for the OPM to switch automatically between FM and FIB based on the streams.

We also introduce a fix for the SmarPod simulator, and add a new MIMAS simulator using the Orsay simulator.