### PR TITLE
[SDEV-1770] refactor: Move focus metrics from acq/align/autofocus.py 

### DIFF
--- a/scripts/analyse-timelapse-secom.py
+++ b/scripts/analyse-timelapse-secom.py
@@ -20,9 +20,10 @@ run as:
 import argparse
 import glob
 import logging
+
+import odemis.util.focus
 from odemis import dataio, model
 from odemis.acq.align.shift import MeasureShift
-from odemis.acq.align import autofocus
 import os
 import sys
 
@@ -62,13 +63,13 @@ def read_timelapse(infn, emfn, fmfn):
                     fmdate = da.metadata[model.MD_ACQ_DATE]
                     fmda = da
                     fmpxs = da.metadata[model.MD_PIXEL_SIZE]
-                    fmfoc = autofocus.MeasureOpticalFocus(da)
+                    fmfoc = odemis.util.focus.MeasureOpticalFocus(da)
                 else: # SEM
                     empos = da.metadata[model.MD_POS]
                     emdate = da.metadata[model.MD_ACQ_DATE]
                     emda = da
                     empxs = da.metadata[model.MD_PIXEL_SIZE]
-                    emfoc = autofocus.MeasureSEMFocus(da)
+                    emfoc = odemis.util.focus.MeasureSEMFocus(da)
             
             # Overlay translation
             ovlpos = fmpos[0] - empos[0], fmpos[1] - empos[1]

--- a/src/odemis/acq/align/autofocus.py
+++ b/src/odemis/acq/align/autofocus.py
@@ -23,17 +23,14 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 from collections.abc import Iterable
 from concurrent.futures import TimeoutError, CancelledError
 from concurrent.futures._base import CANCELLED, FINISHED, RUNNING
-import cv2
 import logging
 import numpy
 from odemis import model
 from odemis.acq.align import light
 from odemis.model import InstantaneousFuture
 from odemis.util import executeAsyncTask, almost_equal
+from odemis.util.focus import MeasureSEMFocus, Measure1d, MeasureSpotsFocus, AssessFocus
 from odemis.util.img import Subtract
-from scipy import ndimage
-from scipy.optimize import curve_fit
-from scipy.signal import medfilt
 import threading
 import time
 
@@ -43,128 +40,6 @@ MTD_EXHAUSTIVE = 1
 
 MAX_STEPS_NUMBER = 100  # Max steps to perform autofocus
 MAX_BS_NUMBER = 1  # Maximum number of applying binary search with a smaller max_step
