### PR TITLE
[fix][METEOR-590] TFS Posture Manager which reads FM features at a fixed imaging plane

### DIFF
--- a/install/linux/usr/share/odemis/sim/meteor-tfs2-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/meteor-tfs2-sim.odm.yaml
@@ -1,0 +1,224 @@
+# For now, this is esssentially just a FM microscope, as the FIB part is handled
+# separately by the SEM
+
+"METEOR TFSv2": {
+    class: Microscope,
+    role: meteor,
+}
+
+"SEM": {
+    class: simsem.SimSEM,
+    role: null,
+    init: {
+           image: "simsem-fake-output.h5", # any large 16 bit image is fine
+    },
+    children: {
+        scanner: "EBeam",
+        detector0: "SE Detector",
+        focus: "EBeam Focus",
+    }
+}
+
+"EBeam": {
+    # Internal child of SimSEM, so no class
+    role: e-beam,  # Not required for the meteor
+    init: {},
+    affects: ["SE Detector"],
+}
+
+"EBeam Focus": {
+    # role: ebeam-focus,
+    role: null,
+    init: {},
+    affects: ["EBeam"]
+}
+
+"SE Detector": {
+    # Internal child of SimSEM, so no class
+    # role: se-detector,
+    role: null,
+    init: {},
+}
+
+
+# Normally provided by the SEM
+"Stage": {
+    class: tmcm.TMCLController,
+    role: stage-bare,
+    init: {
+        port: "/dev/fake6",
+        address: null,
+        axes: ["x", "y", "z", "rx", "rz"],
+        ustepsize: [1.e-7, 1.e-7, 1.e-7, 1.2e-5, 1.2e-5], # unit/µstep
+        rng: [[-0.1, 0.1], [-0.05, 0.05], [-0.05, 0.1], [-2, 2], [0, 6.28]],
+        unit: ["m", "m", "m", "rad", "rad"],
+        refproc: "Standard",
+    },
+    metadata: {
+        # Loading position:
+        FAV_POS_DEACTIVE: { 'rx': 0, 'rz': 1.9076449, 'x': -0.01529, 'y': 0.0506, 'z': 29.e-3 },
+        # XYZ ranges for SEM & METEOR
+        SEM_IMAGING_RANGE: {"x": [-10.e-3, 10.e-3], "y": [-30.e-3, 25.e-3], "z": [15.e-3, 37.e-3]},
+        FM_IMAGING_RANGE: {"x": [0.040, 0.054], "y": [-30.e-3, 25.e-3], "z": [15.e-3, 37.e-3]},
+        # Grid centers in SEM range
+        # Adjusted so that at init (0,0,0), it's at the Grid 1.
+        SAMPLE_CENTERS: {"GRID 1": {'x': 0, 'y': 0, 'z': 32.e-3}, "GRID 2": {'x': 2.98e-3, 'y': 2.46e-3, 'z': 32.e-3}},
+        # dx and dy are mirroring values between SEM - METEOR, pre-tilt is 35°
+        CALIB: {"dx": 0.0506252, "dy": 0.0049832, "version": "tfs_2", "pre-tilt": 0.6108652381980153},
+        # Active tilting (rx) & rotation(rz) angles positions when switching between SEM & FM.
+        # Note: these values are calibrated at installation time.
+        FAV_FM_POS_ACTIVE: {"rx": 0.12213888553625313  , "rz":  1.91986}, # 7° - 270°
+        # Typically rz = 110°, but we make it 0 so that at init it looks like in SEM position
+        FAV_SEM_POS_ACTIVE: {"rx": 0.314159, "rz": 5.06145},    # Note that milling angle (rx) can be changed per session
+    },
+}
+
+"Linked YZ": {
+    class: actuator.ConvertStage,
+    role: null,
+    dependencies: {
+        "under": "Stage"
+    },
+    init: {
+      axes: [ "y", "z" ], # name of the axes in the dependency, mapped to x,y (if identity transformation)
+      rotation:  0.6108652381980153, # rad , 35° same as pre-tilt in Stage component
+    },
+}
+
+"Meteor Stage": {
+    class: actuator.MultiplexActuator,
+    role: stage,
+    dependencies: { "x": "Stage", "y": "Linked YZ", "z": "Linked YZ", },
+    init: {
+        axes_map: { "x": "x", "y": "x", "z": "y",},
+    },
+    affects: ["Camera", "EBeam"],
+    metadata: {
+        # Typically, x range is the same as FM_IMAGING_RANGE, and Y has to be converted
+        POS_ACTIVE_RANGE: {"x": [0.040, 0.054], "y": [-10.e-3, 20.e-3]},
+    },
+}
+
+"Light Source": {
+    class: omicronxx.HubxX,
+    role: light,
+    init: {
+        port: "/dev/fakehub", # Simulator
+        #port: "/dev/ttyFTDI*",
+        },
+    affects: ["Camera"],
+}
+
+"Optical Objective": {
+    class: static.OpticalLens,
+    role: lens,
+    init: {
+        mag: 84.0, # ratio, (actually of the complete light path)
+        na: 0.85, # ratio, numerical aperture
+        ri: 1.0, # ratio, refractive index
+    },
+    affects: ["Camera"]
+}
+
+# Normally a IDS uEye or Zyla
+# Axes: X is horizontal on screen (going left->right), physical: far->close when looking at the door
+#       Y is vertical on screen (going bottom->top), physical: left->right when looking at the door
+"Camera": {
+    class: simcam.Camera,
+    role: ccd,
+    dependencies: {focus: "Optical Focus"},
+    init: {
+        image: "andorcam2-fake-clara.tiff",
+        transp: [-1, 2], # To swap/invert axes
+    },
+    metadata: {
+        # To change what the "good" focus position is on the simulator
+        # It's needed for not using the initial value, which is at deactive position.
+         FAV_POS_ACTIVE: {'z': 1.7e-3},  # good focus position
+         ROTATION: -0.099484,  # [rad] (=-5.7°)
+    },
+}
+
+# Controller for the filter-wheel
+# DIP must be configured with address 7 (= 1110000)
+"Optical Actuators": {
+    class: tmcm.TMCLController,
+    role: null,
+    init: {
+        port: "/dev/fake6", # Simulator
+        address: null, # Simulator
+        axes: ["fw"],
+        ustepsize: [1.227184e-3], # [rad/µstep]  fake value for simulator
+        rng: [[-14, 7]], # rad, more than 0->2 Pi, in order to allow one extra rotation in both direction, when quickly switching
+        unit: ["rad"],
+        refproc: "Standard",
+        refswitch: {"fw": 0}, #digital output used to switch on/off sensor
+        inverted: ["fw"], # for the filter wheel, the direction doesn't matter, as long as the positions are correct
+    },
+}
+
+"AntiBacklash for Filter Wheel": {
+    class: actuator.AntiBacklashActuator,
+    role: null,
+    init: {
+        backlash: {
+            # Force every move to always finish in the same direction
+            "fw": 50.e-3,  # rad
+        },
+    },
+    dependencies: {"slave": "Optical Actuators"},
+}
+
+"Filter Wheel": {
+    class: actuator.FixedPositionsActuator,
+    role: filter,
+    dependencies: {"band": "AntiBacklash for Filter Wheel"},
+    init: {
+        axis_name: "fw",
+        # This filter-wheel is made so that the light goes through two "holes":
+        # the filter, and the opposite hole (left empty). So although it has 8
+        # holes, it only supports 4 filters (from 0° to 135°), and there is no
+        # "fast-path" between the last filter and the first one.
+        positions: {
+             # pos (rad) -> m,m
+             0.08: [414.e-9, 450.e-9], # FF01-432/36
+             0.865398: [500.e-9, 530.e-9], # FF01-515/30
+             1.650796: [579.5e-9, 610.5e-9], # FF01-595/31
+             2.4361944: [663.e-9, 733.e-9], # FF02-698/70
+        },
+        cycle: 6.283185, # position of ref switch (0) after a full turn
+    },
+    # TODO: a way to indicate the best filter to use during alignement and brightfield? via some metadata?
+    affects: ["Camera"],
+}
+
+# CLS3252dsc-1
+"Optical Focus": {
+    class: smaract.MCS2,
+    role: focus,
+    init: {
+        locator: "fake",
+        ref_on_init: True,
+        # TODO: check speed/accel
+        speed: 0.003,  # m/s
+        accel: 0.003,  # m/s²
+        #hold_time: 5 # s, default = infinite
+        # TODO: check the ranges, and the channel
+        axes: {
+            'z': {
+                # -11.5mm is safely parked (FAV_POS_DEACTIVE)
+                # 1.7mm is typically in focus (FAV_POS_ACTIVE)
+                range: [-15.e-3, 5.e-3],
+                unit: 'm',
+                channel: 0,
+            },
+        },
+    },
+    metadata: {
+        # Loading position to retract lens
+        FAV_POS_DEACTIVE: {'z': -11.5e-3},
+        # Initial active position (close from the sample, but not too close, for safety)
+        FAV_POS_ACTIVE: {'z': 1.69e-3}
+    },
+    affects: ["Camera"],
+}

