### PR TITLE
[fix] remove use of parenthesis in class definitions that do not use inheritance.

### DIFF
--- a/src/odemis/acq/path.py
+++ b/src/odemis/acq/path.py
@@ -373,7 +373,7 @@ def affectsGraph(microscope):
     return graph
 
 
-class OpticalPathManager():
+class OpticalPathManager:
     """
     The purpose of this module is setting the physical components contained in
     the optical path of a SPARC system to the right position/configuration with

--- a/src/odemis/gui/test/comp_overlay_test.py
+++ b/src/odemis/gui/test/comp_overlay_test.py
@@ -1174,7 +1174,7 @@ class OverlayTestCase(test.GuiTestCase):
         }
         ccd = mock.FakeCCD(img)  # role is always "ccd"
 
-        class FakeTabData():
+        class FakeTabData:
             def __init__(self):
                 self.mirrorPositionTopPhys = model.TupleContinuous((100e-6, 0),
                                            ((-1e18, -1e18), (1e18, 1e18)), unit="m",


### PR DESCRIPTION
https://github.com/delmic/odemis/pull/2589 adds a pipeline for checking syntax errors, this commit fixes the errors related to old style classes.