### PR TITLE
[CSDM-1101] util.dataio.data_to_static_streams() stop guessing that data with tint means FLM data

### DIFF
--- a/src/odemis/util/dataio.py
+++ b/src/odemis/util/dataio.py
@@ -116,9 +116,6 @@ def data_to_static_streams(data):
         elif model.MD_OUT_WL in d.metadata:  # only MD_OUT_WL
             name = d.metadata.get(model.MD_DESCRIPTION, "Cathodoluminescence")
             klass = stream.StaticCLStream
-        elif model.MD_USER_TINT in d.metadata:  # User requested a colour => fallback to FluoStream
-            name = d.metadata.get(model.MD_DESCRIPTION, "Filtered colour")
-            klass = stream.StaticFluoStream
         elif dims in ("CYX", "YXC") and d.shape[ci] in (3, 4):
             # Only decide it's RGB as last resort, because most microscopy data is not RGB
             name = d.metadata.get(model.MD_DESCRIPTION, "RGB data")


### PR DESCRIPTION
A while ago, only Fluoresence data had tint associated to it. So in case
a DataArray had a MD_USER_TINT, we could easily guess it's FLM data.
That was also helpful for the corner cases where it's not FLM data, but
it needs to be tinted, as that was the only stream that allowed this.

Now, every stream can have tint. So it's not a good hint, and also it's
fine if tinted SEM data is shown as SEM... as it will be tinted.
So we can drop this guessing method.

It fixes two issues:
* On the SPARC, when opening acquisition data, sometimes the SEM data
would be detected as FluoStream, and then it would complain there is no
excitation and emission metadadata.
* When re-stitching tiles from the SPARC, the SEM concurent stream wasn't
detected as SEM data, and so wasn't used for stitching, even if it had
the best scan resolution.