### PR TITLE
[fix] xt_client external VA failed when no detector is used

### DIFF
--- a/src/odemis/driver/xt_client.py
+++ b/src/odemis/driver/xt_client.py
@@ -1711,7 +1711,7 @@ class Scanner(model.Emitter):
             if self.dwellTime.value != self.parent.get_dwell_time():
                 # Set the VA value again to reflect changes on the parent
                 self.dwellTime.value = self.dwellTime.value
-            if self.resolution.value != tuple(self.parent.get_resolution()):
+            if hasattr(self, "resolution") and self.resolution.value != tuple(self.parent.get_resolution()):
                 # Set the VA value again to reflect changes on the parent
                 self.scale.value = self.scale.value
         return external


### PR DESCRIPTION
Changing the external VA if there is no detector connected was broken by
commit 47b9b1d4b (dwell time slider does not work for overview imaging).

This commit fixed reading the resolution VA when external is True.
However, if there are no detector, there is no resolution VA.
=> need to handle such case.