### PR TITLE
[SDEV-1692] Fix and refactor registrar classes

### DIFF
--- a/src/odemis/acq/stitching/_registrar.py
+++ b/src/odemis/acq/stitching/_registrar.py
@@ -140,7 +140,7 @@ class ShiftRegistrar(object):
     def getPositions(self):
         """
         returns:
-        tile_positions (list of N tuples): the adjusted position in X/Y for each tile, in the order they were added
+        tile_positions (list of N tuples): the adjusted position in X/Y for each tile, in the order they were added [m]
         dep_tile_positions (list of N tuples of K tuples of 2 floats): for each tile, it returns
         the adjusted position of each dependent tile (in the order they were passed)
         """

--- a/src/odemis/acq/stitching/test/registrar_test.py
+++ b/src/odemis/acq/stitching/test/registrar_test.py
@@ -43,9 +43,9 @@ logging.getLogger().setLevel(logging.DEBUG)
 
 # Find path for test images
 IMG_PATH = os.path.dirname(odemis.__file__)
+# "simsem-fake-output.h5" and "songbird-sim-ccd.h5" fail. (simsem-fake-output works with global alignment)
 IMGS = [IMG_PATH + "/driver/songbird-sim-sem.h5",
         IMG_PATH + "/acq/align/test/images/Slice69_stretched.tif"]
-# "simsem-fake-output.h5" and "songbird-sim-ccd.h5" fail. (simsem-fake-output works with global alignment)
 
 
 # @unittest.skip("skip")
@@ -80,8 +80,7 @@ class TestIdentityRegistrar(unittest.TestCase):
                     h = int(0.9 * size[0])
                     idx1 = int(0.05 * size[0])
                     idx2 = int(0.05 * size[1])
-                    img[idx1:idx1 + h, idx2:idx2 + l] = \
-                            numpy.zeros((h, l), dtype=dtype)
+                    img[idx1:idx1 + h, idx2:idx2 + l] = numpy.zeros((h, l), dtype=dtype)
 
                     # Crop two tiles with different shifts
                     tsize = (int(0.3 * size[0]), int(0.6 * size[1]))
@@ -103,24 +102,17 @@ class TestIdentityRegistrar(unittest.TestCase):
                         model.MD_PIXEL_SIZE: px_size
                     }
 
-                    tiles = [model.DataArray(
-                        tile1, md1), model.DataArray(tile2, md2)]
+                    tiles = [model.DataArray(tile1, md1),
+                             model.DataArray(tile2, md2)]
                     registrar = IdentityRegistrar()
                     for t in tiles:
                         registrar.addTile(t)
 
-                    diff = numpy.subtract(registrar.getPositions()[
-                                          0][0], md1[model.MD_POS])
-                    # one pixel difference allowed
-                    self.assertLessEqual(diff[0] * px_size[0], 1)
-                    self.assertLessEqual(diff[1] * px_size[1], 1)
-
-                    # Shift is ignored by IdentityRegistrar
-                    diff = (registrar.getPositions()[0][1][0] - (md2[model.MD_POS][0]),
-                            registrar.getPositions()[0][1][1] - (md2[model.MD_POS][1]))
-                    # one pixel difference allowed
-                    self.assertLessEqual(diff[0], 1)
-                    self.assertLessEqual(diff[1], 1)
+                    tile_positions, _ = registrar.getPositions()
+                    for t, md_pos in zip(tile_positions, [md1[model.MD_POS], md2[model.MD_POS]]):
+                        # For the IdentityRegistrar the positions should be exactly equal
+                        self.assertEqual(t[0], md_pos[0])
+                        self.assertEqual(t[1], md_pos[1])
 
     def test_white_image(self):
         """ Position should be left as-is in case of white images """
@@ -158,15 +150,13 @@ class TestIdentityRegistrar(unittest.TestCase):
                  model.DataArray(tile3, md3), model.DataArray(tile4, md4)]
 
         registrar = IdentityRegistrar()
-        calculatedPositions, _ = registrar.getPositions()
-        for t, cp, p in zip(tiles, calculatedPositions, pos):
+        calculated_positions, _ = registrar.getPositions()
+        for t, cp, p in zip(tiles, calculated_positions, pos):
             registrar.addTile(t)
