### PR TITLE
[config] Add Zeiss API connection test microscope file

### DIFF
--- a/install/linux/usr/share/odemis/hwtest/zeiss-only.odm.yaml
+++ b/install/linux/usr/share/odemis/hwtest/zeiss-only.odm.yaml
@@ -1,0 +1,119 @@
+# For Zeiss Gemini SEM
+# Connection via analog for e-beam scan & serial port for e-beam column settings
+SEM: {
+    class: Microscope,
+    role: sem,
+    children: ["SEM E-beam full", "EBeam Focus", "Sample Stage",
+               "SEM Detector"],
+}
+
+"SEM E-beam full": {
+    class: scanner.CompositedScanner,
+    role: e-beam,
+    dependencies: {
+        external: "SEM E-beam",
+        internal: "EBeam control"
+    },
+#    children: {
+#        "detector": "SEM Detector full",
+#    },
+    init: {},
+    properties: {
+        scale: [8, 8], # (ratio) : start with a pretty fast scan
+        dwellTime: 10.e-6, # s
+    },
+    affects: ["SEM Detector"]
+}
+
+# To use the "external" control from the API instead of the analog
+# Merges the analog and digital detectors (zeiss one and the one from the DAQ board), to provide an "external" signal via the API
+#"SEM Detector full": {
+#    role: se-detector,
+#    dependencies: {
+#        external: "SEM Detector",
+#    },
+#    init: {},
+#}
+
+"SEM Scan Interface": {
+    class: semcomedi.SEMComedi,
+    role: null,
+    init: {device: "/dev/comedi0"},
+    # more detectors can be added, if necessary
+    children: {
+        scanner: "SEM E-beam",
+        detector0: "SEM Detector",
+    }
+}
+
+# Connect:
+# X -> AO 0
+# Y -> AO 1
+# Ground -> AO GND
+"SEM E-beam": {
+    role: null,
+    init: {
+        channels: [0, 1],
+        # On Delmic scanning box v2, the voltage is x2, so need to specify twice smaller values than needed.
+        limits: [[-4.85, 4.85], [-3.64, 3.64]],  # V
+        park: [-5, -5], # V
+        max_res: [4096, 3072], # px, to force 4:3 ratio
+        # Digital output port mapping on the Delmic scanning box v2:
+        # 0 = Relay
+        # 1 = Open drain output (Y0.0)
+        # 2 = Digital Out 1
+        # 3 = Digital Out 0
+        # 4 = Status led
+        # output ports -> True (indicate scanning) or False (indicate parked)
+        scanning_ttl: {
+            3: [True, "external"],
+            4: True
+        },
+        settle_time: 120.e-6, # s
+        hfw_nomag: 0.127, # m, to be adjusted to match SEM calibration, and copied to "EBeam control"
+    },
+}
+
+# Must be connected on AI1/AI9 (differential)
+"SEM Detector": { # aka ETD
+    role: se-detector,
+    init: {
+        channel: 1,
+        limits: [0, 5], # V
+    },
+}
+
+"SEM via API": {
+    class: zeiss.SEM,
+    role: null,
+    init: {
+        port: "/dev/ttySEM*",
+        # eol: "\r",  # If using a Point Electronic SEM, use this line
+    },
+    children: {
+        scanner: "EBeam control",
+        focus: "EBeam Focus",
+        stage: "Sample Stage",
+    }
+}
+
+"EBeam control": {
+    role: null,
+    init: {
+        hfw_nomag: 0.127,  # m, theoretical HFW if mag == 1x, should be same as "SEM E-beam"
+    },
+}
+
+"EBeam Focus": {
+    role: ebeam-focus,
+}
+
+"Sample Stage": {
+    role: stage,
+    init: {
+        inverted: ["x", "y"], # Note: +Z goes towards the e-beam column
+        # To limit the range allowed:
+        #rng: {"z": [5.0e-3, 30.0e-3]},
+    },
+    affects: ["SEM E-beam full"],
+}


### PR DESCRIPTION
Almost all SEM APIs have a corresponding test microsope file, which only
uses the SEM. The Zeiss didn't have one yet.