### PR TITLE
[fix] blanker control and arbitrary scan order plugins trying to load on all systems

### DIFF
--- a/plugins/blanker_control.py
+++ b/plugins/blanker_control.py
@@ -53,6 +53,7 @@ class BlankerControlPlugin(Plugin):
         if not main_data.ebeam or not model.hasVA("ebeam", "blanker"):
             logging.info("%s plugin cannot load as the microscope has no e-beam blanker",
                          self.name)
+            return
 
         blanker = main_data.ebeam.blanker
         # Add either a check menu if just on/off, or a radio menu if there are 3 states

--- a/plugins/spectrum_arbscor.py
+++ b/plugins/spectrum_arbscor.py
@@ -168,6 +168,7 @@ class SpectrumArbitraryScanOrderPlugin(Plugin):
         if not (microscope and main_data.role.startswith("sparc") and main_data.spectrometers):
             logging.info("%s plugin cannot load as the microscope is not a SPARC with spectrometer",
                          self.name)
+            return
 
         self._tab = self.main_app.main_data.getTabByName("sparc_acqui")
         stctrl = self._tab.streambar_controller


### PR DESCRIPTION
Forgot to early return from the init if the backend is not compatible
with the plugin. That's mostly annoying on the viewer.