-            diff1 = abs(cp[0] - p[0])
-            diff2 = abs(cp[1] - p[1])
 
-            # should return initial position value, small error of 0.01 allowed
-            self.assertLessEqual(diff1, 1.3e-6)
-            self.assertLessEqual(diff2, 1.3e-6)
+            # should return initial position value, for a white image
+            self.assertEqual(cp[0], p[0])
+            self.assertEqual(cp[1], p[1])
 
     def test_shift_real(self):
         """ Test on decomposed image with known shift """
@@ -185,9 +175,9 @@ class TestIdentityRegistrar(unittest.TestCase):
                         registrar = IdentityRegistrar()
                         for i in range(len(pos)):
                             registrar.addTile(tiles[i])
-                            calculatedPositions = registrar.getPositions()[0]
-                            diff1 = abs(calculatedPositions[i][0] - pos[i][0])
-                            diff2 = abs(calculatedPositions[i][1] - pos[i][1])
+                            calculated_positions = registrar.getPositions()[0]
+                            diff1 = abs(calculated_positions[i][0] - pos[i][0])
+                            diff2 = abs(calculated_positions[i][1] - pos[i][1])
                             # allow difference of 10% of overlap
                             px_size = tiles[i].metadata[model.MD_PIXEL_SIZE]
                             # allow error of 1% of tileSize
@@ -196,10 +186,10 @@ class TestIdentityRegistrar(unittest.TestCase):
 
                             self.assertLessEqual(diff1, margin1,
                                                  "Failed for %s tiles, %s overlap and %s method," % (num, o, a) +
-                                                 " %f != %f" % (calculatedPositions[i][0], pos[i][0]))
+                                                 " %f != %f" % (calculated_positions[i][0], pos[i][0]))
                             self.assertLessEqual(diff2, margin2,
                                                  "Failed for %s tiles, %s overlap and %s method," % (num, o, a) +
-                                                 " %f != %f" % (calculatedPositions[i][1], pos[i][1]))
+                                                 " %f != %f" % (calculated_positions[i][1], pos[i][1]))
 
     def test_shift_real_manual(self):
         """ Test case not generated by decompose.py file and manually cropped """
@@ -222,10 +212,10 @@ class TestIdentityRegistrar(unittest.TestCase):
             })
             registrar.addTile(tile1)
             registrar.addTile(tile2)
-            calculatedPositions = registrar.getPositions()[0]
-            self.assertAlmostEqual(calculatedPositions[1][0], 520 / 20, places=1)
+            calculated_positions = registrar.getPositions()[0]
+            self.assertAlmostEqual(calculated_positions[1][0], 520 / 20, places=1)
             self.assertAlmostEqual(
-                calculatedPositions[1][1], img.shape[1] / 20 - 200 / 20, places=1)
+                calculated_positions[1][1], img.shape[1] / 20 - 200 / 20, places=1)
 
     def test_dependent_tiles(self):
         """ Tests functionality for dependent tiles """
@@ -313,44 +303,58 @@ class TestShiftRegistrar(unittest.TestCase):
         random.seed(1)
 
     def test_synthetic_images(self):
-        """ Test on synthetic images with rectangles """
-
+        """Test stitching works for synthetic images with randomly drawn horizontal and vertical lines"""
         # Image with large rectangle, different shifts, datatypes and tile
         # sizes
-        shifts = [(0, 0), (10, 10), (0, 10), (8, 5), (-6, 5)]
-        t_sizes = [(500, 500), (300, 400), (500, 200)]
+        shifts = [(0, 0), (10, 10), (0, 10), (8, 5), (6, -5)]
+        img_sizes = [(500, 500), (300, 400), (500, 200)]
         dtypes = [numpy.int8, numpy.int16]
+        px_size = (1e-6, 1e-6)
 
         for shift in shifts:
-            for size in t_sizes:
+            for img_size in img_sizes:
                 for dtype in dtypes:
