### PR TITLE
gui model StreamView: fix zooming out completely on an Overview viewport

### DIFF
--- a/src/odemis/gui/model/__init__.py
+++ b/src/odemis/gui/model/__init__.py
@@ -1657,8 +1657,8 @@ class StreamView(View):
         # drawn, including the margins, via fov_buffer). This is used to update
         # the (static) streams with a projection which can be resized via .rect
         # and .mpp.
-        self.fov = model.TupleContinuous((0.0, 0.0), range=((0.0, 0.0), (1e9, 1e9)))
-        self.fov_buffer = model.TupleContinuous((0.0, 0.0), range=((0.0, 0.0), (1e9, 1e9)))
+        self.fov = model.TupleContinuous((0.0, 0.0), cls=(int, float), range=((0.0, 0.0), (1e9, 1e9)))
+        self.fov_buffer = model.TupleContinuous((0.0, 0.0), cls=(int, float), range=((0.0, 0.0), (1e9, 1e9)))
         self.fov_buffer.subscribe(self._onFovBuffer)
 
         # Will be created on the first time it's needed


### PR DESCRIPTION
The FixedOverviewView and FeatureOverviewView allow to zoom out a lot
more than standard views. Up to 1m/px. As the range is stored as an int,
when reaching that range, the mpp would be set to 1. To compute the
.fov, there is some code that just does mpp * width in px. That would
result in an int. However .fov is defined as tuple of floats, only.
So, changing the mpp, changed the FoV, which caused an error.

=> Also allow FoV to be ints. There is nothing wrong with int, they are
real numbers too!