### PR TITLE
[CSDM-1046] gui SPARC2 alignment tab: completly hide panels which cannot be used

### DIFF
--- a/src/odemis/gui/cont/actuators.py
+++ b/src/odemis/gui/cont/actuators.py
@@ -160,29 +160,7 @@ class ActuatorController(object):
                        ("mirror", "rz") in tab_data.axes)
             tab_panel.pnl_sparc_rot.Show(showrot)
 
-        # On SPARC, show the fiber aligner only if present
-        if hasattr(tab_panel, 'pnl_fibaligner'):
-            showfib = ("fibaligner", "x") in tab_data.axes
-            tab_panel.pnl_fibaligner.Show(showfib)
-
-        # On SPARC, show the light aligner only if present
-        if hasattr(tab_panel, 'pnl_light_aligner'):
-            show_la = any(an == "light_aligner" for an, a in tab_data.axes)
-            tab_panel.pnl_light_aligner.Show(show_la)
-            if show_la:
-                # Some hardware only have the X axis (eg, FSLM) and no Z axis,
-                # in this case, hide the Z axis.
-                if not ("light_aligner", "z") in tab_data.axes:
-                    tab_panel.btn_p_light_aligner_z.Show(False)
-                    tab_panel.lbl_p_light_aligner_z.Show(False)
-                    tab_panel.btn_m_light_aligner_z.Show(False)
-                    tab_panel.lbl_m_light_aligner_z.Show(False)
-                    tab_panel.Layout()
-
-        # On SPARC, show the spec switch controls only if present
-        if hasattr(tab_panel, 'pnl_spec_switch'):
-            show_ss = ("spec_switch", "x") in tab_data.axes
-            tab_panel.pnl_spec_switch.Show(show_ss)
+        # On SPARCv2, that the tab controller which decides what is shown and when
 
         tab_data.main.is_acquiring.subscribe(self._on_acquisition)
 

--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -7557,9 +7557,9 @@ class Sparc2AlignTab(Tab):
             mirror = main_data.mirror
             if mirror and set(mirror.axes.keys()) == {"l", "s"}:
                 return 5
-        # Special case for SPARCv2 with ELIM module: only light-aligner
-        if main_data.role == "sparc2" and main_data.light_aligner:
-            return 10
+            elif main_data.light_aligner:
+                # Special case for ELIM module: no mirror, but light-aligner
+                return 5
 
         return None
 

--- a/src/odemis/gui/main.xrc
+++ b/src/odemis/gui/main.xrc
@@ -3192,7 +3192,7 @@
                   <orient>wxVERTICAL</orient>
                   <object class="sizeritem">
                     <object class="wxStaticText">
-                      <label>Lens1</label>
+                      <label>Lens 1</label>
                       <fg>#E5E5E5</fg>
                       <font>
                         <size>16</size>
@@ -3324,7 +3324,7 @@
                   <orient>wxVERTICAL</orient>
                   <object class="sizeritem">
                     <object class="wxStaticText">
-                      <label>Lens2</label>
+                      <label>Lens 2</label>
                       <fg>#E5E5E5</fg>
                       <font>
                         <size>16</size>
@@ -4387,11 +4387,6 @@
       <object class="sizeritem">
         <object class="ViewportGrid" name="pnl_vp_grid">
           <object class="LiveViewport" name="vp_align_lens">
-            <XRCED>
-              <assign_var>1</assign_var>
-            </XRCED>
-          </object>
-          <object class="LiveViewport" name="vp_moi">
             <XRCED>
               <assign_var>1</assign_var>
             </XRCED>

--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -440,7 +440,6 @@ class xrcpnl_tab_sparc2_align(wx.Panel):
         self.btn_log = xrc.XRCCTRL(self, "btn_log")
         self.pnl_vp_grid = xrc.XRCCTRL(self, "pnl_vp_grid")
         self.vp_align_lens = xrc.XRCCTRL(self, "vp_align_lens")
-        self.vp_moi = xrc.XRCCTRL(self, "vp_moi")
         self.vp_align_center = xrc.XRCCTRL(self, "vp_align_center")
         self.vp_align_ek = xrc.XRCCTRL(self, "vp_align_ek")
         self.vp_align_streak = xrc.XRCCTRL(self, "vp_align_streak")
@@ -4307,7 +4306,7 @@ def __init_resources():
                   <orient>wxVERTICAL</orient>
                   <object class="sizeritem">
                     <object class="wxStaticText">
-                      <label>Lens1</label>
+                      <label>Lens 1</label>
                       <fg>#E5E5E5</fg>
                       <font>
                         <size>16</size>
@@ -4439,7 +4438,7 @@ def __init_resources():
                   <orient>wxVERTICAL</orient>
                   <object class="sizeritem">
                     <object class="wxStaticText">
-                      <label>Lens2</label>
+                      <label>Lens 2</label>
                       <fg>#E5E5E5</fg>
                       <font>
                         <size>16</size>
@@ -5502,11 +5501,6 @@ def __init_resources():
       <object class="sizeritem">
         <object class="ViewportGrid" name="pnl_vp_grid">
           <object class="LiveViewport" name="vp_align_lens">
-            <XRCED>
-              <assign_var>1</assign_var>
-            </XRCED>
-          </object>
-          <object class="LiveViewport" name="vp_moi">
             <XRCED>
               <assign_var>1</assign_var>
             </XRCED>

--- a/src/odemis/gui/model/__init__.py
+++ b/src/odemis/gui/model/__init__.py
@@ -1207,6 +1207,8 @@ class Sparc2AlignGUIData(ActuatorGUIData):
 
         if not main.mirror:
             amodes.remove("mirror-align")
+            if "lens-align" in amodes:
+                amodes.remove("lens-align")
 
         if main.lens and model.hasVA(main.lens, "polePosition"):
             # Position of the hole from the center of the AR image (in m)


### PR DESCRIPTION
Depending on the alignement mode, only some hardware axes can be moved.
Until now, the axes which couldn't be moved where disabled. However, on
systems with a lot of axes, that didn't fit in the window.

=> Just hide the controls which are not supposed to be used for each
given alignment mode.