### PR TITLE
[fix][METEOR] resolve C/C++ wrapper runtime error when selecting custom colormap

### DIFF
--- a/src/odemis/gui/comp/stream_panel.py
+++ b/src/odemis/gui/comp/stream_panel.py
@@ -40,7 +40,7 @@ from odemis.gui.comp.slider import UnitFloatSlider, VisualRangeSlider, UnitInteg
 from odemis.gui.comp.stream_bar import StreamBar
 from odemis.gui.comp.text import SuggestTextCtrl, UnitFloatCtrl, FloatTextCtrl, UnitIntegerCtrl
 from odemis.gui.evt import StreamRemoveEvent, StreamVisibleEvent, StreamPeakEvent
-from odemis.gui.util import call_in_wx_main
+from odemis.gui.util import call_in_wx_main, ignore_dead
 from odemis.gui.util.widgets import VigilantAttributeConnector
 from odemis.model import TINT_FIT_TO_RGB, TINT_RGB_AS_IS
 import wx
@@ -406,6 +406,7 @@ class StreamPanelHeader(wx.Control):
             self.label_change_callback(self.ctrl_label.GetValue())
 
     @call_in_wx_main
+    @ignore_dead
     def _on_colormap_value(self, colour):
         """ Update the colormap selector to reflect the provided colour """
         # determine which value to select
@@ -807,6 +808,12 @@ class StreamPanel(wx.Panel):
         self.gb_sizer.Add(lbl_ctrl, (self.num_rows, 0),
                           flag=wx.ALL | wx.ALIGN_CENTER_VERTICAL, border=5)
         return lbl_ctrl
+
+    def Destroy(self):
+        super().Destroy()
+
+        if self.stream.tint:
+            self.stream.tint.unsubscribe(self._header._on_colormap_value)
 
     @control_bookkeeper
     def add_autobc_ctrls(self):


### PR DESCRIPTION
When switching to a different tint colormap after having acquired an overview a C/C++ runtime error is generated referring to wrapped object:

File "/usr/lib/python3/dist-packages/odemis/gui/comp/stream_panel.py", line 422, in _on_colormap_value
    self.combo_colormap.SetClientData(self._colormap_customtint_idx, colour)
RuntimeError: wrapped C/C++ object of type ColorMapComboBox has been deleted

This runtime error does not seem to affect the colormap selection or anything GUI related but does however show an Error in the Odemis-gui.log. This error is now being addressed in a way that if the stream panel would be destroyed the tint is unsubscribed.