### PR TITLE
gui main xrc: fix flag

### DIFF
--- a/src/odemis/gui/main.xrc
+++ b/src/odemis/gui/main.xrc
@@ -8911,7 +8911,7 @@
                   <assign_var>1</assign_var>
                 </XRCED>
               </object>
-              <flag>wxALL|wxALIGN_RIGHT</flag>
+              <flag>wxALL</flag>
               <border>23</border>
             </object>
           </object>
@@ -9341,7 +9341,7 @@
                   <assign_var>1</assign_var>
                 </XRCED>
               </object>
-              <flag>wxALL|wxALIGN_RIGHT</flag>
+              <flag>wxALL</flag>
               <border>23</border>
             </object>
           </object>

--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -9965,7 +9965,7 @@ def __init_resources():
                   <assign_var>1</assign_var>
                 </XRCED>
               </object>
-              <flag>wxALL|wxALIGN_RIGHT</flag>
+              <flag>wxALL</flag>
               <border>23</border>
             </object>
           </object>
@@ -10395,7 +10395,7 @@ def __init_resources():
                   <assign_var>1</assign_var>
                 </XRCED>
               </object>
-              <flag>wxALL|wxALIGN_RIGHT</flag>
+              <flag>wxALL</flag>
               <border>23</border>
             </object>
           </object>


### PR DESCRIPTION
New wxWidget 4.2 complains when using useless align flag.
ALIGN_RIGHT on HORIZONTAL sizer has no effect.