### PR TITLE
[CSDM-1085] sparc chamber tab: don't keep focus on mirror switching button

### DIFF
--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -2520,6 +2520,12 @@ class ChamberTab(Tab):
         self.tab_data_model.main.is_acquiring.value = True
 
         self.panel.btn_cancel.Enable()
+        # We focus the cancel button mostly to not keep the focus on the switch
+        # mirror button, because having the focus means that when pressing "space"
+        # key the button is pressed (immediately). That can be quite dangerous after
+        # parking the mirror, if the user is not paying close attention to the
+        # keyboard. So that's a safety measure.
+        self.panel.btn_cancel.SetFocus()
         self.panel.btn_switch_mirror.SetLabel(btn_text)
 
     def _on_move_done(self, future):


### PR DESCRIPTION
After pressing the "PARK MIRROR" button, it typically gets the focus.
Once it's parked, the button becomes "ENGAGE MIRROR".
That means that as long as the user has the mirror parked, pressing
the "space" key will automatically engage the mirror. Really dangerous.

So now, as soon as the button is pressed, we move the focus to the
Cancel button. This way "space" has a much safer behaviour of stopping
the movement (or doing nothing).

It's still possible to give the focus to the PARK MIRROR button, and
press space, but then it when pressing Tab, or using the mouse first to
give it focus. That a lot more explicit.