### PR TITLE
[fix] allow duplicate metadata keys in tfs metadata

### DIFF
--- a/src/odemis/dataio/tiff.py
+++ b/src/odemis/dataio/tiff.py
@@ -2696,11 +2696,11 @@ def _convert_thermo_fisher_to_odemis_metadata(metadata: str) -> dict:
     # parse ini metadata as dictionary
     tfs_md = {}
     try:
-        cfg = configparser.ConfigParser()
+        cfg = configparser.ConfigParser(strict=False) # allow duplicate keys
         cfg.read_string(metadata)
         tfs_md = cfg
     except Exception as e:
-        logging.warning("Failed to parse metadata as ini: %s", e)
+        logging.warning("Duplicate keys allowed, but failed to parse metadata as ini: %s", e)
         return tfs_md
 
     # convert to odemis format


### PR DESCRIPTION
Specific TFS SEM images were failing to parse correctly due the duplicate metadata keys in the metadata (e..g MultiGISGas parameters). These keys are not used by odemis, and can be discarded, but we need to disable strict parsing mode to do so.  