### PR TITLE
gui comp: ensure that buttons label and text are grey when disabled

### DIFF
--- a/src/odemis/gui/comp/buttons.py
+++ b/src/odemis/gui/comp/buttons.py
@@ -412,13 +412,13 @@ class BtnMixin(object):
         dc.SetFont(self.GetFont())
 
         if text_colour is None:
-            if self.fg_colour_set:
-                text_colour = self.GetForegroundColour()
-            else:
-                if self.IsEnabled():
-                    text_colour = self.btns[self.face_colour]['text_colour']
+            if self.IsEnabled():
+                if self.fg_colour_set:
+                    text_colour = self.GetForegroundColour()
                 else:
-                    text_colour = self.btns[self.face_colour]['text_col_dis']
+                    text_colour = self.btns[self.face_colour]['text_colour']
+            else:
+                text_colour = self.btns[self.face_colour]['text_col_dis']
 
         dc.SetTextForeground(text_colour)
 
@@ -526,10 +526,11 @@ class ImageTextToggleButton(BtnMixin, wxbuttons.GenBitmapTextToggleButton):
         super(ImageTextToggleButton, self).__init__(*args, **kwargs)
 
     def DrawText(self, dc, width, height, dx=0, dy=0):
-        if self.active_colour and self.GetValue():
+        if self.active_colour and self.GetValue() and self.IsEnabled():
             text_colour = self.active_colour
         else:
             text_colour = None
+
         super(ImageTextToggleButton, self).DrawText(dc, width, height, dx=0, dy=0, text_colour=text_colour)
 
 class ImageStateButton(ImageToggleButton):

--- a/src/odemis/gui/comp/text.py
+++ b/src/odemis/gui/comp/text.py
@@ -745,15 +745,15 @@ class _NumberTextCtrl(wx.TextCtrl):
         self.Enable(False)
 
     def Enable(self, enable=True):
+        if enable:
+            self.SetForegroundColour(FG_COLOUR_EDIT)
+        else:
+            self.SetForegroundColour(FG_COLOUR_DIS)
+
         # TODO: Find a better way to deal with this hack that was put in place because under
         # MS Windows the background colour cannot (at all?) be set when a control is disabled
         if os.name == 'nt':
             self.SetEditable(enable)
-
-            if enable:
-                self.SetForegroundColour(FG_COLOUR_EDIT)
-            else:
-                self.SetForegroundColour(FG_COLOUR_DIS)
         else:
             super(_NumberTextCtrl, self).Enable(enable)
 


### PR DESCRIPTION
Now we explicitly set the button text to blue when active. However, the
behaviour of the button was then to use the same colour all the time.
That makes it hard to see when they are enabled/disabled.

=> If disabled, still automatically turn grey.

Same thing for the number texts.