### PR TITLE
[fix][METEOR-521] disable the "use current z" button if live view is not selected

### DIFF
--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -519,11 +519,12 @@ class LocalizationTab(Tab):
         chamber_tab.load_overview_streams(visible_ov_streams)
 
     def _on_view(self, view):
-        """Hide hardware related sub-panels on the right when not in live stream"""
+        """Hide/Disable hardware related sub-panels and controls on the right when not in live stream"""
         live = issubclass(view.stream_classes, odemis.acq.stream._live.LiveStream)
         self.panel.fp_settings_secom_optical.Show(live)
         self.panel.fp_secom_streams.Show(live)
         self.panel.fp_acquisitions.Show(live)
+        self.panel.btn_use_current_z.Enable(live)
 
     @property
     def settingsbar_controller(self):

--- a/src/odemis/gui/main.xrc
+++ b/src/odemis/gui/main.xrc
@@ -8476,6 +8476,7 @@
 											  <height>24</height>
 											    <bg>#000000</bg>
 											  <label>Use Current Z</label>
+                                              <tooltip>Save the current position of the focus as the feature Z position</tooltip>
 											  <style>wxALIGN_CENTRE</style>
 											</object>
 										<flag>wxLEFT</flag>

--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -9552,6 +9552,7 @@ def __init_resources():
 											  <height>24</height>
 											    <bg>#000000</bg>
 											  <label>Use Current Z</label>
+                                              <tooltip>Save the current position of the focus as the feature Z position</tooltip>
 											  <style>wxALIGN_CENTRE</style>
 											</object>
 										<flag>wxLEFT</flag>


### PR DESCRIPTION
Add a tooltip to the button use current z