-                    img = 255 * numpy.ones(size, dtype=dtype)
+                    # create a black image
+                    img = numpy.zeros(img_size, dtype=dtype)
+                    for _ in range(int(img_size[0] / 3)):
+                        # Randomly draw vertical and horizontal lines
+                        is_vertical = random.choice([True, False])
+                        if is_vertical:
+                            # Draw a vertical line
+                            x = random.randint(0, img_size[0])
+                            color = random.randint(1, 256)
+                            img[x:x + 2, :] = color
+                        else:
+                            # Draw a horizontal line
+                            y = random.randint(0, img_size[1])
+                            color = random.randint(1, 256)
+                            img[:, y: y + 2] = color
 
-                    # Rectangle
-                    l = int(0.9 * size[1])
-                    h = int(0.9 * size[0])
-                    idx1 = int(0.05 * size[0])
-                    idx2 = int(0.05 * size[1])
-                    img[idx1:idx1 + h, idx2:idx2 + l] = \
-                            numpy.zeros((h, l), dtype=dtype)
+                    # Crop two tiles from the full image
+                    tile_size = (int(0.4 * img_size[0]), int(0.4 * img_size[1]))
+                    start1 = (0, 0)
+                    end1 = (start1[0] + tile_size[0], start1[1] + tile_size[1])
+                    tile1 = img[start1[0]:end1[0], start1[1]:end1[1]]
 
-                    # Crop two tiles with different shifts
-                    tsize = (int(0.3 * size[0]), int(0.6 * size[1]))
-                    start = (0, 0)
-                    end = (start[0] + tsize[0], start[1] + tsize[1])
-                    tile1 = img[start[0]:end[0], start[1]:end[1]]
+                    # 40% horizontal overlap between the two tiles
+                    start2 = (0, int(0.6 * tile_size[1]))
+                    # shift the start position of the second tile by the shift
+                    shifted_start2 = numpy.add(start2, shift)
+                    end2 = (shifted_start2[0] + tile_size[0], shifted_start2[1] + tile_size[1])
+                    tile2 = img[shifted_start2[0]:end2[0], shifted_start2[1]:end2[1]]
 
-                    start = numpy.add((int(0.2 * size[0]), 0), shift)
-                    end = (start[0] + tsize[0], start[1] + tsize[1])
-                    tile2 = img[start[0]:end[0], start[1]:end[1]]
-
-                    px_size = (1e-6, 2e-5)
+                    # position of the first tile is in the center of the tile,
+                    # use axis 1 first, because the registrar expects physical coordinates.
+                    pos1 = (0.5 * tile_size[1] * px_size[1],
+                            0.5 * tile_size[0] * px_size[0])
                     md1 = {
-                        model.MD_POS: (0.15 * size[0] * px_size[0], 30e-3),
+                        model.MD_POS: pos1,
                         model.MD_PIXEL_SIZE: px_size
                     }
+                    pos2 = ((start2[1] + 0.5 * tile_size[1]) * px_size[1],
+                            (start2[0] + 0.5 * tile_size[0]) * px_size[0])
                     md2 = {
-                        model.MD_POS: (0.35 * size[0] * px_size[0], 30e-3),
+                        model.MD_POS: pos2,
                         model.MD_PIXEL_SIZE: px_size
                     }
 
@@ -360,17 +364,13 @@ class TestShiftRegistrar(unittest.TestCase):
                     for t in tiles:
                         registrar.addTile(t)
 
-                    diff = numpy.subtract(registrar.getPositions()[0][0],
-                                          md1[model.MD_POS])
-                    # one pixel difference allowed
-                    self.assertLessEqual(diff[0], 1)
-                    self.assertLessEqual(diff[1], 1)
-
-                    diff = (registrar.getPositions()[0][1][0] - (md2[model.MD_POS][0] + shift[0] * px_size[0]),
-                            registrar.getPositions()[0][1][1] - (md2[model.MD_POS][1] + shift[1] * px_size[1]))
-                    # one pixel difference allowed
-                    self.assertLessEqual(diff[0], 1)
-                    self.assertLessEqual(diff[1], 1)
+                    tile_positions, _ = registrar.getPositions()
+                    # test the positions of the first tile
+                    self.assertAlmostEqual(tile_positions[0][0], md1[model.MD_POS][0])
+                    self.assertAlmostEqual(tile_positions[0][1], md1[model.MD_POS][1])
+                    # test the positions of the second tile
+                    self.assertAlmostEqual(tile_positions[1][0], (md2[model.MD_POS][0] + shift[1] * px_size[1]))
+                    self.assertAlmostEqual(tile_positions[1][1], (md2[model.MD_POS][1] - shift[0] * px_size[0]))
 
     def test_white_image(self):
         """ Position should be left as-is in case of white images """
