### PR TITLE
driver orsay: connect using "admin" level to access all the presets

### DIFF
--- a/src/odemis/driver/orsay.py
+++ b/src/odemis/driver/orsay.py
@@ -2894,7 +2894,7 @@ class Scanner(model.Emitter):
             # If the connection is done using the default "Python" user, the
             # access level is too low, and this fails because it has no rights
             # to delete/change presets and masks. In this case, we get an error 500.
-            logging.error("Failed CreatePresetMask(), check the connection login has sufficient access level (>= Standard)")
+            logging.error("Failed CreatePresetMask(), check if the connection login has sufficient access level (>= Standard)")
             raise
 
         # List of available probe current: based on presets name

--- a/src/odemis/driver/test/orsay_test.py
+++ b/src/odemis/driver/test/orsay_test.py
@@ -36,10 +36,9 @@ from math import pi
 from time import sleep
 
 from odemis.driver import orsay
-from odemis.driver.orsay import PRESET_MASK_NAME
 from odemis.model import HwError
 from odemis import model
-from odemis.util import almost_equal, find_closest, testing, timeout
+from odemis.util import find_closest, testing, timeout
 
 logging.getLogger().setLevel(logging.DEBUG)
 logging.basicConfig(format="%(asctime)s  %(levelname)-7s %(module)s:%(lineno)d %(message)s")
@@ -62,6 +61,7 @@ CONFIG_DETECTOR = {"name": "detector", "role": "detector"}
 # Simulation:   192.168.56.101
 # Hardware:     192.168.30.101
 CONFIG_ORSAY = {"name": "Orsay", "role": "orsay", "host": "192.168.30.101",
+                "login": "Python",  # default login name, but here for testing
                 "children": {"pneumatic-suspension": CONFIG_PSUS,
                              "pressure": CONFIG_PRESSURE,
                              "pumping-system": CONFIG_PSYS,


### PR DESCRIPTION
This is a temporary work-around while the Orsay Server adjusts its
access rights code. By default the connection runs as "Python", at the
lowest level, which forbid reading/modifying presets.