### PR TITLE
[ci] fix cli main test case "test_help"

### DIFF
--- a/src/odemis/cli/test/main_test.py
+++ b/src/odemis/cli/test/main_test.py
@@ -69,7 +69,7 @@ class TestWithoutBackend(unittest.TestCase):
         self.assertEqual(ret, 0, "trying to run '%s' returned %s" % (cmdline, ret))
 
         output = out.getvalue()
-        self.assertTrue(b"optional arguments" in output)
+        self.assertTrue(b"Microscope management" in output)
 
 #    @skip("Simple")
     def test_error_command_line(self):


### PR DESCRIPTION
In Python 3.10, the output of "--help" has changed from "optional
arugments" to "options". So the test case failed.
=> Change the check to explicitly look for a sentence that we define in
the help text, it should be constant over all the Python versions.