### PR TITLE
acq millmng test: fix failure to create CryoFeature

### DIFF
--- a/src/odemis/acq/test/millmng_test.py
+++ b/src/odemis/acq/test/millmng_test.py
@@ -110,7 +110,7 @@ class MillingManagerTestCase(unittest.TestCase):
         cls.sites = []
         for i in range(0, len(cls.target_position)):
             feature = CryoFeature('object_' + str(i), cls.target_position[i]['x'], cls.target_position[i]['y'],
-                                  cls.target_position[i]['z'], milling_angle=0)
+                                  cls.target_position[i]['z'])
             cls.sites.append(feature)
 
         cls.feature_post_status = FEATURE_ROUGH_MILLED


### PR DESCRIPTION
Since commit 0d577b5fcc9 (acq feature: remove milling angle from
CryoFeature), there are no more milling angles for the CryoFeature.

The commit had forgotten to update one user: the millingmng test case.
This caused a failure in the test case.

=> drop the milling_angle argument.