### PR TITLE
fix TEST_NOHW default value

### DIFF
--- a/src/odemis/acq/test/orsay_milling_test.py
+++ b/src/odemis/acq/test/orsay_milling_test.py
@@ -36,7 +36,7 @@ from odemis.util import timeout
 logging.getLogger().setLevel(logging.DEBUG)
 logging.basicConfig(format="%(asctime)s  %(levelname)-7s %(module)s:%(lineno)d %(message)s")
 
-TEST_NOHW = os.environ.get("TEST_NOHW", "0")  # Default to Hw testing
+TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 
 class TestMilling(unittest.TestCase):


### PR DESCRIPTION
Quick fix of the failing test case due to incorrect setting of TEST_NOHW default value.