### PR TITLE
explicitly find an int value

### DIFF
--- a/src/odemis/gui/util/widgets.py
+++ b/src/odemis/gui/util/widgets.py
@@ -362,7 +362,7 @@ class ProgressiveFutureConnector(object):
             self._last_update = now
 
         # Update progress bar
-        self._bar.Value = PROGRESS_RANGE * ratio
+        self._bar.Value = int(PROGRESS_RANGE * ratio)
 
         if self._future.done():
             # Make sure we don't update the lbl_txt after the future is over as


### PR DESCRIPTION
src/odemis/gui/test/util_widgets_test.py::ConnectorTestCase::test_pf_connector
2023-06-15T23:21:26.0013799Z   /home/testing/development/odemis/src/odemis/gui/util/widgets.py:365: DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.