### PR TITLE
[fix] calibration button label text and colour

### DIFF
--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -7622,9 +7622,7 @@ D\x02\x12\x0c/\x81\x10.\xc4\xcc\xb0\x8f\xa1\x9e\xa1\x81a/\x90\x05\x06\x8d\
                             <object class="sizeritem">
                               <object class="wxStaticText" name="lbl_optical_autofocus">
                                 <label>Optical Autofocus</label>
-                                <font>
-                                  <sysfont>wxSYS_DEFAULT_GUI_FONT</sysfont>
-                                </font>
+                                <fg>#DDDDDD</fg>
                               </object>
                               <flag>wxALL|wxALIGN_CENTRE_VERTICAL</flag>
                               <border>5</border>
@@ -7646,9 +7644,7 @@ D\x02\x12\x0c/\x81\x10.\xc4\xcc\xb0\x8f\xa1\x9e\xa1\x81a/\x90\x05\x06\x8d\
                             <object class="sizeritem">
                               <object class="wxStaticText" name="lbl_sem_autofocus">
                                 <label>SEM Autofocus</label>
-                                <font>
-                                  <sysfont>wxSYS_DEFAULT_GUI_FONT</sysfont>
-                                </font>
+                                <fg>#DDDDDD</fg>
                               </object>
                               <flag>wxALL|wxALIGN_CENTRE_VERTICAL</flag>
                               <border>5</border>
@@ -7670,9 +7666,7 @@ D\x02\x12\x0c/\x81\x10.\xc4\xcc\xb0\x8f\xa1\x9e\xa1\x81a/\x90\x05\x06\x8d\
                             <object class="sizeritem">
                               <object class="wxStaticText" name="lbl_autobrightness_contrast">
                                 <label>Auto-brigtness/contrast</label>
-                                <font>
-                                  <sysfont>wxSYS_DEFAULT_GUI_FONT</sysfont>
-                                </font>
+                                <fg>#DDDDDD</fg>
                               </object>
                               <flag>wxALL|wxALIGN_CENTRE_VERTICAL</flag>
                               <border>5</border>

--- a/src/odemis/gui/xmlh/resources/panel_tab_fastem_overview.xrc
+++ b/src/odemis/gui/xmlh/resources/panel_tab_fastem_overview.xrc
@@ -81,9 +81,7 @@
                             <object class="sizeritem">
                               <object class="wxStaticText" name="lbl_optical_autofocus">
                                 <label>Optical Autofocus</label>
-                                <font>
-                                  <sysfont>wxSYS_DEFAULT_GUI_FONT</sysfont>
-                                </font>
+                                <fg>#DDDDDD</fg>
                               </object>
                               <flag>wxALL|wxALIGN_CENTRE_VERTICAL</flag>
                               <border>5</border>
@@ -105,9 +103,7 @@
                             <object class="sizeritem">
                               <object class="wxStaticText" name="lbl_sem_autofocus">
                                 <label>SEM Autofocus</label>
-                                <font>
-                                  <sysfont>wxSYS_DEFAULT_GUI_FONT</sysfont>
-                                </font>
+                                <fg>#DDDDDD</fg>
                               </object>
                               <flag>wxALL|wxALIGN_CENTRE_VERTICAL</flag>
                               <border>5</border>
@@ -129,9 +125,7 @@
                             <object class="sizeritem">
                               <object class="wxStaticText" name="lbl_autobrightness_contrast">
                                 <label>Auto-brigtness/contrast</label>
-                                <font>
-                                  <sysfont>wxSYS_DEFAULT_GUI_FONT</sysfont>
-                                </font>
+                                <fg>#DDDDDD</fg>
                               </object>
                               <flag>wxALL|wxALIGN_CENTRE_VERTICAL</flag>
                               <border>5</border>


### PR DESCRIPTION
![image](https://github.com/delmic/odemis/assets/46875149/36c819af-b1ff-449e-b0f2-e33e184d7eba)

In Ubuntu 22.04 it looked like this

Now

![image](https://github.com/delmic/odemis/assets/46875149/f4296ac9-37ac-4517-886e-a36dad8f2267)
