### PR TITLE
gui cont: only show MILL button on MIMAS

### DIFF
--- a/src/odemis/gui/cont/milling.py
+++ b/src/odemis/gui/cont/milling.py
@@ -61,11 +61,9 @@ class MillingButtonController:
         self._panel = tab_panel
         self._tab_data = tab_data
 
-        # hide/show some widgets at initialization
-        self._panel.gauge_milling_series.Hide()
-        self._panel.txt_milling_series_left_time.Hide()
+        # By default, all widgets are hidden => show button + estimated time at initialization
         self._panel.txt_milling_est_time.Show()
-        self._panel.btn_milling_cancel.Hide()
+        self._panel.btn_mill_active_features.Show()
         self._panel.Layout()
 
         self._tab_data.main.features.subscribe(self._on_features, init=True)

--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -488,10 +488,13 @@ class LocalizationTab(Tab):
 
         main_data.is_acquiring.subscribe(self._on_acquisition, init=True)
 
-        self._serial_milling_controller = milling.MillingButtonController(
-            tab_data,
-            panel
-        )
+        # For now, only possible to mill on the MIMAS. Eventually, this could be
+        # dependent on the availability of the ion-beam component.
+        if self.main_data.role == "mimas":
+            self._serial_milling_controller = milling.MillingButtonController(
+                tab_data,
+                panel
+            )
 
     @property
     def settingsbar_controller(self):

--- a/src/odemis/gui/main.xrc
+++ b/src/odemis/gui/main.xrc
@@ -8557,6 +8557,7 @@
                         <object class="wxFlexGridSizer">
                             <object class="sizeritem">
                                 <object class="ImageTextButton" name="btn_mill_active_features">
+                                    <hidden>1</hidden>
                                     <icon>img/icon/ico_sem.png</icon>
                                     <height>48</height>
                                     <face_colour>blue</face_colour>
@@ -8578,6 +8579,7 @@
                                 <object class="wxBoxSizer">
                                     <object class="sizeritem">
                                         <object class="wxStaticText" name="txt_milling_est_time">
+                                            <hidden>1</hidden>
                                             <label>Estimated time ...</label>
                                             <fg>#E5E5E5</fg>
                                             <hidden>0</hidden>
@@ -8596,6 +8598,7 @@
                                         <object class="wxBoxSizer">
                                             <object class="sizeritem">
                                                 <object class="wxGauge" name="gauge_milling_series">
+                                                    <hidden>1</hidden>
                                                     <size>-1,10</size>
                                                     <range>100</range>
                                                     <value>0</value>
@@ -8610,6 +8613,7 @@
                                             </object>
                                             <object class="sizeritem">
                                                 <object class="wxStaticText" name="txt_milling_series_left_time">
+                                                    <hidden>1</hidden>
                                                     <label></label>
                                                     <fg>#E5E5E5</fg>
                                                     <hidden>0</hidden>
@@ -8625,6 +8629,7 @@
                                     </object>
                                     <object class="sizeritem">
                                         <object class="ImageTextButton" name="btn_milling_cancel">
+                                            <hidden>1</hidden>
                                             <height>24</height>
                                             <face_colour>def</face_colour>
                                             <label>cancel</label>

--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -9611,6 +9611,7 @@ def __init_resources():
                         <object class="wxFlexGridSizer">
                             <object class="sizeritem">
                                 <object class="ImageTextButton" name="btn_mill_active_features">
+                                    <hidden>1</hidden>
                                     <icon>img_icon_ico_sem_png</icon>
                                     <height>48</height>
                                     <face_colour>blue</face_colour>
@@ -9632,6 +9633,7 @@ def __init_resources():
                                 <object class="wxBoxSizer">
                                     <object class="sizeritem">
                                         <object class="wxStaticText" name="txt_milling_est_time">
+                                            <hidden>1</hidden>
                                             <label>Estimated time ...</label>
                                             <fg>#E5E5E5</fg>
                                             <hidden>0</hidden>
@@ -9650,6 +9652,7 @@ def __init_resources():
                                         <object class="wxBoxSizer">
                                             <object class="sizeritem">
                                                 <object class="wxGauge" name="gauge_milling_series">
+                                                    <hidden>1</hidden>
                                                     <size>-1,10</size>
                                                     <range>100</range>
                                                     <value>0</value>
@@ -9664,6 +9667,7 @@ def __init_resources():
                                             </object>
                                             <object class="sizeritem">
                                                 <object class="wxStaticText" name="txt_milling_series_left_time">
+                                                    <hidden>1</hidden>
                                                     <label/>
                                                     <fg>#E5E5E5</fg>
                                                     <hidden>0</hidden>
@@ -9679,6 +9683,7 @@ def __init_resources():
                                     </object>
                                     <object class="sizeritem">
                                         <object class="ImageTextButton" name="btn_milling_cancel">
+                                            <hidden>1</hidden>
                                             <height>24</height>
                                             <face_colour>def</face_colour>
                                             <label>cancel</label>


### PR DESCRIPTION
Since commit (759b05acd81c3b4bee7a), the MILL button was always shown in
the localization tab. However, milling is only supported with on the
MIMAS (not ENZEL nor METEOR).
=> Hide by default, and detect that it's the MIMAS to show the widgets.