### PR TITLE
[fix] spike removal tool

### DIFF
--- a/plugins/spike_remove.py
+++ b/plugins/spike_remove.py
@@ -221,7 +221,11 @@ class SpikeRemovalPlugin(Plugin):
         # using the values in neighboring pixels in the spectrum.
 
         spikestep = self.threshold.value
-        specdat = numpy.squeeze(raw_spec_dat.copy())
+
+        assert raw_spec_dat.ndim == 5
+        s = raw_spec_dat.shape
+        specdat = numpy.reshape(raw_spec_dat, (s[-5], s[-2], s[-1]))
+
         assert specdat.ndim == 3
         # this diff calculation requires higher numerical precision than 16 bits because it is squared.
         # 32 uint should be good enough as the max diff < 2**16. However for the summation of ms_step it is more convenient to use float32.


### PR DESCRIPTION
Fix the assertion error that is raised when the provided image squeezed down to less than 3 dimensions.

**The error:**
```
File "/home/USER/.local/share/odemis/plugins/spike_remove.py", line 225, in removespikes_spec
    assert specdat.ndim == 3
AssertionError

```
Related Jira issue: [[CSDM-1008](https://delmic.atlassian.net/browse/CSDM-1008)]

[CSDM-1008]: https://delmic.atlassian.net/browse/CSDM-1008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