### PR TITLE
[fix] Fastem SEM autofocus also pass se_detector and ebeam_focus for …

### DIFF
--- a/src/odemis/acq/fastem.py
+++ b/src/odemis/acq/fastem.py
@@ -387,6 +387,8 @@ def acquire(roa, path, scanner, multibeam, descanner, detector, stage, scan_stag
     :param ccd: (model.DigitalCamera) A camera object of the diagnostic camera.
     :param beamshift: (tfsbc.BeamShiftController) Component that controls the beamshift deflection.
     :param lens: (static.OpticalLens) Optical lens component.
+    :param se_detector: (model.Detector) single beam secondary electron detector.
+    :param ebeam_focus: (model.Actuator) SEM focus control.
     :param pre_calibrations: (list[Calibrations]) List of calibrations that should be run before the ROA acquisition.
                              Default is None.
     :param save_full_cells: (bool) If True save the full cell images instead of cropping them
@@ -441,6 +443,8 @@ class AcquisitionTask(object):
         :param ccd: (model.DigitalCamera) A camera object of the diagnostic camera.
         :param beamshift: (tfsbc.BeamShiftController) Component that controls the beamshift deflection.
         :param lens: (static.OpticalLens) Optical lens component.
+        :param se_detector: (model.Detector) single beam secondary electron detector.
+        :param ebeam_focus: (model.Actuator) SEM focus control.
         :param roa: (FastEMROA) The acquisition region object to be acquired (megafield).
         :param path: (str) Path on the external storage where the image data is stored. Here, it is possible
                     to specify sub-directories (such as acquisition date and project name) additional to the main

--- a/src/odemis/acq/fastem.py
+++ b/src/odemis/acq/fastem.py
@@ -366,7 +366,7 @@ def estimate_acquisition_time(roa, pre_calibrations=None):
 
 
 def acquire(roa, path, scanner, multibeam, descanner, detector, stage, scan_stage, ccd, beamshift, lens,
-            pre_calibrations=None, save_full_cells=False, settings_obs=None):
+            se_detector, ebeam_focus, pre_calibrations=None, save_full_cells=False, settings_obs=None):
     """
     Start a megafield acquisition task for a given region of acquisition (ROA).
 
@@ -407,8 +407,8 @@ def acquire(roa, path, scanner, multibeam, descanner, detector, stage, scan_stag
 
     # TODO: pass path through attribute on ROA instead of argument?
     # Create a task that acquires the megafield image.
-    task = AcquisitionTask(scanner, multibeam, descanner, detector, stage, scan_stage, ccd, beamshift, lens, roa, path,
-                           pre_calibrations, save_full_cells, settings_obs, f)
+    task = AcquisitionTask(scanner, multibeam, descanner, detector, stage, scan_stage, ccd, beamshift, lens,
+                           se_detector, ebeam_focus, roa, path, pre_calibrations, save_full_cells, settings_obs, f)
 
     f.task_canceller = task.cancel  # lets the future know how to cancel the task.
 
@@ -425,7 +425,8 @@ class AcquisitionTask(object):
     An ROA consists of multiple single field images.
     """
 
