### PR TITLE
[fix] Temporal spectrum 2D image incorrectly rotated when width > 1

### DIFF
--- a/src/odemis/acq/stream/_projection.py
+++ b/src/odemis/acq/stream/_projection.py
@@ -1557,6 +1557,7 @@ class PixelTemporalSpectrumProjection(RGBProjection):
 
         radius = width / 2
         mean = img.mean_within_circle(spec2d, (x, y), radius)
+        mean = numpy.swapaxes(mean, 0, 1)
 
         return model.DataArray(mean.astype(spec2d.dtype), md)
 


### PR DESCRIPTION
Commit c68988a2f53 (EK1 acquisition) refactored code but introduced a
bug on Temporal spectrum 2D image. When width > 1, the computed data
would be, incorrectly, not rotated.

=> Rotate the 2D image again, as it used to be.