### PR TITLE
[refactor] Simplify comp.GridViewport

### DIFF
--- a/src/odemis/gui/comp/grid.py
+++ b/src/odemis/gui/comp/grid.py
@@ -22,204 +22,114 @@
 
 """
 import logging
+from typing import Sequence
+
 import wx
 
 from odemis.gui.util import AttrDict
 
 
 class ViewportGrid(wx.Panel):
-    """ Place multiple viewports on a grid and allow to swap or hide some of them """
+    """ Place multiple viewports on a grid and allow to swap or hide some of them
+    It has several sets and subsets of viewports:
+    * viewports: all the children viewports of this grid
+    * "valid viewports": subset of all the viewports, with only the one connected to a view
+    * visible_viewports: all the viewports to be shown at a given moment (there should be only valid viewports)
+    """
 
     def __init__(self, *args, **kwargs):
-        super(ViewportGrid, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         self.SetBackgroundColour(wx.BLACK)
 
-        # We need a separate attribute that contains all the child viewports, because the default
-        # Children property in wx.Python does not allow for reordering.
-        self.viewports = None
-
-        self._visible_viewports = []
-        self._invisible_viewports = []
+        self.viewports = None  # Tuple[ViewPort]
+        self.visible_viewports = []  # The ViewPorts to be shown, the order matters
 
         self.grid_layout = None
         # The size of the viewports when they are hidden
         self.hidden_size = (400, 400)
-        self.Bind(wx.EVT_SIZE, self.on_size)
-
-    @property
-    def visible_viewports(self):
-        """ Return all the viewports that are visible """
-        return self._visible_viewports
-
-    @visible_viewports.setter
-    def visible_viewports(self, visible_viewports):
-        self._visible_viewports = visible_viewports
-        self._invisible_viewports = [vp for vp in self.viewports if vp not in visible_viewports]
-
-    @property
-    def invisible_viewports(self):
-        """ Return all the viewports that are invisible """
-        return self._invisible_viewports
-
-    @invisible_viewports.setter
-    def invisible_viewports(self, invisible_viewports):
-        self._invisible_viewports = invisible_viewports
-        self._visible_viewports = [vp for vp in self.viewports if vp not in invisible_viewports]
-
-    def _show_hide_viewports(self):
-        """ Call the Show and Hide method an the appropriate Viewports """
-
-        for vp in self._visible_viewports:
-            vp.Show()
-
-        for vp in self._invisible_viewports:
-            vp.Hide()
+        self.Bind(wx.EVT_SIZE, self._on_size)
 
     # #### Viewport showing and hiding #### #
 
-    def set_shown_viewports(self, *show_viewports):
-        """ Show the given viewports and hide the rest """
-
-        self.visible_viewports = show_viewports
-        self._layout_viewports()
-        self._show_hide_viewports()
-
-    def set_hidden_viewports(self, *hide_viewports):
-        """ Hide the given viewports and show the rest """
-
-        self.invisible_viewports = hide_viewports
-        self._layout_viewports()
-        self._show_hide_viewports()
-
-    def hide_all_viewports(self):
-        """ Hide all viewports """
-        self.set_shown_viewports()
-
-    def get_4_viewports(self):
+    def _iter_valid_viewports(self):
         """
-        Gets the first 4 valid viewports to display in the 2 x 2 grid (ie,
-          viewports connected to a view)
-        return ([ViewPort])
+        Iterates over every viewport which is connected to a view
+        :yield: Viewport
         """
-        viewports = []
         for v in self.viewports:
             try:
                 if v.view is not None:
-                    viewports.append(v)
+                    yield v
             except AttributeError:
                 # Should never happen, unless it's not really a ViewPort.
                 # If so, let's not go completely bad
-                logging.exception("View %s has no view", v)
-                viewports.append(v)
-            if len(viewports) >= 4:
-                break
+                logging.warning("Viewport %s has no view", v)
+                pass
 
-        return viewports
-
-    def get_2_viewports(self):
+    def set_visible_viewports(self, vis_viewports: Sequence):
         """
