### PR TITLE
acq feature: remove milling angle from CryoFeature

### DIFF
--- a/src/odemis/acq/feature.py
+++ b/src/odemis/acq/feature.py
@@ -1,6 +1,4 @@
 import json
-import logging
-import math
 import os
 
 from odemis import model
@@ -8,36 +6,25 @@ from odemis import model
 # The current state of the feature
 FEATURE_ACTIVE, FEATURE_ROUGH_MILLED, FEATURE_POLISHED, FEATURE_DEACTIVE = "Active", "Rough Milled", "Polished", "Discarded"
 
-# Default Milling angle and range for cryo-based microscopes
-DEFAULT_MILLING_ANGLE = math.radians(10)  # rad
-MILLING_ANGLE_RANGE = (math.radians(5), math.radians(25))
-
 
 class CryoFeature(object):
     """
     Model class for a cryo interesting feature
     """
 
-    def __init__(self, name, x, y, z, milling_angle, streams=None):
+    def __init__(self, name, x, y, z, streams=None):
         """
         :param name: (string) the feature name
         :param x: (float) the X axis of the feature position
         :param y: (float) the Y axis of the feature position
         :param z: (float) the Z axis of the feature position
-        :param milling_angle: (float)  angle used for milling (angle between the sample and the ion-beam, similar to the
-        one in the chamber tab, not the actual Rx)
         :param streams: (List of StaticStream) list of acquired streams on this feature
         """
         self.name = model.StringVA(name)
         # The 3D position of an interesting point in the site (Typically, the milling should happen around that
         # volume, never touching it.)
         self.pos = model.TupleContinuous((x, y, z), range=((-1, -1, -1), (1, 1, 1)), cls=(int, float), unit="m")
-        # TODO: Check if negative milling angle is allowed
-        if milling_angle <= 0:
-            milling_angle = DEFAULT_MILLING_ANGLE
-            logging.warning(
-                f"Given milling angle {milling_angle} is negative, setting it to default {DEFAULT_MILLING_ANGLE}")
-        self.milling_angle = model.FloatVA(milling_angle)
+        
         self.status = model.StringVA(FEATURE_ACTIVE)
         # TODO: Handle acquired files
         self.streams = streams if streams is not None else model.ListVA()
@@ -52,7 +39,7 @@ def get_features_dict(features):
     flist = []
     for feature in features:
         feature_item = {'name': feature.name.value, 'pos': feature.pos.value,
-                        'milling_angle': feature.milling_angle.value, 'status': feature.status.value}
+                        'status': feature.status.value}
         flist.append(feature_item)
     return {'feature_list': flist}
 
@@ -69,7 +56,7 @@ class FeaturesDecoder(json.JSONDecoder):
         # Either the object is the feature list or the feature objects inside it
         if 'name' in obj:
             pos = obj['pos']
-            feature = CryoFeature(obj['name'], pos[0], pos[1], pos[2], obj['milling_angle'])
+            feature = CryoFeature(obj['name'], pos[0], pos[1], pos[2])
             feature.status.value = obj['status']
             return feature
         if 'feature_list' in obj:

--- a/src/odemis/acq/test/feature_test.py
+++ b/src/odemis/acq/test/feature_test.py
@@ -16,12 +16,12 @@ class TestFeatureEncoderDecoder(unittest.TestCase):
     """
     Test the json encoder and decoder of the CryoFeature class
     """
-    test_str = '{"feature_list": [{"name": "Feature-1", "pos": [0, 0, 0], "milling_angle": 10.0, "status": "Active"}, '+ \
-               '{"name": "Feature-2", "pos": [0.001, 0.001, 0.002], "milling_angle": 20.0, "status": "Active"}]}'
+    test_str = '{"feature_list": [{"name": "Feature-1", "pos": [0, 0, 0], "status": "Active"}, '+ \
+               '{"name": "Feature-2", "pos": [0.001, 0.001, 0.002], "status": "Active"}]}'
 
     def test_feature_encoder(self):
-        feature1 = CryoFeature("Feature-1", 0, 0, 0, 10)
-        feature2 = CryoFeature("Feature-2", 1e-3, 1e-3, 2e-3, 20)
+        feature1 = CryoFeature("Feature-1", 0, 0, 0)
+        feature2 = CryoFeature("Feature-2", 1e-3, 1e-3, 2e-3)
 
         features = [feature1, feature2]
         json_str = json.dumps(get_features_dict(features))
@@ -33,11 +33,10 @@ class TestFeatureEncoderDecoder(unittest.TestCase):
         self.assertTrue(features[0].name.value, "Feature-1")
         self.assertTrue(features[0].status.value, "Active")
         self.assertTrue(features[1].pos.value, (1e-3, 1e-3, 2e-3))
-        self.assertTrue(features[1].milling_angle.value, 20.0)
 
     def test_save_read_features(self):
-        feature1 = CryoFeature("Feature-1", 0, 0, 0, 10)
-        feature2 = CryoFeature("Feature-2", 1e-3, 1e-3, 2e-3, 20)
+        feature1 = CryoFeature("Feature-1", 0, 0, 0)
+        feature2 = CryoFeature("Feature-2", 1e-3, 1e-3, 2e-3)
 
         features = [feature1, feature2]
         save_features("", features)

--- a/src/odemis/gui/model/__init__.py
+++ b/src/odemis/gui/model/__init__.py
@@ -27,7 +27,7 @@ from collections.abc import Mapping
 import logging
 import math
 
-from odemis.acq.feature import CryoFeature, DEFAULT_MILLING_ANGLE, MILLING_ANGLE_RANGE
+from odemis.acq.feature import CryoFeature
 from odemis.gui import conf
 from odemis.util.filename import create_filename, make_unique_name
 from odemis import model
@@ -721,7 +721,7 @@ class CryoGUIData(MicroscopyGUIData):
                 "Expected a microscope role of 'enzel', 'meteor', or 'mimas' but found it to be %s." % main.role)
         super().__init__(main)
 
-    def add_new_feature(self, pos_x, pos_y, pos_z=None, f_name=None, milling_angle=DEFAULT_MILLING_ANGLE):
+    def add_new_feature(self, pos_x, pos_y, pos_z=None, f_name=None):
         """
         Create a new feature and add it to the features list
         """
@@ -730,7 +730,7 @@ class CryoGUIData(MicroscopyGUIData):
             f_name = make_unique_name("Feature-1", existing_names)
         if pos_z is None:
             pos_z = self.main.focus.position.value['z']
-        feature = CryoFeature(f_name, pos_x, pos_y, pos_z, milling_angle)
+        feature = CryoFeature(f_name, pos_x, pos_y, pos_z)
         self.main.features.value.append(feature)
         self.main.currentFeature.value = feature
         return feature


### PR DESCRIPTION
The idea of the milling angle was that the user would be able to select
the angle at which to mill. However, it turns out with more experience
that the milling angle is more a feature of the milling step. We now
have it part of the milling settings. Can remove this attribute, which
was never used.