@@ -410,13 +410,11 @@ class TestShiftRegistrar(unittest.TestCase):
         registrar = ShiftRegistrar()
         for i in range(len(tiles)):
             registrar.addTile(tiles[i])
-            calculatedPositions = registrar.getPositions()[0]
-            diff1 = abs(calculatedPositions[i][0] - pos[i][0])
-            diff2 = abs(calculatedPositions[i][1] - pos[i][1])
+            calculated_positions = registrar.getPositions()[0]
 
-            # should return initial position value, small error of 0.01 allowed
-            self.assertLessEqual(diff1, 1.3e-6)
-            self.assertLessEqual(diff2, 1.3e-6)
+            # should return initial position value
+            self.assertEqual(calculated_positions[i][0], pos[i][0])
+            self.assertEqual(calculated_positions[i][1], pos[i][1])
 
     def test_shift_real(self):
         """ Test on decomposed image with known shift """
@@ -442,9 +440,12 @@ class TestShiftRegistrar(unittest.TestCase):
             registered_pos = registrar.getPositions()[0]
             diff = numpy.absolute(numpy.subtract(registered_pos, real_pos))
             allowed_px_offset = numpy.repeat(numpy.multiply(px_size, 5), len(diff))
-            numpy.testing.assert_array_less(diff.flatten(), allowed_px_offset.flatten(),
-                        "Position %s pxs off for image '%s', " % (max(diff.flatten()) / px_size[0], img_name) +
-                        "%s x %s tiles, %s ovlp, %s method." % (num, num, o, a))
+            numpy.testing.assert_array_less(diff.flatten(),
+                                            allowed_px_offset.flatten(),
+                                            "Position %s pxs off for image '%s', " % (
+                                                max(diff.flatten()) / px_size[0], img_name) +
+                                            "%s x %s tiles, %s ovlp, %s method." % (num, num, o, a)
+                                            )
 
     def test_shift_real_manual(self):
         """ Test case not generated by decompose.py file and manually cropped """
@@ -467,10 +468,10 @@ class TestShiftRegistrar(unittest.TestCase):
             })
             registrar.addTile(tile1)
             registrar.addTile(tile2)
-            calculatedPositions = registrar.getPositions()[0]
-            diff1 = calculatedPositions[1][0] - 522 / 20
+            calculated_positions = registrar.getPositions()[0]
+            diff1 = calculated_positions[1][0] - 522 / 20
             self.assertLessEqual(diff1, 1 / 20)
-            diff2 = calculatedPositions[1][1] - img.shape[1] / 20 - 204 / 20
+            diff2 = calculated_positions[1][1] - img.shape[1] / 20 - 204 / 20
             self.assertLessEqual(diff2, 1 / 20)
 
     def test_shift_rectangular(self):
@@ -500,14 +501,13 @@ class TestShiftRegistrar(unittest.TestCase):
             })
             registrar.addTile(tile1)
             registrar.addTile(tile2)
-            calculatedPositions = registrar.getPositions()[0]
-            logging.debug("Found shift: %s", calculatedPositions[1])
+            calculated_positions = registrar.getPositions()[0]
+            logging.debug("Found shift: %s", calculated_positions[1])
 
-            testing.assert_tuple_almost_equal(calculatedPositions[0], (0, 0))
+            testing.assert_tuple_almost_equal(calculated_positions[0], (0, 0))
 
             exp_pos2 = shift[0] * pxs[0], -shift[1] * pxs[1]  # m, - to invert Y
-            testing.assert_tuple_almost_equal(calculatedPositions[1], exp_pos2, delta=pxs[0])
-
+            testing.assert_tuple_almost_equal(calculated_positions[1], exp_pos2, delta=pxs[0])
 
     def test_dependent_tiles(self):
         """ Tests functionality for dependent tiles """
