### PR TITLE
acq orsay_milling: improve fake OrsayMilling

### DIFF
--- a/src/odemis/acq/orsay_milling.py
+++ b/src/odemis/acq/orsay_milling.py
@@ -21,6 +21,7 @@ You should have received a copy of the GNU General Public License along with
 Odemis. If not, see http://www.gnu.org/licenses/.
 """
 import logging
+import threading
 import time
 from concurrent import futures
 from typing import Tuple
@@ -316,13 +317,17 @@ class FakeOrsayMilling(OrsayMilling):
         """
         Fake milling function used during simulation
         """
-        logging.info("Fake Milling a rectangle")
-        time.sleep(5)
+        logging.info("Fake rectangle milling of %s s", self.duration)
+        self._fake_milling_stop = threading.Event()
+        if self._fake_milling_stop.wait(1 + self.duration):
+            raise futures.CancelledError()
 
     def cancel_milling(self, future):
         """
         Fake milling function used during simulation
         """
         logging.info("Cancel Fake Milling a rectangle")
+        if hasattr(self, "_fake_milling_stop"):
+            self._fake_milling_stop.set()
 
         return True


### PR DESCRIPTION
Instead of always taking 5s, actually take the amount of time requested
for the milling. Cancelling the milling also works properly now.

This should improve the reliability of test_milling_settings_from_yaml()

Also fix the TEST_NOHW usage to actually default to hardware testing.

Also reduce the milling duration of some tests, to reduce the total run
time.

Also de-duplicate code for the fake milling.