### PR TITLE
[refactor] remove basestring usage

### DIFF
--- a/src/odemis/acq/stream/_static.py
+++ b/src/odemis/acq/stream/_static.py
@@ -23,7 +23,7 @@ see http://www.gnu.org/licenses/.
 # Contains all the static streams, which only provide projections of the data
 # they were initialised with.
 
-from past.builtins import basestring, long
+from past.builtins import long
 from collections.abc import Iterable
 import copy
 import gc
@@ -290,7 +290,7 @@ class StaticCLStream(Static2DStream):
         Static2DStream.__init__(self, name, raw, *args, **kwargs)
         try:
             em_range = raw.metadata[model.MD_OUT_WL]
-            if isinstance(em_range, basestring):
+            if isinstance(em_range, str):
                 unit = None
             else:
                 unit = "m"
@@ -338,7 +338,7 @@ class StaticFluoStream(Static2DStream):
         default_tint = (0, 255, 0)  # green is most typical
         try:
             em_range = raw.metadata[model.MD_OUT_WL]
-            if isinstance(em_range, basestring):
+            if isinstance(em_range, str):
                 unit = None
             else:
                 unit = "m"

--- a/src/odemis/cli/main.py
+++ b/src/odemis/cli/main.py
@@ -22,8 +22,6 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 '''
 # This is a basic command line interface to the odemis back-end
 
-from past.builtins import basestring, unicode
-from builtins import str
 from collections.abc import Iterable, Mapping
 import argparse
 import codecs
@@ -152,7 +150,7 @@ def print_component(comp, pretty=True, level=0):
         pstr = u""
         try:
             pname = comp.parent.name
-            if isinstance(pname, basestring):
+            if isinstance(pname, str):  # Due to Pyro, it could be a (non-existent) RemoteMethod
                 pstr = u"\tparent:" + pname
         except AttributeError:
             pass
@@ -409,7 +407,7 @@ def print_metadata(component, pretty):
         print("\tMetadata:")
         for key, value in md.items():
             name = md2name.get(key, "'%s'" % (key,))
-            if isinstance(value, basestring):
+            if isinstance(value, str):
                 print(u"\t\t%s: '%s'" % (name, value))
             else:
                 print(u"\t\t%s: %s" % (name, value))
@@ -513,7 +511,7 @@ def set_attr(comp_name, attr_val_str):
 
         # Special case for None being referred to as "null" in YAML, but we should
         # also accept "None"
-        elif new_val == "None" and not isinstance(attr.value, basestring):
+        elif new_val == "None" and not isinstance(attr.value, str):
             new_val = None
             logging.debug("Adjusting value to %s (null)", new_val)
         elif isinstance(new_val, list) and isinstance(attr.value, tuple):
@@ -793,7 +791,7 @@ def acquire(comp_name, dataflow_names, filename):
     Acquire an image from one (or more) dataflow
     comp_name (string): name of the detector to find
     dataflow_names (list of string): name of each dataflow to access
-    filename (unicode): name of the output file (format depends on the extension)
+    filename (str): name of the output file (format depends on the extension)
     """
     component = get_detector(comp_name)
 
@@ -1053,7 +1051,7 @@ def main(args):
         if options.scan:
             if status == BACKEND_RUNNING:
                 raise ValueError("Back-end running while trying to scan for devices")
-            if isinstance(options.scan, basestring):
+            if isinstance(options.scan, str):
                 scan(options.scan)
             else:
                 scan()
@@ -1104,10 +1102,7 @@ def main(args):
                 dataflows = ["data"]
             else:
                 dataflows = options.acquire[1:]
-            if isinstance(options.output, unicode):  # python3
-                filename = options.output
-            else:  # python2
-                filename = options.output.decode(sys.getfilesystemencoding())
+            filename = options.output
             acquire(component, dataflows, filename)
         elif options.live is not None:
             component = options.live[0]

--- a/src/odemis/dataio/tiff.py
+++ b/src/odemis/dataio/tiff.py
@@ -19,10 +19,6 @@ PURPOSE. See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along with
 Odemis. If not, see http://www.gnu.org/licenses/.
 '''
