### PR TITLE
[fix] SECOM overview acquisition failed to open

### DIFF
--- a/src/odemis/gui/model/main_gui_data.py
+++ b/src/odemis/gui/model/main_gui_data.py
@@ -372,6 +372,9 @@ class MainGUIData(object):
 
         self.hw_settings_config = get_hw_settings_config(self.role)
 
+        # Used by the MIMAS, but needs to be initialized as empty for the SECOM & cryo microscopes.
+        self.sample_centers: Dict[str, Tuple[float, float]] = {}  # sample name -> center position (x, y)
+
         # Set to True to request debug info to be displayed
         self.debug = model.BooleanVA(False)
         self.level = model.IntVA(0)  # Highest message level not seen by the user so far
@@ -458,7 +461,6 @@ class CryoMainGUIData(MainGUIData):
 
     def __init__(self, microscope):
         super().__init__(microscope)
-        self.sample_centers : Dict[str, Tuple[float, float]] = {}  # sample name -> center position (x, y)
 
         # Controls the stage movement based on the imaging mode
         self.posture_manager = MicroscopePostureManager(microscope)


### PR DESCRIPTION
The overview acquisition dialog has been largely improved for the MIMAS,
but that broke it on the SECOM.
=> Make sure there is an (empty) "sample_centers" attribute
=> After the data is acquired, it now automatically saved, so don't try
to save it again.