### PR TITLE
[SDEV-1770] feat: Add new autostigmation to precalibrations and xt_client

### DIFF
--- a/src/odemis/acq/align/fastem.py
+++ b/src/odemis/acq/align/fastem.py
@@ -29,6 +29,7 @@ from odemis import model
 
 try:
     from fastem_calibrations.autofocus_multiprobe import AutofocusMultiprobe
+    from fastem_calibrations.autostigmation import Autostigmation
     from fastem_calibrations.cell_translation import CellTranslation
     from fastem_calibrations.dark_offset_correction import DarkOffsetCorrection
     from fastem_calibrations.descan_gain import DescanGain
@@ -61,6 +62,7 @@ except ImportError as err:
     ScanRotation = None
     ScanAmplitude = None
     CellTranslation = None
+    Autostigmation = None
 
     fastem_calibrations = False
 
@@ -85,6 +87,7 @@ class Calibrations(Enum):
     SCAN_ROTATION_FINAL = ScanRotation
     SCAN_AMPLITUDE_FINAL = ScanAmplitude
     CELL_TRANSLATION = CellTranslation
+    AUTOSTIGMATION = Autostigmation
 
 
 def align(scanner, multibeam, descanner, detector, stage, ccd, beamshift, det_rotator, calibrations, stage_pos=None):

--- a/src/odemis/gui/conf/file.py
+++ b/src/odemis/gui/conf/file.py
@@ -247,6 +247,7 @@ class AcquisitionConfig(Config):
         self.default.set("acquisition", "fn_ptn", u"{datelng}-{timelng}")
         self.default.set("acquisition", "fn_count", "0")
         self.default.set("acquisition", "overlap", "0.0")
+        self.default.set("acquisition", "autostig_period", "5")
 
         self.default.add_section("export")
         self.default.set("export", "last_path", ACQUI_PATH)
@@ -334,6 +335,14 @@ class AcquisitionConfig(Config):
     @overlap.setter
     def overlap(self, value):
         self.set("acquisition", "overlap", value)
+
+    @property
+    def autostig_period(self):
+        return int(self.get("acquisition", "autostig_period"))
+
+    @autostig_period.setter
+    def autostig_period(self, value):
+        self.set("acquisition", "autostig_period", value)
 
     @property
     def pj_last_path(self):


### PR DESCRIPTION
New autostigmation functionality is available and has been added to the xt_client. The new autostigmation should run during the pre_calibrations of an ROA and run every n sections. The frequency with which to run the autostigmation can be set through the acquisition config.