### PR TITLE
[feat] fastem acquisition: move stage in the scan direction to reduce…

### DIFF
--- a/install/linux/usr/share/odemis/sim/fastem-sim-asm.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/fastem-sim-asm.odm.yaml
@@ -126,8 +126,6 @@ FASTEM-sim: {
         # be opposite of the image axes, so that the center of the image corresponds
         # to the stage position.
         rotation: 3.141592653589793,  # rad (= 180°) won't be changed
-        # TODO: also add a shift between the origin of the stage-bare (at the middle of the carrier)
-        #  and the physical origin of the sample carrier (at the bottom left of the 1st scintillator)  -> translation
     },
 }
 
@@ -149,7 +147,7 @@ FASTEM-sim: {
         # X/Y: position of the scintillators
         # Z: useful range for the (auto) focus
         POS_ACTIVE_RANGE: {"x": [-25.e-3, 25.e-3], "y": [-24.5e-3, 24.5e-3], "z": [-85.e-6, 5.e-6]}, # m, min/max
-        FAV_POS_ACTIVE: {"z": -63.e-6},  # [m] Estimate for good focus position - autofocus starts here to search
+        FAV_POS_ACTIVE: {"z": -63.e-6},  # [m] Estimate for good focus position
         # Centers (X, Y) [m] of each scintillator from bottom-left position with a sample
         SAMPLE_CENTERS: {
             "SCINTILLATOR 1": [7.0e-3, 6.5e-3],
@@ -191,17 +189,16 @@ FASTEM-sim: {
 
 # Sample stage in multiprobe coordinate system:
 # Allows to move the stage in the same coordinate system as the multiprobe.
-# TODO check this
-#   A positive x movement moves a feature on the single field image to the right/left.
-#   A positive y movement moves a feature on the single field image to the top/bottom.
+#   A positive x movement moves a feature on the single field image to the left.
+#   A positive y movement moves a feature on the single field image to the bottom.
 # The X/Y axes are aligned with the X/Y axes of the multiprobe (or scan direction of
 # the ebeam scanner in multi-beam acquisition).
 # At high magnification the ebeam scale is more accurate than the stage movement. Adjust,
 # the scale of the stage to match a distance on the ebeam.
 "Sample Stage in multiprobe coordinates": {
     class: actuator.ConvertStage,
-    role: stage-scan,
-    dependencies: {"orig": "Sample Stage"},
+    role: scan-stage,
+    dependencies: {"orig": "Sample Stage XY Conversion"},
     init: {
         axes: ["x", "y"],  # names of the axes of "Sample Stage"
     },

--- a/src/odemis/acq/fastem.py
+++ b/src/odemis/acq/fastem.py
@@ -52,7 +52,7 @@ from odemis import model, util
 from odemis.acq import fastem_conf, stitching
 from odemis.acq.stitching import REGISTER_IDENTITY, FocusingMethod
 from odemis.acq.stream import SEMStream
-from odemis.util import img, TimeoutError
+from odemis.util import img, TimeoutError, transform
 
 # The executor is a single object, independent of how many times the module (fastem.py) is loaded.
 _executor = model.CancellableThreadPoolExecutor(max_workers=1)
@@ -435,7 +435,7 @@ def estimate_acquisition_time(roa, pre_calibrations=None):
     return tot_time
 
 
-def acquire(roa, path, scanner, multibeam, descanner, detector, stage, ccd, beamshift,
+def acquire(roa, path, scanner, multibeam, descanner, detector, stage, scan_stage, ccd, beamshift,
             lens, pre_calibrations=None, settings_obs=None):
     """
     Start a megafield acquisition task for a given region of acquisition (ROA).
@@ -452,7 +452,7 @@ def acquire(roa, path, scanner, multibeam, descanner, detector, stage, ccd, beam
     :param detector: (technolution.MPPC) The detector object to be used for collecting the image data.
     :param stage: (actuator.ConvertStage) The stage in the sample carrier coordinate system. The x and y axes are
         aligned with the x and y axes of the ebeam scanner.
-        FIXME use: The stage in the corrected scan coordinate system, the x and y axes are
+    :param scan_stage: (actuator.ConvertStage) The stage in the corrected scan coordinate system, the x and y axes are
             aligned with the x and y axes of the multiprobe and the multibeam scanner.
     :param ccd: (model.DigitalCamera) A camera object of the diagnostic camera.
     :param beamshift: (tfsbc.BeamShiftController) Component that controls the beamshift deflection.
@@ -475,7 +475,7 @@ def acquire(roa, path, scanner, multibeam, descanner, detector, stage, ccd, beam
 
     # TODO: pass path through attribute on ROA instead of argument?
     # Create a task that acquires the megafield image.
-    task = AcquisitionTask(scanner, multibeam, descanner, detector, stage, ccd, beamshift, lens, roa, path,
+    task = AcquisitionTask(scanner, multibeam, descanner, detector, stage, scan_stage, ccd, beamshift, lens, roa, path,
                            pre_calibrations, settings_obs, f)
 
     f.task_canceller = task.cancel  # lets the future know how to cancel the task.
@@ -493,7 +493,7 @@ class AcquisitionTask(object):
     An ROA consists of multiple single field images.
     """
 
-    def __init__(self, scanner, multibeam, descanner, detector, stage, ccd, beamshift, lens, roa, path,
+    def __init__(self, scanner, multibeam, descanner, detector, stage, scan_stage, ccd, beamshift, lens, roa, path,
                  pre_calibrations, settings_obs, future):
         """
         :param scanner: (xt_client.Scanner) Scanner component connecting to the XT adapter.
@@ -502,8 +502,8 @@ class AcquisitionTask(object):
         :param detector: (technolution.MPPC) The detector object to be used for collecting the image data.
         :param stage: (actuator.ConvertStage) The stage in the sample carrier coordinate system. The x and y axes are
             aligned with the x and y axes of the ebeam scanner.
-            FIXME use: The stage in the corrected scan coordinate system, the x and y axes are
-                aligned with the x and y axes of the multiprobe and the multibeam scanner.
+        :param scan_stage: (actuator.ConvertStage) The stage in the corrected scan coordinate system, the x and y axes
+            are aligned with the x and y axes of the multiprobe and the multibeam scanner.
         :param ccd: (model.DigitalCamera) A camera object of the diagnostic camera.
         :param beamshift: (tfsbc.BeamShiftController) Component that controls the beamshift deflection.
         :param lens: (static.OpticalLens) Optical lens component.
@@ -528,6 +528,7 @@ class AcquisitionTask(object):
         self._descanner = descanner
         self._detector = detector
         self._stage = stage
+        self._stage_scan = scan_stage
         self._ccd = ccd
         self._beamshift = beamshift
         self._lens = lens
@@ -717,14 +718,16 @@ class AcquisitionTask(object):
             raise ModuleNotFoundError("Need fastem_calibrations repository to run pre-calibrations.")
 
         logging.debug("Start pre-calibration.")
+        pos_hor, pos_vert = self.get_abs_stage_movement()  # get the absolute position for the new tile
 
-        stage_pos = self.get_abs_stage_movement()
+        logging.debug(f"Moving to stage position x: {pos_hor}, y: {pos_vert}")
+        self._stage_scan.moveAbsSync({'x': pos_hor, 'y': pos_vert})
 
         self._pre_calibrations_future = align(self._scanner, self._multibeam,
                                               self._descanner, self._detector,
                                               self._stage, self._ccd,
                                               self._beamshift, None,  # no need for the detector rotator
-                                              calibrations=pre_calibrations, stage_pos=stage_pos)
+                                              calibrations=pre_calibrations)
 
         try:
             self._pre_calibrations_future.result()  # wait for the calibrations to be finished
@@ -765,8 +768,6 @@ class AcquisitionTask(object):
     def get_pos_first_tile(self):
         """
         Get the stage position of the first tile
-        :param pos_first_tile: (float, float)
-            The (x, y) position of the center of the first tile, in the role='stage' coordinate system.
         """
         px_size = self._multibeam.pixelSize.value
         field_res = self._multibeam.resolution.value
@@ -775,11 +776,16 @@ class AcquisitionTask(object):
         # role='stage' coordinate system.
         xmin_roa, _, _, ymax_roa = self._roa.coordinates.value  # TODO: update with boundingbox instead of coordinates
 
+        # Transform from stage to scan-stage coordinate system
+        rot_cor = self._stage_scan.getMetadata()[model.MD_ROTATION_COR]
+        t = transform.RigidTransform(rotation=-rot_cor)
+        coords = t.apply([xmin_roa, ymax_roa])
+
         # The position of the stage when acquiring the top/left tile needs to be matching the center of that tile.
         # The stage coordinate system is pointing to the right in the x direction, and upwards in the y direction,
         # therefore add half a field in the x-direction and subtract half a field in the y-direction.
-        pos_first_tile = (xmin_roa + field_res[0] / 2 * px_size[0],
-                          ymax_roa - field_res[1] / 2 * px_size[1])
+        pos_first_tile = (coords[0] + field_res[0] / 2 * px_size[0],
+                          coords[1] - field_res[1] / 2 * px_size[1])
 
         return pos_first_tile
 
@@ -797,19 +803,14 @@ class AcquisitionTask(object):
         rel_move_vert = self.field_idx[1] * px_size[1] * field_res[1] * (1 - self._roa.overlap)  # in meter
 
         # Acceleration unknown, guessActuatorMoveDuration uses a default acceleration
-        estimated_time_x = guessActuatorMoveDuration(self._stage, "x", abs(rel_move_hor))  # s
-        estimated_time_y = guessActuatorMoveDuration(self._stage, "y", abs(rel_move_hor))  # s
+        estimated_time_x = guessActuatorMoveDuration(self._stage_scan, "x", abs(rel_move_hor))  # s
+        estimated_time_y = guessActuatorMoveDuration(self._stage_scan, "y", abs(rel_move_hor))  # s
         logging.debug(f"Estimated time for stage movement: {estimated_time_x + estimated_time_y} s")
 
         # With role="stage", move positive in x direction, because the second field should be right of the first,
         # and move negative in y direction, because the second field should be bottom of the first.
         pos_hor = self._pos_first_tile[0] + rel_move_hor
         pos_vert = self._pos_first_tile[1] - rel_move_vert
-        # TODO when stage-scan is implemented use commented lines
-        #   With role="stage-scan", move negative in x direction, because the second field should be right of the first,
-        #   and move positive in y direction, because the second field should be bottom of the first.
-        # pos_hor = pos_first_tile[0] - rel_move_hor
-        # pos_vert = pos_first_tile[1] + rel_move_vert
 
         return pos_hor, pos_vert
 
@@ -817,14 +818,14 @@ class AcquisitionTask(object):
         """Move the stage to the next tile (field image) position."""
         pos_hor, pos_vert = self.get_abs_stage_movement()  # get the absolute position for the new tile
 
-        logging.debug(f"Moving to stage position x: {pos_hor}, y: {pos_vert}")
+        logging.debug(f"Moving to scan-stage position x: {pos_hor}, y: {pos_vert}")
         t = time.time()
-        self._stage.moveAbsSync({'x': pos_hor, 'y': pos_vert})  # move the stage
+        self._stage_scan.moveAbsSync({'x': pos_hor, 'y': pos_vert})  # move the stage
         logging.debug(f"Actual time for stage movement: {time.time() - t} s")
-        stage_pos = self._stage.position.value
+        stage_pos = self._stage_scan.position.value
         diff_x = stage_pos["x"] - pos_hor
         diff_y = stage_pos["y"] - pos_vert
-        logging.debug(f"Moved to stage position {stage_pos}, "
+        logging.debug(f"Moved to scan-stage position {stage_pos}, "
                       f"difference in xy between actual and target stage position: {diff_x}, {diff_y} m")
 
     def correct_beam_shift(self):

--- a/src/odemis/gui/cont/fastem_acq.py
+++ b/src/odemis/gui/cont/fastem_acq.py
@@ -516,7 +516,8 @@ class FastEMAcquiController(object):
             for roa in p.roas.value:
                 f = fastem.acquire(roa, p.name.value, self._main_data_model.ebeam,
                                    self._main_data_model.multibeam, self._main_data_model.descanner,
-                                   self._main_data_model.mppc, self._main_data_model.stage, self._main_data_model.ccd,
+                                   self._main_data_model.mppc, self._main_data_model.stage,
+                                   self._main_data_model.scan_stage, self._main_data_model.ccd,
                                    self._main_data_model.beamshift, self._main_data_model.lens,
                                    pre_calibrations=pre_calibrations, settings_obs=self._main_data_model.settings_obs)
                 t = estimate_acquisition_time(roa, pre_calibrations)

--- a/src/odemis/gui/model/__init__.py
+++ b/src/odemis/gui/model/__init__.py
@@ -157,6 +157,8 @@ class MainGUIData(object):
         "chamber-ccd": "chamber_ccd",
         "overview-ccd": "overview_ccd",
         "stage": "stage",
+        # In SPARC scan-stage is an extra stage that scans instead of moving the e-beam,
+        # in FAST-EM scan-stage is the bare stage converted to move in the scan direction.
         "scan-stage": "scan_stage",
         "stage-bare": "stage_bare",
         "focus": "focus",


### PR DESCRIPTION
… the xy-offset between fields

Use the scan-stage instead of the stage component to move the stage during acquisition, this way the stage moves along the scan direction and the fields are placed neatly next to each other. The ROA coordinates are in stage coordinates, therefore are transformed to scan-stage coordinates when calculating the position of the first tile.