### PR TITLE
gui: don't use old variable

### DIFF
--- a/src/odemis/gui/log.py
+++ b/src/odemis/gui/log.py
@@ -75,7 +75,7 @@ def init_logger(level=logging.DEBUG, log_file=None):
     file_handler = RotatingFileHandler(logfile_path, maxBytes=10 * (2 ** 20), backupCount=5)
 
     file_handler.setFormatter(file_format)
-    log.addHandler(file_handler)
+    l.addHandler(file_handler)
 
 
 def create_gui_logger(log_field, debug_va=None, level_va=None):


### PR DESCRIPTION
"log" shouldn't be used anymore => don't use it.
No behavioural change.