### PR TITLE
gui comp: add SampleBackgroundOverlay for MIMAS

### DIFF
--- a/src/odemis/gui/comp/overlay/world.py
+++ b/src/odemis/gui/comp/overlay/world.py
@@ -376,7 +376,12 @@ class SampleBackgroundOverlay(WorldOverlay):
                                                 )
 
     def draw(self, ctx, shift=(0, 0), scale=1.0):
-        """ Draw the background image by displaying all circles. """
+        """
+        Draw the background image by displaying all circles
+        :param ctx: cairo context from the canvas
+        :param shift (float, float): physical coordinates of the center of the canvas buffer
+        :param scale (float > 0): the ratio between the size of a feature in pixels and its actual size, in px/m 
+        """
         if not self.show:
             return
 

--- a/src/odemis/gui/comp/overlay/world.py
+++ b/src/odemis/gui/comp/overlay/world.py
@@ -25,27 +25,31 @@ This file is part of Odemis.
 import logging
 import math
 from abc import ABCMeta, abstractmethod
+from typing import Dict, Tuple
 
 import cairo
-import wx
-from future.utils import with_metaclass
-
 import odemis.gui as gui
 import odemis.gui.img as guiimg
 import odemis.util.conversion as conversion
 import odemis.util.units as units
+import wx
+from future.utils import with_metaclass
 from odemis import model, util
-from odemis.acq.feature import FEATURE_ACTIVE, FEATURE_ROUGH_MILLED, FEATURE_POLISHED, FEATURE_DEACTIVE
+from odemis.acq.feature import (FEATURE_ACTIVE, FEATURE_DEACTIVE,
+                                FEATURE_POLISHED, FEATURE_ROUGH_MILLED)
 from odemis.acq.stream import UNDEFINED_ROI
-from odemis.gui import img
 from odemis.gui.comp.canvas import CAN_DRAG
-from odemis.gui.comp.overlay.base import Vec, WorldOverlay, Label, SelectionMixin, DragMixin, \
-    PixelDataMixin, SEL_MODE_EDIT, SEL_MODE_CREATE, EDIT_MODE_BOX, EDIT_MODE_POINT, SpotModeBase, SEL_MODE_NONE
+from odemis.gui.comp.overlay.base import (EDIT_MODE_BOX, EDIT_MODE_POINT,
+                                          SEL_MODE_CREATE, SEL_MODE_EDIT,
+                                          SEL_MODE_NONE, DragMixin, Label,
+                                          PixelDataMixin, SelectionMixin,
+                                          SpotModeBase, Vec, WorldOverlay)
 from odemis.gui.comp.overlay.view import CenteredLineOverlay
-from odemis.gui.model import TOOL_RULER, TOOL_LABEL, TOOL_NONE, TOOL_FEATURE
+from odemis.gui.model import TOOL_FEATURE, TOOL_LABEL, TOOL_NONE, TOOL_RULER
 from odemis.gui.util import call_in_wx_main
 from odemis.util import clip_line
-from odemis.util.comp import compute_scanner_fov, compute_camera_fov, get_fov_rect
+from odemis.util.comp import (compute_camera_fov, compute_scanner_fov,
+                              get_fov_rect)
 from odemis.util.raster import rasterize_line
 
 
@@ -346,6 +350,67 @@ class CryoFeatureOverlay(StagePointSelectOverlay, DragMixin):
                 self._label.draw(ctx)
 
             ctx.paint()
