### PR TITLE
[CDSM-1094] updated the StaticARStream to contain emission metadata

### DIFF
--- a/src/odemis/acq/stream/_static.py
+++ b/src/odemis/acq/stream/_static.py
@@ -466,6 +466,19 @@ class StaticARStream(StaticStream):
 
         super(StaticARStream, self).__init__(name, list(self._pos.values()), *args, **kwargs)
 
+        # show the selected band filter wavelength in the emission field
+        try:
+            em_range = data[0].metadata[model.MD_OUT_WL]
+            if isinstance(em_range, str):
+                unit = None
+            else:
+                unit = "m"
+            self.emission = VigilantAttribute(em_range, unit=unit,
+                                              readonly=True)
+
+        except KeyError:
+            logging.info("No emission wavelength for AR stream")
+
     def _init_projection_vas(self):
         # override Stream._init_projection_vas.
         # This stream doesn't provide the projection(s) to an .image by itself.


### PR DESCRIPTION
Currently only StaticCLStream supported the read-only emission field which show the band wavelength used in the analysis. When analyzing AR in the analysis tab the user would find the right MD under the button metadata. Therefore  the StaticARStream emission metadata is now updated to show as a RO VA on the stream panel.
