### PR TITLE
[fix] gui PlotCanvas: handle corner cases when data changes outside of the range

### DIFF
--- a/src/odemis/gui/comp/canvas.py
+++ b/src/odemis/gui/comp/canvas.py
@@ -1876,7 +1876,7 @@ class PlotCanvas(BufferedCanvas):
         BufferedCanvas.clear(self)
 
     def has_data(self):
-        return self._data is not None and len(self._data) > 2
+        return self._data is not None and len(self._data) >= 2
 
     # Value calculation methods
 

--- a/src/odemis/gui/comp/miccanvas.py
+++ b/src/odemis/gui/comp/miccanvas.py
@@ -1421,6 +1421,7 @@ class NavigableBarPlotCanvas(BarPlotCanvas):
         # Therefore just display a single bar that fills the the panel
         else:
             xs = [(hi + lo) / 2]
+            lox = hix = min(max(0, lox), len(yst) - 1)
             ys = [yst[lox]]
 
         # Add a few points onto the beginning and end of the array

--- a/src/odemis/gui/comp/viewport.py
+++ b/src/odemis/gui/comp/viewport.py
@@ -1682,9 +1682,13 @@ class NavigablePlotViewport(PlotViewport):
         lo = centre - prop * new_span
         hi = lo + new_span
 
-        # Clamp the ranges to the data range
-        lo = max(self.canvas.data_xrange[0], lo)
-        hi = min(hi, self.canvas.data_xrange[1])
+        # Clamp the ranges to the data range (can happen if the data range changed)
+        if lo < self.canvas.data_xrange[0]:
+            lo = self.canvas.data_xrange[0]
+            hi = lo + new_span
+        if hi > self.canvas.data_xrange[1]:
+            hi = self.canvas.data_xrange[1]
+            lo = max(hi - new_span, self.canvas.data_xrange[0])
 
         self.hrange.value = (lo, hi)
         self.hrange_lock.value = True  # disable autoscaling when the user zooms in
@@ -1717,8 +1721,14 @@ class NavigablePlotViewport(PlotViewport):
         # Clamp the ranges to the data range. We allow seeing a little bit higher
         # than the maximum data as sometimes it's nicer to see a plot if the max
         # value doesn't exactly touch the top of the plot.
-        lo = max(self.canvas.data_yrange[0], lo)
-        hi = min(hi, self.canvas.data_yrange[1] + (self.canvas.data_yrange[1] - self.canvas.data_yrange[0]) * self._vmargin)
+        mn = self.canvas.data_yrange[0]
+        mx = self.canvas.data_yrange[1] + (self.canvas.data_yrange[1] - self.canvas.data_yrange[0]) * self._vmargin
+        if lo < mn:
+            lo = mn
+            hi = lo + new_span
+        if hi > mx:
+            hi = mx
+            lo = max(hi - new_span, mn)
 
         self.vrange.value = (lo, hi)
         self.vrange_lock.value = True  # disable autoscaling when the user zooms in


### PR DESCRIPTION
If the data changes to an entirely different, while the user had zoomed
in a single value, the display of the plot would not work anymore... and
it would not be possible to zoom out.

=> Check that the range of the display is always within the range of the
data, and if not adjust it.

This caused errors like:
File "/home/piel/development/odemis/src/odemis/gui/comp/miccanvas.py", line 1459, in on_size
self.refresh_plot()
File "/home/piel/development/odemis/src/odemis/util/__init__.py", line 589, in limit
return f(self, *args, **kwargs)
File "/home/piel/development/odemis/src/odemis/gui/comp/miccanvas.py", line 1424, in refresh_plot
ys = [yst[lox]]
IndexError: index 1328 is out of bounds for axis 0 with size 1328