-        Gets the first 2 valid viewports to display
-        return ([ViewPort])
+        Set the viewports to be shown, in the order given
+        (top-left, top-right, bottom-left, bottom-right).
+        All other viewports are hidden.
+        :param vis_viewports: the list of Viewports to display. Must be of length compatible with
+        the grid (1, 2, or 4).
         """
-        viewports = []
+        for vvp in vis_viewports:
+            if vvp not in self.viewports:
+                raise ValueError(f"Unknown Viewport ({vvp.view.name.value})!")
 
-        if len(self.visible_viewports) == 2:
-            logging.debug("Only two viewports are visible so these are shown.")
-            return self.visible_viewports
+        if len(vis_viewports) not in (1, 2, 4):
+            raise ValueError("Can only show 1, 2, or 4 viewports, but %d requested", len(vis_viewports))
 
-        else:
-            # If more/less than 2 viewports are visible use the first 2 viewports with a view
-            for v in self.viewports:
-                try:
-                    if v.view is not None and v.Shown:
-                        viewports.append(v)
-                except AttributeError:
-                    # Should never happen, unless it's not really a ViewPort.
-                    # If so, let's not go completely bad
-                    logging.exception("Viewport %s has no view", v)
-                    viewports.append(v)
-                if len(viewports) >= 2:
-                    logging.warning("Found more than two viewports to show, only the first 2 are displayed in this layout.")
-                    break
+        self.visible_viewports = tuple(vis_viewports)
+        logging.debug("Now showing %d viewports: %s", len(vis_viewports),
+                      ", ".join(vvp.view.name.value for vvp in vis_viewports))
 
-            return viewports
-
-    def show_2_vert_stacked_viewports(self):
-        """ Show the first two viewports in a 2x1 grid"""
-        self.visible_viewports = self.get_2_viewports()
         self._layout_viewports()
         self._show_hide_viewports()
-
-    def show_grid_viewports(self):
-        """ Show all grid viewports """
-        self.visible_viewports = self.get_4_viewports()
-        self._layout_viewports()
-        self._show_hide_viewports()
-
-    def show_viewport(self, viewport):
-        """ Show the given viewport """
-        if viewport not in self.visible_viewports:
-            self._visible_viewports.append(viewport)
-            self._invisible_viewports.remove(viewport)
-
-            self._layout_viewports()
-            self._show_hide_viewports()
-
-    def hide_viewport(self, viewport):
-        """ Hide the given viewport """
-        if viewport not in self.invisible_viewports:
-            self._invisible_viewports.append(viewport)
-            self._visible_viewports.remove(viewport)
-
-            self._layout_viewports()
-            self._show_hide_viewports()
 
     def set_enabled_viewports(self, enabled_viewports):
-        """ Disable the given viewports, so they won't update """
-        for viewport in self.viewports:
-            viewport.Enable(viewport in enabled_viewports)
-
-    def set_disabled_viewports(self, disable_viewports):
-        """ Disable the given viewports, so they won't update """
-        for viewport in self.viewports:
-            viewport.Enable(viewport not in disable_viewports)
+        """ Enable the given viewports, so they update, and disable the other ones """
+        for vp in self.viewports:
+            vp.Enable(vp in enabled_viewports)
 
     # #### END Viewport showing and hiding #### #
 
-    def on_size(self, _):
+    def _on_size(self, _):
         """ Grab the child windows and perform layout when the size changes """
+        # Hack: we initialise the visible viewports based on the children which are connected to a view
+        # Doing it at init wouldn't work because the viewports are not connected yet to their views,
+        # and in some cases they are added as children yet. So we wait
+        # for the first size update, which normally happens just after the whole GUI has been initialised.
         if self.viewports is None:
-            self.viewports = list(self.Children)
-            if len(self.viewports) == 1 or len(self.viewports) == 3:
-                # Cannot put uneven numbers on a grid => default to full screen for the 1st one.
-                # For numbers > 4 only the first four are displayed.
-                self.visible_viewports = self.viewports[:1]
-            elif len(self.viewports) == 2:
-                self.visible_viewports = self.get_2_viewports()
-            else:
-                self.visible_viewports = self.get_4_viewports()
+            self.viewports = tuple(self.Children)  # fixed for the rest of the runtime
 
