### PR TITLE
gui cont: protect all callbacks of is_acquiring which use the GUI

### DIFF
--- a/src/odemis/gui/cont/actuators.py
+++ b/src/odemis/gui/cont/actuators.py
@@ -19,6 +19,7 @@ from odemis.gui.util.widgets import VigilantAttributeConnector
 from odemis.gui.comp.combo import ComboBox
 import logging
 import wx
+from odemis.gui.util import call_in_wx_main
 
 
 # Known good key bindings
@@ -161,6 +162,7 @@ class ActuatorController(object):
 
         tab_data.main.is_acquiring.subscribe(self._on_acquisition)
 
+    @call_in_wx_main
     def _on_acquisition(self, acquiring):
         self._enable_buttons(not acquiring)
 

--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -650,6 +650,7 @@ class LocalizationTab(Tab):
             self.tab_data_model.autofocus_active.value = False
         wx.CallAfter(self.tb.enable_button, TOOL_AUTO_FOCUS, f_enable)
 
+    @call_in_wx_main
     def _on_acquired_streams(self, streams):
         """
         Filter out deleted acquired streams (features and overview) from their respective origin
@@ -1631,6 +1632,7 @@ class SparcAcquisitionTab(Tab):
             cur_stream.is_active.value = True
         self.panel.vp_sparc_tl.canvas.fit_view_to_next_image = True
 
+    @call_in_wx_main
     def on_acquisition(self, is_acquiring):
         # TODO: Make sure nothing can be modified during acquisition
 
@@ -2128,6 +2130,7 @@ class FastEMOverviewTab(Tab):
         # The user might not be at the system after the functions complete, so the stream
         # would play idly.
 
+    @call_in_wx_main
     def on_acquisition(self, is_acquiring):
         # Don't allow changes to acquisition/calibration ROIs during acquisition
         if is_acquiring:


### PR DESCRIPTION
All functions which are listening to is_acquiring and change the GUI
should be protected with @call_in_wx_main .
Otherwise, the GUI could crash at the end of an acquisition.

This might affect most of the microscope types, and has the potential to
solve some unresolved "crashes after acquisition".