### PR TITLE
Extend the TESCAN driver to support rotational axes

### DIFF
--- a/src/odemis/driver/tescan.py
+++ b/src/odemis/driver/tescan.py
@@ -1054,7 +1054,9 @@ class Stage(model.Actuator):
                                                   range=(self._degrees_to_rad(axes_rng[0]),
                                                          self._degrees_to_rad(axes_rng[1])))
                     else:
-                        axes_def[ax] = model.Axis(unit="m", range=(axes_rng[0], axes_rng[1]))
+                        # convert the axis min and max range to meters
+                        axis_m = (axes_rng[0] * 1e-3, axes_rng[1] * 1e-3)
+                        axes_def[ax] = model.Axis(unit="m", range=(-axis_m[1], -axis_m[0]))
                 # slice the axes_rng list for the next iteration
                 axes_rng = axes_rng[2::]
             else:

--- a/src/odemis/driver/tescan.py
+++ b/src/odemis/driver/tescan.py
@@ -46,20 +46,20 @@ TESCAN_PXL_LIMIT = 100
 
 
 class SEM(model.HwComponent):
-    '''
+    """
     This is an extension of the model.HwComponent class. It instantiates the scanner
     and se-detector children components and provides an update function for its
     metadata.
-    '''
+    """
 
     def __init__(self, name, role, children, host, daemon=None, **kwargs):
-        '''
+        """
         children (dict string->kwargs): parameters setting for the children.
             Known children are "scanner", "detector", "stage", "focus", "camera"
             and "pressure". They will be provided back in the .children VA
         host (string): ip address of the SEM server 
         Raise an exception if the device cannot be opened