+
+class SampleBackgroundOverlay(WorldOverlay):
+    """
+    Overlay to display the contour of samples (aka TEM grid)
+    Displays a list of circles and, at low zoom levels, also show their name in the middle .
+    """
+
+    def __init__(self, cnvs, samples: Dict[str, Tuple[float, float]], sample_radius: float):
+        """
+        cnvs (Canvas): canvas for the overlay
+        sample: Dict of sample name -> center position (X/Y in m)
+        sample_radius: the radius of a sample in m (all samples are shown with the same radius)
+        """
+        super().__init__(cnvs)
+        self._colour = (0.0, 0.42, 0.8, 1.0)  # Blue
+        self._samples = samples
+        self._radius = sample_radius
+        self._labels = {}
+        for name in self._samples:
+            self._labels[name] = self.add_label(name,
+                                                align = wx.ALIGN_CENTRE_HORIZONTAL | wx.ALIGN_CENTER_VERTICAL,
+                                                colour=self._colour[:3],  # no transparency, to support .opacity
+                                                background=(0, 0, 0, 0.5)  # Black semi-transparent
+                                                )
+
+    def draw(self, ctx, shift=(0, 0), scale=1.0):
+        """ Draw the background image by displaying all circles. """
+        if not self.show:
+            return
+
+        # If the FoV is bigger than the diameter, the user is probably not looking at
+        # specific image, and more looking at the broad view => show the name
+        # Make it about the same size as the diameter (so dependent on the zoom).
+        # If it's too small, no need to show.
+        # To smoothen the transition shown/not shown use transparency between FoV = diameter (full transparent)
+        # to FoV = 4* diameter (full opaque)
+        fov_px = self.cnvs.view_width  # px
+        radius_px = self._radius * scale
+        label_size = radius_px / 2  # height (approximatively in px) => a quarter of the diameter
+        min_opaq = radius_px * 2  # fully transparent => 0
+        max_opaq = radius_px * 2 * 8  # fully opaque => 1
+        label_opacity = min(max(0, (fov_px - min_opaq) / (max_opaq - min_opaq)), 1)
+
+        # Draw the circles (and update the label info)
+        for name, center in self._samples.items():
+            label = self._labels[name]
+            offset = self.cnvs.get_half_buffer_size()
+            b_center = self.cnvs.phys_to_buffer((center[0], center[1]), offset)
+            label.pos = b_center
+            label.font_size = label_size
+            label.opacity = label_opacity
+
+            ctx.set_source_rgba(*self._colour)
+            ctx.set_line_width(2)  # px
+            ctx.new_sub_path()  # avoid connecting the (unknown) current point to the beginning of the circle
+            ctx.arc(b_center[0], b_center[1], radius_px, 0, 2 * math.pi)
+            ctx.stroke()
+
+        # Show the labels, if it's useful: not too zoomed in, nor too zoomed out
+        if self.cnvs.view_width > radius_px * 2 and label_size >= 4:
+            self._write_labels(ctx)
 
 
 class WorldSelectOverlay(WorldOverlay, SelectionMixin):

--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -339,7 +339,6 @@ class Tab(object):
 AUTOFOCUS_BINNING = (8, 8)
 AUTOFOCUS_HFW = 300e-06  # m
 
-
 class LocalizationTab(Tab):
 
     def __init__(self, name, button, panel, main_frame, main_data):
@@ -381,6 +380,11 @@ class LocalizationTab(Tab):
         # remove the play overlay from the top view with static streams
         panel.vp_secom_tl.canvas.remove_view_overlay(panel.vp_secom_tl.canvas.play_overlay)
         panel.vp_secom_tr.canvas.remove_view_overlay(panel.vp_secom_tr.canvas.play_overlay)
+
+        # Add a sample overlay to each view (if we have information)
+        if main_data.sample_centers:
+            for vp in (panel.vp_secom_tl, panel.vp_secom_tr, panel.vp_secom_bl, panel.vp_secom_br):
+                vp.show_sample_overlay(main_data.sample_centers, main_data.sample_radius)
 
         # Default view is the Live 1
         tab_data.focussedView.value = panel.vp_secom_bl.view
