### PR TITLE
[fix] Clarify xt_client error message when xt-adapter failed

### DIFF
--- a/src/odemis/driver/xt_client.py
+++ b/src/odemis/driver/xt_client.py
@@ -358,8 +358,8 @@ class SEM(model.HwComponent):
                     update.show()
                 else:
                     logging.warning("{} is a bad file in {} not transferring latest package.".format(ret, package.path))
-        except Exception as err:
-            logging.exception(err)
+        except Exception:
+            logging.warning("Failure during transfer latest xtadapter package (non critical)", exc_info=True)
 
     def move_stage(self, position: Dict[str, float], rel: bool = False) -> None:
         """


### PR DESCRIPTION
The error message was a copy of the original message. That message is
always shown with logging.exception() anyway. However, it was confusing
because although the driver continues initialisation, the log implied it
was a complete error.