### PR TITLE
[CSDM-1102] driver andorcam2: in case of time out, raise a TimeoutError

### DIFF
--- a/src/odemis/driver/andorcam2.py
+++ b/src/odemis/driver/andorcam2.py
@@ -2289,7 +2289,7 @@ class AndorCam2(model.DigitalCamera):
 
             if time.time() > tend:
                 logging.warning("Timeout after %g s", time.time() - tstart)
-                raise  # seems actually serious
+                raise TimeoutError(f"Timeout after {time.time() - tstart} s")
 
     def _acquire(self):
         """


### PR DESCRIPTION
In case of time out, the code was trying to raise the "current"
exception, however it was not in the context of an exception, so this
caused a RuntimeError exception, which immediately stopped the
acquisition. Example:
2023-10-11 13:21:00,840	ERROR	andorcam2:2303:	Failure in acquisition thread
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/odemis/driver/andorcam2.py", line 2298, in _acquire
    self._acquire_images()
  File "/usr/lib/python3/dist-packages/odemis/driver/andorcam2.py", line 2405, in _acquire_images
    should_stop = self._acq_wait_data(twait)
  File "/usr/lib/python3/dist-packages/odemis/driver/andorcam2.py", line 2284, in _acq_wait_data
    raise  # seems actually serious
RuntimeError: No active exception to reraise

Now properly raise a TimeoutError, which is handled by the caller, and
automatically retry the acquisition.