### PR TITLE
Bugfix transform inverse type

### DIFF
--- a/src/odemis/util/test/transform_test.py
+++ b/src/odemis/util/test/transform_test.py
@@ -517,17 +517,27 @@ class TransformTestBase:
                     tform = self.transform_type(matrix, translation).inverse()
                     numpy.testing.assert_array_almost_equal(src, tform.apply(dst))
 
+    def test_inverse_type(self):
+        """
+        `GeometricTransform.inverse()` should return a result of known type.
+
+        """
+        tform = self.transform_type()
+        inv = tform.inverse()
+        self.assertIs(type(inv), self.inverse_type)
+
 
 class AffineTransformTest(TransformTestBase, unittest.TestCase):
-    transform_type = AffineTransform
+    transform_type = inverse_type = AffineTransform
 
 
 class ScalingTransformTest(TransformTestBase, unittest.TestCase):
     transform_type = ScalingTransform
+    inverse_type = AffineTransform
 
 
 class SimilarityTransformTest(TransformTestBase, unittest.TestCase):
-    transform_type = SimilarityTransform
+    transform_type = inverse_type = SimilarityTransform
 
     def test_similarity_transform_from_pointset_umeyama(self):
         """
@@ -550,7 +560,7 @@ class SimilarityTransformTest(TransformTestBase, unittest.TestCase):
 
 
 class RigidTransformTest(TransformTestBase, unittest.TestCase):
-    transform_type = RigidTransform
+    transform_type = inverse_type = RigidTransform
 
 
 class TransformFromPointsetEquivalence(unittest.TestCase):

--- a/src/odemis/util/transform.py
+++ b/src/odemis/util/transform.py
@@ -1017,7 +1017,6 @@ class ScalingTransform(AffineTransform):
 
     """
 
-    _inverse_type = AffineTransform
     shear = ImplicitParameter(0, constrained=True)
 
     def __init__(
@@ -1032,6 +1031,7 @@ class ScalingTransform(AffineTransform):
         GeometricTransform.__init__(
             self, matrix, translation, scale=scale, rotation=rotation, squeeze=squeeze,
         )
+        self._inverse_type = AffineTransform
 
     @staticmethod
     def _estimate_matrix(x: numpy.ndarray, y: numpy.ndarray) -> numpy.ndarray:


### PR DESCRIPTION
The `GeometricTransform.inverse()` method returned an `AffineTransform` instance when called on a `RigidTransform` or `SimilarityTransform`. Fixed by changing the `_inverse_type` attribute to an instance variable that's set upon initialisation, and not inherited by `RigidTransform` and `SimilarityTransform`.