### PR TITLE
[ci] Update name of self hosted runner

### DIFF
--- a/.github/workflows/self_hosted_runner.yml
+++ b/.github/workflows/self_hosted_runner.yml
@@ -1,4 +1,4 @@
-name: Self Hosted Runner Ubuntu 18 and 20 Unit Testing
+name: Self Hosted Runner Ubuntu Testing
 
 on:
   schedule:


### PR DESCRIPTION
The name still revered Ubuntu 18 and 20, while we are now also testing Ubuntu 22. Remove the reference to Ubuntu versions, so we also do not forget to update the name at a later stage.