### PR TITLE
odemisd: log a better error if component name is missing

### DIFF
--- a/src/odemis/odemisd/test/main_test.py
+++ b/src/odemis/odemisd/test/main_test.py
@@ -43,7 +43,8 @@ logging.getLogger().setLevel(logging.DEBUG)
 
 # ODEMISD_CMD = "/usr/bin/python2 -m odemis.odemisd.main"
 ODEMISD_CMD = [sys.executable, os.path.dirname(odemis.__file__) + "/odemisd/main.py"]
-SIM_CONFIG = os.path.join(os.path.dirname(__file__), "optical-sim.odm.yaml")
+FILE_PATH = os.path.dirname(__file__)
+SIM_CONFIG = os.path.join(FILE_PATH, "optical-sim.odm.yaml")
 
 
 class TestCommandLine(unittest.TestCase):
@@ -61,13 +62,14 @@ class TestCommandLine(unittest.TestCase):
 
         i = 0
         for config in configs_pass:
-            setattr(cls, "test_pass_%d" % i, cls.create_test_validate_pass(config))
+            setattr(cls, "test_pass_%d" % i, cls.create_test_validate_pass(os.path.join(FILE_PATH, config)))
             i += 1
 
         configs_error = ["syntax-error-1.odm.yaml",
                          "syntax-error-2.odm.yaml",
                          # Skipped: for now, double key def is only a warning
                          # "syntax-error-3.odm.yaml",
+                         "syntax-error-4.odm.yaml",
                          "semantic-error-2.odm.yaml",
                          # This one can only be detected on a real instantiation
                          # "semantic-error-3.odm.yaml",
@@ -79,12 +81,13 @@ class TestCommandLine(unittest.TestCase):
                          "semantic-error-7.odm.yaml",
                          # test with multiple role
                          "semantic-error-8.odm.yaml",
+                         "semantic-error-9.odm.yaml",
                          "semantic-error-md.odm.yaml",
                          ]
 
         i = 0
         for config in configs_error:
-            setattr(cls, "test_error_%d" % i, cls.create_test_validate_error(config))
+            setattr(cls, "test_error_%d" % i, cls.create_test_validate_error(os.path.join(FILE_PATH, config)))
             i += 1
 
     @staticmethod
@@ -209,7 +212,7 @@ class TestCommandLine(unittest.TestCase):
     def test_error_instantiate(self):
         """Test config files which should fail on instantiation"""
         # Only for the config files that cannot fail on a standard validation
-        filename = "semantic-error-3.odm.yaml"
+        filename = os.path.join(FILE_PATH, "semantic-error-3.odm.yaml")
         cmdline = "odemisd --log-target=test.log %s" % filename
         ret = main.main(cmdline.split())
         self.assertEqual(ret, 0, "trying to run '%s'" % cmdline)
@@ -227,7 +230,7 @@ class TestCommandLine(unittest.TestCase):
     @timeout(20)
     def test_multiple_parents_old(self):
         """Test creating component with multiple parents"""
-        filename = "multiple-parents-old-style.odm.yaml"
+        filename = os.path.join(FILE_PATH, "multiple-parents-old-style.odm.yaml")
         cmdline = "--log-level=2 --log-target=testdaemon.log --daemonize %s" % filename
         ret = subprocess.call(ODEMISD_CMD + cmdline.split())
         self.assertEqual(ret, 0, "trying to run '%s' gave status %d" % (cmdline, ret))
@@ -249,7 +252,7 @@ class TestCommandLine(unittest.TestCase):
     @timeout(20)
     def test_multiple_parents_new(self):
         """Test creating component with multiple parents"""
-        filename = "multiple-parents-new-style.odm.yaml"
+        filename = os.path.join(FILE_PATH, "multiple-parents-new-style.odm.yaml")
         cmdline = "--log-level=2 --log-target=testdaemon.log --daemonize %s" % filename
         ret = subprocess.call(ODEMISD_CMD + cmdline.split())
         self.assertEqual(ret, 0, "trying to run '%s' gave status %d" % (cmdline, ret))
@@ -271,7 +274,7 @@ class TestCommandLine(unittest.TestCase):
     @timeout(20)
     def test_properties_set(self):
         """Test creating component with specific properties"""
-        filename = "example-secom.odm.yaml"
+        filename = os.path.join(FILE_PATH, "example-secom.odm.yaml")
         cmdline = "--log-level=2 --log-target=testdaemon.log --daemonize %s" % filename
         ret = subprocess.call(ODEMISD_CMD + cmdline.split())
         self.assertEqual(ret, 0, "trying to run '%s'" % cmdline)
@@ -302,7 +305,7 @@ class TestCommandLine(unittest.TestCase):
         """Test initialization with persistent data"""
 
         # Start backend with persistent data specified in yaml file
