### PR TITLE
fastem: change order of calibration 1

### DIFF
--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -1798,10 +1798,10 @@ class FastEMAcquisitionTab(Tab):
                             Calibrations.IMAGE_TRANSLATION_PREALIGN]
         else:  # it is a real microscope
             calibrations = [Calibrations.OPTICAL_AUTOFOCUS,
+                            Calibrations.IMAGE_ROTATION_PREALIGN,
                             Calibrations.SCAN_ROTATION_PREALIGN,
                             Calibrations.DESCAN_GAIN_STATIC,
                             Calibrations.SCAN_AMPLITUDE_PREALIGN,
-                            Calibrations.IMAGE_ROTATION_PREALIGN,
                             Calibrations.IMAGE_TRANSLATION_PREALIGN,
                             Calibrations.IMAGE_ROTATION_FINAL,
                             Calibrations.IMAGE_TRANSLATION_FINAL]


### PR DESCRIPTION
SDEV-1460 Execute the image rotation pre-alignment before the scan rotation and scan amplitude pre-alignments. The latter two calibrations only work if the pattern is roughly aligned with the diagnostic camera x-axis (+/- 5 degrees). The image rotation pre-alignment is independent of the scan rotation pre-alignment, the descan gain alignment and the scan amplitude alignment, therefore it can be moved in front of those three.