### PR TITLE
[fix] test_get_abs_stage_movement_full_cells use the updated ROA inte…

### DIFF
--- a/src/odemis/acq/test/fastem_test.py
+++ b/src/odemis/acq/test/fastem_test.py
@@ -838,13 +838,19 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
         xmax, ymax = (field_size_x * x_fields * (1 - overlap) + field_size_x * overlap,
                       field_size_y * y_fields * (1 - overlap) + field_size_y * overlap)
         coordinates = (xmin, ymin, xmax, ymax)  # in m
+        points = [
+            (coordinates[0], coordinates[1]),  # xmin, ymin
+            (coordinates[2], coordinates[1]),  # xmax, ymin
+            (coordinates[0], coordinates[3]),  # xmin, ymax
+            (coordinates[2], coordinates[3]),  # xmax, ymax
+        ]
 
         # Create an ROA with the coordinates of the field.
         roa_name = "test_megafield_id"
-        roa = fastem.FastEMROA(roa_name, coordinates, None, None,
+        roa = fastem.FastEMROA(roa_name, None, None,
                                self.asm, self.multibeam, self.descanner,
                                self.mppc, overlap)
-
+        roa.points.value = points
         task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner,
                                       self.mppc, self.stage, self.scan_stage, self.ccd,
                                       self.beamshift, self.lens,


### PR DESCRIPTION
…rface

4097bbc35994f398f6215f6d8554a8ad0cd51a0e introduced the test case test_get_abs_stage_movement_full_cells and 99fed8377ef1b44f6164831258aa643620989643 updated the arguments of the FastEM ROA class. The commit that updated the arguments was merged after the other but had not been rebased on the latest master, therefore the test case failed.