### PR TITLE
replace with_metaclass with metaclass=ABCMeta

### DIFF
--- a/src/odemis/acq/stitching/_weaver.py
+++ b/src/odemis/acq/stitching/_weaver.py
@@ -15,7 +15,6 @@ Odemis is distributed in the hope that it will be useful, but WITHOUT ANY WARRAN
 You should have received a copy of the GNU General Public License along with Odemis. If not, see http://www.gnu.org/licenses/.
 """
 
-from future.utils import with_metaclass
 from abc import ABCMeta
 import logging
 import copy
@@ -33,7 +32,7 @@ from odemis.util import img
 # directly copy the image already transformed.
 # TODO: handle higher dimensions by just copying them as-is
 
-class Weaver(with_metaclass(ABCMeta, object)):
+class Weaver(metaclass=ABCMeta):
     """
     Abstract class representing a weaver.
     A weaver assembles a set of small images with MD_POS metadata (tiles) into one large image.

--- a/src/odemis/acq/stream/_sync.py
+++ b/src/odemis/acq/stream/_sync.py
@@ -28,7 +28,6 @@ from abc import ABCMeta, abstractmethod
 from concurrent.futures._base import RUNNING, FINISHED, CANCELLED, TimeoutError, \
     CancelledError
 from functools import partial
-from future.utils import with_metaclass
 import logging
 import math
 import numpy
@@ -74,7 +73,7 @@ GUI_BLUE = (47, 167, 212) # FG_COLOUR_EDIT - from src/odemis/gui/__init__.py
 GUI_ORANGE = (255, 163, 0) # FG_COLOUR_HIGHLIGHT - from src/odemis/gui/__init__.py
 
 
-class MultipleDetectorStream(with_metaclass(ABCMeta, Stream)):
+class MultipleDetectorStream(Stream, metaclass=ABCMeta):
     """
     Abstract class for all specialised streams which are actually a combination
     of multiple streams acquired simultaneously. The main difference from a

--- a/src/odemis/driver/omicronxx.py
+++ b/src/odemis/driver/omicronxx.py
@@ -27,7 +27,6 @@ You should have received a copy of the GNU General Public License along with Ode
 # one which contain multiple source (ie, the LedHUB). In the second case, the
 # commands are indexed with the source number: [X].
 
-from future.utils import with_metaclass
 from abc import ABCMeta, abstractmethod
 import fcntl
 import glob
@@ -619,7 +618,7 @@ class DevxX(object):
         self._setValue("POf")
 
 
-class GenericxX(with_metaclass(ABCMeta, model.Emitter)):
+class GenericxX(model.Emitter, metaclass=ABCMeta):
 
     def __init__(self, name, role, ports, **kwargs):
         """

--- a/src/odemis/driver/phenom.py
+++ b/src/odemis/driver/phenom.py
@@ -19,7 +19,6 @@ PURPOSE. See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along with
 Odemis. If not, see http://www.gnu.org/licenses/.
 '''
-from future.utils import with_metaclass
 from past.builtins import long
 from abc import abstractmethod, ABCMeta
 import base64
@@ -1371,7 +1370,7 @@ class Stage(model.Actuator):
             self._executor = None
 
 
-class PhenomFocus(with_metaclass(ABCMeta, model.Actuator)):
+class PhenomFocus(model.Actuator, metaclass=ABCMeta):
     """
     This is an extension of the model.Actuator class and represents a focus
     actuator. This is an abstract class that should be inherited.

--- a/src/odemis/driver/symphotime.py
+++ b/src/odemis/driver/symphotime.py
@@ -15,19 +15,16 @@ Odemis is distributed in the hope that it will be useful, but WITHOUT ANY WARRAN
 You should have received a copy of the GNU General Public License along with Odemis. If not, see http://www.gnu.org/licenses/.
 '''
 
-from future.utils import with_metaclass
 import logging
-import abc
+import os
+import socket
+import struct
+import threading
+import time
+from abc import ABCMeta, abstractmethod
 
 from odemis import model
 from odemis.model import HwError
-
-import os
-import time
-import threading
-import socket
-import struct
-from abc import abstractmethod
 
 # Define constants
 DEFAULT_PORT = 6000
