### PR TITLE
[fix] fastem save full cell images, set values after calibration valu…

### DIFF
--- a/src/odemis/acq/fastem.py
+++ b/src/odemis/acq/fastem.py
@@ -608,23 +608,6 @@ class AcquisitionTask(object):
             self.pre_calibrate(self._pre_calibrations)
             self._roa.overlap = overlap_init  # set back the overlap to the initial value
 
-        if self._save_full_cells:
-            old_res = self._multibeam.resolution.value
-            old_cell_translation = self._detector.cellTranslation.value
-            old_cell_translation_md = self._detector.getMetadata().get(model.MD_CELL_TRANSLATION, None)
-
-            # set the resolution to the complete resolution, typically 7200px
-            self._multibeam.resolution.value = (
-                self._detector.shape[0] * self._detector.cellCompleteResolution.value[0],
-                self._detector.shape[1] * self._detector.cellCompleteResolution.value[1]
-            )
-
-            # set the cell translation to 0, because we do not want to do any cropping
-            cell_translation = tuple(tuple((0, 0) for i in range(0, self._detector.shape[0]))
-                                     for j in range(0, self._detector.shape[1]))
-            self._detector.updateMetadata({model.MD_CELL_TRANSLATION: cell_translation})
-            self._detector.cellTranslation.value = cell_translation
-
         # set the sub-directories (<user>/<project-name>/<roa-name>)
         # FIXME use username from GUI when that is implemented
         username = self._detector.getMetadata().get(model.MD_USER, "fastem-user")
@@ -647,6 +630,23 @@ class AcquisitionTask(object):
             # configure the HW settings
             fastem_conf.configure_scanner(self._scanner, fastem_conf.MEGAFIELD_MODE)
             fastem_conf.configure_detector(self._detector, self._roc2, self._roc3)
+
+            if self._save_full_cells:
+                old_res = self._multibeam.resolution.value
+                old_cell_translation = self._detector.cellTranslation.value
+                old_cell_translation_md = self._detector.getMetadata().get(model.MD_CELL_TRANSLATION, None)
+
+                # set the resolution to the complete resolution, typically 7200px
+                self._multibeam.resolution.value = (
+                    self._detector.shape[0] * self._detector.cellCompleteResolution.value[0],
+                    self._detector.shape[1] * self._detector.cellCompleteResolution.value[1]
+                )
+
+                # set the cell translation to 0, because we do not want to do any cropping
+                cell_translation = tuple(tuple((0, 0) for i in range(0, self._detector.shape[0]))
+                                         for j in range(0, self._detector.shape[1]))
+                self._detector.updateMetadata({model.MD_CELL_TRANSLATION: cell_translation})
+                self._detector.cellTranslation.value = cell_translation
 
             dataflow.subscribe(self.image_received)
 


### PR DESCRIPTION
…es are applied.

The values to save the full cell images were set before the calibration values were applied to the detector. This means that if calibration 3 was run for the current scintillator the cell translations were first set to 0 to enable saving the full cell images. Then it was set to the calibrated value. This caused an error to be raised on the server side, about invalid cell parameters.