### PR TITLE
[feat] integrate SEM autofocusing in the pre-calibrations

### DIFF
--- a/src/odemis/acq/align/fastem.py
+++ b/src/odemis/acq/align/fastem.py
@@ -93,7 +93,8 @@ class Calibrations(Enum):
     SEM_AUTOFOCUS = AutofocusSEM
 
 
-def align(scanner, multibeam, descanner, detector, stage, ccd, beamshift, det_rotator, calibrations, stage_pos=None):
+def align(scanner, multibeam, descanner, detector, stage, ccd, beamshift, det_rotator,
+          se_detector, ebeam_focus, calibrations, stage_pos=None):
     """
     Start a calibration task for a given list of calibrations.
 
@@ -105,7 +106,9 @@ def align(scanner, multibeam, descanner, detector, stage, ccd, beamshift, det_ro
             aligned with the x and y axes of the multiprobe and the multibeam scanner. Must have x, y and z axes.
     :param ccd: (model.DigitalCamera) A camera object of the diagnostic camera.
     :param beamshift: (tfsbc.BeamShiftController) Component that controls the beamshift deflection.
-    :param det_rotator: (actuator) K-mirror controller. Must have a rotational (rz) axis.
+    :param det_rotator: (model.Actuator) K-mirror controller. Must have a rotational (rz) axis.
+    :param se_detector: (model.Detector) single beam secondary electron detector.
+    :param ebeam_focus: (model.Actuator) SEM focus control.
     :param calibrations: (list[Calibrations]) List of calibrations that should be run.
     :param stage_pos: (float, float) Stage position where the calibration should be run. If None,
                       the calibration is run at the current stage position.
@@ -121,7 +124,7 @@ def align(scanner, multibeam, descanner, detector, stage, ccd, beamshift, det_ro
 
     # Create a task that runs the calibration and alignments.
     task = CalibrationTask(f, scanner, multibeam, descanner, detector, stage, ccd, beamshift, det_rotator,
-                           calibrations, stage_pos)
+                           se_detector, ebeam_focus, calibrations, stage_pos)
 
     f.task_canceller = task.cancel  # lets the future know how to cancel the task.
 
@@ -148,7 +151,7 @@ class CalibrationTask(object):
     """
 
     def __init__(self, future, scanner, multibeam, descanner, detector, stage, ccd, beamshift, det_rotator,
-                 calibrations, stage_pos):
+                 se_detector, ebeam_focus, calibrations, stage_pos):
         """
         :param future: (ProgressiveFuture) Acquisition future object, which can be cancelled.
                        (Exception or None): Exception raised during the calibration or None.
@@ -161,7 +164,9 @@ class CalibrationTask(object):
             aligned with the x and y axes of the multiprobe and the multibeam scanner. Must have x, y and z axes.
         :param ccd: (model.DigitalCamera) A camera object of the diagnostic camera.
         :param beamshift: (tfsbc.BeamShiftController) Component that controls the beamshift deflection.
-        :param det_rotator: (actuator) K-mirror controller. Must have a rotational (rz) axis.
+        :param det_rotator: (model.Actuator) K-mirror controller. Must have a rotational (rz) axis.
+        :param se_detector: (model.Detector) single beam secondary electron detector.
+        :param ebeam_focus: (model.Actuator) SEM focus control.
         :param calibrations: (list[Calibrations]) List of calibrations that should be run.
         :param stage_pos: (float, float) Stage position where the calibration should be run in meter. If None,
                       the calibration is run at the current stage position.
@@ -176,6 +181,8 @@ class CalibrationTask(object):
         self._ccd = ccd
         self._beamshift = beamshift
         self._det_rotator = det_rotator
+        self._se_detector = se_detector
+        self._ebeam_focus = ebeam_focus
         self._future = future
 
         self.calibrations = calibrations
@@ -221,7 +228,9 @@ class CalibrationTask(object):
             "mppc": self._detector,
             "stage": self._stage,
             "diagnostic-ccd": self._ccd,
-            "det-rotator": self._det_rotator
+            "det-rotator": self._det_rotator,
+            "se-detector": self._se_detector,
+            "ebeam-focus": self._ebeam_focus,
         }
 
         # Get the estimated time for all requested calibrations.

--- a/src/odemis/acq/align/fastem.py
+++ b/src/odemis/acq/align/fastem.py
@@ -29,6 +29,7 @@ from odemis import model
 
 try:
     from fastem_calibrations.autofocus_multiprobe import AutofocusMultiprobe
+    from fastem_calibrations.autofocus_sem import AutofocusSEM
     from fastem_calibrations.autostigmation import Autostigmation
     from fastem_calibrations.cell_translation import CellTranslation
     from fastem_calibrations.dark_offset_correction import DarkOffsetCorrection
@@ -63,6 +64,7 @@ except ImportError as err:
     ScanAmplitude = None
     CellTranslation = None
     Autostigmation = None
+    AutofocusSEM = None
 
     fastem_calibrations = False
 
@@ -88,6 +90,7 @@ class Calibrations(Enum):
     SCAN_AMPLITUDE_FINAL = ScanAmplitude
     CELL_TRANSLATION = CellTranslation
     AUTOSTIGMATION = Autostigmation
+    SEM_AUTOFOCUS = AutofocusSEM
 
 
 def align(scanner, multibeam, descanner, detector, stage, ccd, beamshift, det_rotator, calibrations, stage_pos=None):

--- a/src/odemis/acq/align/test/fastem_test.py
+++ b/src/odemis/acq/align/test/fastem_test.py
@@ -73,6 +73,8 @@ class TestFastEMCalibration(unittest.TestCase):
         cls.ccd = model.getComponent(role="diagnostic-ccd")
         cls.beamshift = model.getComponent(role="ebeam-shift")
         cls.det_rotator = model.getComponent(role="det-rotator")
+        cls.se_detector = model.getComponent(role="se-detector")
+        cls.ebeam_focus = model.getComponent(role="ebeam-focus")
 
     def setUp(self):
         self.good_focus = -70e-6  # position where the image of the multiprobe is displayed in focus [m]
@@ -94,7 +96,7 @@ class TestFastEMCalibration(unittest.TestCase):
 
         # Run auto focus
         f = fastem.align(self.scanner, self.multibeam, self.descanner, self.mppc, self.stage, self.ccd,
-                         self.beamshift, self.det_rotator, calibrations)
+                         self.beamshift, self.det_rotator, self.se_detector, self.ebeam_focus, calibrations)
 
         try:
             config = f.result(timeout=900)
@@ -119,7 +121,7 @@ class TestFastEMCalibration(unittest.TestCase):
 
         # Run image translation pre-align
         f = fastem.align(self.scanner, self.multibeam, self.descanner, self.mppc, self.stage, self.ccd,
-                         self.beamshift, self.det_rotator, calibrations)
+                         self.beamshift, self.det_rotator, self.se_detector, self.ebeam_focus, calibrations)
 
         config = f.result(timeout=900)
 
@@ -158,7 +160,7 @@ class TestFastEMCalibration(unittest.TestCase):
 
         # Run the calibrations
         f = fastem.align(self.scanner, self.multibeam, self.descanner, self.mppc, self.stage, self.ccd,
-                         self.beamshift, self.det_rotator, calibrations)
+                         self.beamshift, self.det_rotator, self.se_detector, self.ebeam_focus, calibrations)
 
         config = f.result(timeout=900)
 
@@ -179,7 +181,7 @@ class TestFastEMCalibration(unittest.TestCase):
 
         calibrations = [Calibrations.OPTICAL_AUTOFOCUS, Calibrations.IMAGE_TRANSLATION_PREALIGN]
         f = fastem.align(self.scanner, self.multibeam, self.descanner, self.mppc, self.stage, self.ccd,
-                         self.beamshift, self.det_rotator, calibrations)
+                         self.beamshift, self.det_rotator, self.se_detector, self.ebeam_focus, calibrations)
 
         f.add_update_callback(self.on_progress_update)  # callback executed every time f.set_progress is called
         f.add_done_callback(self.on_done)  # callback executed when f.set_result is called (via bindFuture)
@@ -208,7 +210,7 @@ class TestFastEMCalibration(unittest.TestCase):
 
         calibrations = [Calibrations.OPTICAL_AUTOFOCUS, Calibrations.IMAGE_TRANSLATION_PREALIGN]
         f = fastem.align(self.scanner, self.multibeam, self.descanner, self.mppc, self.stage, self.ccd,
-                         self.beamshift, self.det_rotator, calibrations)
+                         self.beamshift, self.det_rotator, self.se_detector, self.ebeam_focus, calibrations)
 
         f.add_update_callback(self.on_progress_update)  # callback executed every time f.set_progress is called
         f.add_done_callback(self.on_done)  # callback executed when f.set_result is called (via bindFuture)

--- a/src/odemis/gui/conf/file.py
+++ b/src/odemis/gui/conf/file.py
@@ -245,6 +245,7 @@ class AcquisitionConfig(Config):
         self.default.set("acquisition", "fn_count", "0")
         self.default.set("acquisition", "overlap", "0.06")
         self.default.set("acquisition", "autostig_period", "5")
+        self.default.set("acquisition", "autofocus_period", "5")
 
         self.default.add_section("export")
         self.default.set("export", "last_path", ACQUI_PATH)
@@ -340,6 +341,14 @@ class AcquisitionConfig(Config):
     @autostig_period.setter
     def autostig_period(self, value):
         self.set("acquisition", "autostig_period", value)
+
+    @property
+    def autofocus_period(self):
+        return int(self.get("acquisition", "autofocus_period"))
+
+    @autofocus_period.setter
+    def autofocus_period(self, value):
+        self.set("acquisition", "autofocus_period", value)
 
     @property
     def pj_last_path(self):

--- a/src/odemis/gui/conf/file.py
+++ b/src/odemis/gui/conf/file.py
@@ -244,8 +244,8 @@ class AcquisitionConfig(Config):
         self.default.set("acquisition", "fn_ptn", u"{datelng}-{timelng}")
         self.default.set("acquisition", "fn_count", "0")
         self.default.set("acquisition", "overlap", "0.06")
-        self.default.set("acquisition", "autostig_period", "5")
-        self.default.set("acquisition", "autofocus_period", "5")
+        self.default.set("acquisition", "autostig_period", "5")  # unit: number of ROA acquisitions
+        self.default.set("acquisition", "autofocus_period", "5")  # unit: number of ROA acquisitions
 
         self.default.add_section("export")
         self.default.set("export", "last_path", ACQUI_PATH)

--- a/src/odemis/gui/cont/acquisition/fastem_acq.py
+++ b/src/odemis/gui/cont/acquisition/fastem_acq.py
@@ -555,7 +555,7 @@ class FastEMAcquiController(object):
                 pre_calib = pre_calibrations.copy()
                 if idx == 0:
                     pass
-                else:
+                if idx > 0:
                     if idx % autostig_period == 0:
                         pre_calib.append(Calibrations.AUTOSTIGMATION)
                     if idx % autofocus_period == 0:
@@ -660,6 +660,7 @@ class FastEMCalibrationController:
                                self._main_data_model.descanner, self._main_data_model.mppc,
                                self._main_data_model.stage, self._main_data_model.ccd,
                                self._main_data_model.beamshift, self._main_data_model.det_rotator,
+                               self._main_data_model.sed, self._main_data_model.ebeam_focus,
                                calibrations=self.calibration.calibrations.value)
 
         f.add_done_callback(self._on_calibration_done)  # also handles cancelling and exceptions
@@ -818,6 +819,7 @@ class FastEMScintillatorCalibrationController(FastEMCalibrationController):
                                            self._main_data_model.descanner, self._main_data_model.mppc,
                                            self._main_data_model.stage, self._main_data_model.ccd,
                                            self._main_data_model.beamshift, self._main_data_model.det_rotator,
+                                           self._main_data_model.sed, self._main_data_model.ebeam_focus,
                                            calibrations=self.calibration.calibrations.value, stage_pos=roc_center)
                     t = align.fastem.estimate_calibration_time(self.calibration.calibrations.value)
                     # also handles cancelling and exceptions

--- a/src/odemis/gui/cont/tabs/fastem_overview_tab.py
+++ b/src/odemis/gui/cont/tabs/fastem_overview_tab.py
@@ -45,7 +45,6 @@ class FastEMOverviewTab(Tab):
         # Acquisition Controller
         #   Takes care of the acquisition and acquisition selection buttons.
 
-
         self.tab_data = guimod.FastEMOverviewGUIData(main_data)
         super().__init__(name, button, panel, main_frame, self.tab_data)
 
@@ -119,6 +118,8 @@ class FastEMOverviewTab(Tab):
             self.tab_data.main.ccd,
             self.tab_data.main.beamshift,
             self.tab_data.main.det_rotator,
+            self.tab_data.main.sed,
+            self.tab_data.main.ebeam_focus,
             calibrations=[Calibrations.OPTICAL_AUTOFOCUS],
         )
         f.add_done_callback(self._on_optical_autofocus_done)  # also handles cancelling and exceptions
@@ -197,6 +198,8 @@ class FastEMOverviewTab(Tab):
             self.tab_data.main.ccd,
             self.tab_data.main.beamshift,
             self.tab_data.main.det_rotator,
+            self.tab_data.main.sed,
+            self.tab_data.main.ebeam_focus,
             calibrations=[Calibrations.SEM_AUTOFOCUS],
         )
         f.add_done_callback(self._on_autofunction_done)

--- a/src/odemis/gui/cont/tabs/fastem_overview_tab.py
+++ b/src/odemis/gui/cont/tabs/fastem_overview_tab.py
@@ -184,10 +184,21 @@ class FastEMOverviewTab(Tab):
         # TODO also disable btn_autostigmation once autostigmation is working
         self.btn_optical_autofocus.Enable(False)
         self.btn_autobc.Enable(False)
+        self.btn_sem_autofocus.Enable(False)
         self.sem_stream_cont.stream_panel.Enable(False)
         self.sem_stream_cont.pause()
         self.sem_stream_cont.pauseStream()
-        f = self.sem_stream_cont.stream.focuser.applyAutofocus(self.sem_stream_cont.stream.detector)
+        f = fastem.align(
+            self.tab_data.main.ebeam,
+            self.tab_data.main.multibeam,
+            self.tab_data.main.descanner,
+            self.tab_data.main.mppc,
+            self.tab_data.main.stage,
+            self.tab_data.main.ccd,
+            self.tab_data.main.beamshift,
+            self.tab_data.main.det_rotator,
+            calibrations=[Calibrations.SEM_AUTOFOCUS],
+        )
         f.add_done_callback(self._on_autofunction_done)
 
     @call_in_wx_main
@@ -196,6 +207,7 @@ class FastEMOverviewTab(Tab):
         # TODO also disable btn_autostigmation once autostigmation is working
         self.btn_optical_autofocus.Enable(False)
         self.btn_sem_autofocus.Enable(False)
+        self.btn_autobc.Enable(False)
         self.sem_stream_cont.stream_panel.Enable(False)
         self.sem_stream_cont.pause()
         self.sem_stream_cont.pauseStream()


### PR DESCRIPTION
SEM autofocus has been added to fastem-calibrations and is now integrated in the pre-calibrations.
* A constant has been added to define how often to run SEM autofocusing (every n ROAs).
* The SEM autofocus button in the GUI now points to the new autofocusing ** For SEM autofocus and autocontrastbrightness also disable the button of the autofunction that is running, as these cannot be cancelled