### PR TITLE
gui xrc: fix MIMAS optical grey icon

### DIFF
--- a/src/odemis/gui/main.xrc
+++ b/src/odemis/gui/main.xrc
@@ -4443,7 +4443,7 @@
                                         <object class="sizeritem">
                                             <object class="ProgressRadioButton"
                                                     name="btn_switch_optical_chamber_tab">
-                                                <icon>img/icon/ico_imaging.png</icon>
+                                                <icon>img/icon/ico_optical.png</icon>
                                                 <icon_progress>img/icon/ico_optical_orange.png</icon_progress>
                                                 <icon_on>img/icon/ico_optical_green.png</icon_on>
                                                 <height>48</height>

--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -5510,7 +5510,7 @@ def __init_resources():
                                         </object>
                                         <object class="sizeritem">
                                             <object class="ProgressRadioButton" name="btn_switch_optical_chamber_tab">
-                                                <icon>img_icon_ico_imaging_png</icon>
+                                                <icon>img_icon_ico_optical_png</icon>
                                                 <icon_progress>img_icon_ico_optical_orange_png</icon_progress>
                                                 <icon_on>img_icon_ico_optical_green_png</icon_on>
                                                 <height>48</height>


### PR DESCRIPTION
It used the ENZEL icon instead of the simple optical icon.