### PR TITLE
util comp: fix use of MD_POS_ACTIVE_RANGE in generate_zlevels()

### DIFF
--- a/src/odemis/util/comp.py
+++ b/src/odemis/util/comp.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-'''
+"""
 Created on 31 May 2018
 
 @author: Éric Piel
@@ -13,7 +13,7 @@ Odemis is free software: you can redistribute it and/or modify it under the term
 Odemis is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License along with Odemis. If not, see http://www.gnu.org/licenses/.
-'''
+"""
 import copy
 import math
 from typing import List, Tuple
@@ -115,6 +115,7 @@ def get_fov_rect(comp, fov):
 
 MAX_ZLEVELS = 500
 
+
 def generate_zlevels(focuser: "Actuator", zrange: Tuple[float, float], zstep: float) -> List[float]:
     """
     Calculates the zlevels for a zstack acquisition, using the zmax, zmin
@@ -156,24 +157,25 @@ def generate_zlevels(focuser: "Actuator", zrange: Tuple[float, float], zstep: fl
     if zrange_abs[0] == zrange_abs[1]:
         return focuser_pos + zrange[0]
 
-    # find number of samples 
+    # find number of zlevels
     n = (zrange_abs[1] - zrange_abs[0]) / abs(zstep) + 1
     if n > MAX_ZLEVELS:
         raise IndexError(f"The number of zlevels, {n}, is too large. Reduce the zstep value to < {MAX_ZLEVELS}.")
 
-    # try the floor and ceil values for the number of samples, and 
-    # take the one that give smaller error.
-    # note: if n is 1 -> division by zero and step_c will always be picked,
-    # so just choose any large value for step_f (e.g infinite)
-    try:
-        step_f = (zrange_abs[1] - zrange_abs[0]) / (math.floor(n) - 1)
-    except ZeroDivisionError:
-        step_f = math.inf
-    step_c = (zrange_abs[1] - zrange_abs[0]) / (math.ceil(n) - 1)
-    # errors 
-    ef = abs(step_f - abs(zstep))
-    ec = abs(step_c - abs(zstep))
-    n = math.floor(n) if ef < ec else math.ceil(n)
+    # zstep often doesn't exactly fit to have a round number of zlevels. So try
+    # the floor and ceil values for the number of zlevels, and take the one that
+    # give a step closest to the requested zstep.
+    n_f = math.floor(n)
+    n_c = math.ceil(n)
+
+    if n_f <= 1:  # would cause a division by zero
+        # => do the minimum amount of steps
+        n = 2
+    else:
+        # errors
+        ef = abs((zrange_abs[1] - zrange_abs[0]) / (n_f - 1) - abs(zstep))
+        ec = abs((zrange_abs[1] - zrange_abs[0]) / (n_c - 1) - abs(zstep))
+        n = n_f if ef < ec else n_c
 
     if zstep > 0:
         return numpy.linspace(zrange_abs[0], zrange_abs[1], n).tolist()

--- a/src/odemis/util/comp.py
+++ b/src/odemis/util/comp.py
@@ -15,8 +15,10 @@ Odemis is distributed in the hope that it will be useful, but WITHOUT ANY WARRAN
 You should have received a copy of the GNU General Public License along with Odemis. If not, see http://www.gnu.org/licenses/.
 '''
 import copy
+import math
+from typing import List, Tuple
 
-import numpy, math
+import numpy
 from odemis import model
 from odemis.util import img
 
@@ -113,64 +115,67 @@ def get_fov_rect(comp, fov):
 
 MAX_ZLEVELS = 500
 
-def generate_zlevels(focuser, zrange, zstep):
+def generate_zlevels(focuser: "Actuator", zrange: Tuple[float, float], zstep: float) -> List[float]:
     """
     Calculates the zlevels for a zstack acquisition, using the zmax, zmin
-    and zstep, as well as the current focus z position
-    focuser (Actuator): focus component
-    zrange (float, float): contains the zMin and zMax, respectively. Error is raised
-        if the order is not (zMin, zMax). 
-    zstep (float>0 or float<0): distance between two successive zlevels. If negative,
-        the order of the returned list of zlevels is reversed. The actual zstep in the 
-        returned list is adjusted to the closest value of the given zstep that divides
-        the zrange. If zstep is too small, this will lead to too large number of zlevels. 
-        In that case IndexError is raised. 
-    returns (list of floats): list of zlevels, where each zlevel is absolute position for
-        the focuser.  
+    and zstep, as well as the current focus z position.
+    :param focuser: Actuator component with a "z" axis, to control the focus.
+    :param zrange: contains the zmin and zmax, respectively. It's relative to the
+    current position of the focuser. If the range would go out of the actuator
+    range, it's clipped (so there are less zlevels returned than expected).
+    Error is raised if the order is not (zmin, zmax).
+    :param zstep: distance between two successive zlevels. If negative,
+    the order of the returned list of zlevels is reversed. The actual zstep in the
+    returned list is adjusted to the closest value of the given zstep that divides
+    the zrange. If zstep is too small, this will lead to too large number of zlevels.
+    In that case IndexError is raised.
+    :returns: list of zlevels, where each zlevel is absolute position for
+    the focuser.
     """
     if zstep == 0:
-        raise ZeroDivisionError("The step size 'Zstep' can not be zero")
+        raise ZeroDivisionError("The step size 'zstep' can not be zero")
     if zrange[0] > zrange[1]:
-        raise ValueError("The given range is not correct. zmin should be first and zmax second")
+        raise ValueError(f"The given range {zrange} is not correct. The first value should be smaller than the second one.")
     if "z" not in focuser.axes.keys():
-        raise KeyError("The focus actuator %s does not have z axis" %focuser)
+        raise KeyError(f"The focus actuator {focuser} does not have z axis")
 
     focuser_pos = focuser.position.value["z"]
+    zrange_abs = (zrange[0] + focuser_pos, zrange[1] + focuser_pos)
 
     # Get the range from the axis range + extra limit POS_ACTIVE_RANGE
     focuser_rng = focuser.axes["z"].range
     sw_rng = focuser.getMetadata().get(model.MD_POS_ACTIVE_RANGE)
-    if sw_rng:
-        focuser_rng = (max(focuser_rng[0], sw_rng[0]),
-                       min(focuser_rng[1], sw_rng[1]))
+    if sw_rng and "z" in sw_rng:
+        focuser_rng = (max(focuser_rng[0], sw_rng["z"][0]),
+                       min(focuser_rng[1], sw_rng["z"][1]))
 
-    # clip the zMax and zMin to the actuator limits if necessary 
-    if zrange[1] + focuser_pos > focuser_rng[1]:
-        zrange[1] = focuser_rng[1] - focuser_pos
-    if focuser_pos + zrange[0] < focuser_rng[0]:
-        zrange[0] = focuser_rng[0] - focuser_pos
-    if zrange[0] == zrange[1]:
+    # clip the zMax and zMin to the actuator limits if necessary
+    zrange_abs = (min(max(focuser_rng[0], zrange_abs[0]), focuser_rng[1]),
+                  min(max(focuser_rng[0], zrange_abs[1]), focuser_rng[1]))
+
+    if zrange_abs[0] == zrange_abs[1]:
         return focuser_pos + zrange[0]
 
     # find number of samples 
-    n = (zrange[1] - zrange[0]) / abs(zstep) + 1
+    n = (zrange_abs[1] - zrange_abs[0]) / abs(zstep) + 1
     if n > MAX_ZLEVELS:
-        raise IndexError("The number of zlevels, %s, is too large. The max allowable number of zlevels is %s. Reduce the zstep value." %(n, MAX_ZLEVELS))
+        raise IndexError(f"The number of zlevels, {n}, is too large. Reduce the zstep value to < {MAX_ZLEVELS}.")
+
     # try the floor and ceil values for the number of samples, and 
     # take the one that give smaller error.
     # note: if n is 1 -> division by zero and step_c will always be picked,
     # so just choose any large value for step_f (e.g infinite)
     try:
-        step_f = (zrange[1] - zrange[0]) / (math.floor(n) - 1)
+        step_f = (zrange_abs[1] - zrange_abs[0]) / (math.floor(n) - 1)
     except ZeroDivisionError:
-        step_f = float("inf")
-    step_c = (zrange[1] - zrange[0]) / (math.ceil(n) - 1)
+        step_f = math.inf
+    step_c = (zrange_abs[1] - zrange_abs[0]) / (math.ceil(n) - 1)
     # errors 
     ef = abs(step_f - abs(zstep))
     ec = abs(step_c - abs(zstep))
     n = math.floor(n) if ef < ec else math.ceil(n)
 
     if zstep > 0:
-        return (numpy.linspace(zrange[0], zrange[1], n) + focuser_pos).tolist()
+        return numpy.linspace(zrange_abs[0], zrange_abs[1], n).tolist()
     elif zstep < 0:
-        return (numpy.linspace(zrange[1], zrange[0], n) + focuser_pos).tolist()
+        return numpy.linspace(zrange_abs[1], zrange_abs[0], n).tolist()

--- a/src/odemis/util/test/comp_test.py
+++ b/src/odemis/util/test/comp_test.py
@@ -235,6 +235,18 @@ class TestGenerateZlevels(unittest.TestCase):
         actual = generate_zlevels(self.focus, zrange, zStep)
         numpy.testing.assert_array_almost_equal(expected, actual)
 
+    def test_clipping_axis_range(self):
+        self.focus.updateMetadata({model.MD_POS_ACTIVE_RANGE: {"z": [-100e-6, 100e-6]}})
+        try:
+            self.focus.moveAbsSync({"z": 80e-6})
+            zrange = (-50e-6, 50e-6)
+            zStep = 10e-6
+            expected = numpy.arange(30e-6, 100e-6 + 1e-12, 10e-6)
+            actual = generate_zlevels(self.focus, zrange, zStep)
+            numpy.testing.assert_array_almost_equal(expected, actual)
+        finally:
+            self.focus.updateMetadata({model.MD_POS_ACTIVE_RANGE: {}})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/odemis/util/test/comp_test.py
+++ b/src/odemis/util/test/comp_test.py
@@ -240,9 +240,9 @@ class TestGenerateZlevels(unittest.TestCase):
         try:
             self.focus.moveAbsSync({"z": 80e-6})
             zrange = (-50e-6, 50e-6)
-            zStep = 10e-6
-            expected = numpy.arange(30e-6, 100e-6 + 1e-12, 10e-6)
-            actual = generate_zlevels(self.focus, zrange, zStep)
+            zstep = 10e-6
+            expected = numpy.arange(30e-6, 100e-6 + 1e-12, zstep)
+            actual = generate_zlevels(self.focus, zrange, zstep)
             numpy.testing.assert_array_almost_equal(expected, actual)
         finally:
             self.focus.updateMetadata({model.MD_POS_ACTIVE_RANGE: {}})


### PR DESCRIPTION
MD_POS_ACTIVE_RANGE is a dict of the format axis -> tuple. However, the
code assumed that it would just be a tuple.

=> Look explicitly for the "z" axis.