### PR TITLE
[SDEV-1807] configure multibeam

### DIFF
--- a/src/odemis/acq/fastem.py
+++ b/src/odemis/acq/fastem.py
@@ -622,6 +622,7 @@ class AcquisitionTask(object):
             # configure the HW settings
             fastem_conf.configure_scanner(self._scanner, fastem_conf.MEGAFIELD_MODE)
             fastem_conf.configure_detector(self._detector, self._roc2, self._roc3)
+            fastem_conf.configure_multibeam(self._multibeam)
 
             dataflow.subscribe(self.image_received)
 

--- a/src/odemis/acq/fastem_conf.py
+++ b/src/odemis/acq/fastem_conf.py
@@ -178,3 +178,12 @@ def configure_detector(detector, roc2, roc3):
         logging.warning("Region of calibration doesn't have cell translation parameters.")
     else:
         detector.cellTranslation.value = cell_translation
+
+
+def configure_multibeam(multibeam):
+    """
+    :param multibeam: (technolution.EBeamScanner) The multibeam scanner component that needs to be configured.
+    """
+    multibeam_md = multibeam.getMetadata()
+    multibeam.scanOffset.value = multibeam_md[model.MD_SCAN_OFFSET_CALIB]
+    multibeam.scanAmplitude.value = multibeam_md[model.MD_SCAN_AMPLITUDE_CALIB]


### PR DESCRIPTION
Now that we are not running the scan amplitude pre-alignment in calibration 1, but have moved it to monthly maintenance, the calibrated value is not automatically set on the VA. This PR ensures that we are running the acquisition with the calibrated scan offset and amplitude.

@nandishjpatel I'm not sure if this is the best way to fix this, maybe we should rethink how to store calibrated values, now that we want to move some stuff to monthly maintenance.