### PR TITLE
[SWM-129] Fix img_test.py/test_tint_to_colormap_unexpected_input

### DIFF
--- a/src/odemis/util/conversion.py
+++ b/src/odemis/util/conversion.py
@@ -106,10 +106,10 @@ def rgb_to_frgb(rgb):
     """
     # check if the tuple consists of three values
     if len(rgb) != 3:
-        raise ValueError("Illegal RGB colour %s" % rgb)
+        raise ValueError("Illegal RGB colour %s" % (rgb,))
     # check if the tuple values are valid RGB values
-    if not numpy.all(tuple(0 <= c <= 255 for c in rgb)):
-        raise ValueError("Not all values are valid RGB values (0-255)")
+    if not all(0 <= c <= 255 for c in rgb):
+        raise ValueError("Not all values are valid RGB values (0-255) of passed colour %s" % (rgb,))
     return tuple(v / 255.0 for v in rgb)
 
 

--- a/src/odemis/util/conversion.py
+++ b/src/odemis/util/conversion.py
@@ -104,9 +104,12 @@ def rgb_to_frgb(rgb):
     :return: (float, float, float)
 
     """
-
+    # check if the tuple consists of three values
     if len(rgb) != 3:
         raise ValueError("Illegal RGB colour %s" % rgb)
+    # check if the tuple values are valid RGB values
+    if not numpy.all(tuple(0 <= c <= 255 for c in rgb)):
+        raise ValueError("Not all values are valid RGB values (0-255)")
     return tuple(v / 255.0 for v in rgb)
 
 


### PR DESCRIPTION
Test case test_tint_to_colormap_unexpected_input in /util/test/img_test.py was failing on Ubuntu 18.04. 
The expected ValueError was not raised in this case.

On Ubuntu 18.04 RGB values in tuples higher than 255 are somehow accepted or forced in between the range of 0-255.
The root of this reason is not easily traced as the code is distributed over multple .py files and/or classes.

To make sure the ValueError exception is raised a check is added to /util/conversion.py rgb_to_frgb method to make 
sure all the values in the tuple are within the range of 0-255.