+            valid_viewports = list(self._iter_valid_viewports())
+            # Pick the biggest number of valid viewports which can be displayed in a grid
+            n_visible_vp = len(valid_viewports)
+            n_visible_vp = max(n for n in (0, 1, 2, 4) if n <= n_visible_vp)
+            logging.debug("Initializing grid to %d viewports", n_visible_vp)
+            self.visible_viewports = valid_viewports[:n_visible_vp]
+
+        cs_x, cs_y = self.ClientSize
         self.grid_layout = AttrDict({
             'tl': AttrDict({
                 'pos': (0, 0),
-                'size': wx.Size(self.ClientSize.x // 2,
-                                self.ClientSize.y // 2)
+                'size': wx.Size(cs_x // 2, cs_y // 2)
             }),
             'tr': AttrDict({
-                'pos': (self.ClientSize.x // 2, 0),
-                'size': wx.Size(self.ClientSize.x - (self.ClientSize.x // 2),
-                                self.ClientSize.y // 2)
+                'pos': (cs_x // 2, 0),
+                'size': wx.Size(cs_x - (cs_x // 2),  # so that tl+tr sum precisely to the full client size
+                                cs_y // 2)
             }),
             'bl': AttrDict({
-                'pos': (0, self.ClientSize.y // 2),
-                'size': wx.Size(self.ClientSize.x // 2,
-                                self.ClientSize.y - (self.ClientSize.y // 2))
+                'pos': (0, cs_y // 2),
+                'size': wx.Size(cs_x // 2, cs_y - (cs_y // 2))
             }),
             'br': AttrDict({
-                'pos': (self.ClientSize.x // 2, self.ClientSize.y // 2),
-                'size': wx.Size(self.ClientSize.x - (self.ClientSize.x // 2),
-                                self.ClientSize.y - (self.ClientSize.y // 2))
+                'pos': (cs_x // 2, cs_y // 2),
+                'size': wx.Size(cs_x - (cs_x // 2), cs_y - (cs_y // 2))
             }),
         })
 
@@ -229,163 +139,50 @@ class ViewportGrid(wx.Panel):
     def _layout_viewports(self):
         """ Resize, position and display the child viewports
 
-        How the viewports are exactly layed out, depends on the their order and which ones are
+        How the viewports are exactly laid out, depends on their order and which ones are
         visible.
 
-        The first 4 viewports are considered to be in the 2x2 grid. Their order corresponds to
-        top left, top right, bottom left and bottom right.
-
         Number of visible viewports:
-
         0 - Set all sizes of the viewports to 400x400
-        1 - Display the visible viewport 'full screen', completely covering it's parent. The other
+        1 - Display the visible viewport 'full screen', completely covering its parent. The other
             viewports are resized to their default hidden size of 400x400 pixels
         2 - Display the visible viewports in a 2*1 vertically stacked grid.
-        X - If there is more than 2 visible viewports, we start looking at their positions,
-            because we only consider the first 4 to be in the 2x2 view.
-
-        Number of visible viewports in the first 4 positions:
-
-        < X - Raise an error, since when multiple viewports are visible, they should all be located
-              in the first four positions of the 2x2 grid
-        >=X - The rule of thumb we use is, that we iterate over the visible viewports in order and
-              they will expand into the space of any invisible neighbour.
-              (That's the point of forcing the first 4 viewports to be 'special')
-
+        4 - Along the 2x2 view.  Their order corresponds to top left, top right, bottom left and bottom right.
         """
-
         vvps = self.visible_viewports
         num_vis_total = len(vvps)
 
         # Everything hidden, no layout
         if num_vis_total == 0:
-            # Set the size of the invisible viewport to a relative small value, so we make sure that
-            # grabbing the client area for thumbnails will be relatively cheap
-            for viewport in [vp for vp in self.viewports if vp.Size != self.hidden_size]:
-                viewport.SetSize(self.hidden_size)
+            pass
         # One shown, make the viewport match the size of the parent
         elif num_vis_total == 1:
             vvps[0].SetSize(self.ClientSize)
             vvps[0].SetPosition((0, 0))
-            # TODO: Make invisible ones small!
-
         elif num_vis_total == 2:
-            gvps = self.get_2_viewports()
-            num_vis_grid = sum(vp in vvps for vp in gvps)
-            if num_vis_grid != num_vis_total:
-                raise ValueError("If viewports are set to be visible in a 2x1 grid, they should all reside within this "
-                                 "2x1 grid! (%d shown, %d in grid)" % (num_vis_total, num_vis_grid))
-
-            top, bottom = gvps
-            top_view, bottom_view = [vp in vvps for vp in gvps]
-
             gl = self.grid_layout
+            top, bottom = vvps
 
-           # Set the topview position and size
-            if top_view:
-                pos = gl.tl.pos
-                size = (gl.tl.size.x + (gl.tr.size.x),
-                        gl.tl.size.y)
-                top.SetPosition(pos)
-                top.SetSize(size)
-            elif top.Size != self.hidden_size:
-                top.SetSize(self.hidden_size)
-
-            # Set the bottom view position and size
-            if bottom_view:
-                pos = (0, gl.bl.pos[1])
-                size = (gl.bl.size.x + (gl.br.size.x),
-                        gl.bl.size.y)
-
-                bottom.SetPosition(pos)
-                bottom.SetSize(size)
-            elif bottom.Size != self.hidden_size:
-                bottom.SetSize(self.hidden_size)
+            top.SetPosition(gl.tl.pos)
+            top.SetSize((gl.tl.size.x + gl.tr.size.x, gl.tl.size.y))
+            bottom.SetPosition((0, gl.bl.pos[1]))
+            bottom.SetSize((gl.bl.size.x + gl.br.size.x, gl.bl.size.y))
+        elif num_vis_total == 4:
+            gl = self.grid_layout
+            for vp, layout in zip(vvps, (gl.tl, gl.tr, gl.bl, gl.br)):
+                vp.SetPosition(layout.pos)
+                vp.SetSize(layout.size)
 
         else:
-            gvps = self.get_4_viewports()
-            num_vis_grid = sum(vp in vvps for vp in gvps)
-            if num_vis_grid != num_vis_total:
-                raise ValueError("If multiple viewports are visible, they should all reside in the "
-                                 "2x2 grid! (%d shown, %d in grid)" % (num_vis_total, num_vis_grid))
+            raise ValueError("Doesn't know how to display %d viewports in a grid", num_vis_total)
 
-            tl, tr, bl, br = gvps
-            tlv, trv, blv, brv = [vp in vvps for vp in gvps]
+        # Set the size of the invisible viewport to a relative small value, so we make sure that
+        # grabbing the client area for thumbnails will be relatively cheap
+        for vp in self.viewports:
+            if vp not in self.visible_viewports and vp.Size != self.hidden_size:
+                vp.SetSize(self.hidden_size)
 
-            gl = self.grid_layout
-
-            if tlv:
-                pos = gl.tl.pos
-                size = (gl.tl.size.x + (gl.tr.size.x if not trv else 0),
-                        gl.tl.size.y + (gl.bl.size.y if not blv and not brv and trv else 0))
-
-                tl.SetPosition(pos)
-                tl.SetSize(size)
-                logging.debug("Layout top left: %s, %s", pos, size)
-            elif tl.Size != self.hidden_size:
-                tl.SetSize(self.hidden_size)
-
-            if trv:
-                pos = (gl.tr.pos[0] - (gl.tr.size.x if not tlv else 0), 0)
-                size = (gl.tr.size.x + (gl.tl.size.x if not tlv else 0),
-                        gl.tr.size.y + (gl.br.size.y if not brv and not blv and tlv else 0))
-
-                tr.SetPosition(pos)
-                tr.SetSize(size)
-                logging.debug("Layout top right: %s, %s", pos, size)
-            elif tr.Size != self.hidden_size:
-                tr.SetSize(self.hidden_size)
-
-            if blv:
-                pos = (0, gl.bl.pos[1] - (gl.tl.size.y if not tlv and not trv else 0))
-                size = (gl.bl.size.x + (gl.br.size.x if not brv else 0),
-                        gl.bl.size.y + (gl.tl.size.y if not tlv and not trv and brv else 0))
-
-                bl.SetPosition(pos)
-                bl.SetSize(size)
-                logging.debug("Layout bottom left (%s): %s, %s", bl, pos, size)
-            elif bl.Size != self.hidden_size:
-                bl.SetSize(self.hidden_size)
-
-            if brv:
-                pos = (gl.br.pos[0] - (gl.bl.size.x if not blv else 0),
-                       gl.br.pos[1] - (gl.tr.size.y if not trv and not tlv and blv else 0))
-                size = (gl.br.size.x + (gl.bl.size.x if not blv else 0),
-                        gl.br.size.y + (gl.tr.size.y if not trv and not tlv and blv else 0))
-
-                br.SetPosition(pos)
-                br.SetSize(size)
-                logging.debug("Layout bottom right: %s, %s", pos, size)
-            elif br.Size != self.hidden_size:
-                br.SetSize(self.hidden_size)
-
-    def _swap_viewports(self, vpa, vpb):
-        """
-        Switch the position of two viewports.
-        """
-        if vpa is vpb:
-            return
-        a, b = self.viewports.index(vpa), self.viewports.index(vpb)
-        self.viewports[a], self.viewports[b] = self.viewports[b], self.viewports[a]
-
-    def set_visible_viewports(self, vis_viewports):
-        """ Set the viewports to be shown
-
-        This method will move the viewports to be shown to the front of the viewport list (in
-        order) and will show them while hiding all others.
-
-        """
-
-        self.visible_viewports = vis_viewports
-
-        for i, vvp in enumerate(vis_viewports):
-            if vvp not in self.viewports:
-                raise ValueError("Unknown Viewport!")
-            # Swap won't happen if the viewports are the same
-            self._swap_viewports(vvp, self.viewports[i])
-
-        self._layout_viewports()
-        self._show_hide_viewports()
-
-    def get_win_grid_pos(self, win):
-        return self.viewports.index(win)
+    def _show_hide_viewports(self):
+        """ Show the visible viewports, and hide the other ones"""
+        for vp in self.viewports:
+            vp.Show(vp in self.visible_viewports)

--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -3417,8 +3417,8 @@ class AnalysisTab(Tab):
         assert(isinstance(viewports[6], LineSpectrumViewport))
         assert(isinstance(viewports[7], TemporalSpectrumViewport))
         assert(isinstance(viewports[8], ChronographViewport))
-        assert (isinstance(viewports[9], AngularResolvedViewport))
-        assert (isinstance(viewports[10], AngularSpectrumViewport))
+        assert(isinstance(viewports[9], AngularResolvedViewport))
+        assert(isinstance(viewports[10], AngularSpectrumViewport))
         assert(isinstance(viewports[11], ThetaViewport))
 
         vpv = collections.OrderedDict([
@@ -5124,15 +5124,7 @@ class EnzelAlignTab(Tab):
         # Pause all streams
         self.stream_bar_controller.pauseAllStreams()
 
-        for view in self.panel.pnl_two_streams_grid.viewports:
-            if view is top['viewport'] or view is bottom['viewport']:
-                view.Shown = True
-            else:
-                view.Shown = False
-        self.view_controller._grid_panel.set_shown_viewports(top['viewport'], bottom['viewport'])
         self.tab_data_model.visible_views.value = [top['viewport'].view, bottom['viewport'].view]
-
-        self.panel.pnl_two_streams_grid._layout_viewports()
 
         # Destroy the old stream controllers  # TODO This is a temporary fix and it could be handled better
         for stream_controller in self._stream_controllers:

--- a/src/odemis/gui/test/comp_grid_test.py
+++ b/src/odemis/gui/test/comp_grid_test.py
@@ -47,107 +47,67 @@ class GridPanelTestCase(test.GuiTestCase):
             vp.view = v
 
     def test_grid_view(self):
+        """
+        test showing 1, 2 and 4 windows
+        """
 
         gp = self.frame.grid_panel
 
         gui_loop(0.2)
         csize = self.frame.ClientSize
 
-        # Hide 1 windows
-
-        # Hide top left
-        gp.hide_viewport(self.frame.red)
+        f = self.frame
+        gp.set_visible_viewports([f.yellow, f.blue, f.purple, f.brown])
         gui_loop(0.2)
-        self.assertEqual(self.frame.blue.Size, (csize.x, gp.grid_layout.tr.size.y))
-        self.assertEqual(self.frame.purple.Size, gp.grid_layout.bl.size)
-        self.assertEqual(self.frame.brown.Size, gp.grid_layout.br.size)
-        gp.show_viewport(self.frame.red)
+        self.assertEqual(f.yellow.Size, gp.grid_layout.tl.size)
+        self.assertEqual(f.blue.Size, gp.grid_layout.tr.size)
+        self.assertEqual(f.purple.Size, gp.grid_layout.bl.size)
+        self.assertEqual(f.brown.Size, gp.grid_layout.br.size)
 
-        # Hide top right
-        gp.hide_viewport(self.frame.blue)
+        # Mix them around
+        gp.set_visible_viewports([f.green, f.yellow, f.blue, f.purple])
         gui_loop(0.2)
-        self.assertEqual(self.frame.red.Size, (csize.x, gp.grid_layout.tl.size.y))
-        self.assertEqual(self.frame.purple.Size, gp.grid_layout.bl.size)
-        self.assertEqual(self.frame.brown.Size, gp.grid_layout.br.size)
-        gp.show_viewport(self.frame.blue)
+        self.assertEqual(f.green.Size, gp.grid_layout.tl.size)
+        self.assertEqual(f.yellow.Size, gp.grid_layout.tr.size)
+        self.assertEqual(f.blue.Size, gp.grid_layout.bl.size)
+        self.assertEqual(f.purple.Size, gp.grid_layout.br.size)
 
-        # Hide bottom left
-        gp.hide_viewport(self.frame.purple)
+        # Show just 1 viewport
+        gp.set_visible_viewports([f.green])
         gui_loop(0.2)
-        self.assertEqual(self.frame.red.Size, gp.grid_layout.tl.size)
-        self.assertEqual(self.frame.blue.Size, gp.grid_layout.tr.size)
-        self.assertEqual(self.frame.brown.Size, (csize.x, gp.grid_layout.br.size.y))
-        gp.show_viewport(self.frame.purple)
+        self.assertEqual(f.green.Size, csize)
 
-        # Hide bottom right
-        gp.hide_viewport(self.frame.brown)
+        gp.set_visible_viewports([f.purple])
         gui_loop(0.2)
-        self.assertEqual(self.frame.red.Size, gp.grid_layout.tl.size)
-        self.assertEqual(self.frame.blue.Size, gp.grid_layout.tr.size)
-        self.assertEqual(self.frame.purple.Size, (csize.x, gp.grid_layout.bl.size.y))
-        gp.show_viewport(self.frame.brown)
+        self.assertEqual(f.purple.Position, (0, 0))
+        self.assertEqual(f.purple.Size, csize)
+        self.assertTrue(f.purple.Shown)
+        self.assertFalse(f.green.Shown)
 
-        # Hide 2 windows
-
-        # Hide top
-        gp.hide_viewport(self.frame.red)
-        gp.hide_viewport(self.frame.blue)
+        # Back to 2x2
+        gp.set_visible_viewports([f.green, f.yellow, f.blue, f.purple])
         gui_loop(0.2)
-        self.assertEqual(self.frame.purple.Size, (csize.x, gp.grid_layout.tl.size.y))
-        self.assertEqual(self.frame.brown.Size, (csize.x, gp.grid_layout.bl.size.y))
-        gp.show_viewport(self.frame.red)
-        gp.show_viewport(self.frame.blue)
+        self.assertEqual(f.green.Size, gp.grid_layout.tl.size)
+        self.assertEqual(f.yellow.Size, gp.grid_layout.tr.size)
+        self.assertEqual(f.blue.Size, gp.grid_layout.bl.size)
+        self.assertEqual(f.purple.Size, gp.grid_layout.br.size)
 
-        # Hide right
-        gp.hide_viewport(self.frame.blue)
-        gp.hide_viewport(self.frame.brown)
+        # 2 stacked
+
+        gp.set_visible_viewports([f.blue, f.purple])
         gui_loop(0.2)
-        self.assertEqual(self.frame.red.Size, (csize.x, gp.grid_layout.tl.size.y))
-        self.assertEqual(self.frame.purple.Size, (csize.x, gp.grid_layout.bl.size.y))
-        gp.show_viewport(self.frame.brown)
-        gp.show_viewport(self.frame.blue)
+        self.assertEqual(f.blue.Size, (csize.x, gp.grid_layout.tr.size.y))
+        self.assertEqual(f.purple.Size, (csize.x, gp.grid_layout.br.size.y))
+        self.assertTrue(f.purple.Shown)
+        self.assertFalse(f.green.Shown)
 
-        # Hide bottom
-        gp.hide_viewport(self.frame.purple)
-        gp.hide_viewport(self.frame.brown)
+        # Back to 4x2
+        gp.set_visible_viewports([f.green, f.yellow, f.blue, f.purple])
         gui_loop(0.2)
-        self.assertEqual(self.frame.red.Size, (csize.x, gp.grid_layout.tl.size.y))
-        self.assertEqual(self.frame.blue.Size, (csize.x, gp.grid_layout.bl.size.y))
-        gp.show_viewport(self.frame.brown)
-        gp.show_viewport(self.frame.purple)
-
-        # Hide left
-        gp.hide_viewport(self.frame.red)
-        gp.hide_viewport(self.frame.purple)
-        gui_loop(0.2)
-        self.assertEqual(self.frame.blue.Size, (csize.x, gp.grid_layout.tr.size.y))
-        self.assertEqual(self.frame.brown.Size, (csize.x, gp.grid_layout.br.size.y))
-        gp.show_viewport(self.frame.purple)
-        gp.show_viewport(self.frame.red)
-
-        # Hide 3 windows
-
-        gp.set_shown_viewports(self.frame.red)
-        gui_loop(0.2)
-        self.assertEqual(self.frame.red.Size, csize)
-
-        gp.set_shown_viewports(self.frame.blue)
-        gui_loop(0.2)
-        self.assertEqual(self.frame.blue.Size, csize)
-
-        gp.set_shown_viewports(self.frame.purple)
-        gui_loop(0.2)
-        self.assertEqual(self.frame.purple.Size, csize)
-
-        gp.set_shown_viewports(self.frame.brown)
-        gui_loop(0.2)
-        self.assertEqual(self.frame.brown.Size, csize)
-
-        gp.set_shown_viewports(self.frame.yellow)
-        gui_loop(0.2)
-        self.assertEqual(self.frame.yellow.Size, csize)
-
-        gp.show_grid_viewports()
+        self.assertEqual(f.green.Size, gp.grid_layout.tl.size)
+        self.assertEqual(f.yellow.Size, gp.grid_layout.tr.size)
+        self.assertEqual(f.blue.Size, gp.grid_layout.bl.size)
+        self.assertEqual(f.purple.Size, gp.grid_layout.br.size)
 
     def test_grid_edit(self):
 


### PR DESCRIPTION
This component had two main issues:
* A lot of the functions in the interface were never used in Odemis
* It tried to be clever, but was clever differently from what the rest
  of the GUI wanted. So the GUI had to find tricks to make it behave
  as it really wanted it.

Also, it used to support 2,3,and 4 viewports in a grid, with some larger
than others. However, as it wasn't fitting the GUI, the code was
protected and never used.

=> Simplify the code to just show the viewports requested, in the order
requested.

Also simplify the test cases.