### PR TITLE
fixed TestGetColorBar.test_get_colorbar test case in img_test for ubuntu18 compatibility

### DIFF
--- a/src/odemis/util/test/img_test.py
+++ b/src/odemis/util/test/img_test.py
@@ -1383,7 +1383,7 @@ class TestGetColorBar(unittest.TestCase):
         the right tuple shape, within ranges of uint8 and with alpha channel included.
         """
         # input will be color_map (obj matplotlib) height (int), width (int) and alpha (bool)
-        input_cm = cm.get_cmap('cividis')
+        input_cm = cm.get_cmap('autumn')
         input_height = 16
         input_width = 72
 


### PR DESCRIPTION
fixed TestGetColorBar.test_get_colorbar in src>odemis>util>test>img_test.py
this method was failing when running test cases in an Ubuntu18 environment
       => cm.get_colormap('cividis') changed to cm.get_colormap('autumn')
