### PR TITLE
[fix] AngularSpectrumSettingsStream update binning on acquisition start too

### DIFF
--- a/src/odemis/acq/stream/_base.py
+++ b/src/odemis/acq/stream/_base.py
@@ -805,7 +805,6 @@ class Stream(object):
                 # the VA setter to catch again the change
                 self._linkHwVAs()
                 self._linkHwAxes()
-                # TODO: create generic fct linkHWAxes and call here
             else:
                 self._unlinkHwVAs()
                 self._unlinkHwAxes()

--- a/src/odemis/acq/stream/_helper.py
+++ b/src/odemis/acq/stream/_helper.py
@@ -1211,33 +1211,19 @@ class AngularSpectrumSettingsStream(PolarizedCCDSettingsStream):
             simple_md[model.MD_WL_LIST] = md[model.MD_WL_LIST]
         return simple_md
 
-    def _is_active_setter(self, active):
+    def _linkHwVAs(self):
         """
-        Called when stream is active/playing. Links the angular and spectrum binning VAs to
-        the camera resolution VA and the detector binning depending on whether the stream
-        is active or not.
-        :param active: (boolean) True if stream is playing.
-        :returns: (boolean) If stream is playing or not.
+        Subscribes the detector binning to the spectrum and angular binning VAs.
         """
-        self._active = super(AngularSpectrumSettingsStream, self)._is_active_setter(active)
-
-        if self._active:
-            self._linkBin2CamRes()
-        else:
-            self._unlinkBin2CamRes()
-        return self._active
-
-    def _linkBin2CamRes(self):
-        """
-        Subscribes the detector resolution and binning to the spectrum and angular binning VAs.
-        """
+        super()._linkHwVAs()
         self.angular_binning.subscribe(self._onBinning, init=True)
         self.spectrum_binning.subscribe(self._onBinning, init=True)
 
-    def _unlinkBin2CamRes(self):
+    def _unlinkHwVAs(self):
         """
-        Unsubscribes the detector resolution and binning and update the GUI
+        Unsubscribes the detector binning
         """
+        super()._unlinkHwVAs()
         self.angular_binning.unsubscribe(self._onBinning)
         self.spectrum_binning.unsubscribe(self._onBinning)
 


### PR DESCRIPTION
In the EK (AR spectrum) stream, If the user changed the binning settings, and immediately started an
acquisition, without playing the stream, then the binning would not be set.
(This is a rare case)

=> Instead of having a special function for connecting the binning VAs,
override the general _*linkHwVAs() functions. The acquisition MD streams
are aware of these functions and explicitly call them.

This even simplifies the code.