### PR TITLE
Sdev 1457 implement overview tab changes based on feedback after testing on ea1

### DIFF
--- a/src/odemis/gui/conf/data.py
+++ b/src/odemis/gui/conf/data.py
@@ -533,6 +533,16 @@ HW_SETTINGS_CONFIG = {
                            u"Use only if the frequency is very high (see hardware documentation).",
             }),
         )),
+    "se-detector":
+        # Keep the same `contrast` and `brigtness` slider order as in the TFS UI
+        OrderedDict((
+            ("contrast", {
+                "control_type": odemis.gui.CONTROL_SLIDER,
+            }),
+            ("brightness", {
+                "control_type": odemis.gui.CONTROL_SLIDER,
+            }),
+        )),
 }
 
 # Allows to override some values based on the microscope role

--- a/src/odemis/gui/cont/fastem_acq.py
+++ b/src/odemis/gui/cont/fastem_acq.py
@@ -161,7 +161,7 @@ class FastEMOverviewAcquiController(object):
         lvl = None  # icon status shown
         if not self._tab_data_model.is_calib_done.value:
             lvl = logging.WARN
-            txt = "System is not calibrated."
+            txt = "System is not calibrated, please run Optical Autofocus."
         elif not self._main_data_model.active_scintillators.value:
             lvl = logging.WARN
             txt = "No scintillator loaded (go to Chamber tab)."

--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -2033,6 +2033,9 @@ class FastEMOverviewTab(Tab):
             fastem._executor.cancel()
             return
 
+        # Disable other calibration buttons
+        self.btn_sem_autofocus.Enable(False)
+        self.btn_autobc.Enable(False)
         # calibrate
         self.tab_data.is_calibrating.unsubscribe(self._on_is_acquiring)
         # Don't catch this event (is_calibrating = True) - this would disable the button,
@@ -2063,7 +2066,10 @@ class FastEMOverviewTab(Tab):
         a calibration or acquisition is already ongoing or not.
         :param mode: (bool) Whether the system is currently acquiring/calibrating or not acquiring/calibrating.
         """
+        # TODO also include btn_autostigmation once autostigmation is working
         self.btn_optical_autofocus.Enable(not mode)
+        self.btn_sem_autofocus.Enable(not mode)
+        self.btn_autobc.Enable(not mode)
 
     @call_in_wx_main
     def _on_optical_autofocus_done(self, future, _=None):
@@ -2107,6 +2113,10 @@ class FastEMOverviewTab(Tab):
 
     @call_in_wx_main
     def _on_btn_sem_autofocus(self, _):
+        # Disable other calibration buttons
+        # TODO also disable btn_autostigmation once autostigmation is working
+        self.btn_optical_autofocus.Enable(False)
+        self.btn_autobc.Enable(False)
         self.sem_stream_cont.stream_panel.Enable(False)
         self.sem_stream_cont.pause()
         self.sem_stream_cont.pauseStream()
@@ -2115,6 +2125,10 @@ class FastEMOverviewTab(Tab):
 
     @call_in_wx_main
     def _on_btn_autobc(self, _):
+        # Disable other calibration buttons
+        # TODO also disable btn_autostigmation once autostigmation is working
+        self.btn_optical_autofocus.Enable(False)
+        self.btn_sem_autofocus.Enable(False)
         self.sem_stream_cont.stream_panel.Enable(False)
         self.sem_stream_cont.pause()
         self.sem_stream_cont.pauseStream()
@@ -2123,6 +2137,10 @@ class FastEMOverviewTab(Tab):
 
     @call_in_wx_main
     def _on_btn_autostigmation(self, _):
+        # Disable other calibration buttons
+        self.btn_optical_autofocus.Enable(False)
+        self.btn_sem_autofocus.Enable(False)
+        self.btn_autobc.Enable(False)
         self.sem_stream_cont.stream_panel.Enable(False)
         self.sem_stream_cont.pause()
         self.sem_stream_cont.pauseStream()
@@ -2131,6 +2149,10 @@ class FastEMOverviewTab(Tab):
 
     @call_in_wx_main
     def _on_autofunction_done(self, f):
+        # Enable all calibration buttons
+        self.btn_optical_autofocus.Enable(True)
+        self.btn_sem_autofocus.Enable(True)
+        self.btn_autobc.Enable(True)
         self.sem_stream_cont.stream_panel.Enable(True)
         # Resume SettingEntry related control updates of the stream
         self.sem_stream_cont.resume()


### PR DESCRIPTION
Ticket: https://delmic.atlassian.net/browse/SDEV-1457

Changes:

- Have the Contrast slider above the Brightness slider (same setup as the TFS UI)

- Either display, “System not calibrated, please run Optical Autofocus“ or remove this warning and allow the user to acquire Overview Image without running Optical Autofocus

- Handle disabling of calibration buttons when necessary. Disable the calibration buttons when acquiring Overview Image, and when running each calibration disable the other calibration buttons