@@ -275,7 +272,7 @@ def DecodeOptionalDataRecordString(data):
     return records
 
 
-class Message(with_metaclass(abc.ABCMeta, object)):
+class Message(metaclass=ABCMeta):
     '''
     Defines a base class for Messages sent between client and server.
     '''
@@ -1019,4 +1016,3 @@ class DetectorLive(model.Detector):
         '''
         if not self.parent.CheckMeasurement(PQ_MEASTYPE_TEST_POINTMEAS):
             raise RuntimeError("A measurement is already running!")
-

--- a/src/odemis/driver/test/cam_test_abs.py
+++ b/src/odemis/driver/test/cam_test_abs.py
@@ -23,7 +23,6 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 # This is not a real test case, but just a stub to be used for each camera driver.
 
 from abc import ABCMeta, abstractproperty
-from future.utils import with_metaclass
 import gc
 import logging
 import numpy
@@ -52,7 +51,7 @@ CONFIG_SEM = {"name": "sem", "role": "sem", "device": "/dev/comedi0",
               }
 
 
-class VirtualStaticTestCam(with_metaclass(ABCMeta, object)):
+class VirtualStaticTestCam(metaclass=ABCMeta):
     """
     For tests which don't need a camera ready
     """
@@ -86,7 +85,7 @@ class VirtualStaticTestCam(with_metaclass(ABCMeta, object)):
 
 # It doesn't inherit from TestCase because it should not be run by itself
 #class VirtualTestCam(unittest.TestCase):
-class VirtualTestCam(with_metaclass(ABCMeta, object)):
+class VirtualTestCam(metaclass=ABCMeta):
     """
     Abstract class for all the DigitalCameras
     """
@@ -516,7 +515,7 @@ class VirtualTestCam(with_metaclass(ABCMeta, object)):
             pass # good!
 
 
-class VirtualTestSynchronized(with_metaclass(ABCMeta, object)):
+class VirtualTestSynchronized(metaclass=ABCMeta):
     """
     Test the synchronizedOn(Event) interface, using the fake SEM
     """

--- a/src/odemis/gui/comp/overlay/base.py
+++ b/src/odemis/gui/comp/overlay/base.py
@@ -30,7 +30,6 @@ They will *only* receive mouse events if they are active!
 
 """
 
-from future.utils import with_metaclass
 import cairo
 import logging
 import math
@@ -295,7 +294,7 @@ class Vec(tuple):
         return self[1]
 
 
-class Overlay(with_metaclass(ABCMeta, object)):
+class Overlay(metaclass=ABCMeta):
     """ This abstract Overlay class forms the base for a series of classes that
     allow for the drawing of images, text and shapes on top of a Canvas, while
     also facilitating the processing of various (mouse) events.
@@ -1143,7 +1142,7 @@ class WorldOverlay(Overlay):
         pass
 
 
-class SpotModeBase(with_metaclass(ABCMeta, object)):
+class SpotModeBase(metaclass=ABCMeta):
 
     def __init__(self, cnvs, spot_va=None):
         self.colour = conversion.hex_to_frgb(gui.FG_COLOUR_EDIT)

--- a/src/odemis/gui/comp/overlay/world.py
+++ b/src/odemis/gui/comp/overlay/world.py
@@ -33,7 +33,6 @@ import odemis.gui.img as guiimg
 import odemis.util.conversion as conversion
 import odemis.util.units as units
 import wx
-from future.utils import with_metaclass
 from odemis import model, util
 from odemis.acq.feature import (FEATURE_ACTIVE, FEATURE_DEACTIVE,
                                 FEATURE_POLISHED, FEATURE_ROUGH_MILLED)
@@ -1211,7 +1210,7 @@ class SpotModeOverlay(WorldOverlay, DragMixin, SpotModeBase):
         WorldOverlay._deactivate(self)
 
 
-class GadgetToolInterface(with_metaclass(ABCMeta, object)):
+class GadgetToolInterface(metaclass=ABCMeta):
     """
     This abstract GadgetToolInterface class forms the base for a series of classes that
     refer to gadgets tools and their functionality.
@@ -1284,7 +1283,7 @@ LINE_MODE_EDIT_END = 3
 LINE_MODE_EDIT_TEXT = 4
 
 
-class GenericGadgetLine(with_metaclass(ABCMeta, GadgetToolInterface)):
+class GenericGadgetLine(GadgetToolInterface, metaclass=ABCMeta):
     """ This abstract GenericGadgetLine class forms the base for all gadget classes showing a line.
     Used to draw a line and also handle the mouse interaction when dragging/moving the line """
 

--- a/src/odemis/gui/conf/file.py
+++ b/src/odemis/gui/conf/file.py
@@ -17,7 +17,6 @@ This file is part of Odemis.
     see http://www.gnu.org/licenses/.
 
 """
-from future.utils import with_metaclass
 from abc import ABCMeta, abstractproperty
 import configparser
 from configparser import NoOptionError
@@ -35,7 +34,7 @@ CONF_PATH = os.path.join(get_home_folder(), u".config/odemis")
 ACQUI_PATH = get_picture_folder()
 
 
-class Config(with_metaclass(ABCMeta, object)):
+class Config(metaclass=ABCMeta):
     """ Abstract configuration super class
 
     Configurations are built around the :py:class:`configparser.ConfigParser` class.

--- a/src/odemis/gui/cont/settings.py
+++ b/src/odemis/gui/cont/settings.py
@@ -26,7 +26,6 @@ user interface.
 """
 
 from past.builtins import long
-from future.utils import with_metaclass
 from abc import ABCMeta
 from collections.abc import Iterable
 import locale
@@ -54,7 +53,7 @@ import wx
 import odemis.gui.conf as guiconf
 
 
-class SettingsController(with_metaclass(ABCMeta, object)):
+class SettingsController(metaclass=ABCMeta):
     """ Settings base class which describes an indirect wrapper for FoldPanelItems
 
     :param fold_panel_item: (FoldPanelItem) Parent window

--- a/src/odemis/gui/model/__init__.py
+++ b/src/odemis/gui/model/__init__.py
@@ -20,7 +20,6 @@ This file is part of Odemis.
     Odemis. If not, see http://www.gnu.org/licenses/.
 
 """
-from future.utils import with_metaclass
 from past.builtins import basestring, long
 import queue
 from abc import ABCMeta
@@ -546,7 +545,7 @@ class CryoMainGUIData(MainGUIData):
         self.sample_rel_bbox = self.SAMPLE_USABLE_BBOX_TEM_GRID
 
 
-class MicroscopyGUIData(with_metaclass(ABCMeta, object)):
+class MicroscopyGUIData(metaclass=ABCMeta):
     """Contains all the data corresponding to a GUI tab.
 
     In the Odemis GUI, there's basically one MicroscopyGUIData per tab (or just

--- a/src/odemis/gui/plugin/__init__.py
+++ b/src/odemis/gui/plugin/__init__.py
@@ -20,7 +20,6 @@ see http://www.gnu.org/licenses/.
 
 """
 
-from future.utils import with_metaclass
 from functools import partial
 from abc import ABCMeta, abstractmethod, abstractproperty
 import glob
@@ -158,7 +157,7 @@ def load_plugin(filename, microscope, main_app):
     return ret
 
 
-class Plugin(with_metaclass(ABCMeta, object)):
+class Plugin(metaclass=ABCMeta):
     """
     This is the root class for Odemis GUI plugins.
     Every plugin must be a subclass of that class.

--- a/src/odemis/model/_components.py
+++ b/src/odemis/model/_components.py
@@ -19,21 +19,20 @@ PURPOSE. See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along with 
 Odemis. If not, see http://www.gnu.org/licenses/.
 '''
