### PR TITLE
[METEOR-589][feature] display the most recently used settings of stream panels 

### DIFF
--- a/src/odemis/acq/stream_settings.py
+++ b/src/odemis/acq/stream_settings.py
@@ -1,0 +1,177 @@
+# -*- coding: utf-8 -*-
+"""
+Created on 24 Jan 2024
+
+@author: Karishma Kumar
+
+Copyright © 2024 Karishma Kumar, Delmic
+
+This file is part of Odemis.
+
+Odemis is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License version 2 as published by the Free Software Foundation.
+
+Odemis is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with Odemis. If not, see http://www.gnu.org/licenses/.
+"""
+import json
+import logging
+import os
+from typing import List, Dict, Any
+
+from odemis import model, util
+from odemis.acq.stream import FluoStream
+from odemis.util.img import md_format_to_tint, tint_to_md_format
+
+# Power value depends on selected excitation
+# Emission value depends on selected excitation
+# Tint can automatically change if excitation and emission are changed
+# Therefore, the below VAs are changed first in the below order and then the rest of stream VAs
+SETTINGS_ORDER = ["excitation", "power", "emission"]
+# The below VAs are not important for loading the settings of a specific stream
+NON_SETTINGS_VA = ['acquisitionType', 'auto_bc', 'background', 'histogram', 'image', 'intensityRange', 'is_active',
+                   'roi', 'should_update', 'single_frame_acquisition', 'status']
+
+
+def get_settings_order(stream):
+    """
+    Get the VAs for loading a stream setting and sort them so it can applied in the given order while loading
+    a stream later.
+    :param stream: stream object that consists of VAs
+    """
+    stream_vas = model.getVAs(stream)
+    settings = set(stream_vas.keys()).difference(NON_SETTINGS_VA)
+    settings_order = util.sorted_according_to(settings, SETTINGS_ORDER)
+
+    return settings_order
+
+
+class StreamSettingsConfig:
+    """
+    Read and write a list of most recently used (mru) settings from and to a JSON file respectively. The first element
+    in the list will be the latest used setting and the last element will be the oldest used setting. The list will
+    consist of finite number of entries which will update in the above mention order each time the list of stream
+    settings is updated.
+    """
+
+    def __init__(self, file_path, max_entries):
+        """
+        :param file_path: full directory path to save the JSON file
+        :param max_entries: number of entries to save in the JSON file
+        """
+        self.max_entries = max_entries
+        self.config_data: List[Dict[str, Any]] = []
+        self.file_path = file_path
+        try:
+            self._read()  # update the config_data by reading the JSON file
+        except Exception as e:
+            logging.exception(f"Error in reading the stream settings: {e}")
+
+    def _read(self):
+        logging.debug(f"Reading the most recently used stream settings from {self.file_path}")
+        if os.path.exists(self.file_path):
+            with open(self.file_path, 'r') as jsonfile:
+                loaded_data = json.load(jsonfile)
+            if isinstance(loaded_data, list) and all(isinstance(item, dict) for item in loaded_data):
+                self.config_data = loaded_data
+            else:
+                # Log a warning and reset config_data to an empty list
+                logging.warning("The loaded JSON data is not of the expected format.")
+                self.config_data = []
+
+    def _write(self):
+        logging.debug(f"Writing the most recently used stream settings in {self.file_path}")
+        if self.config_data:
+            with open(self.file_path, 'w') as jsonfile:
+                json.dump(self.config_data, jsonfile, indent=2)
+
+    @property
+    def entries(self):
+        return [e["name"] for e in self.config_data]
+
+    def _get_config_index(self, config_data: list, name: str) -> int:
+        """
+        Get the index of the config entry with the given name
+        :param config_data: list of config entries
+        :param name: name of config entry
+        :return: index of config entry with given name
+        """
+        try:
+            index = [x["name"] for x in config_data].index(name)
+        except ValueError:
+            return None
+        except TypeError:
+            return None
+        return index
+
+    def update_data(self, new_entries: List[Dict[str, Any]]):
+        """
+        Update the saved stream setting with the list of new_entries. First element in JSON file
+        is the latest entry while the last element is the oldest stream setting. The file updates
+        its entries based on the new_entries while maintaining a fixed length of entries in the file.
+        Each entry must have a key "name".
+        :param new_entries: Each element in the list represent the setting
+         of the stream saved as a list from oldest to latest stream setting
+        """
+        for e in new_entries:
+            # find if the new entry name exists in the saved self.config_data
+            index = self._get_config_index(self.config_data, e["name"])
+            # pop the entry from the list if the stream name is same to avoid duplication
+            if index is not None:
+                self.config_data.pop(index)
+            # insert the new entry at the first position
+            self.config_data.insert(0, e)
+            # length of list of entries should be constant
+            self.config_data = self.config_data[:self.max_entries]
+
+        try:
+            self._write()
+        except Exception as e:
+            logging.exception(f"Error in writing the stream settings: {e}")
+
+    def update_entries(self, streams: list):
+        """
+        Update the streams settings from the list of streams to update the entries in the JSON file.
+        :param streams: (list of streams) List of vigilant attributes of each stream settings
+        """
+        local_entries = []
+
+        for s in streams:
+            settings_order = get_settings_order(s)
+            entries = {}
+            # set the settings for the stream from a settings json file
+            # self.stream_settings.get_stream_settings(self.stream_controllers)
+            for attr_name in settings_order:
+                # tint requires special handling
+                if attr_name == "tint":
+                    entries["tint"] = tint_to_md_format(s.tint.value)
+                else:
+                    entries.update({attr_name: getattr(s, attr_name).value})
+
+            local_entries.append(entries)
+
+        # read and update the stream settings in the JSON file
+        self.update_data(local_entries)
+
+    def apply_settings(self, stream: FluoStream, name: str):
+        """
+        Apply the values from the saved data of the given name to the stream
+        controller settings.
+        :param stream: FluoStream that needs to be set with the values from the JSON file
+        :param name: Name of the saved setting in the JSON file
+        """
+        index = self._get_config_index(self.config_data, name)
+        if index is not None:
+            settings_order = get_settings_order(stream)
+            prev_setting = self.config_data[index]
+            # Follow the order for setting the values as listed in setting_keys
+            for key in settings_order:
+                current_value = prev_setting[key]  # Get the previous value if it exists
+                # tint requires special handling
+                if key == "tint":
+                    current_value = md_format_to_tint(prev_setting["tint"])
+                # Special handling for attributes that need to be converted to tuples
+                elif isinstance(current_value, list) and all(isinstance(x, (int, float)) for x in current_value):
+                    current_value = tuple(current_value)
+                # Set the attribute value
+                getattr(stream, key).value = current_value

