### PR TITLE
[TRCL-55] add folding of the streams

### DIFF
--- a/src/odemis/acq/stream/_helper.py
+++ b/src/odemis/acq/stream/_helper.py
@@ -1076,7 +1076,6 @@ class ARSettingsStream(PolarizedCCDSettingsStream):
     """
 
     def __init__(self, name, detector, dataflow, emitter, **kwargs):
-
         if "acq_type" not in kwargs:
             kwargs["acq_type"] = model.MD_AT_AR
 
@@ -1361,7 +1360,7 @@ class FastScanningDetector(RepetitionStream):
         self._updateAcquisitionTime()
 
 
-class CLSettingsStream(RepetitionStream):
+class CLSettingsStream(FastScanningDetector):
     """
     A spatial cathodoluminescense stream, typically with a PMT as a detector.
     It's physically very similar to the AR stream, but as the acquisition time
@@ -1498,6 +1497,7 @@ class OverlayStream(Stream):
           by the FindOverlay function to make it return DataArrays, as a normal
           future from a Stream should do.
         """
+
         @wraps(f)
         def result_as_da(timeout=None):
             trans_val, (opt_md, sem_md) = f(timeout)
@@ -1717,6 +1717,7 @@ class ScannedTemporalSettingsStream(CCDSettingsStream):
     """
     Stream that allows to acquire a 2D spatial map with the time correlator for lifetime mapping or g(2) mapping.
     """
+
     def __init__(self, name, detector, dataflow, emitter, **kwargs):
         if "acq_type" not in kwargs:
             kwargs["acq_type"] = model.MD_AT_TEMPORAL

--- a/src/odemis/gui/main.xrc
+++ b/src/odemis/gui/main.xrc
@@ -6082,6 +6082,45 @@
                             <object class="wxBoxSizer">
                               <orient>wxHORIZONTAL</orient>
                               <object class="sizeritem">
+                                <object class="wxStaticBitmap" name="bmp_fold_acq_info">
+                                  <bitmap>img/icon/dialog_info.png</bitmap>
+                                  <hidden>1</hidden>
+                                  <XRCED>
+                                    <assign_var>1</assign_var>
+                                  </XRCED>
+                                </object>
+                              <flag>wxRIGHT</flag>
+                              <border>5</border>
+                              </object>
+                              <object class="sizeritem">
+                                <object class="wxStaticText" name="lbl_sparc_fold_acq">
+                                  <label>Some streams will be acquired simultaneously</label>
+                                  <fg>#DDDDDD</fg>
+                                  <font>
+                                    <size>10</size>
+                                    <sysfont>wxSYS_DEFAULT_GUI_FONT</sysfont>
+                                  </font>
+                                  <hidden>1</hidden>
+                                  <XRCED>
+                                    <assign_var>1</assign_var>
+                                  </XRCED>
+                                </object>
+                              </object>
+                        </object>
+                      </object>
+                        <flag>wxLEFT</flag>
+                        <border>12</border>
+                      <bg>#333333</bg>
+                      <object>
+                        <flag>wxLEFT|wxTOP|wxBOTTOM|wxEXPAND</flag>
+                        <border>12</border>
+                      </object>
+                    </object>
+                        <object class="sizeritem">
+                          <object class="wxPanel">
+                            <object class="wxBoxSizer">
+                              <orient>wxHORIZONTAL</orient>
+                              <object class="sizeritem">
                                 <object class="wxStaticBitmap" name="bmp_acq_status_info">
                                   <bitmap>img/icon/dialog_info.png</bitmap>
                                   <hidden>1</hidden>

--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -612,6 +612,8 @@ class xrcpnl_tab_sparc_acqui(wx.Panel):
         self.txt_filename = xrc.XRCCTRL(self, "txt_filename")
         self.btn_sparc_change_file = xrc.XRCCTRL(self, "btn_sparc_change_file")
         self.txt_destination = xrc.XRCCTRL(self, "txt_destination")
+        self.bmp_fold_acq_info = xrc.XRCCTRL(self, "bmp_fold_acq_info")
+        self.lbl_sparc_fold_acq = xrc.XRCCTRL(self, "lbl_sparc_fold_acq")
         self.bmp_acq_status_info = xrc.XRCCTRL(self, "bmp_acq_status_info")
         self.bmp_acq_status_warn = xrc.XRCCTRL(self, "bmp_acq_status_warn")
         self.lbl_sparc_acq_estimate = xrc.XRCCTRL(self, "lbl_sparc_acq_estimate")
@@ -7154,6 +7156,45 @@ def __init_resources():
                           <flag>wxALL|wxEXPAND</flag>
                           <border>10</border>
                         </object>
+                        <object class="sizeritem">
+                          <object class="wxPanel">
+                            <object class="wxBoxSizer">
+                              <orient>wxHORIZONTAL</orient>
+                              <object class="sizeritem">
+                                <object class="wxStaticBitmap" name="bmp_fold_acq_info">
+                                  <bitmap>img_icon_dialog_info_png</bitmap>
+                                  <hidden>1</hidden>
+                                  <XRCED>
+                                    <assign_var>1</assign_var>
+                                  </XRCED>
+                                </object>
+                              <flag>wxRIGHT</flag>
+                              <border>5</border>
+                              </object>
+                              <object class="sizeritem">
+                                <object class="wxStaticText" name="lbl_sparc_fold_acq">
+                                  <label>Some streams will be acquired simultaneously</label>
+                                  <fg>#DDDDDD</fg>
+                                  <font>
+                                    <size>10</size>
+                                    <sysfont>wxSYS_DEFAULT_GUI_FONT</sysfont>
+                                  </font>
+                                  <hidden>1</hidden>
+                                  <XRCED>
+                                    <assign_var>1</assign_var>
+                                  </XRCED>
+                                </object>
+                              </object>
+                        </object>
+                      </object>
+                        <flag>wxLEFT</flag>
+                        <border>12</border>
+                      <bg>#333333</bg>
+                      <object>
+                        <flag>wxLEFT|wxTOP|wxBOTTOM|wxEXPAND</flag>
+                        <border>12</border>
+                      </object>
+                    </object>
                         <object class="sizeritem">
                           <object class="wxPanel">
                             <object class="wxBoxSizer">


### PR DESCRIPTION
Add folding of the CL intensity and EBIC streams for SPARC if the dwell time, repetition, roi values are the same and the detectors are different

Add an info text on the GUI as well that lets the user know the acquisitions will be folded(merged)

Add test cases with different dwell time, repetition, roi combinations for the folding

Lastly, fix small PEP-8 incompatibilities