### PR TITLE
config mimas: change the FAV_POS_ACTIVE to be the center of GRID 1

### DIFF
--- a/install/linux/usr/share/odemis/sim/mimas-orsay-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/mimas-orsay-sim.odm.yaml
@@ -224,7 +224,7 @@ MIMAS-Sim: {
                            },
         # Initial position when going from loading to imaging.
         # Typically, same as GRID 1, but also with shows the initial Z
-        FAV_POS_ACTIVE: {"x": -4.0e-3, "y": 0, "z": 40.0e-6, "rx": 0 , "ry": 0, "rz": 0},
+        FAV_POS_ACTIVE: {"x": 7.5e-3, "y": -4.5e-3, "z": 40.0e-6, "rx": 0 , "ry": 0, "rz": 0},
         # Centers (X, Y) of each grid. The Z position is assumed to be the same for all grids.
         # They should all be within POS_ACTIVE_RANGE!
         SAMPLE_CENTERS: {

--- a/install/linux/usr/share/odemis/sim/mimas-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/mimas-sim.odm.yaml
@@ -190,7 +190,7 @@ MIMAS-Sim: {
                            },
         # Initial position when going from loading to imaging.
         # Typically, same as GRID 1, but also with shows the initial Z
-        FAV_POS_ACTIVE: {"x": -4.0e-3, "y": 0, "z": 40.0e-6, "rx": 0 , "ry": 0, "rz": 0},
+        FAV_POS_ACTIVE: {"x": 7.5e-3, "y": -4.5e-3, "z": 40.0e-6, "rx": 0 , "ry": 0, "rz": 0},
         # Centers (X, Y) of each grid. The Z position is assumed to be the same for all grids.
         # They should all be within POS_ACTIVE_RANGE!
         SAMPLE_CENTERS: {


### PR DESCRIPTION
That's how it should be at loading. In the simulator it doesn't matter
really of course, but it's better to match the real hardware.