-        filename = "sim-persistent.odm.yaml"
+        filename = os.path.join(FILE_PATH, "sim-persistent.odm.yaml")
         cmdline = "odemisd --log-level=2 --log-target=test.log --check"
         if os.path.isfile("test-settings.yaml"):
             os.remove("test-settings.yaml")
@@ -405,7 +408,7 @@ class TestCommandLine(unittest.TestCase):
         # The broken data should be ignored and a warning should be issued.
 
         # Start backend with persistent data specified in yaml file
-        filename = "sim-persistent.odm.yaml"
+        filename = os.path.join(FILE_PATH, "sim-persistent.odm.yaml")
         cmdline = "odemisd --log-level=2 --log-target=test.log --check"
         ret = main.main(cmdline.split())
         self.assertEqual(ret, 2, "Backend is said to be running")
@@ -482,7 +485,7 @@ class TestCommandLine(unittest.TestCase):
         # Start backend without any settings file defined. As it's not running
         # as root, it will run without persistent data stored.
         # => just show warnings in the log file, and runs fine.
-        filename = "sim-persistent.odm.yaml"
+        filename = os.path.join(FILE_PATH, "sim-persistent.odm.yaml")
         cmdline = "odemisd --log-level=2 --log-target=test.log --check"
         ret = main.main(cmdline.split())
         self.assertEqual(ret, 2, "Backend is said to be running")

--- a/src/odemis/odemisd/test/semantic-error-9.odm.yaml
+++ b/src/odemis/odemisd/test/semantic-error-9.odm.yaml
@@ -1,0 +1,9 @@
+Optical: {
+    class: Microscope,
+    role: epifluorescent,
+}
+
+Light: {
+    class: simulated.Light,
+    # missing "role"
+}

--- a/src/odemis/odemisd/test/syntax-error-4.odm.yaml
+++ b/src/odemis/odemisd/test/syntax-error-4.odm.yaml
@@ -1,0 +1,21 @@
+{
+
+Mic: {
+    class: Microscope,
+    role: epifluorescent,
+},
+
+First: {
+    class: simulated.Light,
+    role: light,
+},
+
+# Forgetting to put the name of the component is hard on normal files, but can easily happen for modular ones
+!extend syntax-error-extend-no-name.odm.yaml,
+
+Second: {
+    class: simulated.Light,
+    role: brightlight,
+},
+
+}

--- a/src/odemis/odemisd/test/syntax-error-extend-no-name.odm.yaml
+++ b/src/odemis/odemisd/test/syntax-error-extend-no-name.odm.yaml
@@ -1,0 +1,6 @@
+{ # Missing component name
+    class: simulated.Light,
+    role: null,
+    children: {c: "Stupid2",
+    }
+}


### PR DESCRIPTION
With the "!extend" syntax it's relatively easy to forget the name of the
component (if using it to insert a whole component).
It would fail in very confusing way. This was noticed by Stefan Sneep.
=> Add a check to more clearly indicate the error.

Note that ideally we'd link back the error to a specific "extend" file,
however it's tricky because technically the YAML is correct, and by the
name we've loaded it, we have discarded the information.

This is an example of the error generated when the component name is absent without the fix:
```
2023-05-08 11:19:28,415 ERROR   main:97:        When instantiating file ../mic-odm-yaml/muenster-sparc-3056/sparc2-muenster-lwd-polarizer-sim.odm.yaml
Traceback (most recent call last):
  File "/home/piel/development/odemis/src/odemis/odemisd/main.py", line 88, in __init__
    self._instantiator = modelgen.Instantiator(model_file, settings_file, self,
  File "/home/piel/development/odemis/src/odemis/odemisd/modelgen.py", line 263, in __init__
    self._preparate_microscope()
  File "/home/piel/development/odemis/src/odemis/odemisd/modelgen.py", line 287, in _preparate_microscope
    microscopes = [(n, a) for n, a in self.ast.items() if a.get("class") == "Microscope"]
  File "/home/piel/development/odemis/src/odemis/odemisd/modelgen.py", line 287, in <listcomp>
    microscopes = [(n, a) for n, a in self.ast.items() if a.get("class") == "Microscope"]
AttributeError: 'str' object has no attribute 'get'
2023-05-08 11:19:28,416 ERROR   main:780:       Unexpected error at instantiation
```

This is an example with the fix:
```
2023-05-08 11:58:21,547 ERROR   main:777:       Error while parsing file ../mic-odm-yaml/muenster-sparc-3056/sparc2-muenster-lwd-polarizer-sim.odm.yaml:
Definition of component "class" should be a dict but got a str
```

Note that this also adds checks for a few other errors that would cause
odd error messages (eg, if a component name is not a string).

Also fixes the test cases to run from any directory.