### PR TITLE
Fix cryo_feature_overlay test case

### DIFF
--- a/src/odemis/gui/test/comp_overlay_test.py
+++ b/src/odemis/gui/test/comp_overlay_test.py
@@ -475,7 +475,8 @@ class OverlayTestCase(test.GuiTestCase):
         # Add features to the tab's features list
         tab_mod.add_new_feature(0, 0)
         tab_mod.add_new_feature(0.001, 0.001)
-
+        # Execute the gui loop, so that the buffer contains the features
+        test.gui_loop(0.1)
         cnvs._dc_buffer.SelectObject(wx.NullBitmap)  # Flush the buffer
         cnvs._dc_buffer.SelectObject(cnvs._bmp_buffer)
         img = wx.Bitmap.ConvertToImage(cnvs._bmp_buffer)


### PR DESCRIPTION
The test case was failing because the gui was not refreshed after drawing the features, so the buffer did not contain the added features.