### PR TITLE
gui comp overlay world: fix RepetitionSelectOverlay not showing icons

### DIFF
--- a/src/odemis/gui/comp/overlay/world.py
+++ b/src/odemis/gui/comp/overlay/world.py
@@ -877,7 +877,7 @@ class RepetitionSelectOverlay(WorldSelectOverlay):
 
                 logging.debug("Rendering %sx%s points", buf_rep_x, buf_rep_y)
 
-                point = img.getBitmap("dot.png")
+                point = guiimg.getBitmap("dot.png")
                 point_dc = wx.MemoryDC()
                 point_dc.SelectObject(point)
                 point.SetMaskColour(wx.BLACK)


### PR DESCRIPTION
Commit dd2d23a588 (gui comp: add SampleBackgroundOverlay for MIMAS)
contained a clean-up of the imports. gui.img was imported twice, under
two different names "img" and "guiimg". It removed one of them, "img", but failed to adjust the
code using that name. So RepetitionSelectOverlay would fail with such
error:
Failed to draw world overlay <odemis.gui.comp.overlay.world.RepetitionSelectOverlay object at 0x7faf703493a0>
Traceback (most recent call last):
  File "/home/piel/development/odemis/src/odemis/gui/comp/canvas.py", line 905, in draw
    o.draw(ctx, self.p_buffer_center, self.scale)
  File "/home/piel/development/odemis/src/odemis/gui/comp/overlay/world.py", line 986, in draw
    self._draw_points(ctx)
  File "/home/piel/development/odemis/src/odemis/gui/comp/overlay/world.py", line 880, in _draw_points
    point = img.getBitmap("dot.png")
NameError: name 'img' is not defined

=> also use guiimg there.