### PR TITLE
[FIX] PARMA stage scanning fixes

### DIFF
--- a/install/linux/usr/share/odemis/sim/sparc2-4spec-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/sparc2-4spec-sim.odm.yaml
@@ -136,15 +136,15 @@ SPARC2-4Spec: {
 #    properties: {
 #        speed: {"x": 100.e-6, "y": 100.e-6},
 #    },
-    metadata: {
-        POS_ACTIVE_RANGE: {"x": [-5.0e-3, 5.0e-3], "y": [-5.0e-3, 5.0e-3]},
-    },
+#    metadata: {
+#        POS_ACTIVE_RANGE: {"x": [-5.0e-3, 5.0e-3], "y": [-5.0e-3, 5.0e-3]},
+#    },
     affects: ["Sample Stage"],
 }
 
 "Sample Stage": {
     class: simulated.Stage,
-    role: sem-stage,
+    role: stage,
     init: {
         axes: ["x", "y"],
         ranges: {"x": [-0.014, 0.014], "y": [-0.028, 0.028]},

--- a/install/linux/usr/share/odemis/sim/sparc2-4spec-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/sparc2-4spec-sim.odm.yaml
@@ -133,12 +133,6 @@ SPARC2-4Spec: {
     init: {
         axes_map: {"x": "x", "y": "y"},
     },
-#    properties: {
-#        speed: {"x": 100.e-6, "y": 100.e-6},
-#    },
-#    metadata: {
-#        POS_ACTIVE_RANGE: {"x": [-5.0e-3, 5.0e-3], "y": [-5.0e-3, 5.0e-3]},
-#    },
     affects: ["Sample Stage"],
 }
 

--- a/src/odemis/acq/test/stream_test.py
+++ b/src/odemis/acq/test/stream_test.py
@@ -2236,7 +2236,7 @@ class SPARC2TestCaseStageWrapper(unittest.TestCase):
         cls.ebeam = model.getComponent(role="e-beam")
         cls.sed = model.getComponent(role="se-detector")
         cls.scan_stage = model.getComponent(role="scan-stage")
-        cls.sem_stage = model.getComponent(role="sem-stage")
+        cls.sem_stage = model.getComponent(role="stage")
         cls.ebic = model.getComponent(role="ebic-detector")
 
     @classmethod

--- a/src/odemis/driver/simsem.py
+++ b/src/odemis/driver/simsem.py
@@ -455,16 +455,19 @@ class Detector(model.Detector):
             trans = scanner.pixelToPhy(pxs_pos)
             updated_phy_pos = (phy_pos[0] + trans[0], phy_pos[1] + trans[1])
 
+            # Extra translation to simulate stage movement in case of stage scanning
+            stage_shift = phy_pos[0] / pxs[0], -phy_pos[1] / pxs[1]  # Y goes opposite
+
             shape = self.fake_img.shape
             # Simulate shift and drift
             center = (shape[1] / 2 - shi[0] / pxs[0] - self.current_drift,
                       shape[0] / 2 - shi[1] / pxs[1] + self.current_drift)
 
             # First and last index (eg, 0 -> 255)
-            ltrb = [center[0] + pxs_pos[0] - (res[0] / 2) * scale[0],
-                    center[1] + pxs_pos[1] - (res[1] / 2) * scale[1],
-                    center[0] + pxs_pos[0] + ((res[0] / 2) - 1) * scale[0],
-                    center[1] + pxs_pos[1] + ((res[1] / 2) - 1) * scale[1]
+            ltrb = [center[0] + pxs_pos[0] + stage_shift[0] - (res[0] / 2) * scale[0],
+                    center[1] + pxs_pos[1] + stage_shift[1] - (res[1] / 2) * scale[1],
+                    center[0] + pxs_pos[0] + stage_shift[0] + ((res[0] / 2) - 1) * scale[0],
+                    center[1] + pxs_pos[1] + stage_shift[1] + ((res[1] / 2) - 1) * scale[1]
                     ]
             # If the shift caused the image to go out of bounds, limit it
             if ltrb[0] < 0:

--- a/src/odemis/gui/cont/tabs/sparc_acquisition_tab.py
+++ b/src/odemis/gui/cont/tabs/sparc_acquisition_tab.py
@@ -290,11 +290,13 @@ class SparcAcquisitionTab(Tab):
         # add "Use scan stage" check box if scan_stage is present
         sstage = main_data.scan_stage
         if sstage:
-            # Move the scan stage to the center (so that scan has maximum range)
             ssaxes = sstage.axes
             posc = {"x": sum(ssaxes["x"].range) / 2,
                     "y": sum(ssaxes["y"].range) / 2}
-            sstage.moveAbs(posc)
+            # In case of a 'real' scan stage, move the scan stage
+            # to the center (so that scan has maximum range)
+            if main_data.stage.name not in sstage.affects.value:
+                sstage.moveAbs(posc)
 
             self.scan_stage_ent = sem_stream_cont.add_setting_entry(
                 "useScanStage",
@@ -303,8 +305,9 @@ class SparcAcquisitionTab(Tab):
                 get_stream_settings_config()[acqstream.SEMStream]["useScanStage"]
             )
 
-            # Draw the limits on the SEM view
             tab_data.useScanStage.subscribe(self._on_use_scan_stage, init=True)
+
+            # In case of a 'real' scan stage, draw the limits on the SEM view
             roi = (ssaxes["x"].range[0] - posc["x"],
                    ssaxes["y"].range[0] - posc["y"],
                    ssaxes["x"].range[1] - posc["x"],

--- a/src/odemis/gui/cont/tabs/sparc_acquisition_tab.py
+++ b/src/odemis/gui/cont/tabs/sparc_acquisition_tab.py
@@ -293,7 +293,7 @@ class SparcAcquisitionTab(Tab):
             ssaxes = sstage.axes
             posc = {"x": sum(ssaxes["x"].range) / 2,
                     "y": sum(ssaxes["y"].range) / 2}
-            # In case of a 'real' scan stage, move the scan stage
+            # In case of a 'independent' scan stage, move the scan stage
             # to the center (so that scan has maximum range)
             if main_data.stage.name not in sstage.affects.value:
                 sstage.moveAbs(posc)
@@ -307,7 +307,7 @@ class SparcAcquisitionTab(Tab):
 
             tab_data.useScanStage.subscribe(self._on_use_scan_stage, init=True)
 
-            # In case of a 'real' scan stage, draw the limits on the SEM view
+            # draw the limits on the SEM view
             roi = (ssaxes["x"].range[0] - posc["x"],
                    ssaxes["y"].range[0] - posc["y"],
                    ssaxes["x"].range[1] - posc["x"],


### PR DESCRIPTION
After recent testing of the stage scanning feature on a real SEM with a stage scan wrapper it turned out a few fixes were needed:
- there needed to be made a few distinctions for automatic moving conditions of the stage, in general with a real stage we do not want to move when starting Odemis or to go back to the center position.
- correction for stage shift when acquiring
- added shift stage translation fake data to simsem detector class