### PR TITLE
[METEOR-520] [fix] Hide hardware settings in the Localization tab when viewing a static stream 

### DIFF
--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -392,6 +392,7 @@ class LocalizationTab(Tab):
 
         # Default view is the Live 1
         tab_data.focussedView.value = panel.vp_secom_bl.view
+        tab_data.focussedView.subscribe(self._on_view, init=True)
 
         self._view_selector = viewcont.ViewButtonController(
             tab_data,
@@ -497,6 +498,13 @@ class LocalizationTab(Tab):
                 panel,
                 self
             )
+
+    def _on_view(self, view):
+        """Hide hardware related sub-panels on the right when not in live stream"""
+        live = issubclass(view.stream_classes, odemis.acq.stream._live.LiveStream)
+        self.panel.fp_settings_secom_optical.Show(live)
+        self.panel.fp_secom_streams.Show(live)
+        self.panel.fp_acquisitions.Show(live)
 
     @property
     def settingsbar_controller(self):

--- a/src/odemis/gui/main.xrc
+++ b/src/odemis/gui/main.xrc
@@ -8576,7 +8576,7 @@
                           <assign_var>1</assign_var>
                         </XRCED>
                       </object>
-                      <object class="FoldPanelItem">
+                      <object class="FoldPanelItem" name="fp_secom_streams">
                         <object class="StreamBar" name="pnl_secom_streams">
                           <size>300,-1</size>
                           <add_button>1</add_button>
@@ -8590,7 +8590,7 @@
                         <fg>#1A1A1A</fg>
                         <bg>#555555</bg>
                       </object>
-                      <object class="FoldPanelItem">
+                      <object class="FoldPanelItem" name="fp_acquisitions">
                         <object class="wxPanel">
                             <object class="wxBoxSizer">
                                 <object class="sizeritem">

--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -944,7 +944,9 @@ class xrcpnl_tab_localization(wx.Panel):
         self.lbl_stigmator_angle = xrc.XRCCTRL(self, "lbl_stigmator_angle")
         self.cmb_stigmator_angle = xrc.XRCCTRL(self, "cmb_stigmator_angle")
         self.fp_settings_secom_optical = xrc.XRCCTRL(self, "fp_settings_secom_optical")
+        self.fp_secom_streams = xrc.XRCCTRL(self, "fp_secom_streams")
         self.pnl_secom_streams = xrc.XRCCTRL(self, "pnl_secom_streams")
+        self.fp_acquisitions = xrc.XRCCTRL(self, "fp_acquisitions")
         self.streams_chk_list = xrc.XRCCTRL(self, "streams_chk_list")
         self.z_stack_chkbox = xrc.XRCCTRL(self, "z_stack_chkbox")
         self.param_Zmin = xrc.XRCCTRL(self, "param_Zmin")
@@ -9649,7 +9651,7 @@ def __init_resources():
                           <assign_var>1</assign_var>
                         </XRCED>
                       </object>
-                      <object class="FoldPanelItem">
+                      <object class="FoldPanelItem" name="fp_secom_streams">
                         <object class="StreamBar" name="pnl_secom_streams">
                           <size>300,-1</size>
                           <add_button>1</add_button>
@@ -9663,7 +9665,7 @@ def __init_resources():
                         <fg>#1A1A1A</fg>
                         <bg>#555555</bg>
                       </object>
-                      <object class="FoldPanelItem">
+                      <object class="FoldPanelItem" name="fp_acquisitions">
                         <object class="wxPanel">
                             <object class="wxBoxSizer">
                                 <object class="sizeritem">


### PR DESCRIPTION
Hide hardware settings in the Localization tab when viewing a static stream and show in live stream