### PR TITLE
acq test move: fix mimas move to coating failure

### DIFF
--- a/install/linux/usr/share/odemis/sim/mimas-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/mimas-sim.odm.yaml
@@ -178,9 +178,6 @@ MIMAS-Sim: {
 
         # Loading position (should NOT be within the POS_ACTIVE_RANGE)
         FAV_POS_DEACTIVE: {"x": 0, "y": 0, "z": -3.0e-3, 'rx': 0, "ry": 0, "rz": 0},
-        # Initial position when coating
-        # TODO: can it change a lot if coating is need for every grid? In such case, we might need a range
-        FAV_POS_COATING: {"x": -0.008, "y": -0.007, "z": -1.0e-3, "rx": 0, "ry": 0, "rz": 0},
         # Safe ranges for imaging (FM/FIB)
         # Note: for the Z, that's the "safe" range, and the "Stage Focus" should have a subset range used to limit the autofocus
         POS_ACTIVE_RANGE: {"x": [-9.0e-3, 9.0e-3], "y": [-6.0e-3, 6.0e-3], "z": [-0.5e-3, 4.0e-3],

--- a/src/odemis/acq/test/move_test.py
+++ b/src/odemis/acq/test/move_test.py
@@ -494,7 +494,6 @@ class TestMimasMove(unittest.TestCase):
 
         cls.stage_active = cls.stage.getMetadata()[model.MD_FAV_POS_ACTIVE]
         cls.stage_deactive = cls.stage.getMetadata()[model.MD_FAV_POS_DEACTIVE]
-        cls.stage_coating = cls.stage.getMetadata()[model.MD_FAV_POS_COATING]
         cls.align_deactive = cls.aligner.getMetadata()[model.MD_FAV_POS_DEACTIVE]
         cls.align_active = cls.aligner.getMetadata()[model.MD_FAV_POS_ACTIVE]
 
@@ -512,6 +511,8 @@ class TestMimasMove(unittest.TestCase):
         """
         stage = self.stage
         align = self.aligner
+        gis_choices = self.gis.axes["arm"].choices
+
         # Get the stage to loading position
         cryoSwitchSamplePosition(LOADING).result()
         testing.assert_pos_almost_equal(stage.position.value, self.stage_deactive,
@@ -519,13 +520,14 @@ class TestMimasMove(unittest.TestCase):
         # Align should be parked
         testing.assert_pos_almost_equal(align.position.value, self.align_deactive, atol=ATOL_LINEAR_POS)
         # GIS should be parked
-        gis_choices = self.gis.axes["arm"].choices
         self.assertEqual(gis_choices[self.gis.position.value["arm"]], "parked")
 
-        # Get the stage to coating position
+        # Go to coating position: in MIMAS, that's the imaging position, with the GIS being engaged
         f = cryoSwitchSamplePosition(COATING)
         f.result()
-        testing.assert_pos_almost_equal(stage.position.value, self.stage_coating, atol=ATOL_LINEAR_POS)
+        testing.assert_pos_almost_equal(stage.position.value, self.stage_active, atol=ATOL_LINEAR_POS)
+        # GIS engaged
+        self.assertEqual(gis_choices[self.gis.position.value["arm"]], "engaged")
         # Align should be parked
         testing.assert_pos_almost_equal(align.position.value, self.align_deactive, atol=ATOL_LINEAR_POS)
         pos_label = getCurrentPositionLabel(stage.position.value, stage, self.aligner)
@@ -541,7 +543,7 @@ class TestMimasMove(unittest.TestCase):
         self.assertEqual(pos_label, FM_IMAGING)
 
         # Test the progress update
-        progress_fm = getMovementProgress(stage.position.value, self.stage_coating, self.stage_active)
+        progress_fm = getMovementProgress(stage.position.value, self.stage_deactive, self.stage_active)
         self.assertAlmostEqual(progress_fm, 1)
 
         # Move a little bit around => still in FM_IMAGING
@@ -553,14 +555,12 @@ class TestMimasMove(unittest.TestCase):
         # Get the stage to FIB
         f = cryoSwitchSamplePosition(MILLING)
         f.result()
-        testing.assert_pos_almost_equal(stage.position.value, self.stage_active, atol=ATOL_LINEAR_POS)
+        # The stage shouldn't have moved
+        testing.assert_pos_almost_equal(stage.position.value, current_pos)
         # Align should be parked
         testing.assert_pos_almost_equal(align.position.value, self.align_deactive, atol=ATOL_LINEAR_POS)
         pos_label = getCurrentPositionLabel(stage.position.value, stage, self.aligner)
         self.assertEqual(pos_label, MILLING)
-
-        # The stage shouldn't have moved
-        testing.assert_pos_almost_equal(stage.position.value, current_pos)
 
         # Switch back to loading position
         cryoSwitchSamplePosition(LOADING).result()


### PR DESCRIPTION
We changed the behaviour of COATING, which now just engages the GIS arm.
However, the test was left as-is.

=> Remove the "COATING" position from the microscope file, and just
check that moving to COATING engages the GIS.