### PR TITLE
[feat] fastem: reference the stage before overview image as well as a…

### DIFF
--- a/src/odemis/acq/fastem.py
+++ b/src/odemis/acq/fastem.py
@@ -1015,6 +1015,10 @@ class OverviewAcquisition(object):
 
         :returns: (DataArray) The complete overview image.
         """
+        logging.debug("Referencing stage axes x and y.")
+        f = stage.reference({"x", "y"})
+        f.result(timeout=180)
+
         # Get the current immersion mode value before configuring the scanner.
         # This value is set back after acquireTiledArea future's result.
         current_immersion_mode = stream.emitter.immersion.value

--- a/src/odemis/gui/cont/microscope.py
+++ b/src/odemis/gui/cont/microscope.py
@@ -1522,6 +1522,9 @@ class FastEMStateController(object):
         current_vacuum = self._main_data.chamber.position.value["vacuum"]
         if current_vacuum == self._vacuum_pos:
             self._main_data.chamberState.value = CHAMBER_VACUUM
+            logging.debug("Referencing stage axes x and y.")
+            f = self._main_data.stage.reference({"x", "y"})
+            f.result(timeout=180)
         elif current_vacuum == self._vented_pos:
             self._main_data.chamberState.value = CHAMBER_VENTED
         else:


### PR DESCRIPTION
…fter reloading the sample holder

The stage was not referenced after reloading a sample, this caused the user to see a misalignment between the live view and the overview image. To make sure this does not happen again we will automatically reference the stage after reloading (and the chamber is thus in vacuum) the sample holder and before acquiring an overview image.