### PR TITLE
[fix] gui util: adjust timing for fix_static_text_clipping()

### DIFF
--- a/src/odemis/gui/util/wx_adapter.py
+++ b/src/odemis/gui/util/wx_adapter.py
@@ -30,8 +30,8 @@ def fix_static_text_clipping(panel):
     # This following forces resizing of all static text found on the panel and its children
     _force_resize_static_text(panel)
     # Eventually, update the size of the parent, based on everything inside it
-    wx.CallLater(100, _update_layout_big_text, panel)  # Quickly
-    wx.CallLater(500, _update_layout_big_text, panel)  # Later, in case the first time was too early
+    wx.CallLater(500, _update_layout_big_text, panel)  # Quickly
+    wx.CallLater(1000, _update_layout_big_text, panel)  # Later, in case the first time was too early
 
 def _update_layout_big_text(panel):
     _force_resize_static_text(panel)


### PR DESCRIPTION
The text size only adjust to the right size if the widget is already
shown. However, it can take some time... which depends on a lot of
factors. To make it happen as soon as possible, but still be certain it
happens, we do it multiples time, with different delays: 0.1 and 0.5s.

It turns out that sometimes, even waiting 0.5 s was not enough.
More tests showed that 0.1s is almost nevery helpful.

So instead of adjusting after 0.1s and 0.5s, adjust at 0.5s and 1s.