### PR TITLE
[TRCL-23] support hamamatsu C16910 streak camera

### DIFF
--- a/install/linux/usr/share/odemis/sim/sparc2-streakcam-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/sparc2-streakcam-sim.odm.yaml
@@ -200,6 +200,7 @@ SPARC2: {
 "Streak Unit": {
     role: streak-unit,
     init: {
+#        settings_ini: "C:\ProgramData\Hamamatsu\HPDTA\SingleSweep.ini" # path of the .ini file for HPDTA to run
     },
     affects: ["Streak Readout CCD"],
 }

--- a/src/odemis/driver/test/hamamatsurx_test.py
+++ b/src/odemis/driver/test/hamamatsurx_test.py
@@ -418,6 +418,21 @@ class TestHamamatsurxCam(unittest.TestCase):
         with self.assertRaises(IndexError):
             self.delaybox.triggerDelay.value = -1
 
+    def test_Shutter(self):
+        """Test Shutter state VA of streak unit."""
+        # set shutter VA
+        self.streakunit.shutter.value = False
+        time.sleep(0.5)  # give it some time to actually change the value
+        prev_shutter = self.streakunit.shutter.value
+        # change shutter VA
+        self.streakunit.shutter.value = True
+        time.sleep(0.5)  # give it some time to actually change the value
+        cur_shutter = self.streakunit.shutter.value
+        # compare previous and current gain
+        self.assertNotEqual(prev_shutter, self.streakunit.shutter.value)
+        # check shutter-VA reports the same value as RemoteEx
+        remoteEx_shutter = self.streakunit.GetShutter()
+        self.assertEqual(cur_shutter, remoteEx_shutter)
 
     ### Streakunit #####################################################
     def test_StreakMode(self):

--- a/src/odemis/driver/test/hamamatsurx_test.py
+++ b/src/odemis/driver/test/hamamatsurx_test.py
@@ -41,12 +41,11 @@ STREAK_CHILDREN = {"readoutcam": CONFIG_READOUTCAM, "streakunit": CONFIG_STREAKU
 STREAK_CHILDREN_NO_DELAYBOX = {"readoutcam": CONFIG_READOUTCAM, "streakunit": CONFIG_STREAKUNIT}
 STREAK_CHILDREN_NO_READOUT_CAM = {"streakunit": CONFIG_STREAKUNIT, "delaybox": CONFIG_DELAYBOX}
 
-KWARGS_STREAKCAM = dict(name="streak cam", role="ccd", host="192.168.42.76", port=1001,
-                        children=STREAK_CHILDREN) # 172.16.4.2
-KWARGS_STREAKCAM_NO_DELAYBOX = dict(name="streak cam", role="ccd", host="192.168.42.76", port=1001,
-                                    children=STREAK_CHILDREN_NO_DELAYBOX) # 172.16.4.2
-KWARGS_STREAKCAM_NO_READOUT_CAM = dict(name="streak cam", role="ccd", host="192.168.42.76", port=1001,
-                                       children=STREAK_CHILDREN_NO_READOUT_CAM) # 172.16.4.2
+KWARGS_STREAKCAM = dict(name="streak cam", role="ccd", host="172.16.4.2", port=1001, children=STREAK_CHILDREN)
+KWARGS_STREAKCAM_NO_DELAYBOX = dict(name="streak cam", role="ccd", host="172.16.4.2", port=1001,
+                                    children=STREAK_CHILDREN_NO_DELAYBOX)
+KWARGS_STREAKCAM_NO_READOUT_CAM = dict(name="streak cam", role="ccd", host="172.16.4.2", port=1001,
+                                       children=STREAK_CHILDREN_NO_READOUT_CAM)
 
 # test with spectrograph
 CLASS_SPECTROGRAPH = andorshrk.Shamrock
@@ -132,32 +131,32 @@ class TestHamamatsurxNoReadoutCamera(unittest.TestCase):
             if child.name == CONFIG_DELAYBOX["name"]:
                 cls.delaybox = child
 
-        cls.delaybox.updateMetadata({model.MD_TIME_RANGE_TO_DELAY:
-            {
-                1.e-9: 7.99e-9,
-                2.e-9: 9.63e-9,
-                5.e-9: 33.2e-9,
-                10.e-9: 45.9e-9,
-                20.e-9: 66.4e-9,
-                50.e-9: 102e-9,
-                100.e-9: 169e-9,
-                200.e-9: 302e-9,
-                500.e-9: 731e-9,
-                1.e-6: 1.39e-6,
-                2.e-6: 2.69e-6,
-                5.e-6: 7.02e-6,
-                10.e-6: 13.8e-6,
-                20.e-6: 26.7e-6,
-                50.e-6: 81.6e-6,
-                100.e-6: 161e-6,
-                200.e-6: 320e-6,
-                500.e-6: 798e-6,
-                1.e-3: 1.62e-3,
-                2.e-3: 3.18e-3,
-                5.e-3: 7.88e-3,
-                10.e-3: 15.4e-3,
-            }
-        })
+        # cls.delaybox.updateMetadata({model.MD_TIME_RANGE_TO_DELAY:
+        #     {
+        #         1.e-9: 7.99e-9,
+        #         2.e-9: 9.63e-9,
+        #         5.e-9: 33.2e-9,
+        #         10.e-9: 45.9e-9,
+        #         20.e-9: 66.4e-9,
+        #         50.e-9: 102e-9,
+        #         100.e-9: 169e-9,
+        #         200.e-9: 302e-9,
+        #         500.e-9: 731e-9,
+        #         1.e-6: 1.39e-6,
+        #         2.e-6: 2.69e-6,
+        #         5.e-6: 7.02e-6,
+        #         10.e-6: 13.8e-6,
+        #         20.e-6: 26.7e-6,
+        #         50.e-6: 81.6e-6,
+        #         100.e-6: 161e-6,
+        #         200.e-6: 320e-6,
+        #         500.e-6: 798e-6,
+        #         1.e-3: 1.62e-3,
+        #         2.e-3: 3.18e-3,
+        #         5.e-3: 7.88e-3,
+        #         10.e-3: 15.4e-3,
+        #     }
+        # })
 
     @classmethod
     def tearDownClass(cls):
@@ -758,7 +757,7 @@ class TestHamamatsurxCamWithSpectrograph(unittest.TestCase):
         STREAK_CHILDREN = {"readoutcam": CONFIG_READOUTCAM, "streakunit": CONFIG_STREAKUNIT,
                            "delaybox": CONFIG_DELAYBOX}
 
-        cls.streakcam = hamamatsurx.StreakCamera("streak cam", "streakcam", host="192.168.42.76", # 192.168.56.103 172.16.4.2
+        cls.streakcam = hamamatsurx.StreakCamera("streak cam", "streakcam", host="172.16.4.2",
                                                  port=1001, children=STREAK_CHILDREN,
                                                  dependencies={"spectrograph": cls.spectrograph})
 

--- a/src/odemis/driver/test/hamamatsurx_test.py
+++ b/src/odemis/driver/test/hamamatsurx_test.py
@@ -38,8 +38,15 @@ CONFIG_STREAKUNIT = {"name": "StreakUnit", "role": "streakunit"}
 CONFIG_DELAYBOX = {"name": "Delaybox", "role": "delaybox"}
 
 STREAK_CHILDREN = {"readoutcam": CONFIG_READOUTCAM, "streakunit": CONFIG_STREAKUNIT, "delaybox": CONFIG_DELAYBOX}
+STREAK_CHILDREN_NO_DELAYBOX = {"readoutcam": CONFIG_READOUTCAM, "streakunit": CONFIG_STREAKUNIT}
+STREAK_CHILDREN_NO_READOUT_CAM = {"streakunit": CONFIG_STREAKUNIT, "delaybox": CONFIG_DELAYBOX}
 
-KWARGS_STREAKCAM = dict(name="streak cam", role="ccd", host="172.16.4.2", port=1001, children=STREAK_CHILDREN)
+KWARGS_STREAKCAM = dict(name="streak cam", role="ccd", host="192.168.42.76", port=1001,
+                        children=STREAK_CHILDREN) # 172.16.4.2
+KWARGS_STREAKCAM_NO_DELAYBOX = dict(name="streak cam", role="ccd", host="192.168.42.76", port=1001,
+                                    children=STREAK_CHILDREN_NO_DELAYBOX) # 172.16.4.2
+KWARGS_STREAKCAM_NO_READOUT_CAM = dict(name="streak cam", role="ccd", host="192.168.42.76", port=1001,
+                                       children=STREAK_CHILDREN_NO_READOUT_CAM) # 172.16.4.2
 
 # test with spectrograph
 CLASS_SPECTROGRAPH = andorshrk.Shamrock
@@ -107,6 +114,158 @@ class TestHamamatsurxCamGenericCamSynchronized(VirtualTestSynchronized, unittest
         super(TestHamamatsurxCamGenericCamSynchronized, cls).tearDownClass()
         cls.streakcam.terminate()
 
+
+class TestHamamatsurxNoReadoutCamera(unittest.TestCase):
+    """Test the Hamamatsu streak camera class with no streak camera HW."""
+
+    @classmethod
+    def setUpClass(cls):
+
+        if TEST_NOHW:
+            raise unittest.SkipTest('No streak camera HW present. Skipping tests.')
+
+        cls.streakcam = CLASS_STREAKCAM(**KWARGS_STREAKCAM_NO_READOUT_CAM)
+
+        for child in cls.streakcam.children.value:
+            if child.name == CONFIG_STREAKUNIT["name"]:
+                cls.streakunit = child
+            if child.name == CONFIG_DELAYBOX["name"]:
+                cls.delaybox = child
+
+        cls.delaybox.updateMetadata({model.MD_TIME_RANGE_TO_DELAY:
+            {
+                1.e-9: 7.99e-9,
+                2.e-9: 9.63e-9,
+                5.e-9: 33.2e-9,
+                10.e-9: 45.9e-9,
+                20.e-9: 66.4e-9,
+                50.e-9: 102e-9,
+                100.e-9: 169e-9,
+                200.e-9: 302e-9,
+                500.e-9: 731e-9,
+                1.e-6: 1.39e-6,
+                2.e-6: 2.69e-6,
+                5.e-6: 7.02e-6,
+                10.e-6: 13.8e-6,
+                20.e-6: 26.7e-6,
+                50.e-6: 81.6e-6,
+                100.e-6: 161e-6,
+                200.e-6: 320e-6,
+                500.e-6: 798e-6,
+                1.e-3: 1.62e-3,
+                2.e-3: 3.18e-3,
+                5.e-3: 7.88e-3,
+                10.e-3: 15.4e-3,
+            }
+        })
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.streakcam.terminate()
+
+    def test_error(self):  # TODO more testcases
+        """Test the different RemoteEx errors possible."""
+        # send wrong command, will timeout
+        with self.assertRaises(util.TimeoutError):
+            self.streakcam.sendCommand("Appinfoo", "type")
+
+    ### Delay generator #####################################################
+    def test_TriggerDelay(self):
+        """Test Acquisition Mode VA for delay generator."""
+        self.delaybox.triggerDelay.value = 0
+        prev_triggerDelay = self.delaybox.triggerDelay.value
+        # change trigger delay VA
+        self.delaybox.triggerDelay.value = 0.000001  # 1us
+        cur_triggerDelay = self.delaybox.triggerDelay.value
+        # check previous and current value are not the same
+        self.assertNotEqual(prev_triggerDelay, cur_triggerDelay)
+        # get trigger delay from hardware
+        remoteEx_triggerDelay = self.delaybox.GetDelayByName("Delay A")
+        self.assertEqual(cur_triggerDelay, remoteEx_triggerDelay)
+
+        # request value, which is not in range of VA
+        with self.assertRaises(IndexError):
+            self.delaybox.triggerDelay.value = -1
+
+    def test_DelayB(self):
+        """Test Acquisition Mode VA for delay generator."""
+
+        if not model.hasVA(self.delaybox, "delayB"):
+            self.skipTest("Delay box measurement mode is synchro scan. Skipping the test")
+
+        self.delaybox.delayB.value = 0
+        prev_delay = self.delaybox.delayB.value
+        # change the delay VA
+        self.delaybox.delayB.value = 0.000001  # 1us
+        cur_delay = self.delaybox.delayB.value
+        # check previous and current value are not the same
+        self.assertNotEqual(prev_delay, cur_delay)
+        # get trigger delay from hardware
+        remoteEx_delay = self.delaybox.GetDelayByName("Delay B")
+        self.assertEqual(cur_delay, remoteEx_delay)
+
+        # request value, which is not in range of VA
+        with self.assertRaises(IndexError):
+            self.delaybox.delayB.value = -1
+
+    def test_DelayC(self):
+        """Test Acquisition Mode VA for delay generator."""
+
+        if not model.hasVA(self.delaybox, "delayC"):
+            self.skipTest("Delay box measurement mode is synchro scan. Skipping the test")
+
+        self.delaybox.delayC.value = 0
+        prev_delay = self.delaybox.delayC.value
+        # change the delay VA
+        self.delaybox.delayC.value = 0.000001  # 1us
+        cur_delay = self.delaybox.delayC.value
+        # check previous and current value are not the same
+        self.assertNotEqual(prev_delay, cur_delay)
+        # get trigger delay from hardware
+        remoteEx_delay = self.delaybox.GetDelayByName("Delay C")
+        self.assertEqual(cur_delay, remoteEx_delay)
+
+        # request value, which is not in range of VA
+        with self.assertRaises(IndexError):
+            self.delaybox.delayC.value = -1
+
+    def test_PLLMode(self):
+        """Test PLL mode VA for the phase lock status"""
+        if not model.hasVA(self.delaybox, "phaseLocked"):
+            self.skipTest("Delay box measurement mode is synchro scan. Skipping the test")
+
+        # set PLL VA
+        self.delaybox.phaseLocked.value = False
+        time.sleep(0.5)  # give it some time to actually change the value
+        prev_pll = self.delaybox.phaseLocked.value
+        # change pll VA
+        self.delaybox.phaseLocked.value = True
+        time.sleep(0.5)  # give it some time to actually change the value
+        cur_pll = self.delaybox.phaseLocked.value
+        # compare previous and current gain
+        self.assertNotEqual(prev_pll, self.delaybox.phaseLocked.value)
+        # check pll-VA reports the same value as RemoteEx
+        remoteEx_pll = self.delaybox.GetPLLMode()
+        self.assertEqual(cur_pll, remoteEx_pll)
+
+
+    def test_TimeRange(self):
+        """Test time range VA for sweeping of streak unit."""
+        for timeRange in self.streakunit.timeRange.choices:  # values different from yaml due to floating point issues
+            # change timeRange VA to value in range
+            self.streakunit.timeRange.value = timeRange
+            self.assertAlmostEqual(self.streakunit.timeRange.value, timeRange)
+
+            tr2d = self.delaybox._metadata.get(model.MD_TIME_RANGE_TO_DELAY)
+            if tr2d:
+                key = util.find_closest(timeRange, tr2d.keys())
+                # check that the corresponding trigger delay is set when changing the .timeRange VA
+                md_triggerDelay = tr2d[key]
+                self.assertAlmostEqual(self.delaybox.triggerDelay.value, md_triggerDelay)
+
+        # request value, which is not in choices of VA
+        with self.assertRaises(IndexError):
+            self.streakunit.timeRange.value = 0.000004  # 4us
 
 class TestHamamatsurxCam(unittest.TestCase):
     """Test the Hamamatsu streak camera class with real streak camera HW."""
@@ -258,6 +417,7 @@ class TestHamamatsurxCam(unittest.TestCase):
         # request value, which is not in range of VA
         with self.assertRaises(IndexError):
             self.delaybox.triggerDelay.value = -1
+
 
     ### Streakunit #####################################################
     def test_StreakMode(self):
@@ -584,7 +744,7 @@ class TestHamamatsurxCamWithSpectrograph(unittest.TestCase):
         STREAK_CHILDREN = {"readoutcam": CONFIG_READOUTCAM, "streakunit": CONFIG_STREAKUNIT,
                            "delaybox": CONFIG_DELAYBOX}
 
-        cls.streakcam = hamamatsurx.StreakCamera("streak cam", "streakcam", host="172.16.4.2",
+        cls.streakcam = hamamatsurx.StreakCamera("streak cam", "streakcam", host="192.168.42.76", # 192.168.56.103 172.16.4.2
                                                  port=1001, children=STREAK_CHILDREN,
                                                  dependencies={"spectrograph": cls.spectrograph})
 

--- a/src/odemis/driver/test/hamamatsurx_test.py
+++ b/src/odemis/driver/test/hamamatsurx_test.py
@@ -422,7 +422,6 @@ class TestHamamatsurxCam(unittest.TestCase):
         """Test Shutter state VA of streak unit."""
         # set shutter VA
         self.streakunit.shutter.value = False
-        time.sleep(0.5)  # give it some time to actually change the value
         prev_shutter = self.streakunit.shutter.value
         # change shutter VA
         self.streakunit.shutter.value = True

--- a/src/odemis/gui/cont/settings.py
+++ b/src/odemis/gui/cont/settings.py
@@ -25,7 +25,6 @@ user interface.
 
 """
 
-from past.builtins import long
 from abc import ABCMeta
 from collections.abc import Iterable
 import locale
@@ -212,11 +211,11 @@ class SettingsController(metaclass=ABCMeta):
             else:
                 # Still try to beautify a bit if it's a number
                 if (
-                    isinstance(value, (int, long, float)) or
+                    isinstance(value, (int, float)) or
                     (
                         isinstance(value, Iterable) and
                         len(value) > 0 and
-                        isinstance(value[0], (int, long, float))
+                        isinstance(value[0], (int, float))
                     )
                 ):
                     nice_str = readable_str(value, sig=3)
@@ -897,17 +896,17 @@ class StreakCamAlignSettingsController(SettingsBarController):
         entry_timeRange.value_ctrl.SetBackgroundColour(odemis.gui.BG_COLOUR_PANEL)
         self.ctrl_timeRange = entry_timeRange.value_ctrl
 
-        entry_triggerDelay = create_setting_entry(self.panel_streak, "Trigger delay",
-                                                  self.streak_delay.triggerDelay,
-                                                  self.streak_delay,
-                                                  conf={"control_type": odemis.gui.CONTROL_FLT,
-                                                        "label": "Trigger delay",
-                                                        "tooltip": "Change the trigger delay value to "
-                                                                   "center the image."},
-                                                  change_callback=self._onUpdateTriggerDelayMD)
-
-        entry_triggerDelay.value_ctrl.SetBackgroundColour(odemis.gui.BG_COLOUR_PANEL)
-        self.ctrl_triggerDelay = entry_triggerDelay.value_ctrl
+        # entry_triggerDelay = create_setting_entry(self.panel_streak, "Trigger delay",
+        #                                           self.streak_delay.triggerDelay,
+        #                                           self.streak_delay,
+        #                                           conf={"control_type": odemis.gui.CONTROL_FLT,
+        #                                                 "label": "Trigger delay",
+        #                                                 "tooltip": "Change the trigger delay value to "
+        #                                                            "center the image."},
+        #                                           change_callback=self._onUpdateTriggerDelayMD)
+        #
+        # entry_triggerDelay.value_ctrl.SetBackgroundColour(odemis.gui.BG_COLOUR_PANEL)
+        # self.ctrl_triggerDelay = entry_triggerDelay.value_ctrl
 
         entry_magnification = create_setting_entry(self.panel_streak, "Magnification",
                                                    self.streak_lens.magnification,
@@ -929,48 +928,48 @@ class StreakCamAlignSettingsController(SettingsBarController):
         self.panel.btn_open_streak_calib_file.Bind(wx.EVT_BUTTON, self._onOpenCalibFile)
         self.panel.btn_save_streak_calib_file.Bind(wx.EVT_BUTTON, self._onSaveCalibFile)
 
-    def _onUpdateTriggerDelayMD(self, evt):
-        """
-        Callback method for trigger delay ctrl GUI element.
-        Overwrites the triggerDelay value in the MD after a new value was requested via the GUI.
-        """
-        evt.Skip()
-        cur_timeRange = self.streak_unit.timeRange.value
-        requested_triggerDelay = self.ctrl_triggerDelay.GetValue()
-        # get a copy of  MD
-        trigger2delay_MD = self.streak_delay.getMetadata()[model.MD_TIME_RANGE_TO_DELAY]
+    # def _onUpdateTriggerDelayMD(self, evt):
+    #     """
+    #     Callback method for trigger delay ctrl GUI element.
+    #     Overwrites the triggerDelay value in the MD after a new value was requested via the GUI.
+    #     """
+    #     evt.Skip()
+    #     cur_timeRange = self.streak_unit.timeRange.value
+    #     requested_triggerDelay = self.ctrl_triggerDelay.GetValue()
+    #     # get a copy of  MD
+    #     trigger2delay_MD = self.streak_delay.getMetadata()[model.MD_TIME_RANGE_TO_DELAY]
+    #
+    #     # check if key already exists (prevent creating new key due to floating point issues)
+    #     key = util.find_closest(cur_timeRange, trigger2delay_MD.keys())
+    #     if util.almost_equal(key, cur_timeRange):
+    #         # Replace the current delay value with the requested for an already existing timeRange in the dict.
+    #         # This avoid duplication of keys, which are only different because of floating point issues.
+    #         trigger2delay_MD[key] = requested_triggerDelay
+    #     else:
+    #         trigger2delay_MD[cur_timeRange] = requested_triggerDelay
+    #         logging.warning("A new entry %s was added to MD_TIME_RANGE_TO_DELAY, "
+    #                         "which is not in the device .timeRange choices.", cur_timeRange)
+    #
+    #     # check the number of keys in the dict is same as choices for VA
+    #     if len(trigger2delay_MD.keys()) != len(self.streak_unit.timeRange.choices):
+    #         logging.warning("MD_TIME_RANGE_TO_DELAY has %d entries, while the device .timeRange has %d choices.",
+    #                         len(trigger2delay_MD.keys()), len(self.streak_unit.timeRange.choices))
+    #
+    #     self.streak_delay.updateMetadata({model.MD_TIME_RANGE_TO_DELAY: trigger2delay_MD})
+    #     # Note: updateMetadata should here never raise an exception as the UnitFloatCtrl already
+    #     # catches errors regarding type and out-of-range inputs
+    #
+    #     # update txt displayed in GUI
+    #     self._onUpdateTriggerDelayGUI("Calibration not saved yet", odemis.gui.FG_COLOUR_WARNING)
 
-        # check if key already exists (prevent creating new key due to floating point issues)
-        key = util.find_closest(cur_timeRange, trigger2delay_MD.keys())
-        if util.almost_equal(key, cur_timeRange):
-            # Replace the current delay value with the requested for an already existing timeRange in the dict.
-            # This avoid duplication of keys, which are only different because of floating point issues.
-            trigger2delay_MD[key] = requested_triggerDelay
-        else:
-            trigger2delay_MD[cur_timeRange] = requested_triggerDelay
-            logging.warning("A new entry %s was added to MD_TIME_RANGE_TO_DELAY, "
-                            "which is not in the device .timeRange choices.", cur_timeRange)
-
-        # check the number of keys in the dict is same as choices for VA
-        if len(trigger2delay_MD.keys()) != len(self.streak_unit.timeRange.choices):
-            logging.warning("MD_TIME_RANGE_TO_DELAY has %d entries, while the device .timeRange has %d choices.",
-                            len(trigger2delay_MD.keys()), len(self.streak_unit.timeRange.choices))
-
-        self.streak_delay.updateMetadata({model.MD_TIME_RANGE_TO_DELAY: trigger2delay_MD})
-        # Note: updateMetadata should here never raise an exception as the UnitFloatCtrl already
-        # catches errors regarding type and out-of-range inputs
-
-        # update txt displayed in GUI
-        self._onUpdateTriggerDelayGUI("Calibration not saved yet", odemis.gui.FG_COLOUR_WARNING)
-
-    def _onUpdateTriggerDelayGUI(self, text, colour=odemis.gui.FG_COLOUR_EDIT):
-        """
-        Updates the GUI elements regarding the new trigger delay value.
-        :parameter text (str): the text to show
-        :parameter colour (wx.Colour): the colour to use
-        """
-        self.panel.txt_StreakCalibFilename.Value = text
-        self.panel.txt_StreakCalibFilename.SetForegroundColour(colour)
+    # def _onUpdateTriggerDelayGUI(self, text, colour=odemis.gui.FG_COLOUR_EDIT):
+    #     """
+    #     Updates the GUI elements regarding the new trigger delay value.
+    #     :parameter text (str): the text to show
+    #     :parameter colour (wx.Colour): the colour to use
+    #     """
+    #     self.panel.txt_StreakCalibFilename.Value = text
+    #     self.panel.txt_StreakCalibFilename.SetForegroundColour(colour)
 
     def _onOpenCalibFile(self, event):
         """
@@ -996,26 +995,26 @@ class StreakCamAlignSettingsController(SettingsBarController):
         filename = dialog.GetFilename()
 
         # read file
-        try:
-            tr2d = calibration.read_trigger_delay_csv(path,
-                                                      self.streak_unit.timeRange.choices,
-                                                      self.streak_delay.triggerDelay.range)
-        except ValueError as error:
-            self._onUpdateTriggerDelayGUI("Error while loading file!", odemis.gui.FG_COLOUR_HIGHLIGHT)
-            logging.error("Failed loading %s: %s", filename, error)
-            return
-
-        # update the MD: overwrite the complete dict
-        self.streak_delay.updateMetadata({model.MD_TIME_RANGE_TO_DELAY: tr2d})
-
-        # update triggerDelay shown in GUI
-        cur_timeRange = self.streak_unit.timeRange.value
-        # find the corresponding trigger delay
-        key = util.find_closest(cur_timeRange, tr2d.keys())
-        # Note: no need to check almost_equal again as we do that already when loading the file
-        self.streak_delay.triggerDelay.value = tr2d[key]  # set the new value
-
-        self._onUpdateTriggerDelayGUI(filename)  # update txt displayed in GUI
+        # try:
+        #     tr2d = calibration.read_trigger_delay_csv(path,
+        #                                               self.streak_unit.timeRange.choices,
+        #                                               self.streak_delay.triggerDelay.range)
+        # except ValueError as error:
+        #     self._onUpdateTriggerDelayGUI("Error while loading file!", odemis.gui.FG_COLOUR_HIGHLIGHT)
+        #     logging.error("Failed loading %s: %s", filename, error)
+        #     return
+        #
+        # # update the MD: overwrite the complete dict
+        # self.streak_delay.updateMetadata({model.MD_TIME_RANGE_TO_DELAY: tr2d})
+        #
+        # # update triggerDelay shown in GUI
+        # cur_timeRange = self.streak_unit.timeRange.value
+        # # find the corresponding trigger delay
+        # key = util.find_closest(cur_timeRange, tr2d.keys())
+        # # Note: no need to check almost_equal again as we do that already when loading the file
+        # self.streak_delay.triggerDelay.value = tr2d[key]  # set the new value
+        #
+        # self._onUpdateTriggerDelayGUI(filename)  # update txt displayed in GUI
 
     def _onSaveCalibFile(self, event):
         """
@@ -1046,9 +1045,9 @@ class StreakCamAlignSettingsController(SettingsBarController):
             filename += ".csv"
             path += ".csv"
 
-        # get a copy of the triggerDelay dict from MD
-        tr2d = self.streak_delay.getMetadata()[model.MD_TIME_RANGE_TO_DELAY]
-        calibration.write_trigger_delay_csv(path, tr2d)
-
-        # update txt displayed in GUI
-        self._onUpdateTriggerDelayGUI(filename)
+        # # get a copy of the triggerDelay dict from MD
+        # tr2d = self.streak_delay.getMetadata()[model.MD_TIME_RANGE_TO_DELAY]
+        # calibration.write_trigger_delay_csv(path, tr2d)
+        #
+        # # update txt displayed in GUI
+        # self._onUpdateTriggerDelayGUI(filename)


### PR DESCRIPTION
extend the hamamatsu streak camera driver to support C16910 model.

update hamamatsu streak camera driver to make it less strict on the delaybox. 
with the new model on new system(s) it should be optional.