### PR TITLE
[SWM-79] scripts cl_acquisition: update numpy.float to numpy.float64

### DIFF
--- a/scripts/cl_acquisition.py
+++ b/scripts/cl_acquisition.py
@@ -105,7 +105,7 @@ class Acquirer(object):
         logging.info("Generating points in the SEM area %s, from rep %s and roi %s",
                      lim_main, rep, roi)
 
-        pos = numpy.empty((rep[1], rep[0], 2), dtype=numpy.float)
+        pos = numpy.empty((rep[1], rep[0], 2), dtype=numpy.float64)
         posy = pos[:, :, 1].swapaxes(0, 1)  # just a view to have Y as last dim
         posy[:, :] = numpy.linspace(lim_main[1], lim_main[3], rep[1])
         # fill the X dimension


### PR DESCRIPTION
numpy.float are deprecated, and stop working with numpy 1.24+ .

=> Use the explicit numpy.float64 type.