### PR TITLE
[fix] MultiplexActuator shortcuts Future to the sub-component also with multiple axes

### DIFF
--- a/src/odemis/driver/actuator.py
+++ b/src/odemis/driver/actuator.py
@@ -92,7 +92,7 @@ class MultiplexActuator(model.Actuator):
         model.Actuator.__init__(self, name, role, axes=axes,
                                 dependencies=dependencies, **kwargs)
 
-        if len(self.dependencies.value) > 1:
+        if len(set(dependencies.values())) > 1:
             # will take care of executing axis move asynchronously
             self._executor = CancellableThreadPoolExecutor(max_workers=1)  # one task at a time
             # TODO: make use of the 'Cancellable' part (for now cancelling a running future doesn't work)


### PR DESCRIPTION
The wrapper has a "shortcut" to not create a dedicated Future for each
move if there is only one axis, because in that case the sub-component
can directly take care of synchronizing the moves. However, the rule can
be slightly extended to multiple axes, as long as they are all handled
by the same sub-component.