### PR TITLE
[fix] release-odemis script failed on new major release to pull branch

### DIFF
--- a/util/release-odemis
+++ b/util/release-odemis
@@ -102,6 +102,7 @@ git push --tags upstream
 # Go to package directory, and build the debian package
 cd ~/development/pkg-native/odemis
 
+git fetch
 git checkout $VBRANCH
 git pull
 


### PR DESCRIPTION
when switching to the clean pkg-native/odemis/ folder, it failed to
check out the branch because the remote hadn't been updated yet.
=> First do a fetch of the remote before the checkout, to ensure git
knows all the branches.