### PR TITLE
util tmcmconfig: adjust min_power to work even if device reports 0V

### DIFF
--- a/util/tmcmconfig
+++ b/util/tmcmconfig
@@ -380,7 +380,7 @@ def main(args):
         ctrl = tmcm.TMCLController("TMCL controller", "config",
                                    port=port, address=options.add,
                                    axes=["a"], ustepsize=[1e-9],
-                                   minpower=0.1)  # No need for external power supply
+                                   minpower=0)  # No need for external power supply
         logging.info("Connected to %s", ctrl.hwVersion)
 
         if options.reset:  # Allow to do it before writing
@@ -392,7 +392,7 @@ def main(args):
             ctrl = tmcm.TMCLController("TMCL controller", "config",
                                    port=port, address=options.add,
                                    axes=["a"], ustepsize=[1e-9],
-                                   minpower=0.1)  # No need for external power supply
+                                   minpower=0)  # No need for external power supply
             logging.info("Connected to %s", ctrl.hwVersion)
 
         if options.read:


### PR DESCRIPTION
The TMCM6110 used to report ~3V, instead of 12V, when it was only connected via USB only.
However, the latest versions report exactly 0V.
For some reasons, we had set the min_power to 0.1V... just for the sake
of not saying 0V. However saying 0V is fine. This allows to work on the
latest versions of the TMCM6110.