### PR TITLE
[feat] fastem: move galvos to extrema when running at the start of ea…

### DIFF
--- a/src/odemis/gui/cont/acquisition/fastem_acq.py
+++ b/src/odemis/gui/cont/acquisition/fastem_acq.py
@@ -524,6 +524,14 @@ class FastEMAcquiController(object):
         self.gauge_acq.Range = self.roa_count
         self.gauge_acq.Value = 0
 
+        # During acquisition the galvo's only move a very small amount. To reduce the wearing of the ball bearing,
+        # the galvo's are moved to their extrema at the start of every acquisition.
+        logging.debug("Move the galvo's to their extrema.")
+        for scan_offset in [[-1, -1], [1, 1]]:  # [a.u.]
+            self._main_data_model.descanner.scanAmplitude.value = (0, 0)
+            self._main_data_model.descanner.scanOffset.value = scan_offset
+            self._main_data_model.mppc.data.get(dataContent="empty")
+
         # Acquire ROAs for all projects
         fs = {}
         pre_calibrations = [Calibrations.OPTICAL_AUTOFOCUS, Calibrations.IMAGE_TRANSLATION_PREALIGN]


### PR DESCRIPTION
…ch acquisition.

To reduce the wearing of the ball bearing, the galvo's should be moved to their extrema regularly.