-
-
-def _convertRBGToGrayscale(image):
-    """
-    Quick and dirty convertion of RGB data to grayscale
-    image (numpy array of shape YX3)
-    return (numpy array of shape YX)
-    """
-    r, g, b = image[:, :, 0], image[:, :, 1], image[:, :, 2]
-    gray = numpy.empty(image.shape[0:2], dtype="uint16")
-    gray[...] = r
-    gray += g
-    gray += b
-
-    return gray
-
-
-def AssessFocus(levels, min_ratio=15):
-    """
-    Given a list of focus levels, it decides if there is any significant value
-    or it only contains noise.
-    levels (list of floats): List of focus levels
-    min_ratio (0 < float): minimum ratio between the focus level max-mean and
-      the standard deviation to be considered "significant".
-    returns (boolean): True if there is significant deviation
-    """
-    std_l = numpy.std(levels)
-
-    levels_nomax = list(levels)
-    max_l = max(levels)
-    levels_nomax.remove(max_l)
-    avg_l = numpy.mean(levels_nomax)
-    l_diff = max_l - avg_l
-
-    logging.debug("Focus level std dev: %f, avg: %f, diff max: %f", std_l, avg_l, l_diff)
-    if std_l > 0 and l_diff >= min_ratio * std_l:
-        logging.debug("Significant focus level deviation was found")
-        return True
-    return False
-
-
-def MeasureSEMFocus(image):
-    """
-    Given an image, focus measure is calculated using the standard deviation of
-    the raw data.
-    image (model.DataArray): SEM image
-    returns (float): The focus level of the SEM image (higher is better)
-    """
-    # Handle RGB image
-    if len(image.shape) == 3:
-        # TODO find faster/better solution
-        image = _convertRBGToGrayscale(image)
-
-    return ndimage.standard_deviation(image)
-
-
-def MeasureOpticalFocus(image):
-    """
-    Given an image, focus measure is calculated using the variance of Laplacian
-    of the raw data.
-    image (model.DataArray): Optical image
-    returns (float): The focus level of the optical image (higher is better)
-    """
-    # Handle RGB image
-    if len(image.shape) == 3:
-        # TODO find faster/better solution
-        image = _convertRBGToGrayscale(image)
-
-    return cv2.Laplacian(image, cv2.CV_64F).var()
-
-
-def Measure1d(image):
-    """
-    Given an image of a 1 line ccd, measure the focus based on the inverse of the width of a gaussian fit of the data.
-    It is assumed that the signal is in focus when the width of the signal is smallest and therefore sigma is smallest.
-    image (model.DataArray): 1D image from 1 line ccd.
-    returns (float): The focus level of the image, based on the inverse of the width of a gaussian fitted on the image.
-    """
-    # Use the gauss function to fit a gaussian to the 1 line image.
-    def gauss(x, amplitude, pos, width, base):
-        y = amplitude * numpy.exp(-(x - pos) ** 2 / (2 * width ** 2)) + base
-        return y
-    # squeeze to make sure the image array is 1d.
-    signal = numpy.squeeze(image)
-    # Apply a median filter with a kernel of 5, to handle noise with up to 2 neighbouring pixels with a very high value,
-    # resembling a peak, which sometimes happens on CCDs.
-    signal = medfilt(signal, 5)
-    x = numpy.arange(len(signal))
-    width = max(3.0, 0.01 * len(signal))
-    # determine the indices and the values of the 1% highest points in the signal.
-    max_ids = signal.argsort()[-int(width):]
-    max_sig = signal[max_ids]
-    med_sig = numpy.median(signal)
-    # give an initial estimate for the parameters of the gaussian fit: [amplitude, expected position, width, base]
-    p_initial = [numpy.median(max_sig) - med_sig, numpy.median(max_ids), width, med_sig]
-    # Use curve_fit to fit the gauss function to the data. Use p_initial as our initial guess.
-    try:
-        popt, pcov = curve_fit(gauss, x, signal, p0=p_initial)
-    except RuntimeError as ex:
-        # No fitting can be found => the focus is really bad
-        logging.debug("Failed to estimate focus level, assuming a very bad level: %s", ex)
-        return 0
-
-    # The focus metric is the inverse of width of the gaussian fit (a smaller width is a higher focus level).
-    return 1 / abs(popt[2])
-
-
-def MeasureSpotsFocus(image):
-    """
-    Focus measurement metric based on Tenengrad variance:
-        Pech, J.; Cristobal, G.; Chamorro, J. & Fernandez, J. Diatom autofocusing in brightfield microscopy: a
-        comparative study. 2000.
-
-    Given an image, the focus measure is calculated using the variance of a Sobel filter applied in the
-    x and y directions of the raw data.
-    image (model.DataArray): Optical image
-    returns (float): The focus level of the image (higher is better)
-    """
-    sobelx = cv2.Sobel(image, cv2.CV_64F, 1, 0, ksize=5)
-    sobely = cv2.Sobel(image, cv2.CV_64F, 0, 1, ksize=5)
-    sobel_image = sobelx ** 2 + sobely ** 2
-    return sobel_image.var()
 
 
 def getNextImage(det, timeout=None):

--- a/src/odemis/acq/align/test/autofocus_test.py
+++ b/src/odemis/acq/align/test/autofocus_test.py
@@ -23,11 +23,12 @@ from concurrent.futures._base import CancelledError
 import logging
 
 import numpy
+
+import odemis.util.focus
 from odemis.dataio import tiff
 from odemis import model, acq
 import odemis
 from odemis.acq import align, stream
