### PR TITLE
[MPM-45] SONA validate off-centre clipping with Andorcam3

### DIFF
--- a/src/odemis/driver/simcam.py
+++ b/src/odemis/driver/simcam.py
@@ -109,7 +109,8 @@ class Camera(model.DigitalCamera):
         self.binning = model.ResolutionVA(self._binning,
                               ((1, 1), (16, 16)), setter=self._setBinning)
 
-        hlf_shape = (self._shape[0] // 2 - 1, self._shape[1] // 2 - 1)
+        # the Numpy dimension order of the DA is YX for greyscale and YXC for RGB images
+        hlf_shape = (self._img.shape[1] // 2 - 1, self._img.shape[0] // 2 - 1)
         tran_rng = [(-hlf_shape[0], -hlf_shape[1]),
                     (hlf_shape[0], hlf_shape[1])]
         self._translation = (0, 0)
@@ -206,8 +207,8 @@ class Camera(model.DigitalCamera):
         """
         # compute the min/max of the shift. It's the same as the margin between
         # the centered ROI and the border, taking into account the binning.
-        max_tran = ((self._shape[0] - self._resolution[0] * self._binning[0]) // 2,
-                    (self._shape[1] - self._resolution[1] * self._binning[1]) // 2)
+        max_tran = ((self._img.shape[-1] - self._resolution[0] * self._binning[0]) // 2,
+                    (self._img.shape[-2] - self._resolution[1] * self._binning[1]) // 2)
 
         # between -margin and +margin
         trans = (max(-max_tran[0], min(value[0], max_tran[0])),


### PR DESCRIPTION
This is only needed for the SONA camera due to mechanical differences.

When max_res is less than the full resolution of the sensor, still allow to set a .translation VA != 0,0 , so that the image can be shifted.
We should then validate that the METEOR GUI doesn’t reset/change .translation when binning  (or other settings) is changed. If it does, either the GUI should be adjusted, or we should find a different way to apply translation.

-> validation was done on a real SONA and did not need modifications to the code.
-> changes are only to the simcam to better simulate the real camera.