### PR TITLE
bugreporter: set POST request content-type as JSON

### DIFF
--- a/src/bugreporter/odemis_bugreporter.py
+++ b/src/bugreporter/odemis_bugreporter.py
@@ -215,7 +215,10 @@ class OdemisBugreporter(object):
 
         description = json.dumps(fields).encode("utf-8")
         # data must be bytes, but the headers can be str or bytes
-        req = Request(OS_TICKET_URL, data=description, headers={"X-API-Key": api_key})
+        # Note the content type does matter in some cases: the default is "x-www-form-urlencoded",
+        # which is incorrect and some servers will refuse the request because of that.
+        req = Request(OS_TICKET_URL, data=description,
+                      headers={"X-API-Key": api_key, "Content-Type": "application/json"})
         f = urlopen(req)
         response = f.getcode()
         f.close()
@@ -223,7 +226,7 @@ class OdemisBugreporter(object):
             return
         else:
             raise ValueError('Ticket creation failed with error code %s.' % response)
-        
+
     def search_api_key(self):
         """
         Searches for a valid osTicket key on the system. First, the customer key


### PR DESCRIPTION
We upload JSON data, so it should be marked as JSON. Typically, the
content-type doesn't matter. At least osTicket doesn't care.
However, the HTTP server has new security rules that check that content,
and automatically rejected POST requests which, by default, reported
x-www-form-urlencoded.

So this fixes the issue that some users are facing when reporting a bug
and it indicates Error 400.