### PR TITLE
[fix] driver simstreakcam: avoid error when stopping the acquisition

### DIFF
--- a/src/odemis/driver/simstreakcam.py
+++ b/src/odemis/driver/simstreakcam.py
@@ -289,6 +289,10 @@ class ReadoutCamera(model.DigitalCamera):
         """
         Generates the fake output image based on the resolution.
         """
+        timer = self._generator  # might be replaced by None afterwards, so keep a copy
+        if timer is None:
+            return
+
         gen_img = self._getNewImage()
 
         # Processes the fake image based on resolution and binning.
@@ -297,7 +301,6 @@ class ReadoutCamera(model.DigitalCamera):
         gen_img = gen_img.reshape((res[1], binning[0], res[0],
                                    binning[1])).mean(axis=3).mean(axis=1).astype(gen_img.dtype)
 
-        timer = self._generator  # might be replaced by None afterwards, so keep a copy
         self._waitSync()
         if self._sync_event:
             # If sync event, we need to simulate period after event (not efficient, but works)
@@ -517,12 +520,6 @@ class StreakCamera(model.HwComponent):
         # terminate children
         for child in self.children.value:
             child.terminate()
-
-    def StartAcquisition(self):
-        """
-        Start an acquisition.
-        """
-        self._readoutcam._generate()
 
 
 class SimpleStreakCameraDataFlow(model.DataFlow):


### PR DESCRIPTION
In some cases, when stopping an acquisition, such error would happen:
ERROR   __init__:707:   Failure while calling repeating timer 'SimCam image generator'
Traceback (most recent call last):
  File "/home/piel/development/odemis/src/odemis/util/__init__.py", line 701, in run
    self.callback()
  File "/home/piel/development/odemis/src/odemis/util/weak.py", line 36, in __call__
    return self.f(ins, *arg, **kwargs)
  File "/home/piel/development/odemis/src/odemis/driver/simstreakcam.py", line 314, in _generate
    exp = timer.period
AttributeError: 'NoneType' object has no attribute 'period'

This is not a big deal, as it's in a thread that's supposed to end when
stopping the acquisition. So it'd be restarted automatically on next
acquisition.
Still, it's nicer to not fail => detect such corner case, and just end
the thread nicely.