### PR TITLE
[fix] xtclient correctly raise hardware error with message

### DIFF
--- a/src/odemis/driver/xt_client.py
+++ b/src/odemis/driver/xt_client.py
@@ -237,7 +237,7 @@ class SEM(model.HwComponent):
             raise HwError("Failed to connect to XT server '%s'. Check that the "
                           "uri is correct and XT server is"
                           " connected to the network. %s" % (address, err))
-        except OSError:
+        except OSError as err:
             raise HwError("XT server reported error: %s." % (err,))
 
         # Transfer latest xtadapter package if available


### PR DESCRIPTION
In commit c4b4f0723949748a71f6675b8703405fb3017acc initialization errors in the xtclient were adjusted to report them with more precision. However the OSError was except as `except OSError:` not `except OSError as err`, since `err` was not assigned this caused a problem when an OSError was raised.