-from odemis.acq.align import autofocus
 from odemis.acq.align.autofocus import Sparc2AutoFocus, MTD_BINARY
 from odemis.dataio import hdf5
 from odemis.util import testing, timeout, img
@@ -103,10 +104,10 @@ class TestAutofocus(unittest.TestCase):
         data[0].shape = Y, X
         input = data[0]
 
-        prev_res = autofocus.MeasureSEMFocus(input)
+        prev_res = odemis.util.focus.MeasureSEMFocus(input)
         for i in range(1, 10, 1):
             blur = ndimage.gaussian_filter(input, sigma=i)
-            res = autofocus.MeasureSEMFocus(blur)
+            res = odemis.util.focus.MeasureSEMFocus(blur)
             self.assertGreater(prev_res, res)
             prev_res = res
 

--- a/src/odemis/acq/stitching/_tiledacq.py
+++ b/src/odemis/acq/stitching/_tiledacq.py
@@ -33,7 +33,8 @@ from scipy.spatial import Delaunay
 
 from odemis import model, dataio
 from odemis.acq import acqmng
-from odemis.acq.align.autofocus import MeasureOpticalFocus, AutoFocus, MeasureSpotsFocus, MTD_EXHAUSTIVE
+from odemis.acq.align.autofocus import AutoFocus, MTD_EXHAUSTIVE
+from odemis.util.focus import MeasureOpticalFocus
 from odemis.acq.align.roi_autofocus import autofocus_in_roi, estimate_autofocus_in_roi_time
 from odemis.acq.stitching._constants import WEAVER_MEAN, REGISTER_IDENTITY, REGISTER_GLOBAL_SHIFT
 from odemis.acq.stitching._simple import register, weave

