### PR TITLE
[TRCL-266] driver semnidaq: extend active state to be available on detectors too

### DIFF
--- a/src/odemis/driver/test/semnidaq_test.py
+++ b/src/odemis/driver/test/semnidaq_test.py
@@ -52,7 +52,11 @@ CONFIG_CLD = {
     "role": "cld",
     "channel": 1,
     # "channel": "ao1",  # Loopback from the AO1, for testing
-    "limits": [3, -3]  # Data inverted
+    "limits": [3, -3],  # Data inverted
+    # Cannot be used as standard board only has 8 channels, and they are all used
+    # "active_ttl": {
+    #     5: [True, False, "protection"],  # high when active, low when protection is True
+    # },
 }
 
 CONFIG_BSD = {
@@ -60,13 +64,17 @@ CONFIG_BSD = {
     "role": "bsd",
     "channel": 2,
     # "channel": "ao1",  # Loopback from the AO1, for testing
-    "limits": [-4, 4]  # Data inverted
+    "limits": [-4, 4]
 }
 
 CONFIG_CNT = {
     "name": "counter",
     "role": "counter",
     "source": 8,  # PFI8
+    "active_ttl": {
+        5: [False, True, "protection"],  # low when active, high when protection is True
+    },
+    "activation_delay": 500e-9,  # s
 }
 
 CONFIG_SCANNER = {
@@ -645,7 +653,6 @@ class TestAnalogSEM(unittest.TestCase):
             self.assertEqual(da.shape, exp_shape)
             self.assertIn(model.MD_DWELL_TIME, da.metadata)
             self.assertAlmostEqual(da.metadata[model.MD_PIXEL_SIZE], exp_pxs)
-
 
     def test_acquisition_counter(self):
         self.scanner.dwellTime.value = 10e-06  # s

--- a/src/odemis/gui/conf/data.py
+++ b/src/odemis/gui/conf/data.py
@@ -629,6 +629,12 @@ HW_SETTINGS_CONFIG_PER_ROLE = {
                 "control_type": odemis.gui.CONTROL_SLIDER,
             },
         },
+        "monochromator": {
+            # protection is to be controlled automatically by the spectrograph to avoid light.
+            "protection": {
+                "control_type": odemis.gui.CONTROL_NONE,
+            },
+        },
     },
     "delphi": {
         # Some settings are continuous values, but it's more convenient to the user


### PR DESCRIPTION
For the counting PMT, we need to have a way to turn it on/off explicitly via a TTL port whenever we are acquiring.
It's essentially the same logic as for the scanner. So generalise the scanning state TTLs manager into a dedicated class, and introduce two arguments to be able to use it on the Detectors.