### PR TITLE
[fix] failing smaract testpicoscale test position testcase

### DIFF
--- a/src/odemis/driver/test/smaract_test.py
+++ b/src/odemis/driver/test/smaract_test.py
@@ -768,7 +768,7 @@ class TestPicoscale(unittest.TestCase):
         self.dev.position.subscribe(pos_listener)
         if TEST_NOHW:
             # New sensor position in simulator
-            self.dev.core.positions[0] = 2.5e-6
+            self.dev.si.positions[0] = 2.5e-6
         time.sleep(1.1)  # position should be updated every second
         self.assertTrue(self.pos_update)
 


### PR DESCRIPTION
core is no longer used, instead si is used which is the fake or actual smaract.si module