### PR TITLE
gui: add grid selection to MIMAS overview acquisition

### DIFF
--- a/src/odemis/acq/stitching/_tiledacq.py
+++ b/src/odemis/acq/stitching/_tiledacq.py
@@ -1000,13 +1000,15 @@ class AcquireOverviewTask(object):
         self.areas = areas  # list of areas
         self._ccd = ccd  # TODO to delete after ccd.data components is used from streams in do_autofocus_roi
         self._focus = focus
-        self.focus_rng = self._focus.getMetadata().get(model.MD_POS_ACTIVE_RANGE, None)
+        active_rng = self._focus.getMetadata().get(model.MD_POS_ACTIVE_RANGE, None)
 
-        if self.focus_rng is None:
+        if active_rng and "z" in active_rng:
+            self.focus_rng = tuple(active_rng["z"])
+        else:
             # No absolute range is available, so use a relative range (e.g. as on METEOR
-            self.focus_rng = self._focus.getMetadata().get(model.MD_SAFE_REL_RANGE, SAFE_REL_RANGE_DEFAULT)
-            self.focus_rng = (self.focus_rng[0] + self._focus.position.value["z"],
-                              self.focus_rng[1] + self._focus.position.value["z"])
+            rel_rng = self._focus.getMetadata().get(model.MD_SAFE_REL_RANGE, SAFE_REL_RANGE_DEFAULT)
+            self.focus_rng = (self._focus.position.value["z"] + rel_rng[0],
+                              self._focus.position.value["z"] + rel_rng[1])
 
         self.conf_level = 0.8
         self.focusing_method = focusing_method

--- a/src/odemis/acq/stitching/test/tiledacq_test.py
+++ b/src/odemis/acq/stitching/test/tiledacq_test.py
@@ -21,7 +21,6 @@ import logging
 import os
 import time
 import unittest
-from _decimal import Decimal
 from concurrent.futures._base import CancelledError, FINISHED
 
 import numpy
@@ -327,7 +326,7 @@ class CRYOSECOMTestCase(unittest.TestCase):
                         [0.0001989, 0.0001485, 4.766e-06]]
         zlevels = [focus_points[0][2], focus_points[1][2], focus_points[2][2]]
         axis_range = self.focus.axes['z'].range
