### PR TITLE
[fix] add stream button works again on Meteor

### DIFF
--- a/src/odemis/gui/cont/streams.py
+++ b/src/odemis/gui/cont/streams.py
@@ -2533,7 +2533,7 @@ class SecomStreamsController(StreamBarController):
                 self._tab_data_model.emState.value = guimodel.STATE_OFF
 
 
-class CryoStreamsController(StreamBarController):
+class CryoStreamsController(SecomStreamsController):
     """
     Controls the display of stream panels without affecting the actual streams
     """


### PR DESCRIPTION
broken by commit 5420cab9e Show relevant static streams in stream panel based on the view selected by the user in the Localisation Tab