### PR TITLE
[feature] cli convert: add filename expansion to tile names

### DIFF
--- a/src/odemis/cli/convert.py
+++ b/src/odemis/cli/convert.py
@@ -22,6 +22,7 @@ You should have received a copy of the GNU General Public License along with Ode
 # convert --input file-as.hdf5 --output file-as.ome.tiff
 
 import argparse
+import glob
 from gettext import ngettext
 import logging
 import numpy
@@ -249,6 +250,14 @@ def main(args):
                      len(data), ngettext("image", "images", len(data)),
                      len(thumbs), ngettext("thumbnail", "thumbnails", len(thumbs)))
     elif tifns:
+        if len(tifns) == 1:
+            # Only passed a single filename for tiling? Most likely that is a pattern, so let's expand it.
+            # In the case it was really a specific file, we just end up with the same file, so it's safe.
+            file_pattern = tifns[0]
+            tifns = glob.glob(file_pattern)
+            if not tifns:
+                raise ValueError(f"No file matching filename {file_pattern}")
+
         registration_method = {"identity": REGISTER_IDENTITY, "shift": REGISTER_SHIFT,
                                "global_shift": REGISTER_GLOBAL_SHIFT}[options.registrar]
         weaving_method = {"collage": WEAVER_COLLAGE, "mean": WEAVER_MEAN,


### PR DESCRIPTION
The --tiles argument can take many filenames. That can be a lot for the
command line. In some cases, it's also not handy to pass the whole list
(ex, when debugging, or running on Windows).

So detect that there is only one argument, and in this case, attempt to
expend it using the standard glob rules.
In the case it was a normal file, just that file is returned. So the
current behaviour is not changed, just "expended".