### PR TITLE
[fix] properly disconnect from stream panels when a window is closed

### DIFF
--- a/src/odemis/gui/comp/stream_bar.py
+++ b/src/odemis/gui/comp/stream_bar.py
@@ -267,6 +267,11 @@ class StreamBar(wx.Panel):
             # Prematurely stop listening to the Destroy event, to only refit the
             # (empty) bar once, after all streams are gone.
             p.Unbind(wx.EVT_WINDOW_DESTROY, source=p, handler=self.on_streamp_destroy)
+            # So call the destroy handler explicitly. Needs to be done *before* it's actually destroyed.
+            on_destroy = self._on_destroy_callbacks.pop(p, None)
+            if on_destroy:
+                on_destroy()
+
             self.remove_stream_panel(p)
 
         self.fit_streams()

--- a/src/odemis/gui/comp/stream_panel.py
+++ b/src/odemis/gui/comp/stream_panel.py
@@ -809,12 +809,6 @@ class StreamPanel(wx.Panel):
                           flag=wx.ALL | wx.ALIGN_CENTER_VERTICAL, border=5)
         return lbl_ctrl
 
-    def Destroy(self):
-        super().Destroy()
-
-        if self.stream.tint:
-            self.stream.tint.unsubscribe(self._header._on_colormap_value)
-
     @control_bookkeeper
     def add_autobc_ctrls(self):
         """ Create and return controls needed for (auto) brightness and contrast manipulation """


### PR DESCRIPTION
When a window containing a list of streams (panels) is closed, the
stream bar.clear() is called to disconnect all the streams.
Commit b075a230a (gui: remove pubsub dependency) broke this behaviour
in .clear() as this function first unbind the DESTROY event.

This explains the issues with the change of tint that commit ca48bbf9e1
(fix C/C++ wrapper runtime error when switching colormap) tried to fix.

Now also call the destroy callback in .clear().

=> This means we don't need to specifically disconnect .tint in the
stream panel. So this code can be removed. This code also had introduced
an issue when the stream has no .tint attribute (because it didn't use
hasattr), so it's even better to not need it.