-        comp_range = self.focus.getMetadata().get(model.MD_POS_ACTIVE_RANGE, axis_range)
+        comp_range = self.focus.getMetadata().get(model.MD_POS_ACTIVE_RANGE["z"], axis_range)
 
         tiled_acq_task = TiledAcquisitionTask(self.fm_streams, self.stage,
                                               area=area, overlap=overlap, future=model.InstantaneousFuture(),

--- a/src/odemis/gui/__init__.py
+++ b/src/odemis/gui/__init__.py
@@ -24,11 +24,12 @@ import wx.lib.newevent
 # Colour definitions
 # Background colours
 BG_COLOUR_MAIN = "#333333"      # Default dark background
-BG_COLOUR_STREAM = "#4D4D4D"    # Stream panel background
+BG_COLOUR_STREAM = "#444444"    # Stream panel background
 BG_COLOUR_LEGEND = "#1A1A1A"    # Legend background
 BG_COLOUR_NOTIFY = "#FFF3A2"    # For the pop-up notification messages
 BG_COLOUR_ERROR = "#701818"
 BG_COLOUR_PANEL = "#444444"     # Background color of panels in alignment tab
+BG_COLOUR_SEPARATOR = "#555555" # Color of separator lines in panels
 
 # Foreground (i.e text) colours
 FG_COLOUR_MAIN = "#DDDDDD"       # Default foreground colour

--- a/src/odemis/gui/comp/settings.py
+++ b/src/odemis/gui/comp/settings.py
@@ -118,6 +118,7 @@ class SettingsPanel(wx.Panel):
     def add_divider(self):
         """ Add a horizontal divider to the panel """
         line_ctrl = wx.StaticLine(self, size=(-1, 1))
+        line_ctrl.SetBackgroundColour(gui.BG_COLOUR_SEPARATOR)
         self.gb_sizer.Add(line_ctrl, (self.num_rows, 0), span=(1, 2),
                           flag=wx.ALL | wx.EXPAND, border=5)
 

--- a/src/odemis/gui/comp/stream.py
+++ b/src/odemis/gui/comp/stream.py
@@ -1188,6 +1188,7 @@ class StreamPanel(wx.Panel):
     def add_divider(self):
         """ Add a dividing line to the stream panel """
         line_ctrl = wx.StaticLine(self._panel, size=(-1, 1))
+        line_ctrl.SetBackgroundColour(gui.BG_COLOUR_SEPARATOR)
         self.gb_sizer.Add(line_ctrl, (self.num_rows, 0), span=(1, 3),
                           flag=wx.ALL | wx.EXPAND, border=5)
 

--- a/src/odemis/gui/model/__init__.py
+++ b/src/odemis/gui/model/__init__.py
@@ -507,10 +507,11 @@ class CryoMainGUIData(MainGUIData):
     """
     Data common to all Cryo tabs (METEOR/ENZEL/MIMAS).
     """
-    SAMPLE_RADIUS_TEM_GRID = 1.8e-3  # m, standard TEM grid size including the borders
+    SAMPLE_RADIUS_TEM_GRID = 1.25e-3  # m, standard TEM grid size including the borders
     # Bounding-box relative to the center of a sample, corresponding to usable area
     # for imaging/milling. Used in particular for the overview image.
-    SAMPLE_USABLE_BBOX_TEM_GRID = (-1e-3, -1e-3, 1e-3, 1e-3)  # m, minx, miny, maxx, maxy
+    hwidth = SAMPLE_RADIUS_TEM_GRID / math.sqrt(2)
+    SAMPLE_USABLE_BBOX_TEM_GRID = (-hwidth, -hwidth, hwidth, hwidth)  # m, minx, miny, maxx, maxy
 
     def __init__(self, microscope):
         super().__init__(microscope)

--- a/src/odemis/gui/test/comp_buttons_test.py
+++ b/src/odemis/gui/test/comp_buttons_test.py
@@ -397,6 +397,27 @@ class ButtonsTestCase(test.GuiTestCase):
 
         self.view_button.Bind(wx.EVT_LEFT_DOWN, switch_image)
 
+    def test_grid_selection(self):
+        """
+        Test a GridSelectionPanel
+        """
+        grid_layout = [["GRID 1", "GRID 2", "GRID 3"],
+                       ["GRID 4", "GRID 5", "GRID 6"]]
+        grid_pnl = buttons.GridSelectionPanel(self.panel, grid_layout)
+        self.add_control(grid_pnl, wx.ALL | wx.ALIGN_CENTER_HORIZONTAL)
+
+        test.gui_loop()
+
+    def test_grid_selection_sparse(self):
+        """
+        Test a GridSelectionPanel with some element empty (None)
+        """
+        grid_layout = [["GRID 1", None, "GRID 3"],
+                       [None, "GRID 5", "GRID 6"]]
+        grid_pnl = buttons.GridSelectionPanel(self.panel, grid_layout)
+        self.add_control(grid_pnl, wx.ALL | wx.ALIGN_CENTER_HORIZONTAL)
+
+        test.gui_loop()
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/odemis/gui/win/acquisition.py
+++ b/src/odemis/gui/win/acquisition.py
@@ -732,6 +732,9 @@ class OverviewAcquisitionDialog(xrcfr_overview_acq):
                 btn.SetValue(name in self._selected_grids)
                 btn.Bind(wx.EVT_BUTTON, self.on_grid_button)
 
+            self.pnl_view_acq.show_sample_overlay(self._main_data_model.sample_centers,
+                                                  self._main_data_model.sample_radius)
+
         orig_view = orig_tab_data.focussedView.value
         self._view = self._tab_data_model.focussedView.value
 

--- a/src/odemis/gui/win/acquisition.py
+++ b/src/odemis/gui/win/acquisition.py
@@ -27,13 +27,12 @@ import math
 import os.path
 from builtins import str
 from concurrent.futures._base import CancelledError
-from typing import List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import numpy
-import wx
-
 import odemis.gui.model as guimodel
-from odemis import dataio, model
+import wx
+from odemis import dataio, gui, model
 from odemis.acq import acqmng, path, stitching, stream
 from odemis.acq.stitching import (REGISTER_IDENTITY, WEAVER_MEAN,
                                   FocusingMethod, acquireOverview)
@@ -42,6 +41,7 @@ from odemis.acq.stream import (NON_SPATIAL_STREAMS, EMStream, LiveStream,
 from odemis.gui.acqmng import (apply_preset, get_global_settings_entries,
                                get_local_settings_entries, preset_as_is,
                                presets)
+from odemis.gui.comp import buttons
 from odemis.gui.comp.overlay.world import RepetitionSelectOverlay
 from odemis.gui.conf import get_acqui_conf, util
 from odemis.gui.cont.settings import (LocalizationSettingsController,
@@ -688,6 +688,10 @@ class OverviewAcquisitionDialog(xrcfr_overview_acq):
         self._autofocus_roi_vac = VigilantAttributeConnector(
             self.autofocus_roi_ckbox, self.autofocus_chkbox, events=wx.EVT_CHECKBOX)
 
+        # Note: if the stage has MD_SAMPLE_CENTERS, self._get_areas() should be
+        # called to list all the areas.
+        self.area = None  # None or 4 floats: left, top, right, bottom positions of the acquisition area (in m)
+
         # Slightly change the interface for the MIMAS:
         # * Run autofocus is always enabled (so it's hidden)
         # * number of tiles is fixed (based on the main.sample_rel_bbox
@@ -703,12 +707,30 @@ class OverviewAcquisitionDialog(xrcfr_overview_acq):
             self.tiles_number_y.Hide()
             self.tiles_number_y_lbl.Hide()
 
-            # TODO: show 8 toggle buttons (or build buttons based on MD_SAMPLE_CENTERS)
+        # Add grid selection, if position of grids is known
+        if self._main_data_model.sample_centers:
+            panel_sizer = self.scr_win_right.GetSizer()
 
+            line_ctrl = wx.StaticLine(self.scr_win_right, size=(-1, 1))
+            line_ctrl.SetBackgroundColour(gui.BG_COLOUR_SEPARATOR)
+            panel_sizer.Add(line_ctrl, flag=wx.ALL | wx.EXPAND, border=5)
 
-        # Note: if the stage has MD_SAMPLE_CENTERS, self._get_areas() should be
-        # called to list all the areas.
-        self.area = None  # None or 4 floats: left, top, right, bottom positions of the acquisition area (in m)
+            label_grids = wx.StaticText(self.scr_win_right, label="Selected grid areas", style=wx.NO_BORDER)
+            label_grids.SetFont(wx.Font(9, wx.DEFAULT, wx.NORMAL, wx.DEFAULT))
+            label_grids.SetForegroundColour(gui.FG_COLOUR_MAIN)
+            panel_sizer.Add(label_grids, flag=wx.LEFT, border=13)
+
+            layout = self.sample_positions_to_layout(self._main_data_model.sample_centers)
+            self._grids = buttons.GridSelectionPanel(self.scr_win_right, layout)
+            panel_sizer.Add(self._grids, flag=wx.LEFT | wx.EXPAND, border=5)
+
+            # Default to selecting all grids
+            self._selected_grids = set(self._main_data_model.sample_centers.keys())
+
+            # Connect the buttons (and update their status)
+            for name, btn in self._grids.buttons.items():
+                btn.SetValue(name in self._selected_grids)
+                btn.Bind(wx.EVT_BUTTON, self.on_grid_button)
 
         orig_view = orig_tab_data.focussedView.value
         self._view = self._tab_data_model.focussedView.value
@@ -769,7 +791,6 @@ class OverviewAcquisitionDialog(xrcfr_overview_acq):
 
         # To update the estimated time & area when streams are removed/added
         self._view.stream_tree.flat.subscribe(self.on_streams_changed, init=True)
-
 
     def start_listening_to_va(self):
         # Get all the VA's from the stream and subscribe to them for changes.
@@ -842,6 +863,36 @@ class OverviewAcquisitionDialog(xrcfr_overview_acq):
         streams = self._view.getStreams()
         return streams
 
+    def _get_areas(self) -> List[Tuple[float]]:
+        """
+        return: the bounding boxes (xmin, ymin, xmax, ymax in physical coordinates)
+        of all areas to acquire.
+        """
+        if not self._main_data_model.sample_centers:
+            if self.area is None:
+                return []
+            else:
+                return [self.area]
+
+        # TODO: for now this is only for the MIMAS, but eventually, on the METEOR,
+        # which often supports 2 grids, this should also be possible to use.
+
+        # .sample_centers contains the center position of each area
+        # .sample_rel_bbox contains the relative bounding box on an area
+        rel_bbox = self._main_data_model.sample_rel_bbox
+
+        # Sort the (selected) centers along X, and for centers with the same X, along the Y.
+        # In theory, the order doesn't really matter (at best it would safe a few
+        # seconds of stage movement), but it's nice for the user that acquisitions
+        # are done always in the same order, as it reduces "astonishment".
+        sorted_centers = sorted(pos
+                                for name, pos in self._main_data_model.sample_centers.items()
+                                if name in self._selected_grids)
+        areas = [(center[0] + rel_bbox[0], center[1] + rel_bbox[1], center[0] + rel_bbox[2], center[1] + rel_bbox[3])
+                 for center in sorted_centers]
+
+        return areas
+
     def update_area_size(self):
         """
         Calculates the requested tiling area size, based on the tiles number
@@ -869,6 +920,46 @@ class OverviewAcquisitionDialog(xrcfr_overview_acq):
             # there is no intersection
             logging.warning("Couldn't find intersection between stage pos %s and tiling range %s" % (pos, self._tiling_rng))
 
+    def sample_positions_to_layout(self, sample_centers: Dict[str, Tuple[float, float]]) -> List[List[Optional[str]]]:
+        """
+        Convert sample positions to a grid layout
+        :param sample_centers: the name -> position of each sample
+        returns: 2D grid layout containing the names of the samples (or None if 
+        no sample at that grid position)
+        """
+        # Find the number of rows and columns
+        xpositions = sorted({p[0] for p in sample_centers.values()})
+        ypositions = sorted({p[1] for p in sample_centers.values()}, reverse=True)  # Y goes up
+
+        # TODO merge values which are very similar (but not identical due to floating point error)
+
+        nx, ny = len(xpositions), len(ypositions)
+
+        layout = [[None for i in range(nx)] for j in range(ny)]
+
+        # Fill up the layout based on the content of sample_centers
+        for name, pos in sample_centers.items():
+            i = xpositions.index(pos[0])
+            j = ypositions.index(pos[1])
+            layout[j][i] = name
+
+        return layout
+
+    def on_grid_button(self, evt: wx.Event = None):
+        """
+        Called when a grid selection button is pressed
+        """
+        # Updates the selected grids based on the button states
+        selected_grids = set()
+        for name, btn in self._grids.buttons.items():
+            if btn.GetValue():
+                selected_grids.add(name)
+
+        self._selected_grids = selected_grids
+
+        # Update the areas and estimated acquisition time
+        self.update_setting_display()
+
     @wxlimit_invocation(0.1)
     def update_setting_display(self):
         if not self:
@@ -886,18 +977,18 @@ class OverviewAcquisitionDialog(xrcfr_overview_acq):
         # the smallest FoV would also affect the area.
         self.update_area_size()
 
-        # Disable acquisition button if no area
-        self.btn_secom_acquire.Enable(self.area is not None)
-
         areas = self._get_areas()
-        if areas[0] is None:
-            self.area_size_txt.SetLabel("Invalid stage position")
-            return
 
-        area_size = (sum(area[2] - area[0] for area in areas),
-                     sum(area[3] - area[1] for area in areas))
-        area_size_str = util.readable_str(area_size, unit="m", sig=3)
-        self.area_size_txt.SetLabel(area_size_str)
+        # Disable acquisition button if no area
+        self.btn_secom_acquire.Enable(bool(areas))
+
+        if not areas:
+            self.area_size_txt.SetLabel("Invalid stage position")
+        else:
+            area_size = (sum(area[2] - area[0] for area in areas),
+                         sum(area[3] - area[1] for area in areas))
+            area_size_str = util.readable_str(area_size, unit="m", sig=3)
+            self.area_size_txt.SetLabel(area_size_str)
 
         self.update_acquisition_time()
 
@@ -925,10 +1016,11 @@ class OverviewAcquisitionDialog(xrcfr_overview_acq):
 
         areas = self._get_areas()
 
-        if not areas[0]:
+        if not areas:
             # This can happen if the stage is situated outside of the active range
-            # (and sample_centers is not used).
+            # or all areas have been unselected (when sample_centers is used).
             logging.debug("Unknown acquisition area, cannot estimate acquisition time")
+            self.lbl_acqestimate.SetLabel("Select an area to acquire.")
             return
 
         streams = self.get_acq_streams()
@@ -1080,32 +1172,6 @@ class OverviewAcquisitionDialog(xrcfr_overview_acq):
 
         fov = (self.area[2] - self.area[0], self.area[3] - self.area[1])
         self.pnl_view_acq.set_mpp_from_fov(fov)
-
-    def _get_areas(self) -> List[Tuple[float]]:
-        """
-        return: the bounding boxes (xmin, ymin, xmax, ymax in physical coordinates)
-        of all areas to acquire.
-        """
-        if not self._main_data_model.sample_centers:
-            return [self.area]
-
-        # TODO: for now this is only for the MIMAS, but eventually, on the METEOR,
-        # which often supports 2 grids, this should also be possible to use.
-
-        # .sample_centers contains the center position of each area
-        # .sample_rel_bbox contains the relative bounding box on an area
-        rel_bbox = self._main_data_model.sample_rel_bbox
-
-        # TODO: once there are toggle buttons, filter to only the button toggled on
-        # Sort the centers along X, and for centers with the same X, along the Y.
-        # In theory, the order doesn't really matter (at best it would safe a few
-        # seconds of stage movement), but it's nice for the user that acquisitions
-        # are done always in the same order, as it reduces "astonishment".
-        sorted_centers = sorted(self._main_data_model.sample_centers.values())
-        areas = [(center[0] + rel_bbox[0], center[1] + rel_bbox[1], center[0] + rel_bbox[2], center[1] + rel_bbox[3])
-                 for center in sorted_centers]
-
-        return areas
 
     def on_acquire(self, evt):
         """ Start the actual acquisition """


### PR DESCRIPTION
Add buttons to the overview acquisition window to select which grid(s) should be acquired.