### PR TITLE
[fix] skip orsay test if ConsoleClient module is not available

### DIFF
--- a/src/odemis/acq/test/orsay_milling_test.py
+++ b/src/odemis/acq/test/orsay_milling_test.py
@@ -21,17 +21,20 @@ import time
 import unittest
 from concurrent import futures
 
-from ConsoleClient.Communication.Connection import Connection
+try:
+    from ConsoleClient.Communication.Connection import Connection
+    console_client_available = True
+except ImportError as err:
+    logging.info(f"Orsay ConsoleClient package not found with error: {err}")
+    console_client_available = False
+else:
+    from odemis.acq.orsay_milling import mill_rectangle
 
-import odemis
-from odemis.acq.orsay_milling import mill_rectangle
-from odemis.driver import orsay
-from odemis import model, util
-from odemis.util import testing
+from odemis import model
 from odemis.util import timeout
 
 # The tests rely on an already running backend that uses Orsay Server.
-# If a microscopy file containing Orsay Server backend is not running, the tests will fail.
+# If a microscope file containing Orsay Server backend is not running, the tests will fail.
 
 logging.getLogger().setLevel(logging.DEBUG)
 logging.basicConfig(format="%(asctime)s  %(levelname)-7s %(module)s:%(lineno)d %(message)s")
@@ -48,6 +51,8 @@ class TestMilling(unittest.TestCase):
     def setUpClass(cls):
         if TEST_NOHW is True:
             raise unittest.SkipTest("No hardware available.")
+        if not console_client_available:
+            raise unittest.SkipTest("ConsoleClient package not available.")
 
         cls.scanner = model.getComponent(role="ion-beam")
         cls.scanner.horizontalFoV.value = 100e-6  # m

--- a/src/odemis/driver/test/orsay_test.py
+++ b/src/odemis/driver/test/orsay_test.py
@@ -21,21 +21,27 @@ You should have received a copy of the GNU General Public License along with
 Odemis. If not, see http://www.gnu.org/licenses/.
 """
 import collections.abc
-import copy
 import logging
 import math
 import os
-import socket
 import threading
 import time
 import unittest
 import itertools
 import numpy
-
 from math import pi
 from time import sleep
 
-from odemis.driver import orsay
+try:
+    # We don't directly need ConsoleClient, but we need to know if it's available
+    import ConsoleClient
+    console_client_available = True
+except ImportError as err:
+    logging.info(f"Orsay ConsoleClient package not found with error: {err}")
+    console_client_available = False
+else:
+    from odemis.driver import orsay
+
 from odemis.model import HwError
 from odemis import model
 from odemis.util import find_closest, testing, timeout
@@ -97,6 +103,10 @@ class TestOrsayStatic(unittest.TestCase):
     """
     Tests which don't need an Orsay component ready
     """
+    @classmethod
+    def setUpClass(cls):
+        if not console_client_available:
+            raise unittest.SkipTest("ConsoleClient package not available.")
 
     def test_creation(self):
         """
@@ -104,6 +114,7 @@ class TestOrsayStatic(unittest.TestCase):
         """
         if TEST_NOHW == True:
             self.skipTest(NO_SERVER_MSG)
+
         try:
             oserver = orsay.OrsayComponent(**CONFIG_ORSAY)
         except Exception as e:
@@ -134,6 +145,9 @@ class TestOrsay(unittest.TestCase):
         """
         if TEST_NOHW != "sim":
             raise unittest.SkipTest(NO_SERVER_MSG)
+        if not console_client_available:
+            raise unittest.SkipTest("ConsoleClient package not available.")
+
         cls.oserver = orsay.OrsayComponent(**CONFIG_ORSAY)
         cls.datamodel = cls.oserver.datamodel
 
@@ -259,6 +273,9 @@ class TestPneumaticSuspension(unittest.TestCase):
         """
         if TEST_NOHW != "sim":
             raise unittest.SkipTest(NO_SERVER_MSG)
+        if not console_client_available:
+            raise unittest.SkipTest("ConsoleClient package not available.")
+
         cls.oserver = orsay.OrsayComponent(**CONFIG_ORSAY)
         cls.datamodel = cls.oserver.datamodel
 
@@ -380,6 +397,9 @@ class TestVacuumChamber(unittest.TestCase):
         """
         if TEST_NOHW == True:
             raise unittest.SkipTest(NO_SERVER_MSG)
+        if not console_client_available:
+            raise unittest.SkipTest("ConsoleClient package not available.")
+
         cls.oserver = orsay.OrsayComponent(**CONFIG_ORSAY)
         cls.datamodel = cls.oserver.datamodel
 
@@ -455,6 +475,10 @@ class TestPumpingSystem(unittest.TestCase):
         """
         if TEST_NOHW == True:
             raise unittest.SkipTest(NO_SERVER_MSG)
+        if not console_client_available:
+            raise unittest.SkipTest("ConsoleClient package not available.")
+
+
         cls.oserver = orsay.OrsayComponent(**CONFIG_ORSAY)
         cls.datamodel = cls.oserver.datamodel
 
@@ -615,6 +639,9 @@ class TestUPS(unittest.TestCase):
         """
         if TEST_NOHW == True:
             raise unittest.SkipTest(NO_SERVER_MSG)
