### PR TITLE
[fix] dataio hdf5: don't warn it's not possible to save MD_WL_LIST if it's empty

### DIFF
--- a/src/odemis/dataio/hdf5.py
+++ b/src/odemis/dataio/hdf5.py
@@ -413,7 +413,7 @@ def _add_image_info(group, dataset, image):
                                 "it will not be saved: %s", ex)
 
         # Wavelength (for spectrograms)
-        if "C" in dims and model.MD_WL_LIST in image.metadata:
+        if "C" in dims:
             try:
                 wll = spectrum.get_wavelength_per_pixel(image)
                 # list or polynomial of degree > 2 => store the values of each
@@ -430,6 +430,8 @@ def _add_image_info(group, dataset, image):
                 _h5svi_set_state(group["DimensionScaleC"], numpy.uint(ST_REPORTED))
                 cpos = dims.index("C")
                 dataset.dims[cpos].attach_scale(group["DimensionScaleC"])
+            except KeyError:
+                pass  # No wavelength information => it's fine, we just don't save it
             except Exception as ex:
                 logging.warning("Failed to record wavelength information, "
                                 "it will not be saved: %s", ex)

--- a/src/odemis/util/spectrum.py
+++ b/src/odemis/util/spectrum.py
@@ -70,6 +70,10 @@ def get_wavelength_per_pixel(da):
     # MD_WL_LIST has priority
     try:
         wl = da.metadata[model.MD_WL_LIST]
+        if wl is None or len(wl) == 0:
+            # This is an indirect way to remove metadata (because it's not possible to delete keys
+            # from a component metadata)
+            raise KeyError("Empty MD_WL_LIST metadata")
 
         if len(wl) != da.shape[ci]:
             raise ValueError("Length of wavelength list does not match length of wavelength data.")


### PR DESCRIPTION
It's not possible to remove metadata from the component. So if there is
no MD_WL_LIST, the best we can do is to make it None or a empty list.
So don't try to save the MD_WL_LIST if it's empty (ex, for AR data), and
so don't warn that it's not possible to store it.