### PR TITLE
[fix][METEOR-1015] Change remove stream icon from a dash to an X.

### DIFF
--- a/src/odemis/gui/comp/stream_panel.py
+++ b/src/odemis/gui/comp/stream_panel.py
@@ -140,9 +140,9 @@ class StreamPanelHeader(wx.Control):
     def _add_remove_btn(self):
         """ Add a button for stream removal """
         btn_rem = buttons.ImageButton(self,
-                                      bitmap=img.getBitmap("icon/ico_rem_str.png"),
+                                      bitmap=img.getBitmap("icon/ico_clear.png"),
                                       size=self.BUTTON_SIZE)
-        btn_rem.bmpHover = img.getBitmap("icon/ico_rem_str_h.png")
+        btn_rem.bmpHover = img.getBitmap("icon/ico_clear_h.png")
         btn_rem.SetToolTip("Remove stream")
         self._add_ctrl(btn_rem)
         return btn_rem


### PR DESCRIPTION
User's are getting confused about the remove stream functionality, as it is mismatched with the OS. Typically the - symbol means minimise, and X means close. This PR changes the icon to be consistent with the OS