### PR TITLE
fix H5pyDeprecationWarning: other_ds.dims.create_scale(ds, name) is d…

### DIFF
--- a/src/odemis/dataio/hdf5.py
+++ b/src/odemis/dataio/hdf5.py
@@ -335,8 +335,12 @@ def _add_image_info(group, dataset, image):
             _h5svi_set_state(group["DimensionScaleY"], ST_REPORTED)
 
             # Attach the scales to each dimensions (referenced by their label)
-            dataset.dims.create_scale(group["DimensionScaleX"], "X")
-            dataset.dims.create_scale(group["DimensionScaleY"], "Y")
+            if hasattr(dataset, "make_scale"):
+                dataset.make_scale(group["DimensionScaleX"], "X")
+                dataset.make_scale(group["DimensionScaleY"], "Y")
+            else:
+                dataset.dims.create_scale(group["DimensionScaleX"], "X")
+                dataset.dims.create_scale(group["DimensionScaleY"], "Y")
             dataset.dims[xpos].attach_scale(group["DimensionScaleX"])
             dataset.dims[ypos].attach_scale(group["DimensionScaleY"])
 
@@ -351,7 +355,10 @@ def _add_image_info(group, dataset, image):
                     _h5svi_set_state(group["DimensionScaleZ"], ST_DEFAULT)
 
                 group["DimensionScaleZ"].attrs["UNIT"] = "m"
-                dataset.dims.create_scale(group["DimensionScaleZ"], "Z")
+                if hasattr(dataset, "make_scale"):
+                    dataset.make_scale(group["DimensionScaleZ"], "Z")
+                else:
+                    dataset.dims.create_scale(group["DimensionScaleZ"], "Z")
                 dataset.dims[zpos].attach_scale(group["DimensionScaleZ"])
 
         # Unknown data, but SVI needs them to take the scales into consideration
@@ -370,7 +377,10 @@ def _add_image_info(group, dataset, image):
                 # A list of values in seconds, for each pixel in the T dim
                 group["DimensionScaleT"] = image.metadata[model.MD_TIME_LIST]
                 group["DimensionScaleT"].attrs["UNIT"] = "s"
-                dataset.dims.create_scale(group["DimensionScaleT"], "T")
+                if hasattr(dataset, "make_scale"):
+                    dataset.make_scale(group["DimensionScaleT"], "T")
+                else:
+                    dataset.dims.create_scale(group["DimensionScaleT"], "T")
                 # pass state as a numpy.uint, to force it being a single value (instead of a list)
                 _h5svi_set_state(group["DimensionScaleT"], numpy.uint(ST_REPORTED))
                 dataset.dims[tpos].attach_scale(group["DimensionScaleT"])
@@ -388,7 +398,10 @@ def _add_image_info(group, dataset, image):
                 # A list of values in radians, for each pixel in the A dim
                 group["DimensionScaleA"] = image.metadata[model.MD_THETA_LIST]
                 group["DimensionScaleA"].attrs["UNIT"] = "rad"
-                dataset.dims.create_scale(group["DimensionScaleA"], "A")
+                if hasattr(dataset, "make_scale"):
+                    dataset.make_scale(group["DimensionScaleA"], "A")
+                else:
+                    dataset.dims.create_scale(group["DimensionScaleA"], "A")
                 # pass state as a numpy.uint, to force it being a single value (instead of a list)
                 _h5svi_set_state(group["DimensionScaleA"], numpy.uint(ST_REPORTED))
                 dataset.dims[apos].attach_scale(group["DimensionScaleA"])
@@ -406,7 +419,10 @@ def _add_image_info(group, dataset, image):
                 group["DimensionScaleC"] = wll  # m
 
                 group["DimensionScaleC"].attrs["UNIT"] = "m"
