### PR TITLE
[fix] driver nfpm: SetVelocity used str instead of bytes

### DIFF
--- a/src/odemis/driver/nfpm.py
+++ b/src/odemis/driver/nfpm.py
@@ -243,7 +243,7 @@ class PM8742(model.Actuator):
         """
         if not 1 <= val <= 2000:
             raise ValueError("Velocity outside of the range 0->2000")
-        self._sendOrderCommand(b"VA", "%d" % (val,), axis)
+        self._sendOrderCommand(b"VA", b"%d" % (val,), axis)
 
     def GetAccel(self, axis):
         """

--- a/src/odemis/driver/test/nfpm_test.py
+++ b/src/odemis/driver/test/nfpm_test.py
@@ -156,6 +156,15 @@ class TestActuator(unittest.TestCase):
         # back (at the end, in case of overshoot)
         self.assertGreater(diff_pos * self.direction, -20e-6) # negative means opposite dir
 
+    def test_set_speed(self):
+
+        orig_speed = self.dev.speed.value
+        new_speed = orig_speed.copy()
+        new_speed["x"] /= 2
+        self.dev.speed.value = new_speed
+        self.assertAlmostEqual(self.dev.speed.value["x"], orig_speed["x"] / 2)
+        self.dev.speed.value = orig_speed
+
     def test_stop(self):
         self.dev.stop()
 


### PR DESCRIPTION
Some left-over from Python 2 times. Missed a "b" in the conversion.

It was not a big deal, as in practice no code in Odemis never changes
the speed. Still, better to fix.