-        '''
+        """
         # we will fill the set of children with Components later in ._children
         model.HwComponent.__init__(self, name, role, daemon=daemon, **kwargs)
 
@@ -1052,7 +1052,7 @@ class Stage(model.Actuator):
 
         # Demand calibrated stage
         if parent._device.StgIsCalibrated() != 1:
-            logging.warning("Stage is not calibrated. Moves will not succeed until it has been calibratred.")
+            logging.warning("Stage is not calibrated. Moves will not succeed until it has been calibrated.")
             # TODO: support doing it from Odemis, via reference()
             # parent._device.StgCalibrate()
 

--- a/src/odemis/driver/tescan.py
+++ b/src/odemis/driver/tescan.py
@@ -1158,7 +1158,7 @@ class Stage(model.Actuator):
                                               -pos["z"] * 1e3,
                                               )
 
-            # a small delay before checking if the stage is busy
+            # a very small delay before checking if the stage is busy
             time.sleep(0.1)
 
             # Wait until move is completed
@@ -1176,12 +1176,13 @@ class Stage(model.Actuator):
         self._updatePosition()
         pos = self._position.copy()
 
-        # add the requested change to the current position except
-        # for the Rz axis as it can fully turn back and forth
+        # add the requested change to the current position
         for axis, change in shift.items():
             if axis not in {"rz"}:
                 pos[axis] += change
+            # different approach for the Rz axis as it can fully turn back and forth
             else:
+                # match against full rotation value to cover over- and underflow
                 pos[axis] = (pos[axis] + change) % math.radians(360)
 
         self._checkMoveAbs(self._applyInversion(pos))

--- a/src/odemis/driver/test/tescan_test.py
+++ b/src/odemis/driver/test/tescan_test.py
@@ -62,7 +62,7 @@ CONFIG_SEM = {"name": "sem", "role": "sem",
                            "focus": CONFIG_FOCUS,
                            # "camera": CONFIG_CM,
                            "pressure": CONFIG_PRESSURE},
-              # "host": "192.168.1.175"
+              # change host ip address according to network settings
               "host": "192.168.56.11"
               }
 
@@ -72,7 +72,7 @@ CONFIG_SEM_NO_DET = {"name": "Mira", "role": "sem",
                                   "stage": CONFIG_STG,
                                   "focus": CONFIG_FOCUS,
                                   "light": CONFIG_LIGHT},
-                     # "host": "192.168.1.175"
+                     # change host ip address according to network settings
                      "host": "192.168.56.11"
                      }
 
@@ -81,6 +81,7 @@ CONFIG_SEM_AMBER = {"name": "Amber", "role": "sem",
                     "children": {"scanner": CONFIG_SCANNER,
                                  "stage": CONFIG_STG,
                                  "focus": CONFIG_FOCUS},
+                    # change host ip address according to network settings
                     "host": "192.168.56.11"
                     }
 
@@ -197,6 +198,7 @@ class TestSEMRotateStage(unittest.TestCase):
         f = self.stage.moveAbs(new_pos)
         f.result()
         new_pos["rz"] = 0.0
+        # software will return 0 on abs position of 360°
         testing.assert_pos_almost_equal(self.stage.position.value, new_pos)
 
         # go back to the original starting point
@@ -228,12 +230,12 @@ class TestSEMRotateStage(unittest.TestCase):
         """
         start_pos = self.stage.position.value.copy()
 
-        # Try a relative move outside the range (less than min)
+        # test a relative move outside the range (more than max)
         axes = self.stage.axes
         with self.assertRaises(ValueError):
             self.stage.moveRel({"x": axes["x"].range[1] - axes["x"].range[0] + 10e-6})
 
-        # test a move out of the minimal moving range
+        # test an absolute move outside the range (less than min)
         with self.assertRaises(ValueError):
             self.stage.moveAbsSync({"rx": math.radians(-90)})
 
@@ -309,7 +311,7 @@ class TestSEMRotateStage(unittest.TestCase):
         f = self.stage.moveRel({"rz": math.radians(180)})
         f.result()
 
-        # wait for 1 second and stop the movement
+        # wait just a tiny bit and stop the movement
         time.sleep(0.2)
         self.stage.stop()
 
@@ -372,7 +374,6 @@ class BaseSEMTest(object):
         time.sleep(6)  # Wait for value refresh
         self.assertAlmostEqual(orig_probe_current, ebeam.probeCurrent.value)
 
-    # @skip
     def test_acceleration_voltage(self):
         ebeam = self.scanner
 
@@ -483,12 +484,12 @@ class BaseSEMTest(object):
         time.sleep(6)
         testing.assert_pos_almost_equal(self.stage.position.value, p)
 
-    @skip  # not working with the newer simulator Tescan Essence v1.2.2
+    # @skip("not working with the newer simulator Tescan Essence v1.2.2")
     def test_stop(self):
         """
         Check it's possible to stop the stage while it's moving.
         """
-        # TODO: make this method work again with Tescan Essence v1.2.2.
+        # TODO: make this method work again with Tescan Essence v1.2.2. will be addressed in separate PR
         pos = self.stage.position.value.copy()
         logging.info("Initial pos = %s", pos)
         f = self.stage.moveRel({"y":-50e-3})

--- a/src/odemis/driver/test/tescan_test.py
+++ b/src/odemis/driver/test/tescan_test.py
@@ -60,16 +60,18 @@ CONFIG_SEM = {"name": "sem", "role": "sem",
                            "focus": CONFIG_FOCUS,
                            # "camera": CONFIG_CM,
                            "pressure": CONFIG_PRESSURE},
-              "host": "192.168.1.175"
+              # "host": "192.168.1.175"
+              "host": "192.168.56.11"
               }
 
 # This one works with the Mira Simulator
-CONFIG_SEM_NO_DET = {"name": "sem", "role": "sem",
+CONFIG_SEM_NO_DET = {"name": "Mira", "role": "sem",
               "children": {"scanner": CONFIG_SCANNER,
                            "stage": CONFIG_STG,
                            "focus": CONFIG_FOCUS,
                            "light": CONFIG_LIGHT},
-              "host": "192.168.1.175"
+              # "host": "192.168.1.175"
+              "host": "192.168.56.11"
               }
 
 
@@ -133,6 +135,7 @@ class TestSEMStatic(unittest.TestCase):
         sem.terminate()
         daemon.shutdown()
 
+
 class BaseSEMTest(object):
 
     @classmethod
@@ -189,6 +192,7 @@ class BaseSEMTest(object):
         time.sleep(6)  # Wait for value refresh
         self.assertAlmostEqual(orig_probe_current, ebeam.probeCurrent.value)
 
+    # @skip
     def test_acceleration_voltage(self):
         ebeam = self.scanner
 

--- a/src/odemis/driver/test/tescan_test.py
+++ b/src/odemis/driver/test/tescan_test.py
@@ -80,8 +80,7 @@ CONFIG_SEM_NO_DET = {"name": "Mira", "role": "sem",
 CONFIG_SEM_AMBER = {"name": "Amber", "role": "sem",
                     "children": {"scanner": CONFIG_SCANNER,
                                  "stage": CONFIG_STG,
-                                 "focus": CONFIG_FOCUS,
-                                 "light": CONFIG_LIGHT},
+                                 "focus": CONFIG_FOCUS},
                     "host": "192.168.56.11"
                     }
 
@@ -164,13 +163,6 @@ class TestSEMRotateStage(unittest.TestCase):
                 cls.stage = child
             elif child.name == CONFIG_FOCUS["name"]:
                 cls.focus = child
-            # Doesn't seem to work with the simulator
-            elif child.name == CONFIG_CM["name"]:
-                cls.camera = child
-            elif child.name == CONFIG_PRESSURE["name"]:
-                cls.pressure = child
-            elif child.name == CONFIG_LIGHT["name"]:
-                cls.light = child
 
     @classmethod
     def tearDownClass(cls):
@@ -190,7 +182,7 @@ class TestSEMRotateStage(unittest.TestCase):
     def test_move_abs(self):
         """
         Test if it's possible to move the stage in absolute coordinates
-        In addition test the edge of the range of the rz axis
+        In addition also test the edge of the range of the rz axis
         """
         start_pos = self.stage.position.value.copy()
         new_pos = {"x": start_pos["x"] + 5e-4, "y": start_pos["y"] + 10e-4, "z": start_pos["z"] + 12e-5,
@@ -212,7 +204,7 @@ class TestSEMRotateStage(unittest.TestCase):
 
     def test_move_rel(self):
         """
-        Test if it's possible to move the stage with relative moves
+        Test if it's possible to move the stage with relative moves with regular move requests
         """
         start_pos = self.stage.position.value.copy()
 
@@ -251,7 +243,7 @@ class TestSEMRotateStage(unittest.TestCase):
     def test_small_relative_movements(self):
         """
         Test to see if very small relative movements are picked up fast enough.
-        In addition test if shifting a couple of times back and forth will end at the same starting location.
+        In addition, test if shifting a couple of times back and forth will end up at the same starting location.
         """
         start_pos = self.stage.position.value.copy()
 
@@ -291,7 +283,7 @@ class TestSEMRotateStage(unittest.TestCase):
     def test_overflow_and_underflow(self):
         """
         With a relative move starting from the absolute zero point move a bit under the range
-        and afterward move a bit over the range. This is applicable for the full rotational axis Rz only.
+        and afterward move a bit over the range. This is tested for the full rotational axis Rz only.
         """
         # start with going to the absolute zero position
         self.stage.moveAbsSync({"rz": 0.0})
@@ -301,7 +293,6 @@ class TestSEMRotateStage(unittest.TestCase):
         f = self.stage.moveRel({"rz": -math.radians(3)})
         f.result()
         self.assertLess(start_pos["rz"], self.stage.position.value["rz"])
-        # self.assertNotEqual(self.stage.position.value, start_pos)
 
         # test if overflow of the range is picked up
         f = self.stage.moveRel({"rz": math.radians(6)})
@@ -323,6 +314,7 @@ class TestSEMRotateStage(unittest.TestCase):
         self.stage.stop()
 
         self.assertNotEqual(self.stage.position.value, start_pos)
+
 
 class BaseSEMTest(object):
 


### PR DESCRIPTION
Since we do not yet support installing a METEOR on a TECAN SEM it is necessary to adjust the current driver to be able to handle controlled stage rotation to be able to align METEOR and the CCD properly.

Right now there is no support for axis other than for linear axis therefore the existing driver should be extended. The addition to the existing driver is only support for moving with the rotational axes.
Basic requirements are that the user will be able to control the stage through Odemis for moving all possible axes installed.

In addition test cases are written to test the  added functionality with moving the 2 newly added axes rx and rz.