### PR TITLE
[fix] cli live view failed to resize image if window size is limited by screen size

### DIFF
--- a/src/odemis/cli/video_displayer.py
+++ b/src/odemis/cli/video_displayer.py
@@ -104,8 +104,8 @@ class VideoDisplayer(object):
                 self.app.magn = disp_size[0] / rgb.shape[1]
             else:
                 self.app.magn = disp_size[1] / rgb.shape[0]
-            self.app.img.Rescale(rgb.shape[1] * self.app.magn,
-                                 rgb.shape[0] * self.app.magn,
+            self.app.img.Rescale(int(rgb.shape[1] * self.app.magn),
+                                 int(rgb.shape[0] * self.app.magn),
                                  rgb.shape[2])
         else:
             self.app.magn = 1


### PR DESCRIPTION
Normally the window size is set to be precisely the image size. So the
magnification is 1, and there is actually no resizing of the image that
happens.

However, if the screen is smaller than the image size, the window is
limited by the screen size... and the magnification is a float < 1.
This caused the resize() input argument to be a float, while it expects
a number of pixels as int. In this case, no image is displayed.

=> Force conversion to an int.