### PR TITLE
[SWM-136] fix: log_test fixed to use logging.warning instead of logging.warn

### DIFF
--- a/src/odemis/gui/test/log_test.py
+++ b/src/odemis/gui/test/log_test.py
@@ -33,7 +33,7 @@ from builtins import range
 log.init_logger(logging.DEBUG)
 test.goto_manual()
 
-LOG_FUNCTIONS = (logging.debug, logging.info, logging.warn, logging.error, logging.exception)
+LOG_FUNCTIONS = (logging.debug, logging.info, logging.warning, logging.error, logging.exception)
 
 
 class TestLogWindow(test.GuiTestCase):


### PR DESCRIPTION
The following warning was raised in the test cases because the test used logging.warn. 
```
2023-10-26T13:31:28.6860663Z src/odemis/gui/test/log_test.py::TestLogWindow::test_log_window
2023-10-26T13:31:28.6861263Z   /home/testing/development/odemis/src/odemis/gui/test/log_test.py:48: DeprecationWarning: The 'warn' function is deprecated, use 'warning' instead
2023-10-26T13:31:28.6861389Z     random.choice(LOG_FUNCTIONS)("WEEEEEE %d" % i)
```
