### PR TITLE
[FIX] Meteor overview imaging failed to start

### DIFF
--- a/src/odemis/gui/win/acquisition.py
+++ b/src/odemis/gui/win/acquisition.py
@@ -688,8 +688,6 @@ class OverviewAcquisitionDialog(xrcfr_overview_acq):
         self._autofocus_roi_vac = VigilantAttributeConnector(
             self.autofocus_roi_ckbox, self.autofocus_chkbox, events=wx.EVT_CHECKBOX)
 
-
-
         # Slightly change the interface if multiple grids available (sample centers).
         # For now this only works on the MIMAS. So in total we have this whole display:
         # * zstack steps
@@ -737,6 +735,7 @@ class OverviewAcquisitionDialog(xrcfr_overview_acq):
             self.whole_grid_chkbox.Value = False
             self.selected_grid_lbl.Hide()
             self.selected_grid_pnl_holder.Hide()
+            self._grids = None
 
         orig_view = orig_tab_data.focussedView.value
         self._view = self._tab_data_model.focussedView.value
@@ -960,6 +959,8 @@ class OverviewAcquisitionDialog(xrcfr_overview_acq):
         """
         Called when a grid selection button is pressed
         """
+        if self._grids is None:
+            raise ValueError("Grid button is pressed while there are no grids.")
         # Updates the selected grids based on the button states
         selected_grids = set()
         for name, btn in self._grids.buttons.items():
@@ -976,6 +977,8 @@ class OverviewAcquisitionDialog(xrcfr_overview_acq):
         Called when the "whole grid acquisition" checkbox is clicked
         => Switch between number of tiles and grid numbers
         """
+        if self._grids is None:
+            raise ValueError("Whole grid acquisition checkbox is clicked while there are no grids.")
         whole_grid = self.whole_grid_chkbox.Value
         # Enable the grid selection
         self._grids.Enable(whole_grid)
@@ -1151,7 +1154,8 @@ class OverviewAcquisitionDialog(xrcfr_overview_acq):
         self.tiles_number_x.Enable(False)
         self.tiles_number_y.Enable(False)
         self.autofocus_chkbox.Enable(False)
-        self._grids.Enable(False)
+        if self._grids:
+            self._grids.Enable(False)
 
     def _resume_settings(self):
         """ Resume the settings of the GUI and save the values for restoring them later """
@@ -1163,8 +1167,9 @@ class OverviewAcquisitionDialog(xrcfr_overview_acq):
 
         self.whole_grid_chkbox.Enable(True)
         self.autofocus_chkbox.Enable(True)
-        # Enable/disable the grid and tile numbers based on the "whole grid" checkbox
-        self._on_whole_grid_chkbox()
+        if self._grids:
+            # Enable/disable the grid and tile numbers based on the "whole grid" checkbox
+            self._on_whole_grid_chkbox()
 
     def _get_zstack_levels(self):
         """


### PR DESCRIPTION
Commit ca419d9a changed the overview imaging interface if multiple grids were available. To do this it added an attribute self._grids if multiple grids were avalable. This attribute was always called at the start and at the beginning of an overview image, causing the overview imaging to fail on the Meteor (see: [jira](https://delmic.atlassian.net/browse/SDEV-1325?focusedCommentId=15488)). With the error:

```
2023-06-28 10:45:11,426 ERROR   main:414:       Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/wx/core.py", line 3285, in <lambda>
    lambda event: event.callable(*event.args, **event.kw) )
  File "/home/pals/development/odemis/src/odemis/gui/win/acquisition.py", line 1295, in on_acquisition_done
    self._resume_settings()
  File "/home/pals/development/odemis/src/odemis/gui/win/acquisition.py", line 1167, in _resume_settings
    self._on_whole_grid_chkbox()
  File "/home/pals/development/odemis/src/odemis/gui/win/acquisition.py", line 981, in _on_whole_grid_chkbox
    self._grids.Enable(whole_grid)
AttributeError: 'OverviewAcquisitionDialog' object has no attribute '_grids'
```

This fix only calls self._grids when it is not None.