### PR TITLE
mark regex expressions as raw strings

### DIFF
--- a/src/odemis/cli/test/main_test.py
+++ b/src/odemis/cli/test/main_test.py
@@ -214,7 +214,7 @@ class TestWithBackend(unittest.TestCase):
     
     def test_set_attr(self):
         # to read attribute power (which is a list of numbers)
-        regex = re.compile(b"\spower.+ value: \[(.*?)\]")
+        regex = re.compile(br"\spower.+ value: \[(.*?)\]")
         
         # read before
         try:

--- a/src/odemis/driver/xt_client.py
+++ b/src/odemis/driver/xt_client.py
@@ -317,12 +317,12 @@ class SEM(model.HwComponent):
         """Check if a latest xtadapter package is available and then transfer it."""
         try:
             package = None
-            bitness = re.search("bitness:\s*([\da-z]+)", self._swVersion)
+            bitness = re.search(r"bitness:\s*([\da-z]+)", self._swVersion)
             bitness = bitness.group(1) if bitness is not None else None
             adapter = "xtadapter"
             if "xttoolkit" in self._swVersion:
                 adapter = "fastem-xtadapter"
-            current_version = re.search("xtadapter:\s*([\d.]+)", self._swVersion)
+            current_version = re.search(r"xtadapter:\s*([\d.]+)", self._swVersion)
             current_version = current_version.group(1) if current_version is not None else None
             if current_version is not None and bitness is not None:
                 package = check_latest_package(

--- a/src/odemis/odemisd/modelgen.py
+++ b/src/odemis/odemisd/modelgen.py
@@ -192,7 +192,7 @@ def get_class(name):
         module_name, class_name = internal_classes[name].rsplit(".", 1)
     else:
         # It comes from the user, so check carefully there is no strange characters
-        if not re.match("(\w|\.)+\.(\w)+\Z", name):
+        if not re.match(r"(\w|\.)+\.(\w)+\Z", name):
             raise ParseError("Syntax error in microscope file: "
                              "class name '%s' is malformed." % name)
 


### PR DESCRIPTION
These regex expressions contain \s or \w which could be interpreted as
escape characters, but are not, so currently fallback to being parsed as
is. However, future Python version will raise an error in such case.
=> Mark the strings as raw, to pass the \ happily.