### PR TITLE
[CSDM-1082] add auto-completion to "odemis" as synonym for "odemis-cli"

### DIFF
--- a/debian/odemis.links
+++ b/debian/odemis.links
@@ -1,1 +1,2 @@
 usr/bin/odemis-cli usr/bin/odemis
+usr/share/bash-completion/completions/odemis-cli usr/share/bash-completion/completions/odemis


### PR DESCRIPTION
The bash auto-completion script already tried to report it also works
for "odemis", but the way the auto-completion works, each command must
have a file named after it.
So make a soft-link from odemis -> odemis-cli so that the
auto-completion also works for odemis. This is the standard way it's
done on Debian for commands with multiple names.