### PR TITLE
[fix] gui: don't fail to start if xrandr doesn't work

### DIFF
--- a/src/odemis/gui/cont/acquisition.py
+++ b/src/odemis/gui/cont/acquisition.py
@@ -307,7 +307,11 @@ class SnapshotController(object):
         """
 
         if not os.name == 'nt':
-            xrandr_out = subprocess.check_output("xrandr")
+            try:
+                xrandr_out = subprocess.check_output("xrandr")
+            except subprocess.CalledProcessError as ex:
+                logging.warning("Failed to detect displays: %s", ex)
+                return []
             # only pick the "connected" outputs
             ret = re.findall(b"^(\\S+) connected ", xrandr_out, re.MULTILINE)
             return [o.decode("utf-8") for o in ret]


### PR DESCRIPTION
On some remote desktop connections, xrandr doesn't work. xrandr is only
use for "video FX" when doing a snapshot. It's really not a big deal.
We already handle the case of Windows, but let's just be open-minded and
not worry either on Linux.