-# Don't import unicode_literals to avoid issues with external functions. Code works on python2 and python3.
-from past.builtins import basestring
-from builtins import range
-
 import calendar
 from datetime import datetime
 import json
@@ -1394,7 +1390,7 @@ def _addImageElement(root, das, ifd, rois, fname=None, fuuid=None):
 
             if model.MD_OUT_WL in da.metadata:
                 owl = da.metadata[model.MD_OUT_WL]
-                if isinstance(owl, basestring):
+                if isinstance(owl, str):
                     filter = ET.SubElement(chan, "Filter", attrib={
                                     "ID": "Filter:%d:%d" % (idnum, subid)})
                     filter.attrib["Type"] = owl

--- a/src/odemis/driver/actuator.py
+++ b/src/odemis/driver/actuator.py
@@ -32,7 +32,6 @@ from concurrent import futures
 from typing import Dict, Union, Set
 
 import numpy
-from past.builtins import basestring
 
 from odemis import model, util
 from odemis.model import (CancellableThreadPoolExecutor, CancellableFuture,
@@ -901,7 +900,7 @@ class AntiBacklashActuator(model.Actuator):
             raise ValueError("AntiBacklashActuator needs 1 dependency")
 
         for a, v in backlash.items():
-            if not isinstance(a, basestring):
+            if not isinstance(a, str):
                 raise ValueError("Backlash key must be a string but got '%s'" % (a,))
             if not isinstance(v, numbers.Real):
                 raise ValueError("Backlash value of %s must be a number but got '%s'" % (a, v))

--- a/src/odemis/driver/andorcam2.py
+++ b/src/odemis/driver/andorcam2.py
@@ -30,7 +30,6 @@ from odemis import model, util, dataio
 from odemis.model import HwError, oneway
 from odemis.util import img
 import os
-from past.builtins import basestring
 import queue
 import random
 import sys
@@ -539,7 +538,7 @@ class AndorCam2(model.DigitalCamera):
 
         self._initpath = None # Will be updated by Initialize()
 
-        if isinstance(device, basestring):
+        if isinstance(device, str):
             self._device, self.handle = self._findDevice(device)
         else:
             # It's a common error to enter the serial number as a number... and

--- a/src/odemis/driver/andorshrk.py
+++ b/src/odemis/driver/andorshrk.py
@@ -16,7 +16,6 @@ You should have received a copy of the GNU General Public License along with Ode
 '''
 # This is a driver for the Andor Shamrock & Kymera spectographs.
 
-from past.builtins import basestring
 from ctypes import *
 import ctypes
 import logging
@@ -359,7 +358,7 @@ class Shamrock(model.Actuator):
         for i, slitn in slits.items():
             if not SLIT_INDEX_MIN <= i <= SLIT_INDEX_MAX:
                 raise ValueError("Slit number must be between 1 and 4, but got %s" % (i,))
-            if isinstance(slitn, basestring):
+            if isinstance(slitn, str):
                 self._slit_names[i] = slitn
             elif len(slitn) >= 2:  # ["name", "option"]
                 self._slit_names[i] = slitn[0]
@@ -372,7 +371,7 @@ class Shamrock(model.Actuator):
         self._reconnecting = False
 
         try:
-            if isinstance(device, basestring):
+            if isinstance(device, str):
                 self._device = self._findDevice(device)
             else:
                 nd = self.GetNumberDevices()
@@ -473,7 +472,7 @@ class Shamrock(model.Actuator):
                                 raise ValueError("Filter position should be between %d and "
                                                  "%d, but got %d." % (FILTERMIN, FILTERMAX, pos))
                             # To support "weird" filter, we accept strings
-                            if isinstance(band, basestring):
+                            if isinstance(band, str):
                                 if not band.strip():
                                     raise ValueError("Name of filter %d is empty" % pos)
                             else:

--- a/src/odemis/driver/pigcs.py
+++ b/src/odemis/driver/pigcs.py
@@ -19,7 +19,6 @@ PURPOSE. See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along with
 Odemis. If not, see http://www.gnu.org/licenses/.
 '''
-from past.builtins import basestring
 import queue
 from concurrent.futures import CancelledError
 import glob
@@ -645,7 +644,7 @@ class Controller(object):
         returns (str): the string representing this parameter
         """
         # SPA? (Get Volatile Memory Parameters)
-        assert(isinstance(axis, basestring) and 1 <= len(axis) <= 8)
+        assert(isinstance(axis, str) and 1 <= len(axis) <= 8)
         assert 0 <= param
         if hasattr(self, "_avail_params") and param not in self._avail_params:
             raise ValueError("Parameter %s %d not available" % (axis, param))
@@ -686,7 +685,7 @@ class Controller(object):
         Raises ValueError if hardware complains
         """
         # SPA (Set Volatile Memory Parameters)
-        assert(isinstance(axis, basestring) and 1 <= len(axis) <= 8)
+        assert(isinstance(axis, str) and 1 <= len(axis) <= 8)
         assert(0 <= param)
         self._sendOrderCommand("SPA %s 0x%X %s\n" % (axis, param, val))
         if check:
@@ -703,7 +702,7 @@ class Controller(object):
         returns (str): the string representing this parameter
         """
         # SEP? (Get Non-Volatile Memory Parameters)
-        assert(isinstance(axis, basestring) and 1 <= len(axis) <= 8)
+        assert(isinstance(axis, str) and 1 <= len(axis) <= 8)
         assert 0 <= param
         if hasattr(self, "_avail_params") and param not in self._avail_params:
             raise ValueError("Parameter %s %d not available" % (axis, param))
@@ -1314,7 +1313,7 @@ class Controller(object):
         opt (0<=int): type of signal to be recorded. See documentation for values.
         """
         assert(table > 0)
-        assert(isinstance(source, basestring))
+        assert(isinstance(source, str))
         assert(opt >= 0)
         self._sendOrderCommand("DRC %d %s %d\n" % (table, source, opt))
 
@@ -3603,7 +3602,7 @@ class SerialBusAccesser(object):
         """
         assert(addr is None or 1 <= addr <= 16 or addr == 254)
 
-        if isinstance(com, basestring):
+        if isinstance(com, str):
             com = [com]
             multicom = False
         else:
@@ -3761,7 +3760,7 @@ class IPBusAccesser(object):
         """
         assert(addr is None or 1 <= addr <= 16 or addr == 254)
 
-        if isinstance(com, basestring):
+        if isinstance(com, str):
             com = [com]
             multicom = False
         else:

--- a/src/odemis/driver/spectrapro.py
+++ b/src/odemis/driver/spectrapro.py
@@ -19,7 +19,6 @@ PURPOSE. See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along with
 Odemis. If not, see http://www.gnu.org/licenses/.
 '''
-from past.builtins import basestring
 from collections.abc import Iterable
 import glob
 import logging
@@ -291,7 +290,7 @@ class SpectraPro(model.Actuator):
         rawv (str or number)
         return (float)
         """
-        if isinstance(rawv, basestring):
+        if isinstance(rawv, str):
             if rawv.startswith("hex:"):
                 rawv = rawv[4:]
             return hextof(rawv)

--- a/src/odemis/driver/tlfw.py
+++ b/src/odemis/driver/tlfw.py
@@ -15,7 +15,6 @@ Odemis is distributed in the hope that it will be useful, but WITHOUT ANY WARRAN
 You should have received a copy of the GNU General Public License along with Odemis. If not, see http://www.gnu.org/licenses/.
 '''
 
-from past.builtins import basestring
 import glob
 import logging
 from odemis import model
@@ -73,7 +72,7 @@ class FW102c(model.Actuator):
                     raise ValueError("Filter position should be between 1 and "
                                      "%d, but got %d." % (self._maxpos, pos))
                 # To support "weird" filter, we accept strings
-                if isinstance(band, basestring):
+                if isinstance(band, str):
                     if not band.strip():
                         raise ValueError("Name of filter %d is empty" % pos)
                 else:

--- a/src/odemis/driver/tmcm.py
+++ b/src/odemis/driver/tmcm.py
@@ -29,14 +29,12 @@ You should have received a copy of the GNU General Public License along with Ode
 # is connected)
 # Bug reported to Trinamic 2015-10-19. => They don't really seem to believe it.
 
-from past.builtins import basestring
 import glob
 import logging
 import os
 import random
 import re
 import struct
-import subprocess
 import threading
 from collections import OrderedDict
 from concurrent.futures import CancelledError
@@ -52,7 +50,6 @@ except ImportError:
     canopen = None
 
 import fcntl
-import math
 import numpy
 import serial
 import time
@@ -428,7 +425,7 @@ class TMCLController(model.Actuator):
                 # If it times out, the user should specify an axis range.
                 self._ref_max_length[i] = sz * 4e6  # m
 
-            if not isinstance(unit[i], basestring):
+            if not isinstance(unit[i], str):
                 raise ValueError("unit argument must only contain strings, but got %s" % (unit[i],))
             axes_def[n] = model.Axis(range=phy_rng, unit=unit[i])
             self._init_axis(i)
@@ -2694,7 +2691,7 @@ class CANController(model.Actuator):
                 # If it times out, the user should specify an axis range.
                 self._ref_max_length[i] = sz * 4e6  # m
 
-            if not isinstance(unit[i], basestring):
+            if not isinstance(unit[i], str):
                 raise ValueError("unit argument must only contain strings, but got %s" % (unit[i],))
             axes_def[n] = model.Axis(range=phy_rng, unit=unit[i])
             try:

--- a/src/odemis/gui/comp/settings.py
+++ b/src/odemis/gui/comp/settings.py
@@ -19,8 +19,6 @@ This file is part of Odemis.
     Odemis. If not, see http://www.gnu.org/licenses/.
 
 """
-from builtins import str
-from past.builtins import basestring
 import wx
 from decorator import decorator
 
@@ -138,11 +136,9 @@ class SettingsPanel(wx.Panel):
 
         lbl_ctrl = self._add_side_label(label_text)
 
-        # Convert value object to str (unicode) iif necessary.
-        # unicode() (which is str() from Python3) fails in Python2 if argument
-        # is bytes with non-ascii characters.
-        # => If value is already bytes or unicode, just pass it as-is to wx.TextCtrl.
-        if not isinstance(value, basestring):
+        # Convert value object to str, only if necessary.
+        # => If value is already bytes or str, just pass it as-is to wx.TextCtrl.
+        if not isinstance(value, (str, bytes)):
             value = str(value)
 
         if value is not None:

--- a/src/odemis/gui/comp/stream.py
+++ b/src/odemis/gui/comp/stream.py
@@ -23,8 +23,6 @@ data streams coming from the microscope.
 
 """
 
-from builtins import str
-from past.builtins import basestring
 from decorator import decorator
 import logging
 from collections import OrderedDict
@@ -1071,11 +1069,9 @@ class StreamPanel(wx.Panel):
 
         lbl_ctrl = self._add_side_label(label_text)
 
-        # Convert value object to str (unicode) iif necessary.
-        # unicode() (which is str() from Python3) fails in Python2 if argument
-        # is bytes with non-ascii characters.
-        # => If value is already bytes or unicode, just pass it as-is to wx.TextCtrl.
-        if not isinstance(value, basestring):
+        # Convert value object to str, only if necessary.
+        # => If value is already bytes or str, just pass it as-is to wx.TextCtrl.
+        if not isinstance(value, (str, bytes)):
             value = str(value)
 
         if value is not None:

--- a/src/odemis/gui/conf/test/conf_test.py
+++ b/src/odemis/gui/conf/test/conf_test.py
@@ -20,7 +20,6 @@ This file is part of Odemis.
 
 """
 
-from past.builtins import basestring
 import logging
 import odemis.gui.conf.file as conffile
 import odemis.gui as gui
@@ -134,8 +133,8 @@ class AcquisitionConfigTest(ConfigTest, unittest.TestCase):
 
     def test_simple(self):
         conf = gui.conf.get_acqui_conf()
-        self.assertIsInstance(conf.last_path, basestring)
-        self.assertIsInstance(conf.last_format, basestring)
+        self.assertIsInstance(conf.last_path, str)
+        self.assertIsInstance(conf.last_format, str)
         self.assertLess(len(conf.last_extension), 12)
 
     def test_save(self):

--- a/src/odemis/gui/conf/util.py
+++ b/src/odemis/gui/conf/util.py
@@ -25,7 +25,7 @@ This module contains functions that help in the generation of dynamic configurat
 """
 
 from builtins import str
-from past.builtins import basestring, long
+from past.builtins import long
 from collections import OrderedDict
 from collections.abc import Iterable, Mapping
 import logging
@@ -591,7 +591,7 @@ def format_axis_choices(name, axis_def):
 
 def choice_to_str(choice):
     """ Return a list of choices, where iterable choices are joined by an `x` """
-    if isinstance(choice, basestring) or not isinstance(choice, Iterable):
+    if isinstance(choice, str) or not isinstance(choice, Iterable):
         return str(choice)
     return u" x ".join(str(c) for c in choice)
 

--- a/src/odemis/gui/cont/microscope.py
+++ b/src/odemis/gui/cont/microscope.py
@@ -18,7 +18,6 @@ You should have received a copy of the GNU General Public License along with
 Odemis. If not, see http://www.gnu.org/licenses/.
 
 """
-from past.builtins import basestring
 from concurrent.futures._base import CancelledError, CANCELLED, FINISHED
 import logging
 import math
@@ -791,7 +790,7 @@ class DelphiStateController(SecomStateController):
         for s in self._tab_data.streams.value:
             if None not in s.status.value:
                 lvl, msg = s.status.value
-                if not isinstance(msg, basestring):
+                if not isinstance(msg, str):
                     # it seems it also contains an action
                     msg, action = msg
 

--- a/src/odemis/gui/cont/streams.py
+++ b/src/odemis/gui/cont/streams.py
@@ -30,7 +30,7 @@ import time
 from builtins import str
 from collections import OrderedDict
 from collections.abc import Iterable
-from past.builtins import basestring, long
+from past.builtins import long
 
 import numpy
 import odemis.acq.stream as acqstream
@@ -960,7 +960,7 @@ class StreamController(object):
         readonly = self.stream.emission.readonly or len(self.stream.emission.choices) <= 1
 
         if center_wl_color is None:
-            if isinstance(em, basestring):
+            if isinstance(em, str):
                 # Unknown colour or non-meaningful
                 center_wl_color = None
             else:
@@ -970,7 +970,7 @@ class StreamController(object):
         r = self.stream_panel.add_dye_emission_ctrl(band, readonly, center_wl_color)
         lbl_ctrl, value_ctrl, self._lbl_em_peak, self._btn_emission = r
 
-        if isinstance(em, basestring) and em != model.BAND_PASS_THROUGH:
+        if isinstance(em, str) and em != model.BAND_PASS_THROUGH:
             if not readonly:
                 logging.error("Emission band is a string (%s), but not readonly", em)
             return

--- a/src/odemis/gui/model/__init__.py
+++ b/src/odemis/gui/model/__init__.py
@@ -20,7 +20,7 @@ This file is part of Odemis.
     Odemis. If not, see http://www.gnu.org/licenses/.
 
 """
-from past.builtins import basestring, long
+from past.builtins import long
 import queue
 from abc import ABCMeta
 from collections.abc import Mapping
@@ -1559,16 +1559,16 @@ class FileInfo(object):
 
     def __init__(self, a_file=None, metadata=None):
         """
-        :param a_file: (unicode or File or None): the full name of the file or
+        :param a_file: (str or File or None): the full name of the file or
             a File that contains the acquisition. If provided (and the file
             exists), some fields will be automatically filled in.
-        :param metadata: (dict String -> value): The meta-data as model.MD_*.
+        :param metadata: (dict str -> value): The meta-data as model.MD_*.
         """
 
         self.file_name = None
         self.file_obj = None
 
-        if isinstance(a_file, basestring):
+        if isinstance(a_file, str):
             # The given parameter is a file name
             self.file_name = a_file
         elif a_file is not None:

--- a/src/odemis/gui/util/conversion.py
+++ b/src/odemis/gui/util/conversion.py
@@ -21,7 +21,6 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 from typing import Dict, List, Optional, Tuple
 
 import wx
-from past.builtins import basestring
 
 from odemis.util.conversion import (frgb_to_rgb, hex_to_frgb, hex_to_rgb,
                                     rgb_to_frgb)
@@ -101,7 +100,7 @@ def change_brightness(colour, weight):
 
     _alpha = None
 
-    if isinstance(colour, basestring):
+    if isinstance(colour, str):
         _col = hex_to_frgb(colour)
         _alpha = None
     elif isinstance(colour, tuple):

--- a/src/odemis/gui/util/img.py
+++ b/src/odemis/gui/util/img.py
@@ -36,7 +36,6 @@ from odemis.model import DataArrayShadow
 from odemis.model import TINT_FIT_TO_RGB, TINT_RGB_AS_IS
 from odemis.util import intersect, fluo, img, units
 from odemis.util import spectrum
-from past.builtins import basestring
 import threading
 import time
 from typing import Tuple, Optional
@@ -2185,7 +2184,7 @@ def _get_stream_legend_text(md):
                 captions.append(u"Z Position: %s" % units.readable_str(pos[2], "m", sig=3))
         if model.MD_OUT_WL in md:
             out_wl = md[model.MD_OUT_WL]
-            if isinstance(out_wl, basestring):
+            if isinstance(out_wl, str):
                 captions.append(u"Emission: %s" % (out_wl,))
             else:
                 captions.append(u"Emission: %s" % units.readable_str(numpy.average(out_wl), "m", sig=3))

--- a/src/odemis/model/_components.py
+++ b/src/odemis/model/_components.py
@@ -26,7 +26,6 @@ from abc import abstractmethod, ABCMeta
 
 import Pyro4
 from future.moves.urllib.parse import quote
-from past.builtins import basestring
 from Pyro4.core import isasync
 
 import odemis
@@ -717,7 +716,7 @@ class Axis(object):
         # TODO: add a way to store some "favorite" positions (at least possible
         # to define at init, and maybe also update online?)
 
-        assert isinstance(unit, (type(None), basestring))
+        assert isinstance(unit, (type(None), str))
         self.unit = unit  # always defined, just sometimes is None
 
         if choices is None and range is None:

--- a/src/odemis/model/_core.py
+++ b/src/odemis/model/_core.py
@@ -28,7 +28,6 @@ from urllib.parse import quote
 
 import Pyro4
 from Pyro4.core import oneway
-from past.builtins import basestring
 
 from odemis.util import inspect_getmembers
 
@@ -377,7 +376,7 @@ class Container(Pyro4.core.Daemon):
          container.
         component (Component)
         """
-        assert isinstance(component._pyroId, basestring)
+        assert isinstance(component._pyroId, str)
         self.rootId = component._pyroId
 
 

--- a/src/odemis/model/_dataflow.py
+++ b/src/odemis/model/_dataflow.py
@@ -23,7 +23,6 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 # updated. Typically it is used to transmit video (sequence of images). It does it
 # losslessly and with metadata attached (see _metadata for the conventional ones).
 
-from past.builtins import basestring
 import Pyro4
 import logging
 import numpy
@@ -334,7 +333,7 @@ class DataFlow(DataFlowBase):
             count_before = self._count_listeners()
 
             # add string to listeners if listener is string
-            if isinstance(listener, basestring):
+            if isinstance(listener, str):
                 self._remote_listeners.add(listener)
             else:
                 assert callable(listener)
@@ -349,7 +348,7 @@ class DataFlow(DataFlowBase):
                     self.start_generate()
                 except Exception as ex:
                     logging.error("Subscribing listener %r to the dataflow failed. %s", listener, ex)
-                    if isinstance(listener, basestring):
+                    if isinstance(listener, str):
                         # remove string from listeners
                         self._remote_listeners.discard(listener)
                     else:
@@ -361,7 +360,7 @@ class DataFlow(DataFlowBase):
     def unsubscribe(self, listener):
         with self._lock:
             count_before = self._count_listeners()
-            if isinstance(listener, basestring):
+            if isinstance(listener, str):
                 # remove string from listeners
                 self._remote_listeners.discard(listener)
             else:

--- a/src/odemis/model/_vattributes.py
+++ b/src/odemis/model/_vattributes.py
@@ -20,7 +20,7 @@ You should have received a copy of the GNU General Public License along with
 Odemis. If not, see http://www.gnu.org/licenses/.
 """
 
-from past.builtins import basestring, long
+from past.builtins import long
 import Pyro4
 from Pyro4.core import oneway
 from collections.abc import Iterable, Set
@@ -306,7 +306,7 @@ class VigilantAttribute(VigilantAttributeBase):
         listener (callable) => method to call (locally)
         """
         # add string to listeners if listener is string
-        if isinstance(listener, basestring):
+        if isinstance(listener, str):
             self._remote_listeners.add(listener)
         else:
             VigilantAttributeBase.subscribe(self, listener, init)
@@ -321,7 +321,7 @@ class VigilantAttribute(VigilantAttributeBase):
         listener (string) => uri of listener of zmq
         listener (callable) => method to call (locally)
         """
-        if isinstance(listener, basestring):
+        if isinstance(listener, str):
             # remove string from listeners
             self._remote_listeners.discard(listener)
         else:
@@ -623,7 +623,7 @@ class StringVA(VigilantAttribute):
         VigilantAttribute.__init__(self, value, *args, **kwargs)
 
     def _check(self, value):
-        if not isinstance(value, basestring):
+        if not isinstance(value, str):
             raise TypeError("Value '%r' is not a string." % value)
 
 

--- a/src/odemis/util/conversion.py
+++ b/src/odemis/util/conversion.py
@@ -27,7 +27,7 @@ from collections.abc import Iterable
 import cv2
 import numpy
 import yaml
-from past.builtins import basestring, long
+from past.builtins import long
 from yaml.emitter import Emitter
 from yaml.representer import SafeRepresenter
 from yaml.resolver import Resolver
@@ -221,7 +221,7 @@ def reproduce_typed_value(typed_value, str_val):
         return int(str_val)
     elif isinstance(typed_value, float):
         return float(str_val)
-    elif isinstance(typed_value, basestring):
+    elif isinstance(typed_value, str):
         return str_val
     # Process dictionaries before matching against Iterables
     elif isinstance(typed_value, dict):
@@ -281,7 +281,7 @@ def ensure_tuple(v):
       otherwise it will be returned as is
     return (tuple or object): same a v, but a tuple if v was iterable
     """
-    if isinstance(v, Iterable) and not isinstance(v, basestring):
+    if isinstance(v, Iterable) and not isinstance(v, str):
         # convert to a tuple, with each object contained also converted
         return tuple(ensure_tuple(i) for i in v)
     else:

--- a/src/odemis/util/fluo.py
+++ b/src/odemis/util/fluo.py
@@ -19,7 +19,6 @@ You should have received a copy of the GNU General Public License along with Ode
 
 from collections.abc import Iterable
 from odemis.model import BAND_PASS_THROUGH
-from past.builtins import basestring  # For Python 2 & 3
 
 # constants to indicate how well a emission/excitation setting fits a dye
 # emission/excitation (peak)
@@ -38,7 +37,7 @@ def get_center(band):
     if band == BAND_PASS_THROUGH:
         return 5000e-9  # Something large, so that if it's sorted, it's after every other band
 
-    if isinstance(band, basestring):
+    if isinstance(band, str):
         raise TypeError("Band must be a list or a tuple")
 
     if isinstance(next(iter(band)), Iterable):
@@ -246,7 +245,7 @@ def to_readable_band(band):
     #   ex: 453/19 nm
     # if multi-band => center, center... nm
     #   ex: 453, 568, 968 nm
-    if isinstance(band, basestring):
+    if isinstance(band, str):
         return band
     if not isinstance(band[0], Iterable):
         b = band


### PR DESCRIPTION
basestring was used for support of Python 2&3, to represent str and
unicode, and bytes.
Now that we only support Python 3, we can usually replace by just "str".
It has to be a little bit carefully done because in some cases that
meant "str or bytes".