### PR TITLE
acq: fix type CTZXY -> CTZYX

### DIFF
--- a/src/odemis/acq/calibration.py
+++ b/src/odemis/acq/calibration.py
@@ -270,7 +270,7 @@ def apply_spectrum_corrections(data, bckg=None, coef=None):
             supported for chronograph data. Spectrum efficiency correction do not apply for this type of data.
     :param bckg: (None or DataArray of at least 5 dims) The background data, with
         CTZYX = C1111 (spectrum), CTZYX = CT111 (temporal spectrum) or CTZYX = 1T111 (time correlator).
-    :param coef: (None or DataArray of at least 5 dims) The coefficient data, with CTZXY = C1111.
+    :param coef: (None or DataArray of at least 5 dims) The coefficient data, with CTZYX = C1111.
     :returns: (DataArray) Same shape as original data. Can have dtype=float.
       If MD_THETA_LIST is present and contains NaN values (which is typical), then
       the A dimension (theta angles) is shorten by removing the indices where the

--- a/src/odemis/acq/test/stream_test.py
+++ b/src/odemis/acq/test/stream_test.py
@@ -2690,7 +2690,7 @@ class SPARC2StreakCameraTestCase(unittest.TestCase):
         ts_da = stss.raw[1]  # temporal spectrum data array
         shape = ts_da.shape
         self.assertEqual(shape[3] * shape[4], num_ts)
-        # len of shape should be 5: CTZXY
+        # len of shape should be 5: CTZYX
         self.assertEqual(len(shape), 5)
 
         # check if metadata is correctly stored
@@ -2785,7 +2785,7 @@ class SPARC2StreakCameraTestCase(unittest.TestCase):
         ts_da = stss.raw[1]  # temporal spectrum data array
         shape = ts_da.shape
         self.assertEqual(shape[3] * shape[4], num_ts)
-        # len of shape should be 5: CTZXY
+        # len of shape should be 5: CTZYX
         self.assertEqual(len(shape), 5)
 
         # check last image in .raw has a time axis greater than 1
@@ -2963,7 +2963,7 @@ class SPARC2StreakCameraTestCase(unittest.TestCase):
         ts_da = stss.raw[1]  # temporal spectrum data array
         shape = ts_da.shape
         self.assertEqual(shape[3] * shape[4], num_ts)
-        # len of shape should be 5: CTZXY
+        # len of shape should be 5: CTZYX
         self.assertEqual(len(shape), 5)
 
         # check last image in .raw has a time axis greater than 1 (last image is the drift correction image)


### PR DESCRIPTION
There are a few places in Odemis where we explicitly want CTZXY, but
that's exceptional, and in practice only in some unit tests.
These places were wrong, but as they were just comments, so no actual error introduced.