### PR TITLE
fix for yaml.representer.RepresenterError raised exception when an ob…

### DIFF
--- a/src/odemis/odemisd/main.py
+++ b/src/odemis/odemisd/main.py
@@ -66,7 +66,7 @@ class CustomSafeRepresenter(SafeRepresenter):
         self.represent_float(data)
 
 
-CustomSafeRepresenter.add_representer(numpy.float_, CustomSafeRepresenter.represent_numpy_float)
+CustomSafeRepresenter.add_representer(numpy.floating, CustomSafeRepresenter.represent_numpy_float)
 
 
 class CustomSafeDumper(Emitter, Serializer, CustomSafeRepresenter, Resolver):

--- a/src/odemis/odemisd/main.py
+++ b/src/odemis/odemisd/main.py
@@ -62,6 +62,8 @@ status_to_xtcode = {BACKEND_RUNNING: 0,
 class CustomSafeRepresenter(SafeRepresenter):
 
     def represent_numpy_float(self, data):
+        # Currently yaml does not support dumping objects of the datatype numpy.floating
+        # hence represent numpy.floating as python float
         data = float(data)
         self.represent_float(data)
 

--- a/src/odemis/util/conversion.py
+++ b/src/odemis/util/conversion.py
@@ -491,7 +491,7 @@ class CustomSafeRepresenter(SafeRepresenter):
 
     def represent_numpy_floating(self, data):
         data = float(data)
-        self.represent_float(data)
+        return self.represent_float(data)
 
 
 CustomSafeRepresenter.add_multi_representer(

--- a/src/odemis/util/conversion.py
+++ b/src/odemis/util/conversion.py
@@ -27,11 +27,11 @@ from collections.abc import Iterable
 import cv2
 import numpy
 import yaml
+from past.builtins import basestring, long
 from yaml.emitter import Emitter
 from yaml.representer import SafeRepresenter
 from yaml.resolver import Resolver
 from yaml.serializer import Serializer
-from past.builtins import basestring, long
 
 from odemis import model
 

--- a/src/odemis/util/conversion.py
+++ b/src/odemis/util/conversion.py
@@ -18,16 +18,22 @@ You should have received a copy of the GNU General Public License along with
 Odemis. If not, see http://www.gnu.org/licenses/.
 """
 
-from past.builtins import basestring, long
-from collections.abc import Iterable
-import cv2
 import json
 import logging
 import math
-import numpy
-from odemis import model
 import re
+from collections.abc import Iterable
+
+import cv2
+import numpy
 import yaml
+from yaml.emitter import Emitter
+from yaml.representer import SafeRepresenter
+from yaml.resolver import Resolver
+from yaml.serializer import Serializer
+from past.builtins import basestring, long
+
+from odemis import model
 
 
 def wavelength2rgb(wavelength):
@@ -471,3 +477,42 @@ class JsonExtraEncoder(json.JSONEncoder):
             return obj.decode()
 
         return json.JSONEncoder.default(self, obj)
+
+
+class CustomSafeRepresenter(SafeRepresenter):
+    """
+    Support for data types that SafeRepresenter
+    does not do.
+    This includes:
+        * Numpy floating
+
+    Use as: yaml.dump(data, Dumper=YamlExtraDumper)
+    """
+
+    def represent_numpy_floating(self, data):
+        data = float(data)
+        self.represent_float(data)
+
+
+CustomSafeRepresenter.add_multi_representer(
+    numpy.floating, CustomSafeRepresenter.represent_numpy_floating
+)
+
+
+class YamlExtraDumper(Emitter, Serializer, CustomSafeRepresenter, Resolver):
+
+    def __init__(self, stream,
+            default_style=None, default_flow_style=False,
+            canonical=None, indent=None, width=None,
+            allow_unicode=None, line_break=None,
+            encoding=None, explicit_start=None, explicit_end=None,
+            version=None, tags=None, sort_keys=True):
+        Emitter.__init__(self, stream, canonical=canonical,
+                indent=indent, width=width,
+                allow_unicode=allow_unicode, line_break=line_break)
+        Serializer.__init__(self, encoding=encoding,
+                explicit_start=explicit_start, explicit_end=explicit_end,
+                version=version, tags=tags)
+        CustomSafeRepresenter.__init__(self, default_style=default_style,
+                default_flow_style=default_flow_style, sort_keys=sort_keys)
+        Resolver.__init__(self)

--- a/src/odemis/util/test/conversion_test.py
+++ b/src/odemis/util/test/conversion_test.py
@@ -22,16 +22,18 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 '''
 import json
 import math
+import unittest
+
 import numpy
+import yaml
+
 from odemis import model
 from odemis.util import conversion
-from odemis.util.conversion import \
-    convert_to_object, \
-    reproduce_typed_value, \
-    get_img_transformation_matrix, \
-    get_tile_md_pos, get_img_transformation_md, ensure_tuple, JsonExtraEncoder, YamlExtraDumper
-import unittest
-import yaml
+from odemis.util.conversion import (JsonExtraEncoder, YamlExtraDumper,
+                                    convert_to_object, ensure_tuple,
+                                    get_img_transformation_matrix,
+                                    get_img_transformation_md, get_tile_md_pos,
+                                    reproduce_typed_value)
 
 
 class TestConversion(unittest.TestCase):

--- a/src/odemis/util/test/conversion_test.py
+++ b/src/odemis/util/test/conversion_test.py
@@ -29,8 +29,9 @@ from odemis.util.conversion import \
     convert_to_object, \
     reproduce_typed_value, \
     get_img_transformation_matrix, \
-    get_tile_md_pos, get_img_transformation_md, ensure_tuple, JsonExtraEncoder
+    get_tile_md_pos, get_img_transformation_md, ensure_tuple, JsonExtraEncoder, YamlExtraDumper
 import unittest
+import yaml
 
 
 class TestConversion(unittest.TestCase):
@@ -346,6 +347,27 @@ class TestConversion(unittest.TestCase):
         self.assertEqual(sorted(dec_obj["set"]), ["a", "b"])  # a list in random order => sorted
         self.assertEqual(dec_obj["complex"], [1, 2])  # as a list
         self.assertEqual(dec_obj["bytes"], "boo")
+
+    def test_yaml_numpy_floating(self):
+        """
+        Test that YAML can serialise a numpy float using YamlExtraDumper.
+        """
+        data = {
+            "floating": (numpy.float16(1.1), numpy.float32(2.1), numpy.float64(3.1)),
+            "float16": numpy.float16(1.1),
+            "float32": numpy.float32(2.1),
+            "float64": numpy.float64(3.1),
+        }
+        # The SafeDumper doesn't support numpy floats
+        self.assertRaises(yaml.representer.RepresenterError, yaml.safe_dump, data)
+        # The YamlExtraDumper does support numpy floats
+        dumped_data = yaml.dump(data, Dumper=YamlExtraDumper)
+        loaded_data = yaml.safe_load(dumped_data)
+        # Check that the data is the same
+        self.assertEqual(loaded_data["floating"], list(data["floating"]))
+        self.assertEqual(loaded_data["float16"], data["float16"])
+        self.assertEqual(loaded_data["float32"], data["float32"])
+        self.assertEqual(loaded_data["float64"], data["float64"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In the `self._persistent_data` dict for FAST-EM, ['Mirror Descanner']['properties']['scanOffset'] is a tuple containing numpy.float64 elements.

This raises a yaml exception while dumping the dictionary. A work-around is inheriting yaml `SafeRepresenter` class and handling `numpy.floating` datatype by converting into float. Finally, `CustomSafeDumper` makes use of `CustomSafeRepresenter` and is used as the dumper during `yaml.dump()`.