### PR TITLE
[fix] Change odemisd.modelgen default to no strict syntax

### DIFF
--- a/src/odemis/odemisd/modelgen.py
+++ b/src/odemis/odemisd/modelgen.py
@@ -233,7 +233,7 @@ class Instantiator(object):
     """
 
     def __init__(self, inst_file, settings_file=None, container=None, create_sub_containers=False,
-                 dry_run=False, strict_children: bool = True):
+                 dry_run=False, strict_children: bool = False):
         """
         inst_file (file): opened file that contains the YAML
         settings_file (file or None): opened settings file in YAML format.


### PR DESCRIPTION
For now, most of the microscope files are still incorrect. Defaulting to
strict syntax made the util.testing functions fail to parse the
microscope files.
We could switch that function alone, but it makes more sense to just
change the default, as long as most of the microscope files have errors.