### PR TITLE
[CSDM-1068] acq calibration: if multiple background data, average should be the same dtype as raw data

### DIFF
--- a/src/odemis/acq/calibration.py
+++ b/src/odemis/acq/calibration.py
@@ -67,9 +67,11 @@ def get_ar_data(das):
             # Just a check that all AR is the same shape (and if not, just pick
             # the ones which are the same as the first found).
             ar_same_shape = [da for da in ldas if da.shape == ldas[0].shape]
-            logging.warning("AR calibration file contained %d AR data, "
-                            "will use the average of %d", len(ldas), len(ar_same_shape))
-            ar_mean = numpy.mean(ar_same_shape, axis=0)
+            logging.info("AR calibration file contained %d AR data, "
+                         "will use the average of %d", len(ldas), len(ar_same_shape))
+            # mean() always generates float64, but we need the same dtype as
+            # original data, otherwise subtraction will not work.
+            ar_mean = numpy.mean(ar_same_shape, axis=0).astype(ar_same_shape[0].dtype)
             ar_data[polmode] = [model.DataArray(ar_mean, ar_same_shape[0].metadata)]
 
     # Merge all the data together as a single

--- a/src/odemis/acq/test/calibration_test.py
+++ b/src/odemis/acq/test/calibration_test.py
@@ -93,13 +93,14 @@ class TestAR(unittest.TestCase):
              model.MD_LENS_MAG: 60,  # ratio
             }
         calib = model.DataArray(dcalib, md)
-        calib2 = model.DataArray(dcalib + 1, md)
+        calib2 = model.DataArray(dcalib + 10, md)
 
         # Give one DA, the correct one, so expect to get it back
         out = calibration.get_ar_data([calib, calib2])
         # The average (of calib=0 and calib2=1)
+        self.assertEqual(calib.dtype, out.dtype)
         numpy.testing.assert_equal(out.shape, calib.shape)
-        numpy.testing.assert_equal(out, 0.5)
+        numpy.testing.assert_equal(out, 5)
         self.assertIsInstance(out, model.DataArray)
         self.assertEqual(out.metadata[model.MD_AR_POLE], md[model.MD_AR_POLE])
 
@@ -109,8 +110,9 @@ class TestAR(unittest.TestCase):
         data2 = model.DataArray(17 * numpy.ones((1, 1), dtype=numpy.uint16),
                                 metadata={model.MD_POS: (1.2e-3, -30e-3)})
         out = calibration.get_ar_data([data1, calib2, data2, calib])
+        self.assertEqual(calib.dtype, out.dtype)
         numpy.testing.assert_equal(out.shape, calib.shape)
-        numpy.testing.assert_equal(out, 0.5)
+        numpy.testing.assert_equal(out, 5)
         self.assertIsInstance(out, model.DataArray)
 
     def test_load_full(self):


### PR DESCRIPTION
If a background data file contains multiple data, now, the average is
returned (it used to return just the first data). However, numpy.mean()
automatically uses float64 when averaging integers. That clashes with
the rest of the background subtraction code which expect the background
data type to be the same as the actual data.

So in such case, the user would get such error message:
"Incompatible encoding of background data float64 with the angular resolved encoding uint16."

=> convert the average value back to the original data type. It's a tiny
bit less precise, but that's typically really not important as the data
has a large range of values. (and it's still better than returning just
the first background data)