### PR TITLE
starting milling stage position changed to grid 1 instead of reading …

### DIFF
--- a/src/odemis/acq/test/millmng_test.py
+++ b/src/odemis/acq/test/millmng_test.py
@@ -108,7 +108,8 @@ class MillingManagerTestCase(unittest.TestCase):
 
         cls.acq_streams = [fs1]
 
-        current_stage_pos = cls.stage.position.value
+        # set the current stage position same as GRID 1 for milling
+        current_stage_pos = cls.stage.getMetadata()[model.MD_FAV_POS_ACTIVE]
         logging.debug("current stage position %s", current_stage_pos)
 
         target_position_1 = {"x": current_stage_pos["x"],


### PR DESCRIPTION
Fixing failing test case @sneepstefan

millmng_test.py::MillingManagerTestCase::test_cancel on Ubuntu 20