### PR TITLE
[ci] Fix unit test util.img.test_fast failing 50% of the time

### DIFF
--- a/.github/workflows/unit_tests_cloud.yml
+++ b/.github/workflows/unit_tests_cloud.yml
@@ -34,6 +34,8 @@ jobs:
         sudo mkdir /var/run/odemisd
         sudo chmod a+rw /var/run/odemisd
 
+        python3 setup.py build_ext --inplace
+
     - name: Run tests from odemis.dataio
       run: |
         export PYTHONPATH="$PWD/src:$PYTHONPATH"

--- a/src/odemis/util/test/img_test.py
+++ b/src/odemis/util/test/img_test.py
@@ -451,6 +451,11 @@ class TestDataArray2RGB(unittest.TestCase):
 
     def test_fast(self):
         """Test the fast conversion"""
+        try:
+            import odemis.util.img_fast
+        except ImportError as ex:
+            self.skipTest(f"img_fast not available ({ex}), cannot test it")
+
         data = numpy.ones((251, 200), dtype="uint16")
         data[:, :] = numpy.arange(200)
         data[2, :] = 56


### PR DESCRIPTION
The CI test cases didn't build the cython files. So the img_fast was not available. As util.img automatically uses the standard numpy implementation if the fast implementation is not available, the test case still ran... but it ended comparing twice the same implementation. So 50% of the time it failed.

Two different ways to fix the unit test failures:
* Actually compile the fast version so that it's possible to compare fast vs normal
* Detect that the fast version is not available, and skip the test.

We do both, to make sure it's really not going to come back!