@@ -549,14 +549,18 @@ class TestShiftRegistrar(unittest.TestCase):
             for p, tile in zip(pos, dep_tile_pos):
                 for dep_tile in tile:
                     diff1 = abs(dep_tile[0] - p[0])
-                    self.assertLessEqual(diff1, margin1,
-                         "Failed for %s tiles, %s overlap and %s method," % (num, o, a) +
-                         " %f != %f" % (dep_tile[0], p[0]))
+                    self.assertLessEqual(diff1,
+                                         margin1,
+                                         "Failed for %s tiles, %s overlap and %s method," % (num, o, a) +
+                                         " %f != %f" % (dep_tile[0], p[0])
+                                         )
 
                     diff2 = abs(dep_tile[1] - p[1])
-                    self.assertLessEqual(diff2, margin2,
-                         "Failed for %s tiles, %s overlap and %s method," % (num, o, a) +
-                         " %f != %f" % (dep_tile[1], p[1]))
+                    self.assertLessEqual(diff2,
+                                         margin2,
+                                         "Failed for %s tiles, %s overlap and %s method," % (num, o, a) +
+                                         " %f != %f" % (dep_tile[1], p[1])
+                                         )
 
             # Test with shifted dependent tiles
             [tiles, pos] = decompose_image(img, o, num, a)
@@ -609,44 +613,58 @@ class TestGlobalShiftRegistrar(unittest.TestCase):
         random.seed(1)
 
     def test_synthetic_images(self):
-        """ Test on synthetic images with rectangles """
-
+        """Test stitching works for synthetic images with randomly drawn horizontal and vertical lines"""
         # Image with large rectangle, different shifts, datatypes and tile
         # sizes
-        shifts = [(0, 0), (10, 10), (0, 10), (8, 5), (-6, 5)]
-        t_sizes = [(500, 500), (300, 400), (500, 200)]
+        shifts = [(0, 0), (10, 10), (0, 10), (8, 5), (6, -5)]
+        img_sizes = [(500, 500), (300, 400), (500, 200)]
         dtypes = [numpy.int8, numpy.int16]
+        px_size = (1e-6, 1e-6)
 
         for shift in shifts:
-            for size in t_sizes:
+            for img_size in img_sizes:
                 for dtype in dtypes:
-                    img = 255 * numpy.ones(size, dtype=dtype)
+                    # create a black image
+                    img = numpy.zeros(img_size, dtype=dtype)
+                    for _ in range(int(img_size[0] / 3)):
+                        # Randomly draw vertical and horizontal lines
+                        is_vertical = random.choice([True, False])
+                        if is_vertical:
+                            # Draw a vertical line
+                            x = random.randint(0, img_size[0])
+                            color = random.randint(1, 256)
+                            img[x:x + 2, :] = color
+                        else:
+                            # Draw a horizontal line
+                            y = random.randint(0, img_size[1])
+                            color = random.randint(1, 256)
+                            img[:, y: y + 2] = color
 
-                    # Rectangle
-                    l = int(0.9 * size[1])
-                    h = int(0.9 * size[0])
-                    idx1 = int(0.05 * size[0])
-                    idx2 = int(0.05 * size[1])
-                    img[idx1:idx1 + h, idx2:idx2 + l] = \
-                            numpy.zeros((h, l), dtype=dtype)
+                    # Crop two tiles from the full image
+                    tile_size = (int(0.4 * img_size[0]), int(0.4 * img_size[1]))
+                    start1 = (0, 0)
+                    end1 = (start1[0] + tile_size[0], start1[1] + tile_size[1])
+                    tile1 = img[start1[0]:end1[0], start1[1]:end1[1]]
 
-                    # Crop two tiles with different shifts
-                    tsize = (int(0.3 * size[0]), int(0.6 * size[1]))
-                    start = (0, 0)
-                    end = (start[0] + tsize[0], start[1] + tsize[1])
-                    tile1 = img[start[0]:end[0], start[1]:end[1]]
+                    # 40% horizontal overlap between the two tiles
+                    start2 = (0, int(0.6 * tile_size[1]))
+                    # shift the start position of the second tile by the shift
+                    shifted_start2 = numpy.add(start2, shift)
+                    end2 = (shifted_start2[0] + tile_size[0], shifted_start2[1] + tile_size[1])
+                    tile2 = img[shifted_start2[0]:end2[0], shifted_start2[1]:end2[1]]
 
