### PR TITLE
[fix] "Stop all axes" action not working

### DIFF
--- a/src/odemis/gui/model/main_gui_data.py
+++ b/src/odemis/gui/model/main_gui_data.py
@@ -391,7 +391,7 @@ class MainGUIData(object):
             return
 
         ts = []
-        for c in self.microscope.children.value:
+        for c in self.microscope.alive.value:
             # Actuators have an .axes roattribute
             if not isinstance(c.axes, Mapping):
                 continue


### PR DESCRIPTION
The microscope doesn't have "children" anymore. The components are only
accessible via the "alive" VA. So the function to stop all axes couldn't
find any component, and had no effect.