### PR TITLE
[METEOR-798] [fix] Hide black rectangles in overview acquisition 

### DIFF
--- a/src/odemis/gui/win/acquisition.py
+++ b/src/odemis/gui/win/acquisition.py
@@ -778,7 +778,7 @@ class OverviewAcquisitionDialog(xrcfr_overview_acq):
         # High overlap percentage is not required as the stitching is based only on stage position,
         # independent of the image content. It just needs to be big enough to make sure that even with some stage
         # imprecision, all the tiles will overlap or at worse be next to each other (i.e. , no space between tiles)
-        self.overlap = 0.05
+        self.overlap = 0.10
         try:
             # Use the stage range, which can be overridden by the MD_POS_ACTIVE_RANGE.
             # Note: this last one might be temporary, until we have a RoA tool provided in the GUI.


### PR DESCRIPTION
Increase the overlap from 5 to 10 percent during tiled acquisition to hide rectangular gap between stitched tiles.