--- a/src/odemis/model/_metadata.py
+++ b/src/odemis/model/_metadata.py
@@ -88,7 +88,7 @@ MD_EBEAM_SPOT_DIAM = MD_BEAM_SPOT_DIAM
 # FIB-SEM metadata
 # position of the stage (in m or rad) for each axis in the chamber (raw hardware values)
 MD_STAGE_POSITION_RAW = "Stage position raw"  # dict of str -> float,
-MD_SAMPLE_PRE_TILT = "Sample pre-tilt"  # (rad) pre-tilt of the sample stage / shuttle (tilt)
+MD_SAMPLE_PRE_TILT = "pre-tilt"  # (rad) pre-tilt of the sample stage / shuttle (tilt)
 
 MD_STREAK_TIMERANGE = "Streak Time Range"  # (s) Time range for one streak/sweep
 MD_STREAK_MCPGAIN = "Streak MCP Gain"  # (int) Multiplying gain for microchannel plate


### PR DESCRIPTION
Read raw z coordinate system in TFS systems and image on fixed plane when performing FM imaging.
- add new posture manager
- add new test functions in move_test.py

https://bitbucket.org/delmic/xtlib-adapter/pull-requests/83

Switch from reading to linked Z coordinated to stage-bare Z coordinate for TFS  xt_client.py driver.

Tested:
- The stage bare Z is always be read with these commit changes irrespective of how TFS software reads Z. The TFS software can read Z as linked Z or stage bare Z depending on the user's workflow.
- SEM to FM switching works
- FM to SEM does not work as shift in y is observed on hardware. Now it is corrected and tested on simulation, needs to be tested on hardware


