### PR TITLE
[METEOR-881] Add test case for multiple images from multiple manufacturers

### DIFF
--- a/src/odemis/dataio/test/generate_test_metadata.py
+++ b/src/odemis/dataio/test/generate_test_metadata.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+'''
+Created on 23 Jan 2024
+
+@author: Patrick Cleeve
+
+Copyright © 2024, Delmic
+
+This file is part of Odemis.
+
+Odemis is free software: you can redistribute it and/or modify it under the terms 
+of the GNU General Public License version 2 as published by the Free Software 
+Foundation.
+
+Odemis is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with 
+Odemis. If not, see http://www.gnu.org/licenses/.
+'''
+import argparse
+import datetime
+import glob
+import json
+import logging 
+import os
+
+from odemis import model
+from odemis.util.dataio import open_acquisition
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+"""The test case in multi_test_tiff.py requires additional test data to be downloaded from Drive/Software Engineering/Test data/metor/test_images
+and the associated metadata to be generated using this generate_test_metadata.py script.
+
+To generate the test metadata, run the following command from the root of the repository:
+
+python -m odemis.dataio.test.generate_test_metadata --path <path to test data>
+
+This will generate a test_metadata.json file in the test data directory. This file is used by the test case in multi_tiff_test.
+"""
+
+def write_test_metadata(path: str):
+    """Write test metadata to json file.
+    Use this function to generate test metadata in the required from a directory of *.tif images.
+    It will write the test_metadata.json file to the same directory as the test data.
+    :param path: (str) path to test data (directory of *.tif images)"""
+
+    filenames = glob.glob(os.path.join(path, "**/*.tif*"), recursive=True) 
+    test_metadata = {}
+
+    for fname in filenames:
+
+        try:
+            data = open_acquisition(fname)[0].getData()
+
+            # format metadata for tests
+            tmd = data.metadata
+            tmd["filename"] = os.path.basename(fname).replace(".tif", "")
+            tmd["shape"] = data.shape
+            tmd["dtype"] = str(data.dtype)
+            tmd["length"] = 1
+
+            # convert timestamp into datetime
+            ts = data.metadata[model.MD_ACQ_DATE]
+            tmd["timestamp"] = ts
+            tmd["datetime"] = datetime.datetime.fromtimestamp(ts).strftime('%Y-%m-%d %H:%M:%S')
+
+            test_metadata[tmd["filename"]] = tmd
+
+        except Exception as e:
+            logging.warning(f"Could not parse {fname}. Exception: {e}")
+
+    # save test_metadata as json
+    with open(os.path.join(path, "test_metadata.json"), "w") as f:
+        json.dump(test_metadata, f)
+    
+    return test_metadata
+
+def main():
+
+    parser = argparse.ArgumentParser(description='Generate test metadata from a directory of *.tif images.')
+    parser.add_argument('--path', type=str, help='Path to test data (directory of *.tif images).')
+    args = parser.parse_args()
+
+    # write test metadata
+    write_test_metadata(args.path)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/odemis/dataio/test/multi_tiff_test.py
+++ b/src/odemis/dataio/test/multi_tiff_test.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+'''
+Created on 23 Jan 2024
+
+@author: Patrick Cleeve
+
+Copyright © 2024, Delmic
+
+This file is part of Odemis.
+
+Odemis is free software: you can redistribute it and/or modify it under the terms 
+of the GNU General Public License version 2 as published by the Free Software 
+Foundation.
+
+Odemis is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; 
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with 
+Odemis. If not, see http://www.gnu.org/licenses/.
+'''
+import glob
+import json
+import os
+import unittest
+
+import numpy
+
+from odemis import model
+from odemis.dataio import tiff
+
+
+"""This test case requires additional test data to be downloaded from Drive/Software Engineering/Test data/metor/test_images 
+and the associated metadata to be generated using the generate_test_metadata.py script.
+
+To generate the test metadata, run the following command from the root of the repository:
+
+python -m odemis.dataio.test.generate_test_metadata --path ~/test_data/meteor/test_images
+
+This will generate a test_metadata.json file in the test data directory. This file is used by the test case below. 
+You will need to re-run this script if you add new test data.
+
+"""
+
+class TestMultiTiffIO(unittest.TestCase):
+
+  def test_manufacturer_metadata_parsers(self):
+    """Test open_data function with multiple manufacturers and metadata parsers."""
+
+    # test data path (only available on hosted runner atm)
+    # To setup or update: copy data from Drive/Software Engineering/Test data/metor/test_images to home directory
+    TEST_PATH = os.path.join(os.path.expanduser('~'), "test_data/meteor/test_images")
+    IGNORED_KEYS = ["shape", "dtype", "length", "filename", "timestamp", "datetime"]
+
+    # if test path doesnt exist, we are on github actions, just ignore for now
+    # TODO: download test data for github actions
+    if not os.path.exists(TEST_PATH):
+        raise unittest.SkipTest(f"Test data not found at {TEST_PATH}. Skipping test.")
+
+    # open metadata from test_metadata.json
+    with open(os.path.join(TEST_PATH, "test_metadata.json"), "r") as f:
+        test_metadata = json.load(f)    
+
+    for fname, md in test_metadata.items():
+
+        # open data    
+        fname = os.path.join(TEST_PATH, "**", f"{fname}*.tif")
+        fname = glob.glob(fname, recursive=True)[0]
+        data = tiff.open_data(fname)
+
+        # assert data
+        self.assertIsInstance(data, tiff.AcquisitionDataTIFF)
+        self.assertEqual(len(data.content), md["length"])
+        numpy.testing.assert_array_equal(data.content[0].shape, md["shape"])
+        self.assertEqual(data.content[0].dtype.__name__, md["dtype"])
+
+        for key, value in md.items():
+            if key in IGNORED_KEYS:
+                continue # skip
+            self.assertIn(key, data.content[0].metadata)
+            if key in [model.MD_PIXEL_SIZE, model.MD_POS]: # array equal
+                numpy.testing.assert_array_equal(value, data.content[0].metadata[key])
+            elif key in [model.MD_DWELL_TIME]:
+                numpy.testing.assert_almost_equal(value, data.content[0].metadata[key])
+            else:
+                self.assertEqual(value, data.content[0].metadata[key])
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
This pull request adds:

- A writer for writing image metadata to test case format.
- A test case for testing the parsers for multiple manufacturers on multiple images