### PR TITLE
[fix] auto brightness/contrast and histrogram display could sometimes return shifted values

### DIFF
--- a/src/odemis/acq/stream/_base.py
+++ b/src/odemis/acq/stream/_base.py
@@ -872,8 +872,8 @@ class Stream(object):
                         # => Two options:
                         # * add 10% margin on each side
                         # * round to the nearest power of 2 on each side
-                        # Take whichever is the smallest... and also ensure that the length is a multiple of 256 because
-                        # the histogram computation is much faster in such case.
+                        # Take whichever is the smallest... and also ensure that the length (mx - mn + 1)
+                        # is a multiple of 256 because the histogram computation is much faster in such case.
                         width10 = max(127, int((mx - mn) / 10))  # 10%, and at least 8 bits
 
                         # Min: only change the range if the previous one doesn't fit anymore
@@ -885,8 +885,7 @@ class Stream(object):
                             if 0 <= mn <= 255:  # if 0 or small positive value => round down to 0
                                 mn_p2 = 0
                             elif mn > 0:
-                                mn_p2 = 2 ** int(math.floor(math.log(mn + 1, 2)))
-                                mn_p2 -= 1  # maximum value represented with N bits
+                                mn_p2 = 2 ** int(math.floor(math.log(mn, 2)))
                             else:  # mn < 0
                                 mn_p2 = max(256, -mn)  # At least assume 8 bits
                                 mn_p2 = 2 ** int(math.ceil(math.log(mn_p2, 2)))
@@ -897,25 +896,31 @@ class Stream(object):
                             mn = prev_drange[0]
 
                         # Max: only change the range if the previous one doesn't fit anymore
+                        # Round to 256, and subtract 1, so that the length of the range is a multiple of 256.
                         if prev_drange is None or mx > prev_drange[1]:
                             mx10 = mx + width10
-                            mx10 = math.ceil(mx10 / 256) * 256
+                            mx10 = math.ceil(mx10 / 256) * 256 - 1  # To make sure the length is a multiple of 256
 
-                            # Round to next power of 2, with at least 8 bits
-                            if -255 <= mx <= 0:  # For 0 or small negative values, round up to 0
-                                mx_p2 = 0
-                            elif mx > 0:
+                            # Round to next power of 2 - 1, with at least 8 bits
+                            if -255 <= mx <= -1:  # For small negative values, round up to -1
+                                mx_p2 = -1
+                            elif mx >= 0:
                                 mx_p2 = max(255, mx)  # At least assume 8 bits
                                 mx_p2 = 2 ** int(math.ceil(math.log(mx_p2 + 1, 2)))
                                 mx_p2 -= 1  # maximum value represented with N bits
-                            else:  # mx < 0
-                                mx_p2 = -mx
-                                mx_p2 = 2 ** int(math.floor(math.log(mx_p2, 2)))
-                                mx_p2 = -mx_p2  # minimum value represented with N bits signed
+                            else:  # mx < -255
+                                mx_p2 = 2 ** int(math.floor(math.log(-mx, 2)))
+                                mx_p2 = -mx_p2 - 1  # minimum value represented with N bits signed
 
                             mx = min(mx10, mx_p2)
                         else:
                             mx = prev_drange[1]
+
+                        # Some sanity check: if we end up with a very small range (eg, because there is a single value)
+                        # make the range at least 256 wide
+                        if mx - mn < 255:
+                            logging.warning(f"{mn} ~= {mx}")
+                            mx = mn + 255
 
                         drange = (mn, mx)
                 else:  # float

--- a/src/odemis/util/img.py
+++ b/src/odemis/util/img.py
@@ -142,7 +142,10 @@ def findOptimalRange(hist, edges, outliers=0):
     edges (tuple of 2 numbers): the values corresponding to the first and last
       bin of the histogram. To get an index, use edges = (0, len(hist)).
     outliers (0<float<0.5): ratio of outliers to discard (on both side). 0
