### PR TITLE
[TRCL-10] validate SE, CL and EBIC simultaneous acquisition

### DIFF
--- a/install/linux/usr/share/odemis/sim/sparc2-streakcam-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/sparc2-streakcam-sim.odm.yaml
@@ -2,15 +2,6 @@
 SPARC2: {
     class: Microscope,
     role: sparc2,
-    children: ["SEM E-beam", "SEM Detector", "Calibration Light",
-               "Optical Path Properties", "Spectrometer Vis-NIR",
-               "Camera", "CL Detector", "Spectrograph",
-               "Spec Filter Wheel", "Spec CCD Flipper", "Spectrograph focus",
-               "Mirror Actuators", "Mirror Actuators in XY referential",
-               "Slit", "CL Selector", "CL Filter Wheel",
-               "Lens1 Mover", "Lens2 Switch",
-               "Streak Readout CCD", "Streak Delay Generator", "Streak Unit",
-               "Streak Lens"],
 }
 
 # Light (lamp with known spectrum)
@@ -57,6 +48,7 @@ SPARC2: {
        scanner: "SEM E-beam",
        detector0: "SEM Detector",
        detector1: "CL PMT",
+       detector2: "EBIC",
     }
 }
 
@@ -79,7 +71,7 @@ SPARC2: {
         dwellTime: 10.e-6, # s
         magnification: 100, # (ratio)
     },
-    affects: ["SEM Detector", "Camera"] # affects the CCD in case of cathodoluminescence
+    affects: ["SEM Detector", "Camera", "EBIC"] # affects the CCD in case of cathodoluminescence
 }
 
 # Must be connected on AI 0/AI GND
@@ -126,6 +118,18 @@ SPARC2: {
        "pmt-control": "CL PMT control unit",
     },
 }
+
+# EBIC: In either configuration, the signal is either ±10V or ±5V. As the signal can be positive and negative, is uses the full range.
+# Must be connected on AI 2/AI 10 (differential)
+"EBIC": {
+    # Internal child of SEM Scan Interface, so no class
+    role: ebic-detector,
+    init: {
+        channel: 2,
+        limits: [-10, 10], # V
+    },
+}
+
 
 # In reality, this is a Zyla, but you need libandor3-dev to simulate an AndorCam3
 # Depending exactly on the configuration, it might also be used for spectrometer

--- a/src/odemis/acq/stream/__init__.py
+++ b/src/odemis/acq/stream/__init__.py
@@ -57,6 +57,7 @@ class EMStream(ABC):
 EMStream.register(SEMStream)
 EMStream.register(SpotSEMStream)
 EMStream.register(StaticSEMStream)
+EMStream.register(EBICSettingsStream)
 
 
 class CLStream(ABC):
@@ -69,7 +70,6 @@ class CLStream(ABC):
 CLStream.register(CLSettingsStream)
 CLStream.register(StaticCLStream)
 # TODO, also include MonochromatorSettingsStream and SEMMDStream?
-
 
 class SpectrumStream(ABC):
     pass

--- a/src/odemis/acq/stream/_helper.py
+++ b/src/odemis/acq/stream/_helper.py
@@ -697,10 +697,6 @@ class CCDSettingsStream(RepetitionStream):
         return duration
 
 
-class PMTSettingsStream(RepetitionStream):
-    pass
-
-
 class SpectrumSettingsStream(CCDSettingsStream):
     """ A Spectrum stream.
 
@@ -860,7 +856,7 @@ class TemporalSpectrumSettingsStream(CCDSettingsStream):
             self.detMCPGain.range = (0, self.detMCPGain.value)
 
 
-class MonochromatorSettingsStream(PMTSettingsStream):
+class MonochromatorSettingsStream(RepetitionStream):
     """
     A stream acquiring a count corresponding to the light at a given wavelength,
     typically with a counting PMT as a detector via a spectrograph.
@@ -1292,29 +1288,13 @@ class AngularSpectrumAlignmentStream(AngularSpectrumSettingsStream):
 
         super(AngularSpectrumSettingsStream, self)._onNewData(dataflow, data)
 
-
-class CLSettingsStream(PMTSettingsStream):
-    """
-    A spatial cathodoluminescense stream, typically with a PMT as a detector.
-    It's physically very similar to the AR stream, but as the acquisition time
-    is many magnitudes shorter (ie, close to the SED), the live view is the
-    entire image.
-
-    In live view, the ROI is not applied, but the pixelSize is.
-
-    Note: It could be possible to acquire an image simultaneously to the
-      SED in live view, but they would need to pick one dwell time/resolution.
-      That would be tricky to handle when starting/stopping one of the streams.
-
-    """
+class FastScanningDetector(RepetitionStream):
 
     def __init__(self, name, detector, dataflow, emitter, **kwargs):
         """
         emtvas: don't put resolution or scale
         """
