### PR TITLE
[fix] skip test_image_dark_gain because it fails for the latest TNL simulator

### DIFF
--- a/src/odemis/acq/align/test/fastem_test.py
+++ b/src/odemis/acq/align/test/fastem_test.py
@@ -35,7 +35,6 @@ from odemis.acq.align.fastem import Calibrations
 from odemis.util import driver, testing
 
 # * TEST_NOHW = 1: use simulator (asm/sam and xt adapter simulators need to be running)
-# technolution_asm_simulator/simulator2/run_the_simulator.py
 # * TEST_NOHW = 0: connected to the real hardware (backend needs to be running)
 TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default is HW testing
 
@@ -132,6 +131,7 @@ class TestFastEMCalibration(unittest.TestCase):
         # check the calibrated descan offset is different from the previous offset
         self.assertNotEqual(descan_offset_cur, descan_offset_calib)
 
+    @unittest.skip("For the technolution ASM API > v3.0 the simulator images have changed and this test case fails.")
     def test_image_dark_gain(self):
         """Run the dark offset and digital gain calibration. Can also be tested with simulator.
         It calibrates the dark offset and digital gain per mppc detector cell."""


### PR DESCRIPTION
Skip the test case because, in the latest technolution asm simulator the simulated images have changed and the dark gain test case fails.