-      discards no value, 0.5 discards every value (and so returns the median).
+    discards no value, 0.5 discards every value (and so returns the median).
+    Note: if outliers > 0, there is a trick that treats bin 0 (which represents pure black) as "special".
+    If bin 1 is empty, bin 0 will be considered empty. This is to handle images which have a black frame,
+    or black legend, so they are not included in the outliers count, and only the actual data counts.
     return (tuple of 2 values): the range (min and max values)
     """
     # If we got an histogram with only one value, don't try too hard.
@@ -162,7 +165,7 @@ def findOptimalRange(hist, edges, outliers=0):
         cum_hist = hist.cumsum()
         nval = cum_hist[-1]
 
-        # If it's an histogram of an empty array, don't try too hard.
+        # If it's a histogram of an empty array, don't try too hard.
         if nval == 0:
             return edges
 
@@ -170,7 +173,7 @@ def findOptimalRange(hist, edges, outliers=0):
         # value just above it, it's a sign that the black is not part of the
         # signal and so is all outliers
         if hist[1] == 0 and cum_hist[0] / nval > 0.01 and cum_hist[0] < nval:
-            cum_hist -= cum_hist[0] # don't count 0's in the outliers
+            cum_hist -= cum_hist[0]  # don't count 0's in the outliers
             nval = cum_hist[-1]
 
         # find out how much is the value corresponding to outliers

--- a/src/odemis/util/test/img_test.py
+++ b/src/odemis/util/test/img_test.py
@@ -312,6 +312,23 @@ class TestHistogram(unittest.TestCase):
         nchist = img.compactHistogram(hist, depth)
         numpy.testing.assert_array_equal(hist, nchist)
 
+    def test_compact_not_multiple(self):
+        """
+        test the compactHistogram()
+        """
+        # Histogram 1 pixel "too" long -> 1025px -> bins of 5 px -> length of 205px (multiple of bin size)
+        hist = numpy.ones(1025, dtype="uint16")
+        # make it compact
+        chist = img.compactHistogram(hist, 256)
+        self.assertEqual(len(chist), 205)
+        self.assertEqual(numpy.sum(chist), numpy.sum(hist))
+
+        # Histogram size deliberately not a multiple of 2: 401px -> bins of 2px -> length of 201px
+        hist = numpy.ones(401, dtype="uint16")
+        chist = img.compactHistogram(hist, 256)
+        self.assertEqual(len(chist), 201)
+        self.assertEqual(numpy.sum(chist), numpy.sum(hist))
+
 
 class TestDataArray2RGB(unittest.TestCase):
     @staticmethod

--- a/src/odemis/util/test/img_test.py
+++ b/src/odemis/util/test/img_test.py
@@ -75,11 +75,19 @@ class TestFindOptimalRange(unittest.TestCase):
         self.assertEqual(irange, (0, 255))
 
     def test_with_outliers(self):
-        # almost nothing, but more than 0
+        # almost no outliers, but more than 0 to trigger the "standard" path
         hist = numpy.zeros(256, dtype="int32")
         hist[128] = 4564
         irange = img.findOptimalRange(hist, (0, 255), 1e-6)
         self.assertEqual(irange, (128, 128))
+
+        # first + last
+        hist = numpy.zeros(256, dtype="int32")
+        hist[0] = 4564
+        hist[1] = 1  # to not trigger the special "trick" that skips the bin 0 if the bin 1 is empty
+        hist[255] = 4564
+        irange = img.findOptimalRange(hist, (0, 255), 1e-6)
+        self.assertEqual(irange, (0, 255))
 
         # 1%
         hist = numpy.zeros(256, dtype="int32")


### PR DESCRIPTION
This fixes display issues related to the histrogram in the GUI, and should also speed up a little bit the histrogram computation (not that it was really noticeable anyway).
Also makes some test cases pass again.