### PR TITLE
[perf][METEOR-590] save z axis of meteor stage in feature position

### DIFF
--- a/src/odemis/acq/feature.py
+++ b/src/odemis/acq/feature.py
@@ -12,19 +12,23 @@ class CryoFeature(object):
     Model class for a cryo interesting feature
     """
 
-    def __init__(self, name, x, y, z, streams=None):
+    def __init__(self, name, x, y, z, d=None, streams=None):
         """
         :param name: (string) the feature name
         :param x: (float) the X axis of the feature position
         :param y: (float) the Y axis of the feature position
         :param z: (float) the Z axis of the feature position
+        :param d: (float) distance of feature position from focus
         :param streams: (List of StaticStream) list of acquired streams on this feature
         """
         self.name = model.StringVA(name)
         # The 3D position of an interesting point in the site (Typically, the milling should happen around that
         # volume, never touching it.)
-        self.pos = model.TupleContinuous((x, y, z), range=((-1, -1, -1), (1, 1, 1)), cls=(int, float), unit="m")
-        
+        if d:
+            self.pos = model.TupleContinuous((x, y, z, d), range=((-1, -1, -1, -1), (1, 1, 1, 1)), cls=(int, float),
+                                             unit="m")
+        else:
+            self.pos = model.TupleContinuous((x, y, z), range=((-1, -1, -1), (1, 1, 1)), cls=(int, float), unit="m")
         self.status = model.StringVA(FEATURE_ACTIVE)
         # TODO: Handle acquired files
         self.streams = streams if streams is not None else model.ListVA()

--- a/src/odemis/gui/cont/features.py
+++ b/src/odemis/gui/cont/features.py
@@ -61,7 +61,7 @@ class CryoFeatureController(object):
         if feature:
             pos = feature.pos.value
             current_focus = self._main_data_model.focus.position.value['z']
-            feature.pos.value = (pos[0], pos[1], current_focus)
+            feature.pos.value = (pos[0], pos[1], pos[2], current_focus)
 
     def _on_btn_go_to_feature(self, _):
         """
@@ -72,8 +72,8 @@ class CryoFeatureController(object):
             return
         pos = feature.pos.value
         logging.info(f"Moving to position: {pos}")
-        self._main_data_model.stage.moveAbs({'x': pos[0], 'y': pos[1]})
-        self._main_data_model.focus.moveAbs({'z': pos[2]})
+        self._main_data_model.stage.moveAbs({'x': pos[0], 'y': pos[1], 'z': pos[2]})
+        self._main_data_model.focus.moveAbs({'z': pos[3]})
 
     def _enable_feature_ctrls(self, enable: bool):
         """
@@ -177,8 +177,8 @@ class CryoFeatureController(object):
                                                                   va_2_ctrl=self._on_feature_pos)
 
     def _on_feature_pos(self, feature_pos):
-        # Set the feature Z ctrl with the 3rd (focus) element of the feature position
-        self._panel.ctrl_feature_z.SetValue(feature_pos[2])
+        #  Set the feature Z ctrl with the 4th (focus) element of the feature position
+        self._panel.ctrl_feature_z.SetValue(feature_pos[3])
         save_features(self._tab.conf.pj_last_path, self._tab_data_model.main.features.value)
 
     def _on_feature_name(self, _):
@@ -236,6 +236,6 @@ class CryoFeatureController(object):
         feature = self._tab_data_model.main.currentFeature.value
         if not feature:
             logging.error("No feature connected, but Z position changed!")
-            return None, None, zpos
+            return None, None, None, zpos
         pos = feature.pos.value
-        return pos[0], pos[1], zpos
+        return pos[0], pos[1], pos[2], zpos

--- a/src/odemis/gui/model/__init__.py
+++ b/src/odemis/gui/model/__init__.py
@@ -745,7 +745,8 @@ class CryoGUIData(MicroscopyGUIData):
             f_name = make_unique_name("Feature-1", existing_names)
         if pos_z is None:
             pos_z = self.main.focus.position.value['z']
-        feature = CryoFeature(f_name, pos_x, pos_y, pos_z)
+        stage_pos = self.main.stage.position.value
+        feature = CryoFeature(f_name, pos_x, pos_y, stage_pos['z'], pos_z)
         self.main.features.value.append(feature)
         self.main.currentFeature.value = feature
         return feature


### PR DESCRIPTION


Now z axis of meteor stage will be used to move to a selected feature along with x, y position of meteor stage and z position of focus