### PR TITLE
[SDEV-1539] technolution driver: Add support for '.' in the allowed charct…

### DIFF
--- a/src/odemis/driver/technolution.py
+++ b/src/odemis/driver/technolution.py
@@ -64,7 +64,7 @@ ASM_USER_CHARS = r'[A-Za-z0-9]+'  # + -> should be at least one character
 ASM_PASSWORD_CHARS = r'[A-Za-z0-9]+'
 ASM_HOST_CHARS = r'[A-Za-z0-9.]+'
 ASM_PATH_CHARS = r'[A-Za-z0-9/_()-]+'
-ASM_SUBDIR_CHARS = r'[A-Za-z0-9/_()-]*'  # * -> subdirectories can also be empty string
+ASM_SUBDIR_CHARS = r'[A-Za-z0-9/_()-.]*'  # * -> subdirectories can also be empty string
 ASM_FILE_CHARS = r'[A-Za-z0-9_()-]+'
 
 


### PR DESCRIPTION
…ers of the storage directory

In the update of the ASM v3 API it is now allowed to have a '.' in the storage directory. If a name starts with a '.' this directory is not taking into account in the post-processing. For the calibrations we need to acquire an image to update acquisition settings, these acquisitions where previously post-processed which takes up a lot of time. This is now not needed anymore.

SDEV-1539