### PR TITLE
[NSRPARMA-16] Add test case for scan-stage actuator wrapper

### DIFF
--- a/install/linux/usr/share/odemis/sim/sparc2-4spec-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/sparc2-4spec-sim.odm.yaml
@@ -13,6 +13,7 @@ SPARC2-4Spec: {
                "External Spectrograph", "Ext Spectrograph focus", "Ext Spec CCD Flipper",
                "Spec Camera 2", "Ext Spectrometer 2", "Spec Camera 3", "Ext Spectrometer 3",
                "Mirror Actuators", "Mirror Actuators in XY referential",
+               "Scan Stage", "Sample Stage", "EBIC",
                ],
 }
 
@@ -67,6 +68,7 @@ SPARC2-4Spec: {
     children: {
        scanner: "SEM E-beam",
        detector0: "SEM Detector",
+       detector1: "EBIC",
     }
 }
 
@@ -92,7 +94,7 @@ SPARC2-4Spec: {
         # 4 = Status led
         scanning_ttl: {1: [True, "external"], 4: True}, # output ports -> True (indicate scanning) or False (indicate parked)
         settle_time: 10.e-6, # s
-        hfw_nomag: 0.1285, # m 
+        hfw_nomag: 0.1285, # m
     },
     properties: {
         scale: [8, 8], # (ratio) : start with a pretty fast scan
@@ -112,6 +114,45 @@ SPARC2-4Spec: {
         channel: 0, # 0-> sawtooth waves, 1-> square waves
         limits: [-3, 3] # V
     },
+}
+
+# In either configuration, the signal is either ±10V or ±5V. As the signal can be positive and negative, is uses the full range.
+# Must be connected on AI 2/AI 10 (differential)
+"EBIC": {
+    role: ebic-detector,
+    init: {
+        channel: 2,
+        limits: [-10, 10], # V
+    },
+}
+
+"Scan Stage": { # wrapper to be able to scan with the stage instead of the e-beam
+    class: actuator.MultiplexActuator,
+    role: scan-stage,
+    dependencies: {"x": "Sample Stage", "y": "Sample Stage"},
+    init: {
+        axes_map: {"x": "x", "y": "y"},
+    },
+#    properties: {
+#        speed: {"x": 100.e-6, "y": 100.e-6},
+#    },
+    metadata: {
+        POS_ACTIVE_RANGE: {"x": [-5.0e-3, 5.0e-3], "y": [-5.0e-3, 5.0e-3]},
+    },
+    affects: ["Sample Stage"],
+}
+
+"Sample Stage": {
+    class: simulated.Stage,
+    role: sem-stage,
+    init: {
+        axes: ["x", "y"],
+        ranges: {"x": [-0.014, 0.014], "y": [-0.028, 0.028]},
+    },
+    properties: {
+        speed: {"x": 0.01, "y": 0.01}, # m/s
+    },
+    affects: ["SEM E-beam"],
 }
 
 "Optical Path Properties": {
@@ -311,7 +352,7 @@ SPARC2-4Spec: {
 # In reality, this is a Zyla, but you need libandor3-dev to simulate an AndorCam3
 "AR Camera": {
     class: andorcam2.AndorCam2,
-    role: ccd0,
+    role: ccd,
     power_supplier: "Power Control Unit",
     init: {
        device: "fake",
@@ -321,7 +362,7 @@ SPARC2-4Spec: {
 
 "Int Spectrometer 0": {
     class: spectrometer.CompositedSpectrometer,
-    role: spectrometer0,
+    role: spectrometer,
     dependencies: {detector: "AR Camera", spectrograph: "Integrated Spectrograph"},
     init: {
         transp: [1, 2], # only applied to the spectrometer data (not raw CCD)

--- a/install/linux/usr/share/odemis/sim/sparc2-4spec-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/sparc2-4spec-sim.odm.yaml
@@ -352,7 +352,7 @@ SPARC2-4Spec: {
 # In reality, this is a Zyla, but you need libandor3-dev to simulate an AndorCam3
 "AR Camera": {
     class: andorcam2.AndorCam2,
-    role: ccd,
+    role: ccd0,
     power_supplier: "Power Control Unit",
     init: {
        device: "fake",
@@ -362,7 +362,7 @@ SPARC2-4Spec: {
 
 "Int Spectrometer 0": {
     class: spectrometer.CompositedSpectrometer,
-    role: spectrometer,
+    role: spectrometer0,
     dependencies: {detector: "AR Camera", spectrograph: "Integrated Spectrograph"},
     init: {
         transp: [1, 2], # only applied to the spectrometer data (not raw CCD)

--- a/src/odemis/util/testing.py
+++ b/src/odemis/util/testing.py
@@ -115,7 +115,7 @@ def run_backend(config):
 
     time.sleep(3)  # give some time to the backend to start a little bit
 
-    timeout = 30  # s timeout
+    timeout = 40  # s timeout
     end = time.time() + timeout
     while time.time() < end:
         status = driver.get_backend_status()

--- a/src/odemis/util/testing.py
+++ b/src/odemis/util/testing.py
@@ -115,7 +115,7 @@ def run_backend(config):
 
     time.sleep(3)  # give some time to the backend to start a little bit
 
-    timeout = 40  # s timeout
+    timeout = 30  # s timeout
     end = time.time() + timeout
     while time.time() < end:
         status = driver.get_backend_status()


### PR DESCRIPTION
Addition of a fake scan-stage test case in stream_test as a separate class. Consists of testing of the wrapper through a big configuration file containing the new wrapper actuator type. In addition contains a method to test for ccd-type detector only. Also made the roi_to_phys method a global one to use for other test cases.