### PR TITLE
[fix] semnidaq make the canary actually detect issues

### DIFF
--- a/src/odemis/driver/semnidaq.py
+++ b/src/odemis/driver/semnidaq.py
@@ -231,7 +231,7 @@ class AnalogSEM(model.HwComponent):
             HwError: if the installation has some issue
         """
         # Normally does nothing, but will fail if NI-DAQmx is not ready
-        canary_cmd = [sys.executable, "-c", "import nidaqmx; nidaqmx.system.System.local().devices"]
+        canary_cmd = [sys.executable, "-c", "import nidaqmx; all(nidaqmx.system.System.local().devices)"]
         process = subprocess.run(canary_cmd)
         return_code = process.returncode
 


### PR DESCRIPTION
First time that the NI driver was updated since this code was written,
and it's finally possible to test it.
Just a small tweak need to make it detect issues correctly.