### PR TITLE
[fix] Mock the stage in the fastem mocked test cases.

### DIFF
--- a/src/odemis/acq/test/fastem_test.py
+++ b/src/odemis/acq/test/fastem_test.py
@@ -1034,7 +1034,12 @@ class TestFastEMAcquisitionTaskMock(TestFastEMAcquisitionTask):
         cls.multibeam.resolution.value = (6400, 6400)
 
         cls.descanner = None
-        cls.stage = None
+        cls.stage = Mock()
+        cls.stage.axes = {
+            "x": model.Axis(unit="m", range=(-100.0e-6, 100.0e-6)),
+            "y": model.Axis(unit="m", range=(-100.0e-6, 100.0e-6)),
+            "z": model.Axis(unit="m", range=(-100.0e-6, 100.0e-6)),
+        }
         cls.ccd = None
         cls.beamshift = None
         cls.lens = None


### PR DESCRIPTION
The stage was not mocked because it previously was not called in the test cases. Commit a1baa166 added the use of guessActuatorMoveDuration to estimate the duration of a move. This checks if the stage object is an actuator. Since it was not mocked at all and it was just None, the following error was raised: ValueError: The component None should be an actuator, but it is not. Now the stage is also mocked and the check if it is an actuator passes.