### PR TITLE
[fix] correct image shape index in _setTranslation in simcam.py

### DIFF
--- a/src/odemis/driver/simcam.py
+++ b/src/odemis/driver/simcam.py
@@ -207,8 +207,8 @@ class Camera(model.DigitalCamera):
         """
         # compute the min/max of the shift. It's the same as the margin between
         # the centered ROI and the border, taking into account the binning.
-        max_tran = ((self._img.shape[-1] - self._resolution[0] * self._binning[0]) // 2,
-                    (self._img.shape[-2] - self._resolution[1] * self._binning[1]) // 2)
+        max_tran = ((self._img_res[0] - self._resolution[0] * self._binning[0]) // 2,
+                    (self._img_res[1] - self._resolution[1] * self._binning[1]) // 2)
 
         # between -margin and +margin
         trans = (max(-max_tran[0], min(value[0], max_tran[0])),


### PR DESCRIPTION
This fix addresses the wrong index numbers of self._img.shape used in the _setTranslation function which causes the translation to be calculated wrong. The index of self._img.shape should be YXC so always select X and Y for the translation.