-                dataset.dims.create_scale(group["DimensionScaleC"], "C")
+                if hasattr(dataset, "make_scale"):
+                    dataset.make_scale(group["DimensionScaleC"], "C")
+                else:
+                    dataset.dims.create_scale(group["DimensionScaleC"], "C")
                 # pass state as a numpy.uint, to force it being a single value (instead of a list)
                 _h5svi_set_state(group["DimensionScaleC"], numpy.uint(ST_REPORTED))
                 cpos = dims.index("C")

--- a/src/odemis/dataio/hdf5.py
+++ b/src/odemis/dataio/hdf5.py
@@ -335,6 +335,8 @@ def _add_image_info(group, dataset, image):
             _h5svi_set_state(group["DimensionScaleY"], ST_REPORTED)
 
             # Attach the scales to each dimensions (referenced by their label)
+            # TODO remove the else statement when the installed python3-h5py (>= 2.1)
+            # https://docs.h5py.org/en/stable/whatsnew/2.1.html#dimension-scales
             if hasattr(dataset, "make_scale"):
                 group["DimensionScaleX"].make_scale("X")
                 group["DimensionScaleY"].make_scale("Y")

--- a/src/odemis/dataio/hdf5.py
+++ b/src/odemis/dataio/hdf5.py
@@ -336,8 +336,8 @@ def _add_image_info(group, dataset, image):
 
             # Attach the scales to each dimensions (referenced by their label)
             if hasattr(dataset, "make_scale"):
-                dataset.make_scale(group["DimensionScaleX"], "X")
-                dataset.make_scale(group["DimensionScaleY"], "Y")
+                group["DimensionScaleX"].make_scale("X")
+                group["DimensionScaleY"].make_scale("Y")
             else:
                 dataset.dims.create_scale(group["DimensionScaleX"], "X")
                 dataset.dims.create_scale(group["DimensionScaleY"], "Y")
@@ -356,7 +356,7 @@ def _add_image_info(group, dataset, image):
 
                 group["DimensionScaleZ"].attrs["UNIT"] = "m"
                 if hasattr(dataset, "make_scale"):
-                    dataset.make_scale(group["DimensionScaleZ"], "Z")
+                    group["DimensionScaleZ"].make_scale("Z")
                 else:
                     dataset.dims.create_scale(group["DimensionScaleZ"], "Z")
                 dataset.dims[zpos].attach_scale(group["DimensionScaleZ"])
@@ -378,7 +378,7 @@ def _add_image_info(group, dataset, image):
                 group["DimensionScaleT"] = image.metadata[model.MD_TIME_LIST]
                 group["DimensionScaleT"].attrs["UNIT"] = "s"
                 if hasattr(dataset, "make_scale"):
-                    dataset.make_scale(group["DimensionScaleT"], "T")
+                    group["DimensionScaleT"].make_scale("T")
                 else:
                     dataset.dims.create_scale(group["DimensionScaleT"], "T")
                 # pass state as a numpy.uint, to force it being a single value (instead of a list)
@@ -399,7 +399,7 @@ def _add_image_info(group, dataset, image):
                 group["DimensionScaleA"] = image.metadata[model.MD_THETA_LIST]
                 group["DimensionScaleA"].attrs["UNIT"] = "rad"
                 if hasattr(dataset, "make_scale"):
-                    dataset.make_scale(group["DimensionScaleA"], "A")
+                    group["DimensionScaleA"].make_scale("A")
                 else:
                     dataset.dims.create_scale(group["DimensionScaleA"], "A")
                 # pass state as a numpy.uint, to force it being a single value (instead of a list)
@@ -420,7 +420,7 @@ def _add_image_info(group, dataset, image):
 
                 group["DimensionScaleC"].attrs["UNIT"] = "m"
                 if hasattr(dataset, "make_scale"):
-                    dataset.make_scale(group["DimensionScaleC"], "C")
+                    group["DimensionScaleC"].make_scale("C")
                 else:
                     dataset.dims.create_scale(group["DimensionScaleC"], "C")
                 # pass state as a numpy.uint, to force it being a single value (instead of a list)


### PR DESCRIPTION
…eprecated. Use ds.make_scale(name) instead with backwards compatibility for Ubuntu 18