+        if not console_client_available:
+            raise unittest.SkipTest("ConsoleClient package not available.")
+
         cls.oserver = orsay.OrsayComponent(**CONFIG_ORSAY)
         cls.datamodel = cls.oserver.datamodel
 
@@ -652,6 +679,9 @@ class TestGIS(unittest.TestCase):
         """
         if TEST_NOHW == True:
             raise unittest.SkipTest(NO_SERVER_MSG)
+        if not console_client_available:
+            raise unittest.SkipTest("ConsoleClient package not available.")
+
         cls.oserver = orsay.OrsayComponent(**CONFIG_ORSAY)
         cls.datamodel = cls.oserver.datamodel
 
@@ -848,6 +878,8 @@ class TestGISReservoir(unittest.TestCase):
         """
         if TEST_NOHW == True:
             raise unittest.SkipTest(NO_SERVER_MSG)
+        if not console_client_available:
+            raise unittest.SkipTest("ConsoleClient package not available.")
 
         cls.oserver = orsay.OrsayComponent(**CONFIG_ORSAY)
         cls.datamodel = cls.oserver.datamodel
@@ -1060,6 +1092,8 @@ class TestOrsayParameterConnector(unittest.TestCase):
         """
         if TEST_NOHW == True:
             raise unittest.SkipTest(NO_SERVER_MSG)
+        if not console_client_available:
+            raise unittest.SkipTest("ConsoleClient package not available.")
 
         cls.oserver = orsay.OrsayComponent(**CONFIG_ORSAY)
         cls.datamodel = cls.oserver.datamodel
@@ -1178,6 +1212,8 @@ class TestFIBVacuum(unittest.TestCase):
         """
         if TEST_NOHW == True:
             raise unittest.SkipTest(NO_SERVER_MSG)
+        if not console_client_available:
+            raise unittest.SkipTest("ConsoleClient package not available.")
 
         cls.oserver = orsay.OrsayComponent(**CONFIG_ORSAY)
         cls.datamodel = cls.oserver.datamodel
@@ -1346,6 +1382,8 @@ class TestFIBSource(unittest.TestCase):
         """
         if TEST_NOHW == True:
             raise unittest.SkipTest(NO_SERVER_MSG)
+        if not console_client_available:
+            raise unittest.SkipTest("ConsoleClient package not available.")
 
         cls.oserver = orsay.OrsayComponent(**CONFIG_ORSAY)
         cls.datamodel = cls.oserver.datamodel
@@ -1466,6 +1504,8 @@ class TestFIBBeam(unittest.TestCase):
         """
         if TEST_NOHW == True:
             raise unittest.SkipTest(NO_SERVER_MSG)
+        if not console_client_available:
+            raise unittest.SkipTest("ConsoleClient package not available.")
 
         cls.oserver = orsay.OrsayComponent(**CONFIG_ORSAY)
         cls.datamodel = cls.oserver.datamodel
@@ -1867,6 +1907,8 @@ class TestLight(unittest.TestCase):
         """
         if TEST_NOHW == True:
             raise unittest.SkipTest(NO_SERVER_MSG)
+        if not console_client_available:
+            raise unittest.SkipTest("ConsoleClient package not available.")
 
         cls.oserver = orsay.OrsayComponent(**CONFIG_ORSAY)
         cls.datamodel = cls.oserver.datamodel
@@ -1902,6 +1944,8 @@ class TestScanner(unittest.TestCase):
         """
         if TEST_NOHW == True:
             raise unittest.SkipTest(NO_SERVER_MSG)
+        if not console_client_available:
+            raise unittest.SkipTest("ConsoleClient package not available.")
 
         cls.oserver = orsay.OrsayComponent(**CONFIG_ORSAY)
         cls.datamodel = cls.oserver.datamodel
@@ -2185,6 +2229,8 @@ class TestDetector(unittest.TestCase):
         """
         if TEST_NOHW == 1:
             raise unittest.SkipTest(NO_SERVER_MSG)
+        if not console_client_available:
+            raise unittest.SkipTest("ConsoleClient package not available.")
 
         cls.oserver = orsay.OrsayComponent(**CONFIG_ORSAY)
         for child in cls.oserver.children.value:
@@ -2545,6 +2591,8 @@ class TestFocus(unittest.TestCase):
         """
         if TEST_NOHW == True:
             raise unittest.SkipTest(NO_SERVER_MSG)
+        if not console_client_available:
+            raise unittest.SkipTest("ConsoleClient package not available.")
 
         cls.oserver = orsay.OrsayComponent(**CONFIG_ORSAY)
         cls.datamodel = cls.oserver.datamodel
@@ -2665,6 +2713,8 @@ class TestFIBAperture(unittest.TestCase):
         """
         if TEST_NOHW == True:
             raise unittest.SkipTest(NO_SERVER_MSG)
+        if not console_client_available:
+            raise unittest.SkipTest("ConsoleClient package not available.")
 
         cls.oserver = orsay.OrsayComponent(**CONFIG_ORSAY)
         cls.datamodel = cls.oserver.datamodel


### PR DESCRIPTION
The Orsay ConsoleClient module only works on Ubuntu 20.04+. When running
the tests on Ubuntu 18.04, this would cause the tests to fail.
Instead, just skip the tests with an informative message.