### PR TITLE
[fix] technolution driver does not support an overlap of 0%

### DIFF
--- a/src/odemis/acq/fastem.py
+++ b/src/odemis/acq/fastem.py
@@ -99,8 +99,7 @@ class FastEMROA(object):
     and detector.
     """
 
-    def __init__(self, name, coordinates, roc_2, roc_3, asm, multibeam, descanner, detector, overlap=0):
-
+    def __init__(self, name, coordinates, roc_2, roc_3, asm, multibeam, descanner, detector, overlap=0.06):
         """
         :param name: (str) Name of the region of acquisition (ROA). It is the name of the megafield (id) as stored on
                      the external storage.
@@ -117,8 +116,7 @@ class FastEMROA(object):
         :param detector: (technolution.MPPC) The detector object to be used for collecting the image data.
         :param overlap: (float), optional
             The amount of overlap required between single fields. An overlap of 0.2 means that two neighboring fields
-            overlap by 20%. By default, the overlap is 0, this means there is no overlap and one field is exactly next
-            to the neighboring field.
+            overlap by 20%. By default, the overlap is 0.06, this means there is 6% overlap between the fields.
         """
         self.name = model.StringVA(name)
         self.coordinates = model.TupleContinuous(coordinates,

--- a/src/odemis/driver/technolution.py
+++ b/src/odemis/driver/technolution.py
@@ -1737,7 +1737,14 @@ class MPPC(model.Detector):
         if model.MD_FIELD_SIZE in md:
             # The ASM API only accepts an effective field size that is a multiple of 32
             eff_field_size = md.get(model.MD_FIELD_SIZE)
-            if eff_field_size[0] % 32 != 0 or eff_field_size[1] % 32 != 0:
+            # FIXME there is a bug on technolutions side, therefore an overlap of 0% is not allowed.
+            #  Once this bug is fixed the first check can be removed.
+            if (eff_field_size[0] == self._scanner.resolution.value[0] or
+                    eff_field_size[1] == self._scanner.resolution.value[0]):
+                sug_field_size = self._scanner.resolution.value[0] - 32
+                suggested_overlap = 1 - sug_field_size / self._scanner.resolution.value[0]
+                raise ValueError(f"Overlap of 0 is not allowed, suggested overlap: {suggested_overlap * 100}%")
+            elif eff_field_size[0] % 32 != 0 or eff_field_size[1] % 32 != 0:
                 # Calculate the suggested overlap only based on the first axis,
                 # because the overlap is a single number and it is just a suggestion.
                 if eff_field_size[0] % 32 <= 16:


### PR DESCRIPTION
raise a ValueError when the overlap results in an effective field size of 6400. The default overlap has been updated to be 6%, this is currently used on all systems so is a reasonable default.