### PR TITLE
[clean-up] Fix header of blinkstick_test

### DIFF
--- a/src/odemis/driver/test/blinkstick_test.py
+++ b/src/odemis/driver/test/blinkstick_test.py
@@ -1,5 +1,5 @@
-    # -*- coding: utf-8 -*-
-'''
+# -*- coding: utf-8 -*-
+"""
 Created on 10 Jul 2015
 
 @author: Kimon Tsitsikas
@@ -13,7 +13,7 @@ Odemis is free software: you can redistribute it and/or modify it under the term
 Odemis is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License along with Odemis. If not, see http://www.gnu.org/licenses/.
-'''
+"""
 import logging
 import numpy
 from odemis.driver import blinkstick


### PR DESCRIPTION
Drop extra spaces in the header.
Also change to the new standard of triple double quotes instead of
triple single quotes.