### PR TITLE
gui cont tabs SparcAcquisitionTab: also create a "Temporal Intensity" view if time-correlator present

### DIFF
--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -1422,9 +1422,9 @@ class SparcAcquisitionTab(Tab):
                 "stream_classes": AngularSpectrumStream,
             }
             viewport_br = panel.vp_sparc_as
-        if main_data.monochromator or len(vpv) < 4:
+        if main_data.monochromator or main_data.time_correlator or len(vpv) < 4:
             vpv[viewports[4]] = {
-                "name": "Monochromator",
+                "name": "Temporal Intensity",
                 "stream_classes": (MonochromatorSettingsStream, ScannedTemporalSettingsStream),
             }
             viewport_br = panel.vp_sparc_br


### PR DESCRIPTION
Until now, it was create in case a monochromator is present (to show the
intensity of the monochromator every 1s), or if there is space.
However, the time correlator stream also needs this view. When there is
EK support, that view would not be created (because there is already
enough view). => explicitly create the view.

Also change the name of the view, from "Monochromator" to a more generic
"Temporal Intensity".