### PR TITLE
[fix] don't fail during App destruction in viewport

### DIFF
--- a/src/odemis/gui/comp/viewport.py
+++ b/src/odemis/gui/comp/viewport.py
@@ -797,6 +797,9 @@ class LiveViewport(MicroscopeViewport):
         Called whenever the current (playing) stream changes.
         Used to update the focus capability based on the stream
         """
+        if self._view is None:  # In case it's called after being destroyed
+            return
+
         if CAN_FOCUS not in self._orig_abilities:
             return
         # find out the current playing stream in the view


### PR DESCRIPTION
Once the viewport is destroyed, it automatically drops the reference to
the view. However, it can happen that the streams still change, so in
this case, that would cause failures. Not a big deal as the App is
closing, but annoying to see in the logs.

=> just don't do anything in this case.