### PR TITLE
[fix] autostig period for idx 0 behaved incorrectly

### DIFF
--- a/src/odemis/gui/cont/acquisition/fastem_acq.py
+++ b/src/odemis/gui/cont/acquisition/fastem_acq.py
@@ -32,7 +32,6 @@ import math
 import os
 from builtins import str
 from concurrent.futures._base import CancelledError
-from datetime import datetime
 from functools import partial
 
 import wx
@@ -43,8 +42,9 @@ from odemis.acq.align import fastem as align_fastem
 from odemis.acq.align.fastem import Calibrations
 from odemis.acq.fastem import estimate_acquisition_time
 from odemis.acq.stream import FastEMOverviewStream
-from odemis.gui import FG_COLOUR_BUTTON, conf
+from odemis.gui import FG_COLOUR_BUTTON
 from odemis.gui.conf.data import get_hw_config
+from odemis.gui.conf.file import AcquisitionConfig
 from odemis.gui.conf.util import process_setting_metadata
 from odemis.gui.util import (call_in_wx_main, get_picture_folder,
                              wxlimit_invocation)
@@ -533,12 +533,16 @@ class FastEMAcquiController(object):
 
         # Read the period with which to run autostigmation, if the value is 5 it should run for
         # ROAs with index 0, 5, 10, etc., if the value is 0 it should never run autostigmation
-        acqui_conf = conf.get_acqui_conf()
+        acqui_conf = AcquisitionConfig()
         autostig_period = math.inf if acqui_conf.autostig_period == 0 else acqui_conf.autostig_period
+        logging.debug(f"Will run autostigmation every {autostig_period} sections.")
 
         for p in self._tab_data_model.projects.value:
             for idx, roa in enumerate(p.roas.value):
-                pre_calib = pre_calib_plus if idx % autostig_period == 0 else pre_calibrations
+                if idx == 0 or idx % autostig_period != 0:
+                    pre_calib = pre_calibrations
+                else:
+                    pre_calib = pre_calib_plus
                 f = fastem.acquire(roa, p.name.value, self._main_data_model.ebeam,
                                    self._main_data_model.multibeam, self._main_data_model.descanner,
                                    self._main_data_model.mppc, self._main_data_model.stage,

--- a/src/odemis/gui/cont/project.py
+++ b/src/odemis/gui/cont/project.py
@@ -26,16 +26,17 @@ as the region of acquisition (ROA), region of calibration (ROC) and projects in 
 FASTEM system.
 """
 
-from functools import partial
 import logging
+from functools import partial
 
 import wx
 
-from odemis.acq.fastem import CALIBRATION_2, CALIBRATION_3, FastEMROA
 import odemis.acq.stream as acqstream
 import odemis.gui.model as guimodel
-from odemis.gui import conf, FG_COLOUR_RADIO_INACTIVE, FG_COLOUR_BUTTON
+from odemis.acq.fastem import CALIBRATION_2, CALIBRATION_3, FastEMROA
+from odemis.gui import FG_COLOUR_RADIO_INACTIVE, FG_COLOUR_BUTTON
 from odemis.gui.comp.fastem import FastEMProjectPanel, FastEMROAPanel, FastEMCalibrationPanel
+from odemis.gui.conf.file import AcquisitionConfig
 from odemis.gui.util import call_in_wx_main
 from odemis.util.filename import make_unique_name
 
@@ -281,7 +282,7 @@ class FastEMROAController(object):
         self._viewport = viewport
 
         # Read the overlap from the acquisition configuration
-        acqui_conf = conf.get_acqui_conf()
+        acqui_conf = AcquisitionConfig()
 
         self.model = FastEMROA(name, acqstream.UNDEFINED_ROI, roc_2, roc_3,
                                self._tab_data.main.asm, self._tab_data.main.multibeam,


### PR DESCRIPTION
For idx 0 even if the autostig period was set to 0 it would still run the extended pre-calibrations. Additionally it should not run for idx 0, only for subsequent indices.