### PR TITLE
Bugfix of estimate_grid_orientation

### DIFF
--- a/src/odemis/util/graph.py
+++ b/src/odemis/util/graph.py
@@ -172,6 +172,27 @@ class GraphBase(UserList, metaclass=ABCMeta):
                     continue
                 yield (vertex, neighbor)
 
+    def size(self, directed: Optional[bool] = None) -> int:
+        """
+        Return the number of edges in the graph.
+
+        Parameters
+        ----------
+        directed : bool, optional
+            If `True` the edges `(j, i)` and `(i, j)` will be considered as
+            being two separate edges. If `False`, these are counted as a single
+            edge. If not specified, uses `self.directed`.
+
+        Returns
+        -------
+        size : int
+            The number of edges in the graph.
+
+        """
+        counter = itertools.count()
+        collections.deque(zip(self.iter_edges(directed), counter), maxlen=0)
+        return next(counter)
+
 
 class UnweightedGraph(GraphBase):
     """

--- a/src/odemis/util/graph.py
+++ b/src/odemis/util/graph.py
@@ -189,9 +189,7 @@ class GraphBase(UserList, metaclass=ABCMeta):
             The number of edges in the graph.
 
         """
-        counter = itertools.count()
-        collections.deque(zip(self.iter_edges(directed), counter), maxlen=0)
-        return next(counter)
+        return sum(1 for _ in self.iter_edges(directed))
 
 
 class UnweightedGraph(GraphBase):

--- a/src/odemis/util/registration.py
+++ b/src/odemis/util/registration.py
@@ -363,7 +363,7 @@ def _cluster_edges(
         matched centroids.
 
     """
-    n_edges = graph.size(False)
+    n_edges = graph.size(directed=False)
     if n_edges < 2:
         # theoretical minimum
         raise ValueError(

--- a/src/odemis/util/registration.py
+++ b/src/odemis/util/registration.py
@@ -235,6 +235,8 @@ def nearest_neighbor_graph(ji: numpy.ndarray) -> SkewSymmetricAdjacencyGraph:
         returned, and for the corners only 2.
 
     """
+    n, m = ji.shape
+
     # Find the closest 4 neighbors (excluding itself) for each point.
     tree = scipy.spatial.cKDTree(ji)
     # NOTE: Starting SciPy v1.6.0 the `n_jobs` argument will be renamed `workers`
@@ -246,6 +248,9 @@ def nearest_neighbor_graph(ji: numpy.ndarray) -> SkewSymmetricAdjacencyGraph:
     graph = SkewSymmetricAdjacencyGraph(len(ji))
     for vertex, neighbors in enumerate(indices):
         for neighbor, distance in zip(neighbors, distances[vertex]):
+            # Missing neighbors are indicated with `n`, see `scipy.spatial.cKDTree`.
+            if neighbor == n:
+                continue
             # An edge connects two vertices that are each others nearest neighbor.
             if (vertex < neighbor) and (vertex in indices[neighbor]):
                 shift = ji[neighbor] - ji[vertex]
@@ -358,6 +363,13 @@ def _cluster_edges(
         matched centroids.
 
     """
+    n_edges = graph.size(False)
+    if n_edges < 2:
+        # theoretical minimum
+        raise ValueError(
+            "Expected a graph with at least 2 edges, but got %d." % n_edges
+        )
+
     if not is_connected(graph):
         # no point in continuing if the graph is disconnected.
         raise ValueError("Expected a connected graph, but got a disconnected graph.")
@@ -479,7 +491,13 @@ def estimate_grid_orientation(
     tform : instance of `transform_type`
         The orientation of the pattern.
     error_metric : float
-        The RMS value of the fiducial error registration of the square grid compared to ji.
+        The RMS value of the fiducial error registration of the square grid
+        compared to `ji`.
+
+    Raises
+    ------
+    ValueError
+        If the orientation of the square grid cannot be determined.
 
     """
     if shape[0] != shape[1]:
@@ -538,6 +556,11 @@ def estimate_grid_orientation_from_img(
     error_metric : float
         The RMS value of the fiducial error registration of the square grid
         compared to the spots measured on the image.
+
+    Raises
+    ------
+    ValueError
+        If the orientation of the square grid cannot be determined.
 
     """
     if num_spots is None:

--- a/src/odemis/util/test/graph_test.py
+++ b/src/odemis/util/test/graph_test.py
@@ -274,6 +274,36 @@ class GraphTest(unittest.TestCase):
                     out = graph.iter_edges(directed=True)
                     self.assertCountEqual(edges, out)
 
+    def test_size_undirected(self) -> None:
+        """
+        `size()` should return the number of edges in an undirected complete
+        graph. The edges `(j, i)` and `(i, j)` should be counted as a single
+        edge when `directed=False`.
+
+        """
+        for graph_type in GraphBase.__subclasses__():
+            with self.subTest(graph_type=graph_type.__name__):
+                for n in range(3, 10):
+                    graph = complete_graph(n, graph_type)
+                    expected = n * (n - 1) // 2
+                    out = graph.size(directed=False)
+                    self.assertEqual(out, expected)
+
+    def test_size_directed(self) -> None:
+        """
+        `size()` should return the number of edges in a directed complete
+        graph. The edges `(j, i)` and `(i, j)` should be counted as two
+        distinct edges when `directed=True`.
+
+        """
+        for graph_type in GraphBase.__subclasses__():
+            with self.subTest(graph_type=graph_type.__name__):
+                for n in range(3, 10):
+                    graph = complete_graph(n, graph_type)
+                    expected = n * (n - 1)
+                    out = graph.size(directed=True)
+                    self.assertEqual(out, expected)
+
 
 class SkewSymmetricAdjacencyGraphTest(unittest.TestCase):
     """Unit tests for `SkewSymmetricAdjacencyGraph`."""

--- a/src/odemis/util/test/registration_test.py
+++ b/src/odemis/util/test/registration_test.py
@@ -277,6 +277,16 @@ class NearestNeighborGraphTest(unittest.TestCase):
                         graph.adjacency_matrix(), out.adjacency_matrix()
                     )
 
+    def test_empty_graph(self):
+        """
+        `nearest_neighbor_graph()` should return a graph of zero size (i.e. no
+        neighbors) when given only a single coordinate as input.
+
+        """
+        ji = self._rng.random_sample((1, 2))
+        out = nearest_neighbor_graph(ji)
+        self.assertEqual(out.size(False), 0)
+
 
 class CanonicalMatrixFormTest(unittest.TestCase):
     """Unittest for `_canonical_matrix_form()`."""


### PR DESCRIPTION
`estimate_grid_orientation` and `estimate_grid_orientation_from_img` no longer raise an IndexError when providing (an image of) a single point as input