### PR TITLE
acq orsay_milling: detect better end of milling

### DIFF
--- a/src/odemis/acq/test/orsay_milling_test.py
+++ b/src/odemis/acq/test/orsay_milling_test.py
@@ -242,3 +242,7 @@ class TestMilling(unittest.TestCase):
         self.assertTrue(f.cancelled())
         with self.assertRaises(futures.CancelledError):
             f.result()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
MillingActivationState sometimes goes at init to 1, then 0, and then
back to 1. Finally, at the end it becomes 0 again.
That meant that sometimes the detection of the end would be triggered
just before the actual acquisition.
=> Use .Target (as recommanded by Orsay Physics) and CurrentMillingPoint
to be really certain the milling is stated & finished.

Also generalise the parameter logger.