-        if "acq_type" not in kwargs:
-            kwargs["acq_type"] = model.MD_AT_CL
-        super(CLSettingsStream, self).__init__(name, detector, dataflow, emitter, **kwargs)
+        super().__init__(name, detector, dataflow, emitter, **kwargs)
         # Don't change pixel size, as we keep the same as the SEM
 
         # Fuzzing is not handled for SEM/SEM streams (and doesn't make much
@@ -1372,7 +1352,7 @@ class CLSettingsStream(PMTSettingsStream):
         logging.debug("Setting scale to %f, based on pxs = %g m", scale, self.pixelSize.value)
         self._emitter.scale.value = (scale, scale)
 
-        # use full FoV
+        # use the full FoV
         res = tuple(int(round(s / scale)) for s in self._emitter.shape[:2])
         self._emitter.resolution.value = res
 
@@ -1384,7 +1364,7 @@ class CLSettingsStream(PMTSettingsStream):
         if active:
             self._applyROI()
 
-        super(CLSettingsStream, self)._onActive(active)
+        super()._onActive(active)
 
     def _onDwellTime(self, value):
         # TODO: restarting the acquisition means also resetting the protection.
@@ -1394,13 +1374,58 @@ class CLSettingsStream(PMTSettingsStream):
     def _onResolution(self, value):
         self._updateAcquisitionTime()
 
+
+class CLSettingsStream(RepetitionStream):
+    """
+    A spatial cathodoluminescense stream, typically with a PMT as a detector.
+    It's physically very similar to the AR stream, but as the acquisition time
+    is many magnitudes shorter (ie, close to the SED), the live view is the
+    entire image.
+
+    In live view, the ROI is not applied, but the pixelSize is.
+
+    Note: It could be possible to acquire an image simultaneously to the
+      SED in live view, but they would need to pick one dwell time/resolution.
+      That would be tricky to handle when starting/stopping one of the streams.
+
+    """
+
+    def __init__(self, name, detector, dataflow, emitter, **kwargs):
+        """
+        emtvas: don't put resolution or scale
+        """
+        if "acq_type" not in kwargs:
+            kwargs["acq_type"] = model.MD_AT_CL
+        super().__init__(name, detector, dataflow, emitter, **kwargs)
+        # Don't change pixel size, as we keep the same as the SEM
+
     def _onNewData(self, dataflow, data):
         # TODO: read protection status just after acquisition
         # How? Export protection VA from PMT? Have a warning status?
         # protection = self._detector.protection.value
         # And update the stream status if protection was triggered
-        super(CLSettingsStream, self)._onNewData(dataflow, data)
+        super()._onNewData(dataflow, data)
 
+
+class EBICSettingsStream(FastScanningDetector):
+    """
+    A SEM stream, typically with a EBIC (current) as a detector.
+    It's physically very similar to the SEM stream, but as we want to select just a region
+    it's in practice similar to the CLSettingStream.
+
+    In live view, the ROI is not applied, but the pixelSize is.
+
+    Note: It could be possible to acquire an image simultaneously to the
+      SED in live view, but they would need to pick one dwell time/resolution.
+      That would be tricky to handle when starting/stopping one of the streams.
+    """
+    def __init__(self, name, detector, dataflow, emitter, **kwargs):
+        """
+        emtvas: don't put resolution or scale
+        """
+        if "acq_type" not in kwargs:
+            kwargs["acq_type"] = model.MD_AT_EM
+        super().__init__(name, detector, dataflow, emitter, **kwargs)
 
 # Maximum allowed overlay difference in electron coordinates.
 # Above this, the find overlay procedure will consider an error occurred and

--- a/src/odemis/gui/comp/stream.py
+++ b/src/odemis/gui/comp/stream.py
@@ -1381,6 +1381,7 @@ class StreamBar(wx.Panel):
         acq.stream.ScannerSettingsStream,
         acq.stream.SEMStream,
         acq.stream.StaticSEMStream,
+        acq.stream.EBICSettingsStream,
         acq.stream.BrightfieldStream,
         acq.stream.StaticStream,
         acq.stream.FluoStream,


### PR DESCRIPTION
add test cases with SE, CL and EBIC acquisitions
validate to have SE, CL and EBIC acquisitions simultaneously
remove unnecessary `children` from sparc2 streak cam sim microscope file