### PR TITLE
[fix] acq path test force fan speed to 1 to avoid failure on second run

### DIFF
--- a/src/odemis/acq/test/path_test.py
+++ b/src/odemis/acq/test/path_test.py
@@ -1332,6 +1332,11 @@ class SecomPathTestCase(unittest.TestCase):
     def tearDownClass(cls):
         del cls.optmngr  # To garbage collect it
 
+    def setUp(self):
+        # Set the fan speed to on, as we expect in the tests, because the OPM uses the
+        # fan speed at init to use with "best quality".
+        self.ccd.fanSpeed.value = 1
+
     def test_set_acq_quality(self):
         sems = stream.SEMStream("test sem", self.sed, self.sed.data, self.ebeam)
 


### PR DESCRIPTION
After running the test cases, the fan speed was set to 0.
On the next run, it would be used as the "default" speed, for best quality,
leading the test cases to fail.
=> Explicitly set the default speed to 1