--- a/src/odemis/util/focus.py
+++ b/src/odemis/util/focus.py
@@ -1,0 +1,150 @@
+# -*- coding: utf-8 -*-
+"""
+Created on 12 Apr 2013
+
+@author: Rinze de Laat
+
+Copyright © 2013-2024 Éric Piel, Rinze de Laat, Thera Pals, Delmic
+
+This file is part of Odemis.
+
+Odemis is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License version 2 as published by the Free
+Software Foundation.
+
+Odemis is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+Odemis. If not, see http://www.gnu.org/licenses/.
+"""
+import logging
+
+import cv2
+import numpy
+from scipy import ndimage
+from scipy.optimize import curve_fit
+from scipy.signal import medfilt
+
+
+def _convertRBGToGrayscale(image):
+    """
+    Quick and dirty convertion of RGB data to grayscale
+    image (numpy array of shape YX3)
+    return (numpy array of shape YX)
+    """
+    r, g, b = image[:, :, 0], image[:, :, 1], image[:, :, 2]
+    gray = numpy.empty(image.shape[0:2], dtype="uint16")
+    gray[...] = r
+    gray += g
+    gray += b
+
+    return gray
+
+
+def MeasureSEMFocus(image):
+    """
+    Given an image, focus measure is calculated using the standard deviation of
+    the raw data.
+    image (model.DataArray): SEM image
+    returns (float): The focus level of the SEM image (higher is better)
+    """
+    # Handle RGB image
+    if len(image.shape) == 3:
+        # TODO find faster/better solution
+        image = _convertRBGToGrayscale(image)
+
+    return ndimage.standard_deviation(image)
+
+
+def MeasureOpticalFocus(image):
+    """
+    Given an image, focus measure is calculated using the variance of Laplacian
+    of the raw data.
+    image (model.DataArray): Optical image
+    returns (float): The focus level of the optical image (higher is better)
+    """
+    # Handle RGB image
+    if len(image.shape) == 3:
+        # TODO find faster/better solution
+        image = _convertRBGToGrayscale(image)
+
+    return cv2.Laplacian(image, cv2.CV_64F).var()
+
+
+def Measure1d(image):
+    """
+    Given an image of a 1 line ccd, measure the focus based on the inverse of the width of a gaussian fit of the data.
+    It is assumed that the signal is in focus when the width of the signal is smallest and therefore sigma is smallest.
+    image (model.DataArray): 1D image from 1 line ccd.
+    returns (float): The focus level of the image, based on the inverse of the width of a gaussian fitted on the image.
+    """
+    # Use the gauss function to fit a gaussian to the 1 line image.
+    def gauss(x, amplitude, pos, width, base):
+        y = amplitude * numpy.exp(-(x - pos) ** 2 / (2 * width ** 2)) + base
+        return y
+    # squeeze to make sure the image array is 1d.
+    signal = numpy.squeeze(image)
+    # Apply a median filter with a kernel of 5, to handle noise with up to 2 neighbouring pixels with a very high value,
+    # resembling a peak, which sometimes happens on CCDs.
+    signal = medfilt(signal, 5)
+    x = numpy.arange(len(signal))
+    width = max(3.0, 0.01 * len(signal))
+    # determine the indices and the values of the 1% highest points in the signal.
+    max_ids = signal.argsort()[-int(width):]
+    max_sig = signal[max_ids]
+    med_sig = numpy.median(signal)
+    # give an initial estimate for the parameters of the gaussian fit: [amplitude, expected position, width, base]
+    p_initial = [numpy.median(max_sig) - med_sig, numpy.median(max_ids), width, med_sig]
+    # Use curve_fit to fit the gauss function to the data. Use p_initial as our initial guess.
+    try:
+        popt, pcov = curve_fit(gauss, x, signal, p0=p_initial)
+    except RuntimeError as ex:
+        # No fitting can be found => the focus is really bad
+        logging.debug("Failed to estimate focus level, assuming a very bad level: %s", ex)
+        return 0
+
+    # The focus metric is the inverse of width of the gaussian fit (a smaller width is a higher focus level).
+    return 1 / abs(popt[2])
+
+
+def MeasureSpotsFocus(image):
+    """
+    Focus measurement metric based on Tenengrad variance:
+        Pech, J.; Cristobal, G.; Chamorro, J. & Fernandez, J. Diatom autofocusing in brightfield microscopy: a
+        comparative study. 2000.
+
+    Given an image, the focus measure is calculated using the variance of a Sobel filter applied in the
+    x and y directions of the raw data.
+    image (model.DataArray): Optical image
+    returns (float): The focus level of the image (higher is better)
+    """
+    sobelx = cv2.Sobel(image, cv2.CV_64F, 1, 0, ksize=5)
+    sobely = cv2.Sobel(image, cv2.CV_64F, 0, 1, ksize=5)
+    sobel_image = sobelx ** 2 + sobely ** 2
+    return sobel_image.var()
+
+
+def AssessFocus(levels, min_ratio=15):
+    """
+    Given a list of focus levels, it decides if there is any significant value
+    or it only contains noise.
+    levels (list of floats): List of focus levels
+    min_ratio (0 < float): minimum ratio between the focus level max-mean and
+      the standard deviation to be considered "significant".
+    returns (boolean): True if there is significant deviation
+    """
+    std_l = numpy.std(levels)
+
+    levels_nomax = list(levels)
+    max_l = max(levels)
+    levels_nomax.remove(max_l)
+    avg_l = numpy.mean(levels_nomax)
+    l_diff = max_l - avg_l
+
+    logging.debug("Focus level std dev: %f, avg: %f, diff max: %f", std_l, avg_l, l_diff)
+    if std_l > 0 and l_diff >= min_ratio * std_l:
+        logging.debug("Significant focus level deviation was found")
+        return True
+    return False


### PR DESCRIPTION
to avoid circular import

MeasureSpotsFocus will need to be re-used in the fastem-calibrations code, but because that gets imported in odemis/acq/align/fastem.py it is causing a circular import. Since the functions are more utility functions of the autofocus code, I moved them to odemis/util/focus.py

relates to: https://bitbucket.org/delmic/fastem-calibrations/pull-requests/143