### PR TITLE
driver zeiss: support for Point Electronic simulator

### DIFF
--- a/src/odemis/driver/test/zeiss_test.py
+++ b/src/odemis/driver/test/zeiss_test.py
@@ -53,9 +53,10 @@ CONFIG_STAGE6 = {"name": "stage", "role": "stage",
                  }
 CONFIG_FOCUS = {"name": "focuser", "role": "ebeam-focus"}
 CONFIG_SEM3 = {"name": "sem", "role": "sem", "port": "/dev/ttyUSB*",  # "/dev/fake*"
-              "children": {"scanner": CONFIG_SCANNER,
-                           "focus": CONFIG_FOCUS,
-                           "stage": CONFIG_STAGE3, }
+               "eol": "\r\n", # Standard, but to check that the conversion to bytes work
+               "children": {"scanner": CONFIG_SCANNER,
+                            "focus": CONFIG_FOCUS,
+                            "stage": CONFIG_STAGE3, }
                }
 CONFIG_SEM6 = copy.deepcopy(CONFIG_SEM3)
 CONFIG_SEM6["children"]["stage"] = CONFIG_STAGE6


### PR DESCRIPTION
Point Electronic has SEM software which accepts the same protocol as
Zeiss, as a "simulator". However, there are some minor differences that
prevented the driver from working.
=> Add an option to change the end-of-line characters
=> Don't make a fuss if beam blanker cannot be controlled