### PR TITLE
[fix] gui comp viewport shouldn't fail when closing the GUI

### DIFF
--- a/src/odemis/gui/comp/viewport.py
+++ b/src/odemis/gui/comp/viewport.py
@@ -906,6 +906,8 @@ class ARLiveViewport(LiveViewport):
 
     def _on_stream_update(self, _):
         """ Hide the play icon overlay if no stream are present """
+        if self._view is None:  # In case it's called after being destroyed
+            return
         show = len(self._view.stream_tree) > 0
         self.canvas.play_overlay.show = show
 
@@ -952,6 +954,8 @@ class EKLiveViewport(LiveViewport):
 
     def _on_stream_update(self, _):
         """ Hide the play icon overlay if no stream are present """
+        if self._view is None:  # In case it's called after being destroyed
+            return
         show = len(self._view.stream_tree) > 0
         self.canvas.play_overlay.show = show
 


### PR DESCRIPTION
If an AR stream was opened, when closing the GUI, the widget could
already be destroyed while the stream is removed, which causes a
failure.

It's not a big deal as the whole app is ending, but having clean logs
reduces confusion (in case a real error happens)