-                    start = numpy.add((int(0.2 * size[0]), 0), shift)
-                    end = (start[0] + tsize[0], start[1] + tsize[1])
-                    tile2 = img[start[0]:end[0], start[1]:end[1]]
-
-                    px_size = (1e-6, 2e-5)
+                    # position of the first tile is in the center of the tile,
+                    # use axis 1 first, because the registrar expects physical coordinates.
+                    pos1 = (0.5 * tile_size[1] * px_size[1],
+                            0.5 * tile_size[0] * px_size[0])
                     md1 = {
-                        model.MD_POS: (0.15 * size[0] * px_size[0], 30e-3),
+                        model.MD_POS: pos1,
                         model.MD_PIXEL_SIZE: px_size
                     }
+                    pos2 = ((start2[1] + 0.5 * tile_size[1]) * px_size[1],
+                            (start2[0] + 0.5 * tile_size[0]) * px_size[0])
                     md2 = {
-                        model.MD_POS: (0.35 * size[0] * px_size[0], 30e-3),
+                        model.MD_POS: pos2,
                         model.MD_PIXEL_SIZE: px_size
                     }
 
@@ -656,17 +674,13 @@ class TestGlobalShiftRegistrar(unittest.TestCase):
                     for t in tiles:
                         registrar.addTile(t)
 
-                    diff = numpy.subtract(registrar.getPositions()[0][0],
-                                          md1[model.MD_POS])
-                    # one pixel difference allowed
-                    self.assertLessEqual(diff[0], 1)
-                    self.assertLessEqual(diff[1], 1)
-
-                    diff = (registrar.getPositions()[0][1][0] - (md2[model.MD_POS][0] + shift[0] * px_size[0]),
-                            registrar.getPositions()[0][1][1] - (md2[model.MD_POS][1] + shift[1] * px_size[1]))
-                    # one pixel difference allowed
-                    self.assertLessEqual(diff[0], 1)
-                    self.assertLessEqual(diff[1], 1)
+                    tile_positions, _ = registrar.getPositions()
+                    # test the positions of the first tile
+                    self.assertAlmostEqual(tile_positions[0][0], md1[model.MD_POS][0])
+                    self.assertAlmostEqual(tile_positions[0][1], md1[model.MD_POS][1])
+                    # test the positions of the second tile
+                    self.assertAlmostEqual(tile_positions[1][0], (md2[model.MD_POS][0] + shift[1] * px_size[1]))
+                    self.assertAlmostEqual(tile_positions[1][1], (md2[model.MD_POS][1] - shift[0] * px_size[0]))
 
     def test_white_image(self):
         """ Position should be left as-is in case of white images """
@@ -708,13 +722,11 @@ class TestGlobalShiftRegistrar(unittest.TestCase):
             registrar.addTile(tiles[i])
 
         for i in range(len(tiles)):
-            calculatedPositions = registrar.getPositions()[0]
-            diff1 = abs(calculatedPositions[i][0] - pos[i][0])
-            diff2 = abs(calculatedPositions[i][1] - pos[i][1])
+            calculated_positions = registrar.getPositions()[0]
 
-            # should return initial position value, small error of 0.01 allowed
-            self.assertLessEqual(diff1, 1.3e-6)
-            self.assertLessEqual(diff2, 1.3e-6)
+            # should return initial position value
+            self.assertEqual(calculated_positions[i][0], pos[i][0])
+            self.assertEqual(calculated_positions[i][1], pos[i][1])
 
     def test_shift_real(self):
         """ Test on decomposed image with known shift """
@@ -740,9 +752,12 @@ class TestGlobalShiftRegistrar(unittest.TestCase):
             registered_pos = registrar.getPositions()[0]
             diff = numpy.absolute(numpy.subtract(registered_pos, real_pos))
             allowed_px_offset = numpy.repeat(numpy.multiply(px_size, 5), len(diff))
