### PR TITLE
[feature] extend HwTrigger with .affects VA

### DIFF
--- a/install/linux/usr/share/odemis/hwtest/semnidaq-only.odm.yaml
+++ b/install/linux/usr/share/odemis/hwtest/semnidaq-only.odm.yaml
@@ -8,7 +8,10 @@ SEM: {
 "SEM ExtXY": {
     class: semnidaq.AnalogSEM,
     role: null,
-    init: {device: "Dev1"},  # see nilsdev
+    init: {
+        device: "Dev1",  # see nilsdev output
+        multi_detector_min_period: 1.e-6,  # s, to limit sampling frequency when acquiring with multiple detector (and reduce cross-talk)
+    },
     # more detectors can be added, if necessary
     children: {
         scanner: "SEM E-beam",
@@ -33,6 +36,10 @@ SEM: {
         settle_time: 100.e-6,  # s
         scan_active_delay: 0.01,  # s, time to wait before starting a new acquisition
         hfw_nomag: 0.4,  # m
+        # scanning_ttl = output ports -> [high_auto, high_enabled, prop_name]
+        # * high_auto: True = high when scanning, False = high when parked
+        # * high_enabled: True = high when property set to True, False = high when set to False
+        # * prop_name: name of the property to control it (null to not show any property)
         # Digital output port mapping on the Delmic scanning box v2:
         # 0 = Relay
         # 1 = Open drain output (Y0.0)
@@ -40,7 +47,7 @@ SEM: {
         # 3 = Digital Out 0
         # 4 = Status led
         scanning_ttl: {
-            4: [True, True, null],
+            4: [True, True, null],  # Status LED
             2: [True, True, "external"],  # High when scanning, High when VA set to True
             3: [False, True, "blanker"],  # Low when scanning, High when VA set to True
         },
@@ -56,7 +63,7 @@ SEM: {
     affects: ["SE Detector", "Back-Scatter Detector"],
 }
 
-# Must be connected on AI 0/AI GND
+# Must be connected on AI1/AI9 (differential)
 "SE Detector": { # aka ETD
     role: se-detector,
     init: {

--- a/install/linux/usr/share/odemis/hwtest/semnidaq-only.odm.yaml
+++ b/install/linux/usr/share/odemis/hwtest/semnidaq-only.odm.yaml
@@ -51,9 +51,17 @@ SEM: {
             2: [True, True, "external"],  # High when scanning, High when VA set to True
             3: [False, True, "blanker"],  # Low when scanning, High when VA set to True
         },
-        pixel_ttl: [0],
-        line_ttl: [1],
-        frame_ttl: [6],
+        image_ttl: {
+            pixel: {
+                 ports: [0],
+            },
+            line: {
+                 ports: [1],
+            },
+            frame: {
+                 ports: [6],
+            },
+        },
     },
     properties: {
         scale: [4, 4], # (ratio) : start with a pretty fast scan

--- a/install/linux/usr/share/odemis/sim/sparc2-nidaq-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/sparc2-nidaq-sim.odm.yaml
@@ -91,9 +91,18 @@ SPARC2: {
             2: [True, True, "external"],  # High when scanning, High when VA set to True
             3: [False, True, "blanker"],  # Low when scanning, High when VA set to True
         },
-        pixel_ttl: [0, 7],
-        line_ttl: [1],
-        frame_ttl: [6],
+        image_ttl: {
+            pixel: {
+                 ports: [0, 7],
+                 affects: ["Spectrometer Vis-NIR", "Camera"],
+            },
+            line: {
+                 ports: [1],
+            },
+            frame: {
+                 ports: [6],
+            },
+        },
     },
     properties: {
         scale: [8, 8], # (ratio) : start with a pretty fast scan

--- a/install/linux/usr/share/odemis/sim/sparc2-nidaq-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/sparc2-nidaq-sim.odm.yaml
@@ -50,7 +50,7 @@ SPARC2: {
     class: semnidaq.AnalogSEM,
     role: null,
     init: {
-        device: "Dev1",
+        device: "Dev1",  # see nilsdev output
         multi_detector_min_period: 1.e-6,  # s, to limit sampling frequency when acquiring with multiple detector (and reduce cross-talk)
     },
     # more detectors can be added, if necessary
@@ -70,14 +70,16 @@ SPARC2: {
     role: e-beam,
     init: {
         channels: [1, 0],
-        limits: [[0, 5], [0, 3.2]],  # V
-        park: [0, 0], # V
-        max_res: [4096, 3072],  # px, 4:3 ratio
-        settle_time: 5.e-6, # s
-        scan_active_delay: 0.5, # s
-        hfw_nomag: 0.25, # m
-        # output ports -> True (high when scanning) or False (high when parked)
-        # + property name + True (high when set to True) or False (high when set to False)
+        limits: [[-2.8, 2.8], [4.0, -4.0]],  # V
+        park: [-3.0, -4.5], # V
+        max_res: [6144, 4096],  # px, to force the same ratio as the SEM (~8/7)
+        settle_time: 100.e-6,  # s
+        scan_active_delay: 0.01,  # s, time to wait before starting a new acquisition
+        hfw_nomag: 0.4,  # m
+        # scanning_ttl = output ports -> [high_auto, high_enabled, prop_name]
+        # * high_auto: True = high when scanning, False = high when parked
+        # * high_enabled: True = high when property set to True, False = high when set to False
+        # * prop_name: name of the property to control it (null to not show any property)
         # Digital output port mapping on the Delmic scanning box v2:
         # 0 = Relay
         # 1 = Open drain output (Y0.0)

--- a/src/odemis/driver/semnidaq.py
+++ b/src/odemis/driver/semnidaq.py
@@ -1879,9 +1879,7 @@ class Scanner(model.Emitter):
                  limits: List[List[float]],
                  park: Optional[List[float]] = None,
                  scanning_ttl: Dict[int, List] = None,
-                 pixel_ttl: Optional[List[int]] = None,
-                 line_ttl: Optional[List[int]] = None,
-                 frame_ttl: Optional[List[int]] = None,
+                 image_ttl: Optional[Dict[str, Dict[str, Any]]] = None,
                  settle_time: float = 0,
                  scan_active_delay: float = 0,
                  hfw_nomag: float = 0.1,
@@ -1897,14 +1895,17 @@ class Scanner(model.Emitter):
         :param park (None or 2-tuple of (0<=float)): voltage (in V) of resting position,
         if None, it will default to top-left corner. If the beam cannot be blanked
         this will be the position of the beam when not scanning.
-        :param pixel_ttl: digital output channels (on port0) to indicate the beginning
-        of a scan of a pixel. It goes high the first half of the duration of a pixel.
-        :param line_ttl: digital output channels (on port0) to indicate the beginning
-        of a line, not including the settling time. It goes high on the first
-        pixel of the line, and goes down at the end of the last pixel.
-        :param frame_ttl: digital output channels (on port0) to indicate the beginning
-        of a frame, not including the settling time. It goes high on the first
+        :param image_ttl: digital output channels (on port0) to indicate various moments of
+        the image acquisition: "pixel" defines the beginning of a scan of a pixel. It goes high
+        the first half of the duration of a pixel. "line" defines the beginning of a scan of a line,
+        not including the settling time. It goes high on the first pixel of the line,
+        and goes down at the end of the last pixel. "frame" defines the beginning of a scan of a
+        frame, not including the settling time. It goes high on the first
         pixel of the frame, and goes down at the end of the last pixel.
+        For each of the 3 types of TTL, a dictionary can be provided with the following keys:
+        * "port": list of int, defining the digital output port(s) to use.
+        * "affects": list of str, containing the names of components which are physically connected
+        to the signal.
         :param scanning_ttl (None or dict of int -> (bool, bool, Optional[str])):
         List of digital output ports to indicate the ebeam is scanning or not.
         * First argument is "high_auto": if True, it is set to high when scanning,
@@ -2021,28 +2022,49 @@ class Scanner(model.Emitter):
 
         # Validate fast TTLs
         fast_do_channels = set()  # set of ints, to check all channels are unique
-        if not all (v is None or isinstance(v, list) for v in (pixel_ttl, line_ttl, frame_ttl)):
-            raise ValueError("pixel_ttl, line_ttl and frame_ttl should be lists of int, but got %s, %s, %s" %
-                             (pixel_ttl, line_ttl, frame_ttl))
-        pixel_ttl = pixel_ttl or []
-        line_ttl = line_ttl or []
-        frame_ttl = frame_ttl or []
-        for do_channel in pixel_ttl + line_ttl + frame_ttl:
-            # Check it's a valid channel
-            if do_channel not in available_do_ports:
-                raise ValueError("DAQ device '%s' does not have digital output %s, available ones: %s" %
-                                 (parent._device_name, do_channel, sorted(available_do_ports)))
+        if image_ttl is None:
+            image_ttl = {}
+        if (not isinstance(image_ttl, dict)
+            or not all(isinstance(k, str) and isinstance(v, dict) for k, v in image_ttl.items())
+           ):
+            raise ValueError(f"image_ttl should be a dict[str->dict], but got '{image_ttl}'")
 
-            if do_channel in scanning_ttl:
-                raise ValueError(f"scanning_ttl and pixel_ttl/line_ttl/frame_ttl cannot have the same channel ({do_channel})")
+        for ttl_type, ttl_info in image_ttl.items():
+            if ttl_type not in ("pixel", "line", "frame"):
+                raise ValueError(f"image_ttl keys should be 'pixel', 'line' or 'frame', but got '{ttl_type}'")
+            try:
+                ports = ttl_info["ports"]
+            except KeyError:
+                raise ValueError(f"image_ttl['{ttl_type}'] should have a 'ports' key")
 
-            if do_channel in fast_do_channels:
-                raise ValueError(f"pixel_ttl/line_ttl/frame_ttl cannot have the same channel ({do_channel})")
-            fast_do_channels.add(do_channel)
+            # Check it's all valid channels
+            for do_channel in ports:
+                if do_channel not in available_do_ports:
+                    raise ValueError("DAQ device '%s' does not have digital output %s requested for %s. Available ones: %s" %
+                                     (parent._device_name, do_channel, ttl_type, sorted(available_do_ports)))
 
-        self._pixel_ttl = pixel_ttl
-        self._line_ttl = line_ttl
-        self._frame_ttl = frame_ttl
+                if do_channel in scanning_ttl:
+                    raise ValueError(
+                        f"Port ({do_channel}) requested for {ttl_type} is already used by scanning_ttl")
+
+                if do_channel in fast_do_channels:
+                    raise ValueError(f"Port {do_channel} requested for {ttl_type} is already used by another TTL")
+                fast_do_channels.add(do_channel)
+
+        self._pixel_ttl = []
+        self._line_ttl = []
+        self._frame_ttl = []
+
+        for ttl_type, ports_name, ev_name in (("pixel", "_pixel_ttl", "newPixel"),
+                                              ("line", "_line_ttl", "newLine"),
+                                              ("frame", "_frame_ttl", "newFrame")):
+            if ttl_type in image_ttl:
+                ttl_info = image_ttl[ttl_type]
+                setattr(self, ports_name, ttl_info["ports"])
+                event = model.HwTrigger()
+                affects = ttl_info.get("affects", [])
+                event.affects.value.extend(affects)
+                setattr(self, ev_name, event)
 
         # TODO: have a better way to indicate the channel number as it's limited to port0
         # while there is also port 1 & 2. Explicitly ask the full NI name? as "port1/line3"? Or as written on hardware "P1.3"?

--- a/src/odemis/driver/semnidaq.py
+++ b/src/odemis/driver/semnidaq.py
@@ -39,7 +39,7 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 # SED : AI1/AI GND = pins 33/32
 # BSD : AI2/AI GND = pins 65/64
 #
-# To install the NI driver, here is a summarry of the commands needed:
+# To install the NI driver, here is a summary of the commands needed:
 # Download from https://www.ni.com/nl-nl/support/documentation/supplemental/18/downloading-and-installing-ni-driver-software-on-linux-desktop.html
 # sudo apt install ./ni-ubuntu2004-drivers-stream.deb
 # sudo apt update
@@ -1905,7 +1905,7 @@ class Scanner(model.Emitter):
         :param frame_ttl: digital output channels (on port0) to indicate the beginning
         of a frame, not including the settling time. It goes high on the first
         pixel of the frame, and goes down at the end of the last pixel.
-        :param scanning_ttl (None or dict of int -> (bool, Optional[str], bool))):
+        :param scanning_ttl (None or dict of int -> (bool, bool, Optional[str])):
         List of digital output ports to indicate the ebeam is scanning or not.
         * First argument is "high_auto": if True, it is set to high when scanning,
         with False, the output is inverted.

--- a/src/odemis/driver/test/cam_test_abs.py
+++ b/src/odemis/driver/test/cam_test_abs.py
@@ -614,7 +614,7 @@ class VirtualTestSynchronized(metaclass=ABCMeta):
         self.ccd_left = numbert # unsubscribe after receiving
 
         try:
-            self.ccd.data.synchronizedOn(self.scanner.newPosition)
+            self.ccd.data.synchronizedOn(self.scanner.newPixel)
         except IOError:
             self.skipTest("Camera doesn't support synchronisation")
         self.ccd.data.subscribe(self.receive_ccd_image)

--- a/src/odemis/driver/test/semcomedi_test.py
+++ b/src/odemis/driver/test/semcomedi_test.py
@@ -547,7 +547,7 @@ class TestSEM(unittest.TestCase):
         self.events = 0 # reset
 
         # simulate the synchronizedOn() method of a DataFlow
-        self.scanner.newPosition.subscribe(self)
+        self.scanner.newPixel.subscribe(self)
 
         self.sed.data.subscribe(self.receive_image)
         for i in range(10):
@@ -563,7 +563,7 @@ class TestSEM(unittest.TestCase):
         # acquisition immediately after receiving the right number of images)
         self.assertEqual(self.events, numbert)
 
-        self.scanner.newPosition.unsubscribe(self)
+        self.scanner.newPixel.unsubscribe(self)
         self.sed.data.get()
         time.sleep(0.1)
         self.assertEqual(self.events, numbert)

--- a/src/odemis/driver/test/semnidaq_test.py
+++ b/src/odemis/driver/test/semnidaq_test.py
@@ -85,9 +85,18 @@ CONFIG_SCANNER = {
         2: [True, True, "external"],  # High when scanning, High when VA set to True
         3: [False, True, "blanker"],  # Low when scanning, High when VA set to True
     },
-    "pixel_ttl": [0, 7],
-    "line_ttl": [1],
-    "frame_ttl": [6],
+    "image_ttl": {
+         "pixel": {
+             "ports": [0, 7],
+             "affects": ["IR Camera", "UV Camera"],
+        },
+        "line": {
+             "ports": [1],
+        },
+        "frame": {
+             "ports": [6],
+        },
+    },
 }
 
 # For loop-back testing (currently on the breadboard):
@@ -127,9 +136,9 @@ class TestAnalogSEM(unittest.TestCase):
                 cls.counter = child
 
         # Compute the fast TTL masks, for the waveform checks
-        cls.pixel_bit = sum(1 << c for c in CONFIG_SCANNER["pixel_ttl"])
-        cls.line_bit = sum(1 << c for c in CONFIG_SCANNER["line_ttl"])
-        cls.frame_bit = sum(1 << c for c in CONFIG_SCANNER["frame_ttl"])
+        cls.pixel_bit = sum(1 << c for c in CONFIG_SCANNER["image_ttl"]["pixel"]["ports"])
+        cls.line_bit = sum(1 << c for c in CONFIG_SCANNER["image_ttl"]["line"]["ports"])
+        cls.frame_bit = sum(1 << c for c in CONFIG_SCANNER["image_ttl"]["frame"]["ports"])
 
     @classmethod
     def tearDownClass(cls) -> None:


### PR DESCRIPTION
Change/extend the hardware trigger API on Emitter components. Now HwTrigger have a .affects VA (like components themselves) to specify which detector receives the trigger from the emitter.
Adjust the semcomedi and semnidaq drivers to use this new API.
It will be used in the SPARC hardware synchronized acquisition.