### PR TITLE
[feature] model.DataFlow automatically keep all data when synchronized

### DIFF
--- a/doc/develop/base-api.rst
+++ b/doc/develop/base-api.rst
@@ -198,11 +198,6 @@ received).
 
         Registers a function (callable) which will receive new version of the data every time it is available with the metadata. The format of the callback is callback(dataflow, dataarray), with dataflow the dataflow which calls it and dataarray the new data coming (which should not be modified, as other subscribers might receive the same object). It returns nothing.
 
-    .. TODO: optionally a “recommended update rate” which indicates how often we want data update maximum?
-
-    .. TODO: optionally indicate whether the subscriber wants all the data, or only 
-        cares about the last one generated.
-
     .. py:method:: unsubscribe(callback)
 
         Unregister a given callback. Can be called from the callback itself.
@@ -223,9 +218,12 @@ received).
         If None is passed, no synchronization is taking place.
         See :py:class:`Event` for more information on synchronization.
 
-    .. py:attribute:: parent
+    .. py:attribute:: max_discard
 
-        The component which owns this data-flow.
+        (int) number of DataArray (or "frame") which can be discarded in a row if it comes
+        in too fast to be handled by the subscribers.
+        Setting it to 0 indicates that no data should be discarded (unless there
+        is a huge memory usage).
 
 
     The rest of the methods are private and should only be used by the DataFlow 
@@ -273,6 +271,11 @@ Each listener has a separate queue, which ensures it will never miss the fact an
     .. py:method:: notify()
 
         Indicates an event has just occurred. Only to be done by the owner of the event.
+
+    .. py:attribute:: affects
+
+        *(VA, list of str)* Names of the components that are receiving the event
+        physically. This is mainly intended to be used for hardware triggers.
 
 
 Future

--- a/src/odemis/driver/andorcam3.py
+++ b/src/odemis/driver/andorcam3.py
@@ -2006,7 +2006,6 @@ class AndorCam3DataFlow(model.DataFlow):
         model.DataFlow.__init__(self)
         self.component = weakref.ref(camera)
         self._sync_event = None # synchronization Event
-        self._prev_max_discard = self._max_discard
 
 #    def get(self):
 #        # TODO if camera is already acquiring, wait for the coming picture
@@ -2044,6 +2043,7 @@ class AndorCam3DataFlow(model.DataFlow):
           disable synchronization.
         The DataFlow can be synchronized only with one Event at a time.
         """
+        super().synchronizedOn(event)
         if self._sync_event == event:
             return
 
@@ -2059,7 +2059,6 @@ class AndorCam3DataFlow(model.DataFlow):
 
         if self._sync_event:
             self._sync_event.unsubscribe(comp)
-            self.max_discard = self._prev_max_discard
         else:
             # report problem if the acquisition was started without expecting synchronization
             assert (not comp.acquire_thread or
@@ -2068,10 +2067,6 @@ class AndorCam3DataFlow(model.DataFlow):
 
         self._sync_event = event
         if self._sync_event:
-            # if the df is synchronized, the subscribers probably don't want to
-            # skip some data
-            self._prev_max_discard = self._max_discard
-            self.max_discard = 0
             self._sync_event.subscribe(comp)
 
 

--- a/src/odemis/driver/avantes.py
+++ b/src/odemis/driver/avantes.py
@@ -1014,7 +1014,6 @@ class AvantesDataFlow(model.DataFlow):
         model.DataFlow.__init__(self)
         self._detector = detector
         self._sync_event = None  # synchronization Event
-        self._prev_max_discard = self._max_discard
 
     # start/stop_generate are _never_ called simultaneously (thread-safe)
     def start_generate(self):
@@ -1031,19 +1030,15 @@ class AvantesDataFlow(model.DataFlow):
           disable synchronization.
         The DataFlow can be synchronized only with one Event at a time.
         """
+        super().synchronizedOn(event)
         if self._sync_event == event:
             return
 
         if self._sync_event:
             self._sync_event.unsubscribe(self._detector)
-            self.max_discard = self._prev_max_discard
 
         self._sync_event = event
         if self._sync_event:
-            # if the df is synchronized, the subscribers probably don't want to
-            # skip some data
-            self._prev_max_discard = self._max_discard
-            self.max_discard = 0
             self._detector.set_trigger(True)
             self._sync_event.subscribe(self._detector)
         else:

--- a/src/odemis/driver/hamamatsurx.py
+++ b/src/odemis/driver/hamamatsurx.py
@@ -2146,4 +2146,5 @@ class StreakCameraDataFlow(model.DataFlow):
         """
         Synchronize the dataflow.
         """
+        super().synchronizedOn(event)
         self._sync(event)

