### PR TITLE
Changed the UserWarning to a FIXME in the FindTransform method.

### DIFF
--- a/src/odemis/acq/align/keypoint.py
+++ b/src/odemis/acq/align/keypoint.py
@@ -60,8 +60,7 @@ def FindTransform(ima, imb, fd_type=None):
     raises:
     ValueError: if no good transformation is found.
     """
-
-    warnings.warn("Please be aware that the FindTransform function does not work reliably at the moment.")
+    # FIXME: modify this method to make it work reliable
 
     # Instantiate the feature detector and the matcher
     # TODO: try BRISK, AZAKE and other detectors?


### PR DESCRIPTION
Changed this user warning to a FIXME so we dont get a warning message in the report of the test cases:
`/home/testing/development/odemis/src/odemis/acq/align/keypoint.py:64: UserWarning: Please be aware that the FindTransform function does not work reliably at the moment `