-from future.utils import with_metaclass
-from past.builtins import basestring
-
-import Pyro4
-from Pyro4.core import isasync
-from abc import ABCMeta, abstractmethod
 import logging
 import math
-import odemis
-from future.moves.urllib.parse import quote
 import weakref
+from abc import abstractmethod, ABCMeta
 
-from . import _core, _dataflow, _vattributes, _metadata
-from ._core import roattribute
+import Pyro4
+from future.moves.urllib.parse import quote
+from past.builtins import basestring
+from Pyro4.core import isasync
+
+import odemis
 from odemis.util import inspect_getmembers, synthetic
+from . import _core, _dataflow, _metadata, _vattributes
+from ._core import roattribute
 
 
 class HwError(IOError):
@@ -96,7 +95,7 @@ def getEvents(component):
     return dict(evts)
 
 
-class ComponentBase(with_metaclass(ABCMeta, object)):
+class ComponentBase(metaclass=ABCMeta):
     """Abstract class for a component"""
 
 
@@ -276,7 +275,7 @@ def ComponentSerializer(self):
 Pyro4.Daemon.serializers[Component] = ComponentSerializer
 
 
-class HwComponent(with_metaclass(ABCMeta, Component)):
+class HwComponent(Component, metaclass=ABCMeta):
     """
     A generic class which represents a physical component of the microscope
     This is an abstract class that should be inherited.
@@ -573,7 +572,7 @@ class Microscope(HwComponent):
         return self._model
 
 
-class Detector(with_metaclass(ABCMeta, HwComponent)):
+class Detector(HwComponent, metaclass=ABCMeta):
     """
     A component which represents a detector.
     This is an abstract class that should be inherited.
