### PR TITLE
[feature] add spectrograph iris support to SPARC GUI

### DIFF
--- a/src/odemis/gui/conf/data.py
+++ b/src/odemis/gui/conf/data.py
@@ -472,7 +472,12 @@ HW_SETTINGS_CONFIG = {
             ("grating", {}),
             ("slit-in", {
                 "label": "Input slit",
-                "tooltip": u"Opening size of the spectrograph input slit.\nA wide opening means more light and worse resolution.",
+                "tooltip": "Opening size of the spectrograph input slit.\nA wide opening means more light and worse resolution.",
+            }),
+            ("iris-in", {
+                "label": "Input iris",
+                "tooltip": "Opening size of the spectrograph iris.\n"
+                           "Use full opening if possible, but reduce iris to minimize optical path length variation.",
             }),
         )),
     "slit-in-big":
@@ -766,6 +771,11 @@ STREAM_SETTINGS_CONFIG = {
                 "label": "Input slit",
                 "tooltip": u"Opening size of the spectrograph input slit.\nA wide opening means more light and a worse resolution.",
             }),
+            ("iris-in", {
+                "label": "Input iris",
+                "tooltip": "Opening size of the spectrograph iris.\n"
+                           "Use full opening if possible, but reduce iris to minimize optical path length variation.",
+            }),
             ("filter", {  # from filter
                 "choices": util.format_band_choices,
             }),
@@ -896,6 +906,11 @@ STREAM_SETTINGS_CONFIG = {
                 "label": "Input slit",
                 "tooltip": u"Opening size of the spectrograph input slit.\n"
                            u"A wide opening means more light and a worse resolution.",
+            }),
+            ("iris-in", {
+                "label": "Input iris",
+                "tooltip": "Opening size of the spectrograph iris.\n"
+                           "Use full opening if possible, but reduce iris to minimize optical path length variation.",
             }),
             ("filter", {  # from filter
                 "choices": util.format_band_choices,

--- a/src/odemis/gui/cont/stream_bar.py
+++ b/src/odemis/gui/cont/stream_bar.py
@@ -1759,6 +1759,7 @@ class SparcStreamsController(StreamBarController):
 
         axes = {"wavelength": ("wavelength", spg),
                 "grating": ("grating", spg),
+                "iris-in": ("iris-in", spg),
                 "slit-in": ("slit-in", spg),
                }
 
@@ -1815,6 +1816,7 @@ class SparcStreamsController(StreamBarController):
 
         axes = {"wavelength": ("wavelength", spectrograph),
                 "grating": ("grating", spectrograph),
+                "iris-in": ("iris-in", spectrograph),
                 "slit-in": ("slit-in", spectrograph),
                 "filter": ("band", main_data.light_filter),
                 }
@@ -1843,7 +1845,7 @@ class SparcStreamsController(StreamBarController):
 
     def addTemporalSpectrum(self):
         """
-        Create a temporal spectrum stream and add to to all compatible viewports
+        Create a temporal spectrum stream and add to all compatible viewports
         """
 
         main_data = self._main_data_model
@@ -1858,6 +1860,7 @@ class SparcStreamsController(StreamBarController):
 
         axes = {"wavelength": ("wavelength", spg),
                 "grating": ("grating", spg),
+                "iris-in": ("iris-in", spg),
                 "slit-in": ("slit-in", spg)}
 
         axes = self._filter_axes(axes)
@@ -1898,6 +1901,7 @@ class SparcStreamsController(StreamBarController):
 
         axes = {"wavelength": ("wavelength", spg),
                 "grating": ("grating", spg),
+                "iris-in": ("iris-in", spg),
                 "slit-in": ("slit-in", spg),
                 "slit-monochromator": ("slit-monochromator", spg),
                }


### PR DESCRIPTION
Allow the user to control the "iris-in" axis from the spectrum and
temporal spectrum streams. This is to support the Kymera 328i, which has
an input iris.