--- a/src/odemis/acq/stream_settings.py
+++ b/src/odemis/acq/stream_settings.py
@@ -64,8 +64,11 @@ class StreamSettingsConfig:
         self.file_path = file_path
         try:
             self._read()  # update the config_data by reading the JSON file
+        except FileNotFoundError:
+            # Log that the file doesn't exist, which is expected on the first run
+            logging.info("Stream settings file does not exist.")
         except Exception as e:
-            logging.exception(f"Error in reading the stream settings: {e}")
+            logging.exception("Error in reading the stream settings.")
 
     def _read(self):
         logging.debug(f"Reading the most recently used stream settings from {self.file_path}")
@@ -126,8 +129,8 @@ class StreamSettingsConfig:
 
         try:
             self._write()
-        except Exception as e:
-            logging.exception(f"Error in writing the stream settings: {e}")
+        except Exception:
+            logging.exception(f"Error in writing the stream settings")
 
     def update_entries(self, streams: list):
         """

--- a/src/odemis/acq/test/stream_settings_test.py
+++ b/src/odemis/acq/test/stream_settings_test.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8 -*-
+"""
+Created on 24 Jan 2024
+
+@author: Karishma Kumar
+
+Copyright © 2024 Karishma Kumar, Delmic
+
+This file is part of Odemis.
+
+Odemis is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License version 2 as published by the Free Software Foundation.
+
+Odemis is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with Odemis. If not, see http://www.gnu.org/licenses/.
+"""
+import logging
+import os
+import unittest
+
+import odemis
+from odemis import model
+from odemis.acq.stream import FluoStream
+from odemis.acq.stream_settings import StreamSettingsConfig, get_settings_order
+from odemis.util import testing
+
+logging.getLogger().setLevel(logging.DEBUG)
+
+CONFIG_PATH = os.path.dirname(odemis.__file__) + "/../../install/linux/usr/share/odemis/"
+METEOR_CONFIG = CONFIG_PATH + "sim/meteor-sim.odm.yaml"
+
+
+class TestAcquiredStreamSettings(unittest.TestCase):
+    """
+    Test the json file for reading and writing the most recently used acquired stream settings
+    """
+    # 11 entries and two duplication of the key "name"
+    test_data = [{'name': 'Filtered Colour 1', 'excitation': [0, 1, 2],
+                  'power': 0.0000000012, 'emission': [0.00001, 1.234e-07],
+                  'detExposureTime': 0.00123456789, 'auto_bc_outliers': 0.12345},
+                 {'name': 'Filtered Colour 2', 'excitation': [0, 1, 2],
+                  'power': 0.0000000034, 'emission': [0.00001, 1.234e-07],
+                  'detExposureTime': 0.00123456789, 'auto_bc_outliers': 0.12345},
+                 {'name': 'Filtered Colour 3', 'excitation': [0, 1, 2],
+                  'power': 0.0000000045, 'emission': [0.00001, 1.234e-07],
+                  'detExposureTime': 0.00123456789, 'auto_bc_outliers': 0.12345},
+                 {'name': 'Filtered Colour 4', 'excitation': [0, 1, 2],
+                  'power': 0.0000000056, 'emission': [0.00001, 1.234e-07],
+                  'detExposureTime': 0.00123456789, 'auto_bc_outliers': 0.12345},
+                 {'name': 'Filtered Colour 5', 'excitation': [0, 1, 2],
+                  'power': 0.0000000067, 'emission': [0.00001, 1.234e-07],
+                  'detExposureTime': 0.00123456789, 'auto_bc_outliers': 0.12345},
+                 {'name': 'Filtered Colour 6', 'excitation': [0, 1, 2],
+                  'power': 0.0000000078, 'emission': [0.00001, 1.234e-07],
+                  'detExposureTime': 0.00123456789, 'auto_bc_outliers': 0.12345},
+                 {'name': 'Filtered Colour 7', 'excitation': [0, 1, 2],
+                  'power': 0.0000000091, 'emission': [0.00001, 1.234e-07],
+                  'detExposureTime': 0.00123456789, 'auto_bc_outliers': 0.12345},
+                 {'name': 'Filtered Colour 8', 'excitation': [0, 1, 2],
+                  'power': 0.0000000092, 'emission': [0.00001, 1.234e-07],
+                  'detExposureTime': 0.00123456789, 'auto_bc_outliers': 0.12345},
+                 {'name': 'Filtered Colour 9', 'excitation': [0, 1, 2],
+                  'power': 0.0000000093, 'emission': [0.00001, 1.234e-07],
+                  'detExposureTime': 0.00123456789, 'auto_bc_outliers': 0.12345},
+                 {'name': 'Filtered Colour 10', 'excitation': [0, 1, 2],
+                  'power': 0.0000000094, 'emission': [0.00001, 1.234e-07],
+                  'detExposureTime': 0.00123456789, 'auto_bc_outliers': 0.12345},
+                 # Add tint
+                 {'name': 'Filtered Colour 1', 'excitation': [0, 1, 2],
+                  'power': 0.0000000095, 'emission': [0.00001, 1.234e-07], "tint": "red",
+                  'detExposureTime': 0.00123456789, 'auto_bc_outliers': 0.12345}]
+
+    @classmethod
+    def setUpClass(cls):
+        file_path = os.path.abspath(os.path.join("", "settings.json"))
+        cls.acq_settings = StreamSettingsConfig(file_path, 10)
+
+        testing.start_backend(METEOR_CONFIG)
+        cls.stage = model.getComponent(role="stage")
+        cls.ccd = model.getComponent(role="ccd")
+        cls.light = model.getComponent(role="light")
+        cls.focus = model.getComponent(role="focus")
+        cls.filter = model.getComponent(role="filter")
+
+    def test_entries(self):
+        """The name of entries in the json file is unique"""
+        # Use the test_data as config_data
+        self.acq_settings.update_data(self.test_data)
+        # Only one stream should have Filtered Colour 1 as the name
+        index = next((i for i, k in enumerate(self.acq_settings.config_data) if k["name"] == "Filtered Colour 1"),
+                     None)
+        # Find other streams having the same stream name
+        # by leaving the first entry with the same name
+        is_duplicate = next((False for k in self.acq_settings.config_data[index + 1] if k != "Filtered Colour 1"), True)
+        # Assert that there are no duplicates
+        self.assertFalse(is_duplicate, "Duplicate stream names found")
+
+        # the length of extracted data to save should be less or equal to set maximum
+        self.assertLessEqual(len(self.acq_settings.config_data), self.acq_settings.max_entries)
+        # the length of saved data after reading should be less or equal to set maximum
+        # self.acq_settings.read()
+        self.assertLessEqual(len(self.acq_settings.config_data), self.acq_settings.max_entries,
+                             "entries are more than maximum entries")
+
+        # the last entry in test_data i.e. the latest should be the first entry of the json file
+        self.assertEqual(self.acq_settings.config_data[0], self.test_data[-1])
+        # the first entry in test_data should no longer be in the json file as it will be the 11th entry in the json
+        if len(self.test_data) > self.acq_settings.max_entries:
+            is_existing = next((True for k in self.acq_settings.config_data if k == self.test_data[0]), False)
+            self.assertFalse(is_existing, "JSON file is not updated correctly with the new entries")
+
+    def test_get_streams_settings(self):
+        """Get the stream settings from the input stream and save the settings in the JSON file"""
+        fms = FluoStream("fluo", self.ccd, self.ccd.data,
+                         self.light, self.filter, focuser=self.focus, detvas={"exposureTime"})
+        fms.excitation.value = (3.9e-07, 3.97e-07, 4.0000000000000003e-07, 4.0300000000000005e-07,
+                                4.1000000000000004e-07)
+        fms.power.value = 0.24
+        fms.emission.value = (5.795e-07, 6.105e-07)
+        fms.tint.value = (12, 13, 14)
+        fms.detExposureTime.value = 0.12
+        fms.auto_bc_outliers.value = 0.45
+        # save the fluo stream settings in the JSON file
+        self.acq_settings.update_entries([fms])
+        # find the index of the list for the recently saved fluo stream
+        index = self.acq_settings._get_config_index(self.acq_settings.config_data, "fluo")
+        # get the saved data from the JSON file
+        data = self.acq_settings.config_data[index]
+        # check the values of the given stream with the values saved in the JSON file
+        settings_order = get_settings_order(fms)
+        for key in settings_order:
+            self.assertEqual(data[key], getattr(fms, key).value)
+
+    def test_set_streams_settings(self):
+        """Load the stream from the JSON file and set the input stream with loaded settings"""
+        # save a stream setting in the JSON file
+        s = FluoStream("fluo", self.ccd, self.ccd.data,
+                       self.light, self.filter, focuser=self.focus, detvas={"exposureTime"})
+        s.excitation.value = (3.9e-07, 3.97e-07, 4.0000000000000003e-07, 4.0300000000000005e-07,
+                              4.1000000000000004e-07)
+        s.power.value = 0.24
+        s.emission.value = (5.795e-07, 6.105e-07)
+        s.tint.value = (12, 13, 14)
+        s.detExposureTime.value = 0.12
+        s.auto_bc_outliers.value = 0.45
+        self.acq_settings.update_entries([s])
+        # Set the values of test_fluo stream from the values of saved fluo stream
+        fms = FluoStream("fluo", self.ccd, self.ccd.data,
+                         self.light, self.filter, focuser=self.focus, detvas={"exposureTime"})
+        self.acq_settings.apply_settings(fms, "fluo")
+        index = self.acq_settings._get_config_index(self.acq_settings.config_data, "fluo")
+        data = self.acq_settings.config_data[index]
+        settings_order = get_settings_order(fms)
+        for key in settings_order:
+            self.assertEqual(getattr(fms, key).value, data[key])
+
+    def test_get_settings_order(self):
+        """Test the list of required setting parameters used for loading/saving an old stream"""
+        required_setting_keys = ["excitation", "power", "emission", "auto_bc_outliers", "tint", "name",
+                                 "detExposureTime"]
+        fms = FluoStream("fluo", self.ccd, self.ccd.data,
+                         self.light, self.filter, focuser=self.focus, detvas={"exposureTime"})
+        settings_order = get_settings_order(fms)
+        is_missing_settings = set(required_setting_keys).difference(settings_order)
+        # Check if all required settings are present
+        self.assertTrue(is_missing_settings == set())
+        # Check if tint is present after excitation, power and emission
+        self.assertTrue(
+            settings_order.index("excitation") < settings_order.index("emission") < settings_order.index("tint"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/odemis/gui/cont/tabs/localization_tab.py
+++ b/src/odemis/gui/cont/tabs/localization_tab.py
@@ -422,8 +422,9 @@ class LocalizationTab(Tab):
                 chamber_tab = self.main_data.getTabByName("cryosecom_chamber")
                 chamber_tab.remove_overview_streams([st])
 
-        # Update and save the used stream settings
-        self._streambar_controller.update_stream_settings()
+        # Update and save the used stream settings on acquisition
+        if acquired_streams:
+            self._streambar_controller.update_stream_settings()
 
     @call_in_wx_main
     def display_acquired_data(self, data):

--- a/src/odemis/gui/cont/tabs/localization_tab.py
+++ b/src/odemis/gui/cont/tabs/localization_tab.py
@@ -422,6 +422,8 @@ class LocalizationTab(Tab):
                 chamber_tab = self.main_data.getTabByName("cryosecom_chamber")
                 chamber_tab.remove_overview_streams([st])
 
+        # Update and save the used stream settings
+        self._streambar_controller.update_stream_settings()
 
     @call_in_wx_main
     def display_acquired_data(self, data):


### PR DESCRIPTION
Display most recently used settings (MRU) in the combo box of add stream button in the localisation tab.

Things left to do:-
1. **Add the tint settings** - It is a bit tricky to add tint. When it is in tuple format of 3 floats, it is easy to save it. But, when the tint value is of type LinearSegmentedColormap which is a custom color map, I am still exploring how to save such a type and read it. - **DONE**
2. **Test cases for the gui** - the testing for the full process i.e. save the setting of the stream controller and reading to checking the values in the json file and also vice-versa i.e. check the values of the recently used setting with the settings displayed in the gui. For both the workflows, I am not sure if it can be tested in the unit testing. 
3. **Review of Specifications document** -  Document incomplete for the review stage

@pieleric and @patrickcleeve2 taggig you to update you with the progress on this task. 

@pieleric I have for now directly saved the stream values in the json file as it is easy to read it and write it. I checked with the the functions in preset.py. The  input argument of the function apply_preset(preset) , consists of stream settings saved as dict of SettingEntries -> value.  In order to save such type in the json file, I have to decode SettingEntries in json format. As we just need the value of the vigilant attribute, I am not sure if saving the value_ctrl and label_ctrl in SettingEntries will be advantageous or needed. Is it a good idea to save directly the values without using preset.py functions?
