### PR TITLE
driver scanner: add support for synchronization on the DataFlow

### DIFF
--- a/src/odemis/driver/scanner.py
+++ b/src/odemis/driver/scanner.py
@@ -291,3 +291,9 @@ class CompositedDataflow(model.DataFlow):
         Wrapper to only pass data to the notify of the base class.
         """
         super().notify(data)
+
+    def synchronizedOn(self, event):
+        """
+        Wrapper to pass synchronization requests to the external dataflow
+        """
+        self._external_dataflow.synchronizedOn(event)


### PR DESCRIPTION
Just need to pass the synchrnonization request to the external
dataflow. Without this, most of the SPARC acquisition code doesn't work.