### PR TITLE
config: change grid numbering scheme on MIMAS

### DIFF
--- a/install/linux/usr/share/odemis/sim/mimas-orsay-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/mimas-orsay-sim.odm.yaml
@@ -224,18 +224,18 @@ MIMAS-Sim: {
                            },
         # Initial position when going from loading to imaging.
         # Typically, same as GRID 1, but also with shows the initial Z
-        FAV_POS_ACTIVE: {"x": 7.5e-3, "y": -4.5e-3, "z": 40.0e-6, "rx": 0 , "ry": 0, "rz": 0},
+        FAV_POS_ACTIVE: {"x": -7.5e-3, "y": 4.5e-3, "z": 40.0e-6, "rx": 0 , "ry": 0, "rz": 0},
         # Centers (X, Y) of each grid. The Z position is assumed to be the same for all grids.
         # They should all be within POS_ACTIVE_RANGE!
         SAMPLE_CENTERS: {
-            "GRID 1": {'x':  7.5e-3, 'y': -4.5e-3},
-            "GRID 2": {'x':  2.5e-3, 'y': -4.5e-3},
-            "GRID 3": {'x': -2.5e-3, 'y': -4.5e-3},
-            "GRID 4": {'x': -7.5e-3, 'y': -4.5e-3},
-            "GRID 5": {'x':  7.5e-3, 'y':  4.5e-3},
-            "GRID 6": {'x':  2.5e-3, 'y':  4.5e-3},
-            "GRID 7": {'x': -2.5e-3, 'y':  4.5e-3},
-            "GRID 8": {'x': -7.5e-3, 'y':  4.5e-3},
+            "GRID 1": {'x': -7.5e-3, 'y':  4.5e-3},
+            "GRID 2": {'x': -2.5e-3, 'y':  4.5e-3},
+            "GRID 3": {'x':  2.5e-3, 'y':  4.5e-3},
+            "GRID 4": {'x':  7.5e-3, 'y':  4.5e-3},
+            "GRID 5": {'x': -7.5e-3, 'y': -4.5e-3},
+            "GRID 6": {'x': -2.5e-3, 'y': -4.5e-3},
+            "GRID 7": {'x':  2.5e-3, 'y': -4.5e-3},
+            "GRID 8": {'x':  7.5e-3, 'y': -4.5e-3},
         },
 
         # For computing the angle between the stage (rx) and the ion-beam

--- a/install/linux/usr/share/odemis/sim/mimas-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/mimas-sim.odm.yaml
@@ -190,18 +190,18 @@ MIMAS-Sim: {
                            },
         # Initial position when going from loading to imaging.
         # Typically, same as GRID 1, but also with shows the initial Z
-        FAV_POS_ACTIVE: {"x": 7.5e-3, "y": -4.5e-3, "z": 40.0e-6, "rx": 0 , "ry": 0, "rz": 0},
+        FAV_POS_ACTIVE: {"x": -7.5e-3, "y": 4.5e-3, "z": 40.0e-6, "rx": 0 , "ry": 0, "rz": 0},
         # Centers (X, Y) of each grid. The Z position is assumed to be the same for all grids.
         # They should all be within POS_ACTIVE_RANGE!
         SAMPLE_CENTERS: {
-            "GRID 1": {'x':  7.5e-3, 'y': -4.5e-3},
-            "GRID 2": {'x':  2.5e-3, 'y': -4.5e-3},
-            "GRID 3": {'x': -2.5e-3, 'y': -4.5e-3},
-            "GRID 4": {'x': -7.5e-3, 'y': -4.5e-3},
-            "GRID 5": {'x':  7.5e-3, 'y':  4.5e-3},
-            "GRID 6": {'x':  2.5e-3, 'y':  4.5e-3},
-            "GRID 7": {'x': -2.5e-3, 'y':  4.5e-3},
-            "GRID 8": {'x': -7.5e-3, 'y':  4.5e-3},
+            "GRID 1": {'x': -7.5e-3, 'y':  4.5e-3},
+            "GRID 2": {'x': -2.5e-3, 'y':  4.5e-3},
+            "GRID 3": {'x':  2.5e-3, 'y':  4.5e-3},
+            "GRID 4": {'x':  7.5e-3, 'y':  4.5e-3},
+            "GRID 5": {'x': -7.5e-3, 'y': -4.5e-3},
+            "GRID 6": {'x': -2.5e-3, 'y': -4.5e-3},
+            "GRID 7": {'x':  2.5e-3, 'y': -4.5e-3},
+            "GRID 8": {'x':  7.5e-3, 'y': -4.5e-3},
         },
 
         # For computing the angle between the stage (rx) and the ion-beam


### PR DESCRIPTION
We use an arbitrary scheme, so let's make it logical for the user to
just read as:
1 2 3 4
5 6 7 8