### PR TITLE
[fix] Extend andorshrk to detect if flipper failed to move

### DIFF
--- a/src/odemis/driver/andorshrk.py
+++ b/src/odemis/driver/andorshrk.py
@@ -1296,6 +1296,12 @@ class Shamrock(model.Actuator):
         with self._hw_access:
             logging.debug("Moving flipper %d to pos %d", flipper, port)
             self._dll.ShamrockSetFlipperMirror(self._device, flipper, port)
+            if self.GetFlipperMirror(flipper) != port:
+                logging.warning("Flipper %d doesn't seem to have moved yet to pos %d, trying again",
+                                flipper, port)
+                self._dll.ShamrockSetFlipperMirror(self._device, flipper, port)
+                if self.GetFlipperMirror(flipper) != port:
+                    raise IOError(f"Flipper {flipper} failed to move to pos {port}")
 
     @callWithReconnect
     def GetFlipperMirror(self, flipper):


### PR DESCRIPTION
Some hardware have sometimes issues with the flipper, and fail to move
it. In such case the move would "succeed" and the position left as the
previous position.

Instead, try to move again, which seems to work around some hardware
issues, and if that didn't help report an error with the move.