--- a/src/odemis/driver/phenom.py
+++ b/src/odemis/driver/phenom.py
@@ -1217,6 +1217,7 @@ class SEMDataFlow(model.DataFlow):
         event (model.Event or None): event to synchronize with. Use None to
           disable synchronization.
         """
+        super().synchronizedOn(event)
         if self._sync_event == event:
             return
 

--- a/src/odemis/driver/pvcam.py
+++ b/src/odemis/driver/pvcam.py
@@ -1378,7 +1378,6 @@ class PVCamDataFlow(model.DataFlow):
         model.DataFlow.__init__(self)
         self._sync_event = None # synchronization Event
         self.component = weakref.ref(camera)
-        self._prev_max_discard = self._max_discard
 
 #    def get(self):
 #        # TODO if camera is already acquiring, subscribe and wait for the coming picture with an event
@@ -1425,6 +1424,7 @@ class PVCamDataFlow(model.DataFlow):
           disable synchronization.
         The DataFlow can be synchronize only with one Event at a time.
         """
+        super().synchronizedOn(event)
         if self._sync_event == event:
             return
 
@@ -1434,7 +1434,6 @@ class PVCamDataFlow(model.DataFlow):
 
         if self._sync_event:
             self._sync_event.unsubscribe(comp)
-            self.max_discard = self._prev_max_discard
         else:
             # report problem if the acquisition was started without expecting synchronization
             assert (not comp.acquire_thread or
@@ -1443,10 +1442,6 @@ class PVCamDataFlow(model.DataFlow):
 
         self._sync_event = event
         if self._sync_event:
-            # if the df is synchronized, the subscribers probably don't want to
-            # skip some data
-            self._prev_max_discard = self._max_discard
-            self.max_discard = 0
             self._sync_event.subscribe(comp)
 
 # vim:tabstop=4:shiftwidth=4:expandtab:spelllang=en_gb:spell:

--- a/src/odemis/driver/scanner.py
+++ b/src/odemis/driver/scanner.py
@@ -283,6 +283,16 @@ class CompositedDataflow(model.DataFlow):
         self._external_dataflow = external_detector.data
         self._composited_scanner = composited_scanner
 
+    # Wrap max_discard to reflect the value of the original DataFlow
+    @property
+    def max_discard(self):
+        return self._external_dataflow.max_discard
+
+    @max_discard.setter
+    def max_discard(self, value):
+        self._external_dataflow.max_discard = value
+        model.DataFlow.max_discard.fset(self, value)  # This calls the super of the property setter
+
     def start_generate(self):
         """
         Sets the scan mode to "external" and subscribes self.notify to the external dataflow
@@ -309,3 +319,6 @@ class CompositedDataflow(model.DataFlow):
         Wrapper to pass synchronization requests to the external dataflow
         """
         self._external_dataflow.synchronizedOn(event)
+        # Don't call super(), as it only updates max_discard. Instead, we update max_discard based
+        # on the value decided by the original DataFlow.
+        model.DataFlow.max_discard.fset(self, self._external_dataflow.max_discard)  # This calls the super of max_discard.setter

--- a/src/odemis/driver/semcomedi.py
+++ b/src/odemis/driver/semcomedi.py
@@ -3702,7 +3702,6 @@ class SEMDataFlow(model.DataFlow):
 
         self._sync_event = None  # event to be synchronised on, or None
         self._evtq = None  # a Queue to store received events (= float, time of the event)
-        self._prev_max_discard = self._max_discard
 
     # start/stop_generate are _never_ called simultaneously (thread-safe)
     def start_generate(self):
@@ -3741,22 +3740,18 @@ class SEMDataFlow(model.DataFlow):
         event (model.Event or None): event to synchronize with. Use None to
           disable synchronization.
         """
+        super().synchronizedOn(event)
         if self._sync_event == event:
             return
 
         if self._sync_event:
             self._sync_event.unsubscribe(self)
-            self.max_discard = self._prev_max_discard
             if not event:
                 self._evtq.put(None)  # in case it was waiting for this event
 
         self._sync_event = event
         if self._sync_event:
-            # if the df is synchronized, the subscribers probably don't want to
-            # skip some data
             self._evtq = queue.Queue()  # to be sure it's empty
-            self._prev_max_discard = self._max_discard
-            self.max_discard = 0
             self._sync_event.subscribe(self)
 
     @oneway

--- a/src/odemis/driver/semnidaq.py
+++ b/src/odemis/driver/semnidaq.py
@@ -2951,7 +2951,6 @@ class SEMDataFlow(model.DataFlow):
 
         self._sync_event = None  # event to be synchronised on, or None
         self._evtq = None  # a Queue to store received events (= float, time of the event)
-        self._prev_max_discard = self._max_discard
 
         self.inverted = inverted
 
@@ -3001,12 +3000,12 @@ class SEMDataFlow(model.DataFlow):
         event (model.Event or None): event to synchronize with. Use None to
           disable synchronization.
         """
+        super().synchronizedOn(event)
         if self._sync_event == event:
             return
 
         if self._sync_event:
             self._sync_event.unsubscribe(self)
-            self.max_discard = self._prev_max_discard
             if not event:
                 self._evtq.put(None)  # in case it was waiting for this event
 
@@ -3015,8 +3014,6 @@ class SEMDataFlow(model.DataFlow):
             # if the df is synchronized, the subscribers probably don't want to
             # skip some data
             self._evtq = queue.Queue()  # to be sure it's empty
-            self._prev_max_discard = self._max_discard
-            self.max_discard = 0
             self._sync_event.subscribe(self)
 
     @oneway

--- a/src/odemis/driver/simcam.py
+++ b/src/odemis/driver/simcam.py
@@ -420,8 +420,10 @@ class SimpleDataFlow(model.DataFlow):
             self._evtq.put(None)  # in case it was waiting for an event
 
     def synchronizedOn(self, event):
+        super().synchronizedOn(event)
         if self._sync_event == event:
             return
+
         if self._sync_event:
             self._sync_event.unsubscribe(self)
             if not event:

--- a/src/odemis/driver/simsem.py
+++ b/src/odemis/driver/simsem.py
@@ -589,6 +589,7 @@ class SEMDataFlow(model.DataFlow):
         event (model.Event or None): event to synchronize with. Use None to
           disable synchronization.
         """
+        super().synchronizedOn(event)
         if self._sync_event == event:
             return
 

--- a/src/odemis/driver/simstreakcam.py
+++ b/src/odemis/driver/simstreakcam.py
@@ -554,4 +554,5 @@ class SimpleStreakCameraDataFlow(model.DataFlow):
         """
         Synchronize the dataflow.
         """
+        super().synchronizedOn(event)
         self._sync(event)

--- a/src/odemis/driver/tescan.py
+++ b/src/odemis/driver/tescan.py
@@ -952,7 +952,6 @@ class SEMDataFlow(model.DataFlow):
 
         self._sync_event = None  # event to be synchronised on, or None
         self._evtq = None  # a Queue to store received events (= float, time of the event)
-        self._prev_max_discard = self._max_discard
 
     # start/stop_generate are _never_ called simultaneously (thread-safe)
     def start_generate(self):
@@ -991,12 +990,12 @@ class SEMDataFlow(model.DataFlow):
         event (model.Event or None): event to synchronize with. Use None to
           disable synchronization.
         """
+        super().synchronizedOn(event)
         if self._sync_event == event:
             return
 
         if self._sync_event:
             self._sync_event.unsubscribe(self)
-            self.max_discard = self._prev_max_discard
             if not event:
                 self._evtq.put(None)  # in case it was waiting for this event
 
@@ -1005,8 +1004,6 @@ class SEMDataFlow(model.DataFlow):
             # if the df is synchronized, the subscribers probably don't want to
             # skip some data
             self._evtq = queue.Queue()  # to be sure it's empty
-            self._prev_max_discard = self._max_discard
-            self.max_discard = 0
             self._sync_event.subscribe(self)
 
     @oneway

--- a/src/odemis/driver/ueye.py
+++ b/src/odemis/driver/ueye.py
@@ -1488,19 +1488,15 @@ class UEyeDataFlow(model.DataFlow):
           disable synchronization.
         The DataFlow can be synchronized only with one Event at a time.
         """
+        super().synchronizedOn(event)
         if self._sync_event == event:
             return
 
         if self._sync_event:
             self._sync_event.unsubscribe(self._detector)
-            self.max_discard = self._prev_max_discard
 
         self._sync_event = event
         if self._sync_event:
-            # if the df is synchronized, the subscribers probably don't want to
-            # skip some data
-            self._prev_max_discard = self._max_discard
-            self.max_discard = 0
             self._detector.set_trigger(True)
             self._sync_event.subscribe(self._detector)
         else:


### PR DESCRIPTION
Introduce a way to have the .max_discard attribute of the DataFlow be
directly seen by the DataFlowProxy.

With this functionality in place, it's now really worthy to adjust
max_discard when the DataFlow is synchronized, on the backend side
(only).

So introduce a generic .synchronizedOn() method on DataFlow that all
inheriting DataFlows (implemented by the drivers) can use. A lot of
drivers actually already did this, so this mostly simplifies the code.
The main change is that now the proxy really will NOT discard data
when the DataFlow is synchronized (as most of the discard happend on the
client side).

Note that this now "upgrade" the code to only support 0MQ v3+. That is
available since Ubuntu 16.04, so should really not be an issue!