### PR TITLE
util conversion: Add **kwargs to the init of YamlExtraDumper, to fix …

### DIFF
--- a/src/odemis/util/conversion.py
+++ b/src/odemis/util/conversion.py
@@ -502,17 +502,17 @@ CustomSafeRepresenter.add_multi_representer(
 class YamlExtraDumper(Emitter, Serializer, CustomSafeRepresenter, Resolver):
 
     def __init__(self, stream,
-            default_style=None, default_flow_style=False,
-            canonical=None, indent=None, width=None,
-            allow_unicode=None, line_break=None,
-            encoding=None, explicit_start=None, explicit_end=None,
-            version=None, tags=None):
+                 default_style=None, default_flow_style=False,
+                 canonical=None, indent=None, width=None,
+                 allow_unicode=None, line_break=None,
+                 encoding=None, explicit_start=None, explicit_end=None,
+                 version=None, tags=None, **kwargs):
         Emitter.__init__(self, stream, canonical=canonical,
-                indent=indent, width=width,
-                allow_unicode=allow_unicode, line_break=line_break)
+                         indent=indent, width=width,
+                         allow_unicode=allow_unicode, line_break=line_break)
         Serializer.__init__(self, encoding=encoding,
-                explicit_start=explicit_start, explicit_end=explicit_end,
-                version=version, tags=tags)
+                            explicit_start=explicit_start, explicit_end=explicit_end,
+                            version=version, tags=tags)
         CustomSafeRepresenter.__init__(self, default_style=default_style,
-                default_flow_style=default_flow_style)
+                                       default_flow_style=default_flow_style)
         Resolver.__init__(self)

--- a/src/odemis/util/conversion.py
+++ b/src/odemis/util/conversion.py
@@ -506,13 +506,19 @@ class YamlExtraDumper(Emitter, Serializer, CustomSafeRepresenter, Resolver):
                  canonical=None, indent=None, width=None,
                  allow_unicode=None, line_break=None,
                  encoding=None, explicit_start=None, explicit_end=None,
-                 version=None, tags=None, **kwargs):
+                 version=None, tags=None,
+                 **kwargs):  # kwargs added to support sort_keys argument in newer PyYaml versions
         Emitter.__init__(self, stream, canonical=canonical,
                          indent=indent, width=width,
                          allow_unicode=allow_unicode, line_break=line_break)
         Serializer.__init__(self, encoding=encoding,
                             explicit_start=explicit_start, explicit_end=explicit_end,
                             version=version, tags=tags)
+
+        kwargs_representer = {}
+        if "sort_keys" in kwargs:
+            kwargs_representer["sort_keys"] = kwargs["sort_keys"]
         CustomSafeRepresenter.__init__(self, default_style=default_style,
-                                       default_flow_style=default_flow_style)
+                                       default_flow_style=default_flow_style,
+                                       **kwargs_representer)
         Resolver.__init__(self)


### PR DESCRIPTION
…passing along sort_keys

In 18140fbad328520717036585bdaad625deca7b15 the keyword argument sort_keys was removed for compatibility with ubuntu 18. However this caused the test case and starting of odemis to fail on ubuntu 20, because the class is called with the argument sort_keys in yaml.dump_all(). This fix adds **kwargs to the input arguments of YamlExtraDumper class and does not pass the keyword arguments along, for compatibility with both ubuntu 18 and 20.