### PR TITLE
[refactor] move all MIRROR_* constants from sparc2_chamber_tab back to tabs

### DIFF
--- a/src/odemis/gui/cont/tabs/__init__.py
+++ b/src/odemis/gui/cont/tabs/__init__.py
@@ -23,6 +23,7 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 
 """
 
+from ._constants import *
 from .analysis_tab import AnalysisTab
 from .correlation_tab import CorrelationTab
 from .cryo_chamber_tab import CryoChamberTab

--- a/src/odemis/gui/cont/tabs/_constants.py
+++ b/src/odemis/gui/cont/tabs/_constants.py
@@ -28,3 +28,9 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 # Used in Sparc2AlignTab, ChamberTab
 MIRROR_POS_PARKED = {"l": 0, "s": 0}  # (Hopefully) constant, and same as reference position
 MIRROR_ONPOS_RADIUS = 2e-3  # m, distance from a position that is still considered that position
+
+# Different states of the mirror stage positions
+MIRROR_NOT_REFD = 0
+MIRROR_PARKED = 1
+MIRROR_BAD = 2  # not parked, but not fully engaged either
+MIRROR_ENGAGED = 3

--- a/src/odemis/gui/cont/tabs/sparc2_chamber_tab.py
+++ b/src/odemis/gui/cont/tabs/sparc2_chamber_tab.py
@@ -35,15 +35,10 @@ from odemis.gui.cont.stream_bar import StreamBarController
 import odemis.gui.cont.views as viewcont
 import odemis.gui.model as guimod
 from odemis.gui.conf.data import get_local_vas
-from odemis.gui.cont.tabs._constants import MIRROR_ONPOS_RADIUS, MIRROR_POS_PARKED
+from odemis.gui.cont.tabs._constants import MIRROR_ONPOS_RADIUS, MIRROR_POS_PARKED, MIRROR_ENGAGED, \
+    MIRROR_PARKED, MIRROR_BAD, MIRROR_NOT_REFD
 from odemis.gui.cont.tabs.tab import Tab
 from odemis.gui.util import call_in_wx_main
-
-# Different states of the mirror stage positions
-MIRROR_NOT_REFD = 0
-MIRROR_PARKED = 1
-MIRROR_BAD = 2  # not parked, but not fully engaged either
-MIRROR_ENGAGED = 3
 
 
 class ChamberTab(Tab):


### PR DESCRIPTION
The MIRROR_* constants are used by the "sparc_engage_warn" plugin, and
soon by another one.
We could change the imports, but it's nicer to put them back to where
they were so that we don't break old plugin versions. Also, it seems
to make more sense to have all MIRROR_* constants in the same place.