-            numpy.testing.assert_array_less(diff.flatten(), allowed_px_offset.flatten(),
-                        "Position %s pxs off for image '%s', " % (max(diff.flatten()) / px_size[0], img_name) +
-                        "%s x %s tiles, %s ovlp, %s method." % (num, num, o, a))
+            numpy.testing.assert_array_less(diff.flatten(),
+                                            allowed_px_offset.flatten(),
+                                            "Position %s pxs off for image '%s', " % (
+                                                max(diff.flatten()) / px_size[0], img_name) +
+                                            "%s x %s tiles, %s ovlp, %s method." % (num, num, o, a)
+                                            )
 
     def test_shift_real_manual(self):
         """ Test case not generated by decompose.py file and manually cropped """
@@ -765,10 +780,10 @@ class TestGlobalShiftRegistrar(unittest.TestCase):
             })
             registrar.addTile(tile1)
             registrar.addTile(tile2)
-            calculatedPositions = registrar.getPositions()[0]
-            diff1 = calculatedPositions[1][0] - 522 / 20
+            calculated_positions = registrar.getPositions()[0]
+            diff1 = calculated_positions[1][0] - 522 / 20
             self.assertLessEqual(diff1, 1 / 20)
-            diff2 = calculatedPositions[1][1] - img.shape[1] / 20 - 204 / 20
+            diff2 = calculated_positions[1][1] - img.shape[1] / 20 - 204 / 20
             self.assertLessEqual(diff2, 1 / 20)
 
     def test_shift_rectangular(self):
@@ -795,13 +810,13 @@ class TestGlobalShiftRegistrar(unittest.TestCase):
             })
             registrar.addTile(tile1)
             registrar.addTile(tile2)
-            calculatedPositions = registrar.getPositions()[0]
-            logging.debug("Found shift: %s", calculatedPositions[1])
+            calculated_positions = registrar.getPositions()[0]
+            logging.debug("Found shift: %s", calculated_positions[1])
 
-            testing.assert_tuple_almost_equal(calculatedPositions[0], (0, 0))
+            testing.assert_tuple_almost_equal(calculated_positions[0], (0, 0))
 
             exp_pos2 = shift[0] * pxs[0], -shift[1] * pxs[1]  # m, - to invert Y
-            testing.assert_tuple_almost_equal(calculatedPositions[1], exp_pos2, delta=pxs[0])
+            testing.assert_tuple_almost_equal(calculated_positions[1], exp_pos2, delta=pxs[0])
 
     def test_dependent_tiles(self):
         """ Tests functionality for dependent tiles """
@@ -843,14 +858,18 @@ class TestGlobalShiftRegistrar(unittest.TestCase):
             for p, tile in zip(pos, dep_tile_pos):
                 for dep_tile in tile:
                     diff1 = abs(dep_tile[0] - p[0])
-                    self.assertLessEqual(diff1, margin1,
-                         "Failed for %s tiles, %s overlap and %s method," % (num, o, a) +
-                         " %f != %f" % (dep_tile[0], p[0]))
+                    self.assertLessEqual(diff1,
+                                         margin1,
+                                         "Failed for %s tiles, %s overlap and %s method," % (num, o, a) +
+                                         " %f != %f" % (dep_tile[0], p[0])
+                                         )
 
                     diff2 = abs(dep_tile[1] - p[1])
-                    self.assertLessEqual(diff2, margin2,
-                         "Failed for %s tiles, %s overlap and %s method," % (num, o, a) +
-                         " %f != %f" % (dep_tile[1], p[1]))
+                    self.assertLessEqual(diff2,
+                                         margin2,
+                                         "Failed for %s tiles, %s overlap and %s method," % (num, o, a) +
+                                         " %f != %f" % (dep_tile[1], p[1])
+                                         )
 
             # Test with shifted dependent tiles
             [tiles, pos] = decompose_image(img, o, num, a)


### PR DESCRIPTION
    [fix] ShiftRegistrar._compute_registration a position in pixels was compared to a position in meters
    [refactor] Renaming of registered_positions to registered_positions_m and addition of registered_positions_px
    [refactor] Let GlobalShiftRegistrar inherit from the ShiftRegistrar class.
    [fix] shift registrar synthetic test case