### PR TITLE
[SDEV-1356] fix fastem test cases

### DIFF
--- a/.github/workflows/unit_tests_cloud.yml
+++ b/.github/workflows/unit_tests_cloud.yml
@@ -177,3 +177,9 @@ jobs:
       run: |
         export PYTHONPATH="$PWD/src:$PYTHONPATH"
         python3 -m unittest src/odemis/gui/win/test/acquisition_test.py --verbose
+
+    - name: Run mocked tests from odemis.acq.fastem
+      if: ${{ !cancelled() }}
+      run: |
+        export PYTHONPATH="$PWD/src:$PYTHONPATH"
+        python3 -m unittest src.odemis.acq.test.fastem_test.TestFastEMAcquisitionTaskMock --verbose


### PR DESCRIPTION
[fix] fastem test cases fixed after being broken due to overlap and scan-stage updates
    
Commit 0c32be368bd491b416d5973abefba227b62367da fixed that the overlap is not allowed to be zero in the technolution API. The commit also updated the default value of the overlap to be 0.06 instead of 0.0. The test cases were written for an overlap of 0.0 and failed because of this.
Commit 9f40d9af143c305871a172ee0ff5581ffa397836 added the scan-stage as an input argument for the acquire function and the AcquisitionTask, but the test cases that called these functions were not updated.
Because of these commits the test cases were failing, this has now been fixed by using an overlap of 0.06 in the test cases and using the scan-stage.

[add] fastem test case for expected stage location with rotation correction
    
9f40d9af143c305871a172ee0ff5581ffa397836 added the movement of the stage in the scan-stage direction, but there was no test case added.

[ci] fastem mocked test cases added to cloud hosted CI