@@ -5135,7 +5139,7 @@ class MimasAlignTab(Tab):
 
         # Connect the view (for now, only optical)
         vpv = collections.OrderedDict([
-            (panel.pnl_viewport.viewports[0],  # focused view
+            (panel.vp_optical,
              {
                 "name": "Optical",
                 "stage": self._stage,
@@ -5148,10 +5152,14 @@ class MimasAlignTab(Tab):
         # Add a CryoFeatureOverlay to the canvas, not to show the features, but
         # to support moving the stage by double clicking, even if the stream is paused.
         # (So that the user can move the stage when looking at the FIB image in the separate computer)
-        cnvs = panel.pnl_viewport.viewports[0].canvas
+        cnvs = panel.vp_optical.canvas
         cryofeature_overlay = CryoFeatureOverlay(cnvs, tab_data)
         cnvs.add_world_overlay(cryofeature_overlay)
         cryofeature_overlay.active.value = True
+
+        # Add a sample overlay (if we have information)
+        if main_data.sample_centers:
+            panel.vp_optical.show_sample_overlay(main_data.sample_centers, main_data.sample_radius)
 
         # Create the Optical stream.
         # The focuser is "aligner" to calibrate the optical focus (while the stage Z stays constant)

--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -339,6 +339,7 @@ class Tab(object):
 AUTOFOCUS_BINNING = (8, 8)
 AUTOFOCUS_HFW = 300e-06  # m
 
+
 class LocalizationTab(Tab):
 
     def __init__(self, name, button, panel, main_frame, main_data):

--- a/src/odemis/gui/main.py
+++ b/src/odemis/gui/main.py
@@ -133,6 +133,8 @@ class OdemisGUIApp(wx.App):
 
         if microscope and microscope.role == "mbsem":
             self.main_data = guimodel.FastEMMainGUIData(microscope)
+        elif microscope and microscope.role in ("meteor", "enzel", "mimas"):
+            self.main_data = guimodel.CryoMainGUIData(microscope)
         else:
             self.main_data = guimodel.MainGUIData(microscope)
         # Load the main frame

--- a/src/odemis/gui/main.xrc
+++ b/src/odemis/gui/main.xrc
@@ -2008,7 +2008,7 @@
 
       <object class="sizeritem">
         <object class="ViewportGrid" name="pnl_viewport">
-          <object class="LiveViewport" name="view_optical">
+          <object class="LiveViewport" name="vp_optical">
             <fg>#BFBFBF</fg>
             <bg>#000000</bg>
           </object>

--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -262,7 +262,7 @@ class xrcpnl_tab_mimas_align(wx.Panel):
         self.html_alignment_doc = xrc.XRCCTRL(self, "html_alignment_doc")
         self.btn_log = xrc.XRCCTRL(self, "btn_log")
         self.pnl_viewport = xrc.XRCCTRL(self, "pnl_viewport")
-        self.view_optical = xrc.XRCCTRL(self, "view_optical")
+        self.vp_optical = xrc.XRCCTRL(self, "vp_optical")
         self.scr_win_right = xrc.XRCCTRL(self, "scr_win_right")
         self.pnl_streams = xrc.XRCCTRL(self, "pnl_streams")
 
@@ -3090,7 +3090,7 @@ def __init_resources():
 
       <object class="sizeritem">
         <object class="ViewportGrid" name="pnl_viewport">
-          <object class="LiveViewport" name="view_optical">
+          <object class="LiveViewport" name="vp_optical">
             <fg>#BFBFBF</fg>
             <bg>#000000</bg>
           </object>

--- a/src/odemis/gui/model/__init__.py
+++ b/src/odemis/gui/model/__init__.py
@@ -521,13 +521,15 @@ class CryoMainGUIData(MainGUIData):
         # Ex: {"grid 1": {"x": 0.1, "y": -0.2}} -> {"grid 1": (0.1, -0.2)}
         sample_centers_raw = self.stage.getMetadata().get(model.MD_SAMPLE_CENTERS)
 
-        # TODO: on the METEOR, the MD_SAMPLE_CENTER is on the stage-bare, in the stage-bare
-        # coordinates (SEM). To display them, we'd need to convert them to the stage coordinates.
-        # The acq.move code only needs the stage-bare coordinates (even if in FM), but we
-        # would need the sample centers position during the FLM mode, in the stage coordinates...
-        # and we don't have explicit functions for that (the stage wrapper knows how to convert
-        # a position from the dependencies stages, which can be ot her wrappers, but we don't
-        # have an explicit way to ask "if the stage-bare was at this position, what
+        # TODO: on the METEOR, the MD_SAMPLE_CENTERS is on the stage-bare, in
+        # the stage-bare coordinates (SEM). To display them, we'd need to
+        # convert them to the stage coordinates. The acq.move code only needs
+        # the stage-bare coordinates (even if in FM), but we would need the
+        # sample centers position during the FLM mode, in the stage coordinates...
+        # and we don't have explicit functions for that. The "stage" component
+        # knows how to convert a position from it dependencies stages, which
+        # themselves are other wrappers to the "stage-bare", but we don't have
+        # an explicit way to ask "if the stage-bare was at this position, what
         # would the stage position be?".
 
         if sample_centers_raw:

--- a/src/odemis/gui/model/__init__.py
+++ b/src/odemis/gui/model/__init__.py
@@ -43,7 +43,7 @@ from odemis.gui.log import observe_comp_state
 import os
 import threading
 import time
-from typing import Tuple
+from typing import Dict, Tuple
 
 
 # The different states of a microscope
@@ -501,6 +501,46 @@ class MainGUIData(object):
 
         if model.hasVA(self.lens, "mirrorPositionTop") and model.hasVA(self.lens, "mirrorPositionBottom"):
             return True
+
+
+class CryoMainGUIData(MainGUIData):
+    """
+    Data common to all Cryo tabs (METEOR/ENZEL/MIMAS).
+    """
+    SAMPLE_RADIUS_TEM_GRID = 1.8e-3  # m, standard TEM grid size including the borders
+    # Bounding-box relative to the center of a sample, corresponding to usable area
+    # for imaging/milling. Used in particular for the overview image.
+    SAMPLE_USABLE_BBOX_TEM_GRID = (-1e-3, -1e-3, 1e-3, 1e-3)  # m, minx, miny, maxx, maxy
+
+    def __init__(self, microscope):
+        super().__init__(microscope)
+        self.sample_centers : Dict[str, Tuple[float, float]] = {}  # sample name -> center position (x, y)
+
+        # stage.MD_SAMPLE_CENTERS contains the date in almost the right format, but the
+        # position is a dict instead of a tuple. => Convert it, while checking the data.
+        # Ex: {"grid 1": {"x": 0.1, "y": -0.2}} -> {"grid 1": (0.1, -0.2)}
+        sample_centers_raw = self.stage.getMetadata().get(model.MD_SAMPLE_CENTERS)
+
+        # TODO: on the METEOR, the MD_SAMPLE_CENTER is on the stage-bare, in the stage-bare
+        # coordinates (SEM). To display them, we'd need to convert them to the stage coordinates.
+        # The acq.move code only needs the stage-bare coordinates (even if in FM), but we
+        # would need the sample centers position during the FLM mode, in the stage coordinates...
+        # and we don't have explicit functions for that (the stage wrapper knows how to convert
+        # a position from the dependencies stages, which can be ot her wrappers, but we don't
+        # have an explicit way to ask "if the stage-bare was at this position, what
+        # would the stage position be?".
+
+        if sample_centers_raw:
+            try:
+                self.sample_centers = {n: (p["x"], p["y"]) for n, p in sample_centers_raw.items()}
+            except Exception as exp:
+                raise ValueError(f"Failed to parse MD_SAMPLE_CENTERS, expected format "
+                                 f"{{\"grid 1\": {{\"x\": 0.1, \"y\": -0.2}}}}: {exp}")
+
+        # Radius of a sample, for display
+        self.sample_radius = self.SAMPLE_RADIUS_TEM_GRID
+        # Bounding-box of the "useful area" relative to the center of a grid
+        self.sample_rel_bbox = self.SAMPLE_USABLE_BBOX_TEM_GRID
 
 
 class MicroscopyGUIData(with_metaclass(ABCMeta, object)):

--- a/src/odemis/gui/test/comp_overlay_test.py
+++ b/src/odemis/gui/test/comp_overlay_test.py
@@ -34,7 +34,7 @@ from odemis.gui.comp.overlay import view as vol
 from odemis.gui.comp.overlay import world as wol
 from odemis.gui.comp.overlay.view import HORIZONTAL_LINE, VERTICAL_LINE, CROSSHAIR
 from odemis.gui.comp.overlay.world import EKOverlay
-from odemis.gui.comp.viewport import ARLiveViewport
+from odemis.gui.comp.viewport import ARLiveViewport, MicroscopeViewport
 from odemis.gui.model import TOOL_POINT, TOOL_LINE, TOOL_RULER, TOOL_LABEL, FeatureOverviewView
 from odemis.gui.util.img import wxImage2NDImage
 from odemis.util import mock
@@ -1217,6 +1217,32 @@ class OverlayTestCase(test.GuiTestCase):
         cnvs.Bind(wx.EVT_MOUSEWHEEL, zoom)
 
         test.gui_loop()
+
+    def test_sample_background_overlay(self):
+        # 4 samples along a rectangle of 1.5 x 1 mm, with a diameter of 1 mm
+        SAMPLE_CENTERS = {"SAMPLE 1": (0, 0), "SAMPLE 2": (1.5e-3, 0),
+                          "SAMPLE 3": (0, -1e-3), "SAMPLE 4": (1.5e-3, -1e-3)
+                         }
+        RADIUS = 0.5e-3  # m
+        vp = MicroscopeViewport(self.panel)
+        vp.show_sample_overlay(SAMPLE_CENTERS, RADIUS)
+        self.add_control(vp, wx.EXPAND, proportion=1, clear=True)
+
+        cnvs = vp.canvas
+        cnvs.scale = 20000
+        cnvs.update_drawing()
+
+        def zoom(evt):
+            if evt.GetWheelRotation() > 0:
+                cnvs.scale *= 1.1
+            else:
+                cnvs.scale *= 0.9
+            cnvs.update_drawing()
+
+        cnvs.Bind(wx.EVT_MOUSEWHEEL, zoom)
+
+        test.gui_loop()
+
 
     # END World overlay test cases
 


### PR DESCRIPTION
Shows the (theoretical) position of the samples based on the YAML
metadata into the view, as blue wireframe.

It could almost work for METEOR, but the metadata is in the SEM stage
(stage-bare) referential, while we need to have it in the FM referential
(stage).