### PR TITLE
[fix] plugins spectrum_raw should only load on SPARC

### DIFF
--- a/plugins/spectrum_raw.py
+++ b/plugins/spectrum_raw.py
@@ -321,6 +321,7 @@ class SpectrumRawPlugin(Plugin):
         if not (microscope and main_data.ccd and main_data.spectrograph and main_data.role.startswith("sparc")):
             logging.info("%s plugin cannot load as the microscope is not a SPARC with CCD",
                          self.name)
+            return
 
         self._tab = self.main_app.main_data.getTabByName("sparc_acqui")
         stctrl = self._tab.streambar_controller


### PR DESCRIPTION
In case the backend is not compatible, it would display a warning... and
just keep trying to load. => add the missing "return"