### PR TITLE
[perf] odemis-cli only import odemis.dataio when needed

### DIFF
--- a/src/odemis/cli/main.py
+++ b/src/odemis/cli/main.py
@@ -30,7 +30,7 @@ import inspect
 import logging
 import math
 import numbers
-from odemis import model, dataio, util
+from odemis import model, util
 import odemis
 from odemis.util import units, inspect_getmembers
 from odemis.util.conversion import convert_to_object
@@ -793,6 +793,7 @@ def acquire(comp_name, dataflow_names, filename):
     dataflow_names (list of string): name of each dataflow to access
     filename (str): name of the output file (format depends on the extension)
     """
+    from odemis import dataio  # Only import it here, as it's quite slow (~0.5s), and not used in other cases
     component = get_detector(comp_name)
 
     # check the dataflow exists


### PR DESCRIPTION
odemis.dataio pulls a lot of dependencies. It takes a little more than
0.5s to load. That represents half of the time of standard command.

=> Only load dataio when acquiring an image, which is the only moment
it's required.

This way, most of the cli commands now take ~0.5s instead of ~1s.