### PR TITLE
Fixed a NoneType error in overlay selection base.py and world.py

### DIFF
--- a/src/odemis/gui/comp/overlay/base.py
+++ b/src/odemis/gui/comp/overlay/base.py
@@ -620,7 +620,7 @@ class SelectionMixin(DragMixin):
 
         logging.debug("Stopping selection")
 
-        if max(self.get_height(), self.get_width()) < gui.SELECTION_MINIMUM:
+        if max(self.get_height() or 0, self.get_width() or 0) < gui.SELECTION_MINIMUM:
             logging.debug("Selection too small")
             self.clear_selection()
         else:

--- a/src/odemis/gui/comp/overlay/world.py
+++ b/src/odemis/gui/comp/overlay/world.py
@@ -3445,7 +3445,7 @@ class FastEMROAOverlay(FastEMSelectOverlay):
         Check if left click was in ROA. If so, activate the overlay. Otherwise, deactivate.
         """
         abort_roa_creation = (self._coordinates.value == UNDEFINED_ROI and
-                              max(self.get_height(), self.get_width()) < gui.SELECTION_MINIMUM)
+                              max(self.get_height() or 0, self.get_width() or 0) < gui.SELECTION_MINIMUM)
         if abort_roa_creation:
             # Process aborted by clicking in the viewport
             # VA did not change, so notify explicitly to make sure aborting the process works


### PR DESCRIPTION
Fixed an NoneType error in src > odemis > gui > comp > overlay > base.py and world.py. If both of the values returned by get_width and get_height is None the max() method in stop_selection will raise a NoneType error.

Now an int() conversion is applied with a default int value of 0.