### PR TITLE
Fix for parsing extend yaml files which consists of a single component.

### DIFF
--- a/src/odemis/odemisd/modelgen.py
+++ b/src/odemis/odemisd/modelgen.py
@@ -120,6 +120,14 @@ class SafeLoader(yaml.SafeLoader):
                     with open(filename, 'r') as f:
                         try:
                             node_extension = SafeLoader(f).get_single_node()  # Get the data from the external file.
+
+                            # if the node is the only component in the file raise a ParseError
+                            # if the component name is absent or incorrect
+                            if node_extension.value[0][0].value in {"class", "role", "creator"}:
+                                error = f"wrong or missing component name in file {filename}"
+                                raise ParseError(
+                                    "Parsing of file '%s' using the '!extend' key failed with the error:\n%s"
+                                    % (key_node.value, error))
                         except yaml.parser.ParserError as error:
                             raise ParseError("Parsing of file '%s' using the '!extend' key failed with the error:\n%s"
                                              % (key_node.value, error))


### PR DESCRIPTION
Problem occurs when an !extend yaml file parsed contains just one component. If the component name is absent or incorrect the error that is generated is not concise. With this fix it will point out the file in which the error was generated.

This is an example of the error generated when the component name is absent without the fix:
`ERROR	main:97:	When instantiating file /home/stefan/development/mic-odm-yaml/muenster-sparc-3056/sparc2-muenster-swd-uv-pmt-sim.odm.yaml
AttributeError: 'str' object has no attribute 'get'
2023-05-04 14:56:55,307	ERROR	main:780:	Unexpected error at instantiation`

This is an example of the state error with the fix:
`ERROR	main:777:	Error while parsing file /home/stefan/development/mic-odm-yaml/muenster-sparc-3056/sparc2-muenster-swd-uv-pmt-sim.odm.yaml:
Parsing of file 'lens-swd-mirror.odm.yaml' using the '!extend' key failed with the error:
wrong or missing component name in file /home/stefan/development/mic-odm-yaml/muenster-sparc-3056/lens-swd-mirror.odm.yaml`