### PR TITLE
[fix] increase pixel scaling step size limits in correlation tab

### DIFF
--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -3538,9 +3538,9 @@ u\xb5\x17\x8a\x0c\xe7\xc1\xb6w\x88\x1c\x954\xf4\xc1\xd1\x0f\x96\xdeN>1M\
                                 <object class="sizeritem">
                                   <object class="UnitFloatCtrl" name="dpx_step_cntrl">
                                     <value>1</value>
-                                    <key_step>0.000001</key_step>
+                                    <key_step>1</key_step>
                                     <min>0</min>
-                                    <max>10</max>
+                                    <max>250</max>
                                     <unit>%</unit>
                                     <accuracy>3</accuracy>
                                     <XRCED>

--- a/src/odemis/gui/xmlh/resources/panel_tab_correlation.xrc
+++ b/src/odemis/gui/xmlh/resources/panel_tab_correlation.xrc
@@ -405,9 +405,9 @@
                                 <object class="sizeritem">
                                   <object class="UnitFloatCtrl" name="dpx_step_cntrl">
                                     <value>1</value>
-                                    <key_step>0.000001</key_step>
+                                    <key_step>1</key_step>
                                     <min>0</min>
-                                    <max>10</max>
+                                    <max>250</max>
                                     <unit>%</unit>
                                     <accuracy>3</accuracy>
                                     <XRCED>


### PR DESCRIPTION
Based on user feedback increase limits for pixel size scaling in the correlation tab. 