-    def __init__(self, scanner, multibeam, descanner, detector, stage, scan_stage, ccd, beamshift, lens, roa, path,
+    def __init__(self, scanner, multibeam, descanner, detector, stage, scan_stage, ccd, beamshift, lens,
+                 se_detector, ebeam_focus, roa, path,
                  pre_calibrations, save_full_cells, settings_obs, future):
         """
         :param scanner: (xt_client.Scanner) Scanner component connecting to the XT adapter.
@@ -467,6 +468,8 @@ class AcquisitionTask(object):
         self._ccd = ccd
         self._beamshift = beamshift
         self._lens = lens
+        self._se_detector = se_detector
+        self._ebeam_focus = ebeam_focus
         self._roa = roa  # region of acquisition object
         self._roc2 = roa.roc_2.value  # object for region of calibration 2
         self._roc3 = roa.roc_3.value  # object for region of calibration 3
@@ -699,6 +702,7 @@ class AcquisitionTask(object):
                                               self._descanner, self._detector,
                                               self._stage, self._ccd,
                                               self._beamshift, None,  # no need for the detector rotator
+                                              self._se_detector, self._ebeam_focus,
                                               calibrations=pre_calibrations)
 
         try:

--- a/src/odemis/acq/test/fastem_test.py
+++ b/src/odemis/acq/test/fastem_test.py
@@ -304,6 +304,8 @@ class TestFastEMAcquisition(unittest.TestCase):
         cls.ccd = model.getComponent(role="diagnostic-ccd")
         cls.beamshift = model.getComponent(role="ebeam-shift")
         cls.lens = model.getComponent(role="lens")
+        cls.se_detector = model.getComponent(role="se-detector")
+        cls.ebeam_focus = model.getComponent(role="ebeam-focus")
 
         # Normally the beamshift MD_CALIB is set when running the calibrations.
         # Set it here explicitly because we do not run the calibrations in these test cases.
@@ -355,7 +357,7 @@ class TestFastEMAcquisition(unittest.TestCase):
         path_storage = "test_project_megafield"
         f = fastem.acquire(roa, path_storage,
                            self.scanner, self.multibeam, self.descanner, self.mppc, self.stage, self.scan_stage,
-                           self.ccd, self.beamshift, self.lens)
+                           self.ccd, self.beamshift, self.lens, self.se_detector, self.ebeam_focus)
         data, e = f.result()
 
         self.assertIsNone(e)  # check no exceptions were returned
@@ -399,7 +401,8 @@ class TestFastEMAcquisition(unittest.TestCase):
         path_storage = "test_project_field_indices"
         f = fastem.acquire(roa, path_storage,
                            self.scanner, self.multibeam, self.descanner, self.mppc,
-                           self.stage, self.scan_stage, self.ccd, self.beamshift, self.lens)
+                           self.stage, self.scan_stage, self.ccd, self.beamshift, self.lens,
+                           self.se_detector, self.ebeam_focus)
         data, e = f.result()
 
         self.assertIsNone(e)  # check no exceptions were returned
@@ -443,7 +446,8 @@ class TestFastEMAcquisition(unittest.TestCase):
         path_storage = "test_project_progress"
         f = fastem.acquire(roa, path_storage,
                            self.scanner, self.multibeam, self.descanner, self.mppc,
-                           self.stage, self.scan_stage, self.ccd, self.beamshift, self.lens)
+                           self.stage, self.scan_stage, self.ccd, self.beamshift, self.lens,
+                           self.se_detector, self.ebeam_focus)
         f.add_update_callback(self.on_progress_update)  # callback executed every time f.set_progress is called
         f.add_done_callback(self.on_done)  # callback executed when f.set_result is called (via bindFuture)
 
@@ -491,7 +495,8 @@ class TestFastEMAcquisition(unittest.TestCase):
         path_storage = "test_project_cancel"
         f = fastem.acquire(roa, path_storage,
                            self.scanner, self.multibeam, self.descanner, self.mppc,
-                           self.stage, self.scan_stage, self.ccd, self.beamshift, self.lens)
+                           self.stage, self.scan_stage, self.ccd, self.beamshift, self.lens,
+                           self.se_detector, self.ebeam_focus)
         f.add_update_callback(self.on_progress_update)  # callback executed every time f.set_progress is called
         f.add_done_callback(self.on_done)  # callback executed when f.set_result is called (via bindFuture)
 
@@ -544,7 +549,8 @@ class TestFastEMAcquisition(unittest.TestCase):
         path_storage = "test_project_stage_move"
         f = fastem.acquire(roa, path_storage,
                            self.scanner, self.multibeam, self.descanner, self.mppc,
-                           self.stage, self.scan_stage, self.ccd, self.beamshift, self.lens)
+                           self.stage, self.scan_stage, self.ccd, self.beamshift, self.lens,
+                           self.se_detector, self.ebeam_focus)
         data, e = f.result()
 
         self.assertIsNone(e)  # check no exceptions were returned
@@ -607,7 +613,8 @@ class TestFastEMAcquisition(unittest.TestCase):
         path_storage = "test_project_stage_move_rot_cor"
         f = fastem.acquire(roa, path_storage,
                            self.scanner, self.multibeam, self.descanner, self.mppc,
-                           self.stage, self.scan_stage, self.ccd, self.beamshift, self.lens)
+                           self.stage, self.scan_stage, self.ccd, self.beamshift, self.lens,
+                           self.se_detector, self.ebeam_focus)
         data, e = f.result()
 
         self.assertIsNone(e)  # check no exceptions were returned
@@ -652,6 +659,8 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
         cls.ccd = model.getComponent(role="diagnostic-ccd")
         cls.beamshift = model.getComponent(role="ebeam-shift")
         cls.lens = model.getComponent(role="lens")
+        cls.se_detector = model.getComponent(role="se-detector")
+        cls.ebeam_focus = model.getComponent(role="ebeam-focus")
 
         cls.beamshift.shift.value = (0, 0)
         cls.stage.reference({"x", "y"}).result()
@@ -692,6 +701,7 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
             task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner,
                                           self.mppc, self.stage, self.scan_stage, self.ccd,
                                           self.beamshift, self.lens,
+                                          self.se_detector, self.ebeam_focus,
                                           roa, path=None, pre_calibrations=None,
                                           save_full_cells=False, future=None,
                                           settings_obs=None)
@@ -775,6 +785,7 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
             task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner,
                                           self.mppc, self.stage, self.scan_stage, self.ccd,
                                           self.beamshift, self.lens,
+                                          self.se_detector, self.ebeam_focus,
                                           roa, path=None, pre_calibrations=None,
                                           save_full_cells=False, future=None,
                                           settings_obs=None)
@@ -854,6 +865,7 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
         task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner,
                                       self.mppc, self.stage, self.scan_stage, self.ccd,
                                       self.beamshift, self.lens,
+                                      self.se_detector, self.ebeam_focus,
                                       roa, path=None, pre_calibrations=None,
                                       save_full_cells=True, future=None,
                                       settings_obs=None)
@@ -931,6 +943,7 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
         task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner,
                                       self.mppc, self.stage, self.scan_stage, self.ccd,
                                       self.beamshift, self.lens,
+                                      self.se_detector, self.ebeam_focus,
                                       roa, path=None, pre_calibrations=None,
                                       save_full_cells=False, future=None, settings_obs=None)
         # Set the _pos_first_tile, which would normally be set in the run function.
@@ -984,6 +997,7 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
         task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner,
                                       self.mppc, self.stage, self.scan_stage, self.ccd,
                                       self.beamshift, self.lens,
+                                      self.se_detector, self.ebeam_focus,
                                       roa, path=None, pre_calibrations=None,
                                       save_full_cells=False, future=None, settings_obs=None)
 
@@ -1037,6 +1051,7 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
             task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner,
                                           self.mppc, self.stage, self.scan_stage, self.ccd,
                                           self.beamshift, self.lens,
+                                          self.se_detector, self.ebeam_focus,
                                           roa, path=None, pre_calibrations=None,
                                           save_full_cells=False, future=None,
                                           settings_obs=None)
@@ -1064,6 +1079,7 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
         task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner,
                                       self.mppc, self.stage, self.scan_stage, self.ccd,
                                       self.beamshift, self.lens,
+                                      self.se_detector, self.ebeam_focus,
                                       roa, path=None, pre_calibrations=None,
                                       save_full_cells=False, future=None,
                                       settings_obs=settings_obs)
@@ -1104,6 +1120,7 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
         task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner,
                                       self.mppc, self.stage, self.scan_stage, self.ccd,
                                       self.beamshift, self.lens,
+                                      self.se_detector, self.ebeam_focus,
                                       roa, path="test-path", pre_calibrations=None,
                                       save_full_cells=False, future=Mock(),
                                       settings_obs=settings_obs)
@@ -1114,6 +1131,7 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
         task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner,
                                       self.mppc, self.stage, self.scan_stage, self.ccd,
                                       self.beamshift, self.lens,
+                                      self.se_detector, self.ebeam_focus,
                                       roa, path="test-path", pre_calibrations=None,
                                       save_full_cells=True, future=Mock(),
                                       settings_obs=settings_obs)
@@ -1179,6 +1197,9 @@ class TestFastEMAcquisitionTaskMock(TestFastEMAcquisitionTask):
         cls.lens = Mock()
         cls.lens.magnification.value = 10
 
+        cls.se_detector = Mock()
+        cls.ebeam_focus = Mock()
+
         cls.beamshift = Mock()
         cls.beamshift.shift.value = [1, 1]
 
@@ -1217,6 +1238,7 @@ class TestFastEMAcquisitionTaskMock(TestFastEMAcquisitionTask):
         task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner,
                                       self.mppc, self.stage, self.scan_stage, self.ccd,
                                       self.beamshift, self.lens,
+                                      self.se_detector, self.ebeam_focus,
                                       roa, path="test-path", pre_calibrations=None,
                                       save_full_cells=False, future=Mock(),
                                       settings_obs=settings_obs)
@@ -1235,6 +1257,7 @@ class TestFastEMAcquisitionTaskMock(TestFastEMAcquisitionTask):
         task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner,
                                       self.mppc, self.stage, self.scan_stage, self.ccd,
                                       self.beamshift, self.lens,
+                                      self.se_detector, self.ebeam_focus,
                                       roa, path="test-path", pre_calibrations=None,
                                       save_full_cells=True, future=Mock(),
                                       settings_obs=settings_obs)

--- a/src/odemis/gui/cont/acquisition/fastem_acq.py
+++ b/src/odemis/gui/cont/acquisition/fastem_acq.py
@@ -534,8 +534,8 @@ class FastEMAcquiController(object):
 
         # The user should focus manually before an acquisition, thus the current
         # position is saved as "good focus"
-        self._main_data_model.focus.updateMetadata(
-            {model.MD_FAV_POS_ACTIVE: self._main_data_model.focus.position.value}
+        self._main_data_model.ebeam_focus.updateMetadata(
+            {model.MD_FAV_POS_ACTIVE: self._main_data_model.ebeam_focus.position.value}
         )
 
         # Acquire ROAs for all projects
@@ -565,6 +565,7 @@ class FastEMAcquiController(object):
                                    self._main_data_model.mppc, self._main_data_model.stage,
                                    self._main_data_model.scan_stage, self._main_data_model.ccd,
                                    self._main_data_model.beamshift, self._main_data_model.lens,
+                                   self._main_data_model.sed, self._main_data_model.ebeam_focus,
                                    pre_calibrations=pre_calib, save_full_cells=self.save_full_cells.value,
                                    settings_obs=self._main_data_model.settings_obs)
                 t = estimate_acquisition_time(roa, pre_calibrations)


### PR DESCRIPTION
…pre-calibrations

The SEM autofocus was added to the pre-calibrations. However the components used for running the SEM autofocus were not passed, this caused the acquisition to fail.

SDEV-1843