@@ -618,7 +617,7 @@ class Detector(with_metaclass(ABCMeta, HwComponent)):
         return self._transposeSizeToUser(self._shape)
 
 
-class DigitalCamera(with_metaclass(ABCMeta, Detector)):
+class DigitalCamera(Detector, metaclass=ABCMeta):
     """
     A component which represent a digital camera (i.e., CCD or CMOS)
     It's basically a detector with a few more compulsory VAs
@@ -771,7 +770,7 @@ class Axis(object):
         return "%s in %s%s%s" % (self.__class__.__name__, pos_str, abs_str, speed_str)
 
 
-class Actuator(with_metaclass(ABCMeta, HwComponent)):
+class Actuator(HwComponent, metaclass=ABCMeta):
     """
     A component which represents an actuator (motorised part).
     This is an abstract class that should be inherited.
@@ -966,7 +965,7 @@ class Actuator(with_metaclass(ABCMeta, HwComponent)):
             raise ValueError("Cannot reference the following axes: %s" % (nonref,))
 
 
-class PowerSupplier(with_metaclass(ABCMeta, HwComponent)):
+class PowerSupplier(HwComponent, metaclass=ABCMeta):
     """
     A component which represents a power supplier for one or multiple components.
     This is an abstract class that should be inherited.
@@ -1003,7 +1002,7 @@ class PowerSupplier(with_metaclass(ABCMeta, HwComponent)):
                 raise ValueError("Unknown component %s" % (component,))
 
 
-class Emitter(with_metaclass(ABCMeta, HwComponent)):
+class Emitter(HwComponent, metaclass=ABCMeta):
     """
     A component which represents an emitter.
     This is an abstract class that should be inherited.

--- a/src/odemis/model/_dataio.py
+++ b/src/odemis/model/_dataio.py
@@ -19,11 +19,10 @@ PURPOSE. See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along with
 Odemis. If not, see http://www.gnu.org/licenses/.
 '''
-from future.utils import with_metaclass
 from abc import ABCMeta, abstractmethod
 
 
-class DataArrayShadow(with_metaclass(ABCMeta, object)):
+class DataArrayShadow(metaclass=ABCMeta):
     """
     This class contains information about a DataArray.
     It has all the useful attributes of a DataArray, but not the actual data.
@@ -79,7 +78,7 @@ class DataArrayShadow(with_metaclass(ABCMeta, object)):
 #         """
 
 
-class AcquisitionData(with_metaclass(ABCMeta, object)):
+class AcquisitionData(metaclass=ABCMeta):
     """
     It's an abstract class to represent an opened file. It allows
     to have random access to a sub-part of any image in the file. It's extended by


### PR DESCRIPTION
with_metaclass() was used to support both Python 2 & 3.
Now that we only support Python 3, we can use the new standard syntax "metaclass=ABCMeta".