### PR TITLE
[refactor] Remove GUI dependency of fastem acquisition and clean up i…

### DIFF
--- a/src/odemis/acq/fastem.py
+++ b/src/odemis/acq/fastem.py
@@ -26,16 +26,9 @@ import math
 import os
 import threading
 import time
-import warnings
 from concurrent.futures import CancelledError
 
 import numpy
-
-from odemis.acq.align.fastem import align, estimate_calibration_time
-from odemis.gui import FG_COLOUR_WARNING
-from odemis.util.driver import guessActuatorMoveDuration
-from odemis.util.registration import estimate_grid_orientation_from_img
-from odemis.util.transform import to_physical_space, SimilarityTransform
 
 try:
     from fastem_calibrations import (
@@ -52,9 +45,13 @@ except ImportError as err:
 
 from odemis import model, util
 from odemis.acq import fastem_conf, stitching
+from odemis.acq.align.fastem import align, estimate_calibration_time
 from odemis.acq.stitching import REGISTER_IDENTITY, FocusingMethod
 from odemis.acq.stream import SEMStream
 from odemis.util import img, TimeoutError, transform
+from odemis.util.driver import guessActuatorMoveDuration
+from odemis.util.registration import estimate_grid_orientation_from_img
+from odemis.util.transform import to_physical_space, SimilarityTransform
 
 # The executor is a single object, independent of how many times the module (fastem.py) is loaded.
 _executor = model.CancellableThreadPoolExecutor(max_workers=1)
@@ -329,7 +326,7 @@ class FastEMROC(object):
     scintillator is acquired and assigned with all ROAs on the respective scintillator.
     """
 
-    def __init__(self, name, coordinates, colour=FG_COLOUR_WARNING):
+    def __init__(self, name, coordinates, colour="#FFA300"):
         """
         :param name: (str) Name of the region of calibration (ROC). It is the name of the megafield (id) as stored on
                      the external storage.


### PR DESCRIPTION
…mports

To have a default value for the ROC color the fastem acquisition module dependent on `odemis.gui.FG_COLOUR_WARNING`. Ideally, nothing from odemis.acq depends on odemis.gui. Since FG_COLOUR_WARNING was only used as a default for an input argument, and in practice it is overwritten the code was refactored to use the string value of FG_COLOUR_WARNING as default.

Additionally the import order of odemis.acq.fastem has been refactored to match the guidelines.