### PR TITLE
Fix type annotations for python 3.8

### DIFF
--- a/src/odemis/gui/cont/tabs.py
+++ b/src/odemis/gui/cont/tabs.py
@@ -26,6 +26,7 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 import collections
 from concurrent.futures import CancelledError
 from functools import partial
+from typing import List
 import gc
 import logging
 import math
@@ -1843,7 +1844,7 @@ class CorrelationTab(Tab):
     def correlation_controller(self):
         return self._correlation_controller
 
-    def _create_views(self, viewports: list) -> collections.OrderedDict:
+    def _create_views(self, viewports: List) -> collections.OrderedDict:
         """
         Create views depending on the actual hardware present
         :param viewports: list of viewports
@@ -1882,7 +1883,7 @@ class CorrelationTab(Tab):
     def _on_add_tileset(self) -> None:
         self.select_acq_file(extend=True, tileset=True)
 
-    def load_tileset(self, filenames: list[str], extend: bool = False) -> None:
+    def load_tileset(self, filenames: List[str], extend: bool = False) -> None:
         data = open_files_and_stitch(filenames) # TODO: allow user defined registration / weave methods
         self.load_streams(data)
 
@@ -1933,7 +1934,7 @@ class CorrelationTab(Tab):
                 extend = True  # If multiple files loaded, the first one is considered main one
 
     @call_in_wx_main
-    def load_streams(self, data: list[model.DataArray]) -> None:
+    def load_streams(self, data: List[model.DataArray]) -> None:
         """ Load the data in the overview viewports
         :param data: (list[model.DataArray]) list of data arrays to load as streams
         """
@@ -1946,7 +1947,7 @@ class CorrelationTab(Tab):
         for vp in self.panel.pnl_correlaton_grid.viewports:
             vp.canvas.fit_view_to_content()
    
-    def add_streams(self, streams:list) -> None:
+    def add_streams(self, streams: List) -> None:
         """add streams to correlation tab
         :param streams: (list[Stream]) list of streams to add"""
         self.correlation_controller.add_streams(streams)


### PR DESCRIPTION
Revert type annotations to use typing module instead of type

```
Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/pals/development/odemis/src/odemis/gui/main.py", line 40, in <module>
    import odemis.gui.cont.tabs as tabs
  File "/home/pals/development/odemis/src/odemis/gui/cont/tabs.py", line 1766, in <module>
    class CorrelationTab(Tab):
  File "/home/pals/development/odemis/src/odemis/gui/cont/tabs.py", line 1885, in CorrelationTab
    def load_tileset(self, filenames: list[str], extend: bool = False) -> None:
TypeError: 'type' object is not subscriptable
```