### PR TITLE
[fix] acq EnzelPostureManager: report the posture based on both the stage and lens positions

### DIFF
--- a/src/odemis/acq/test/move_test.py
+++ b/src/odemis/acq/test/move_test.py
@@ -255,7 +255,13 @@ class TestEnzelMove(unittest.TestCase):
         pos_label = self.posture_manager.getCurrentPostureLabel()
         self.assertEqual(pos_label, THREE_BEAMS)
 
-        # Test disabled, because typically ALIGNEMENT is the same as
+        # Move away the align (only), and check that this is now considered an UNKNOWN position
+        f = self.posture_manager._cryoSwitchAlignPosition(LOADING)
+        f.result(30)
+        pos_label = self.posture_manager.getCurrentPostureLabel()
+        self.assertEqual(pos_label, UNKNOWN)
+
+        # Test disabled, because typically ALIGNMENT is the same as
         # THREE_BEAMS, so it's not possible to differentiate them.
         # Move to alignment
         # f = cryoSwitchSamplePosition(ALIGNMENT)
@@ -264,6 +270,7 @@ class TestEnzelMove(unittest.TestCase):
         # self.assertEqual(pos_label, ALIGNMENT)
 
         # Move to SEM imaging
+        self.posture_manager.cryoSwitchSamplePosition(LOADING).result()
         f = self.posture_manager.cryoSwitchSamplePosition(SEM_IMAGING)
         f.result()
         pos_label = self.posture_manager.getCurrentPostureLabel()


### PR DESCRIPTION
So far on the ENZEL the current posture was detected only based on the
stage position. If all the hardware moves fine, and the user only uses
the GUI, that's sufficient. However, in case of issue with "align"
(ie, the lens stage), the position could still be reported as "fine"
although the lens is at the wrong place.

=> Take the position of the lens into account too.