### PR TITLE
acq millmng: fix milling with drift correction milling too long

### DIFF
--- a/src/odemis/acq/millmng.py
+++ b/src/odemis/acq/millmng.py
@@ -355,7 +355,7 @@ class MillingRectangleTask(object):
 
                         self._scanner.probeCurrent.value = milling_settings.current.value
                         self._future.running_subf = mill_rectangle(milling_settings.roi.value, self._scanner,
-                                                                   iteration=self._iterations[setting_nb],
+                                                                   iteration=1,
                                                                    duration=self._pass_duration[setting_nb],
                                                                    probe_size=probe_size, overlap=overlap)
                     try:


### PR DESCRIPTION
The milling is cut in N passes. For each pass, the milling would mill
for N * duration. It should be just 1 * duration.