### PR TITLE
[FIX] driver piezomotor: fix the current position not updating proper…

### DIFF
--- a/src/odemis/driver/piezomotor.py
+++ b/src/odemis/driver/piezomotor.py
@@ -19,22 +19,23 @@ PURPOSE. See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along with
 Odemis. If not, see http://www.gnu.org/licenses/.
 """
-from concurrent.futures import CancelledError
 import copy
 import glob
 import logging
+import os
+import re
+import threading
+import time
+from concurrent.futures import CancelledError
+from threading import Thread
+
+import serial
+import serial.tools.list_ports
+
 from odemis import model
 from odemis.model import Actuator, CancellableThreadPoolExecutor, CancellableFuture, isasync, HwError
 from odemis.util import to_str_escape
 from odemis.util.driver import getSerialDriver
-import os
-import re
-import serial
-from threading import Thread
-import threading
-import time
-
-import serial.tools.list_ports
 
 BAUDRATE = 115200
 DEFAULT_AXIS_SPEED = 0.001  # m / s
@@ -1159,5 +1160,5 @@ class PMDSimulator(object):
                 return
             else:
                 time.sleep(0.1)
-        self.current_pos = target_pos
+        self.current_pos = copy.deepcopy(target_pos)
         self.is_moving = False

--- a/src/odemis/driver/piezomotor.py
+++ b/src/odemis/driver/piezomotor.py
@@ -1051,13 +1051,13 @@ class PMDSimulator(object):
                     steps = int(args[0]) - self.target_pos[axis]
                     self.target_pos[axis] = int(args[0])
                     steps = int(steps * DEFAULT_ENCODER_RESOLUTION / DEFAULT_MOTORSTEP_RESOLUTION)
-                    self.move(steps)
+                    self.move(steps, self.target_pos)
                 elif len(args) == 2:
                     steps = int(args[0]) - self.target_pos[axis]
                     self.target_pos[axis] = int(args[0])
                     self.speed = int(args[1])
                     steps = int(steps * DEFAULT_ENCODER_RESOLUTION / DEFAULT_MOTORSTEP_RESOLUTION)
-                    self.move(steps)
+                    self.move(steps, self.target_pos)
                 else:
                     raise ValueError()
             elif cmd == "S":  # stop axis
@@ -1071,12 +1071,12 @@ class PMDSimulator(object):
                 elif len(args) == 1:
                     self.target_pos[axis] += int(args[0])
                     steps = int(int(args[0]) * DEFAULT_ENCODER_RESOLUTION / DEFAULT_MOTORSTEP_RESOLUTION)
-                    self.move(steps)
+                    self.move(steps, self.target_pos)
                 elif len(args) == 2:
                     self.target_pos[axis] += int(args[0])
                     self.speed = int(args[1])
                     steps = int(int(args[0]) * DEFAULT_ENCODER_RESOLUTION / DEFAULT_MOTORSTEP_RESOLUTION)
-                    self.move(steps)
+                    self.move(steps, self.target_pos)
                 else:
                     raise ValueError()
             elif cmd == "E":
@@ -1135,9 +1135,9 @@ class PMDSimulator(object):
 
         self._output_buf += sEOL
 
-    def move(self, steps):
+    def move(self, steps, target_pos):
         # simple move, same duration for every length, don't care about speed
-        self.executor.submit(self._do_move, steps)
+        self.executor.submit(self._do_move, steps, target_pos)
 
     def find_index(self):
         t = Thread(target=self._do_indexing)
@@ -1148,7 +1148,7 @@ class PMDSimulator(object):
         time.sleep(1)
         self.indexing = False
 
-    def _do_move(self, steps):
+    def _do_move(self, steps, target_pos):
         self.is_moving = True
         startt = time.time()
         dur = abs(steps / self.speed)
@@ -1159,5 +1159,5 @@ class PMDSimulator(object):
                 return
             else:
                 time.sleep(0.1)
-        self.current_pos = copy.deepcopy(self.target_pos)
+        self.current_pos = target_pos
         self.is_moving = False


### PR DESCRIPTION
…ly in the simulator

_do_move updated the current position by deep copying self.target_pos, sometimes this caused that the wrong position got stored on self.current_pos. Pass the target_pos to _do_move so that after the move the current_pos gets updated with the correct target_pos.