### PR TITLE
[fix] hdf5: decode all strings from hdf5 files when they are bytes

### DIFF
--- a/src/odemis/dataio/test/hdf5_test.py
+++ b/src/odemis/dataio/test/hdf5_test.py
@@ -418,11 +418,11 @@ class TestHDF5IO(unittest.TestCase):
         ypos = f["Acquisition0/ImageData/YOffset"][()]
         self.assertAlmostEqual(metadata[model.MD_POS][1], ypos)
 
-        # Check physical metadata
-        desc = f["Acquisition0/PhysicalData/Title"][()]
+        # Check physical metadata, read_str converts from bytes to str
+        desc = hdf5.convert_to_str(f["Acquisition0/PhysicalData/Title"][()])
         self.assertEqual(metadata[model.MD_DESCRIPTION], desc)
 
-        iwl = f["Acquisition0/PhysicalData/ExcitationWavelength"][()] # m
+        iwl = f["Acquisition0/PhysicalData/ExcitationWavelength"][()]  # m
         self.assertTrue((metadata[model.MD_IN_WL][0] <= iwl <= metadata[model.MD_IN_WL][1]))
 
         expt = f["Acquisition0/PhysicalData/IntegrationTime"][()] # s


### PR DESCRIPTION
Sometimes when reading strings from hdf5 files bytes are returned instead of a string. This fix ensures that if bytes are returned they are always converted. The code has been refactored to move the function read_str out of the for-loop it was in and to it's own function.

On Ubuntu 22.04 the following test case failed:

FAIL: testMetadata (hdf5_test.TestHDF5IO)
checks that the metadata is saved with every picture ---------------------------------------------------------------------- Traceback (most recent call last):
  File "/home/runner/work/odemis/odemis/src/odemis/dataio/test/hdf5_test.py", line 423, in testMetadata
    self.assertEqual(metadata[model.MD_DESCRIPTION], desc)
AssertionError: 'tÉst' != b't\xc3\x89st'