### PR TITLE
[fix] PixelAngularSpectrumProjection failed to project with Fit-to-RGB tint

### DIFF
--- a/src/odemis/acq/stream/_projection.py
+++ b/src/odemis/acq/stream/_projection.py
@@ -1577,7 +1577,11 @@ class PixelTemporalSpectrumProjection(RGBProjection):
         try:
             data = self._computeSpec()
             if data is not None:
-                self.image.value = self._project2RGB(data, self.stream.tint.value)
+                tint = self.stream.tint.value
+                if tint == TINT_FIT_TO_RGB:
+                    # Not supported for this view => fallback to greyscale
+                    tint = (255, 255, 255)
+                self.image.value = self._project2RGB(data, tint)
             else:
                 self.image.value = None
 
@@ -1660,7 +1664,11 @@ class PixelAngularSpectrumProjection(RGBProjection):
         try:
             data = self._computeSpec()
             if data is not None:
-                self.image.value = self._project2RGB(data, self.stream.tint.value)
+                tint = self.stream.tint.value
+                if tint == TINT_FIT_TO_RGB:
+                    # Not supported for this view => fallback to greyscale
+                    tint = (255, 255, 255)
+                self.image.value = self._project2RGB(data, tint)
             else:
                 self.image.value = None
         except Exception:


### PR DESCRIPTION
The special tint Fit-to-RGB has no meaning for this projection.
So it wasn't handled... and prevented the data from being shown.

=> Do the same as in LineSpectrumProjection: use white tint in such
case.