### PR TITLE
[fix] add rotational axes for Thermofisher when switching using grid mode 

### DIFF
--- a/src/odemis/acq/move.py
+++ b/src/odemis/acq/move.py
@@ -503,6 +503,7 @@ class MeteorTFS1PostureManager(MeteorPostureManager):
                 # The current mode doesn't change. Only X/Y/Z should move (typically
                 # only X/Y).
                 sub_moves.append((self.stage, filter_dict({'x', 'y', 'z'}, target_pos)))
+                sub_moves.append((self.stage, filter_dict({'rx', 'rz'}, target_pos)))
             elif target in (LOADING, SEM_IMAGING, FM_IMAGING):
                 # Park the focuser for safety
                 if not isNearPosition(self.focus.position.value, focus_deactive, self.focus.axes):

--- a/src/odemis/acq/move.py
+++ b/src/odemis/acq/move.py
@@ -501,8 +501,8 @@ class MeteorTFS1PostureManager(MeteorPostureManager):
 
             if target in (GRID_1, GRID_2):
                 # The current mode doesn't change. Only X/Y/Z should move (typically
-                # only X/Y).
-                # TODO: probably a better way would be to forbid grid switch if not in SEM/FM imaging posture
+                # only X/Y). In the same mode, GRID 1/2, the rx/rz values should not change
+                # TODO: probably a better way would be to forbid grid switching if not in SEM/FM imaging posture
                 sub_moves.append((self.stage, filter_dict({'x', 'y', 'z'}, target_pos)))
                 sub_moves.append((self.stage, filter_dict({'rx', 'rz'}, target_pos)))
             elif target in (LOADING, SEM_IMAGING, FM_IMAGING):

--- a/src/odemis/acq/move.py
+++ b/src/odemis/acq/move.py
@@ -502,6 +502,7 @@ class MeteorTFS1PostureManager(MeteorPostureManager):
             if target in (GRID_1, GRID_2):
                 # The current mode doesn't change. Only X/Y/Z should move (typically
                 # only X/Y).
+                # TODO: probably a better way would be to forbid grid switch if not in SEM/FM imaging posture
                 sub_moves.append((self.stage, filter_dict({'x', 'y', 'z'}, target_pos)))
                 sub_moves.append((self.stage, filter_dict({'rx', 'rz'}, target_pos)))
             elif target in (LOADING, SEM_IMAGING, FM_IMAGING):


### PR DESCRIPTION
The rotational axes are updated when target is moved using GRID 1 and GRID 2.

With the old workflow. when the stage is moved from Loading to GRID 1 position (default SEM mode), then the resultant stage position will not be updated in rx and rz but only in x, y, z. The current changes, update rx and rz.