### PR TITLE
[feature] spectrometer wrapper force settings when synchronized

### DIFF
--- a/src/odemis/driver/spectrometer.py
+++ b/src/odemis/driver/spectrometer.py
@@ -262,6 +262,11 @@ class SpecDataFlow(model.DataFlow):
         logging.debug("Spectrometer acquisition finished")
 
     def synchronizedOn(self, event):
+        # Trick: for the frameDuration VA, all the settings must be applied... but this normally
+        # only happens when starting the acquisition. So we force the settings to be applied when
+        # setting synchronization.
+        if event is not None:
+            self.component._applyCCDSettings()
         self._ccddf.synchronizedOn(event)
         # Don't call super(), as it only updates max_discard. Instead, we update max_discard based
         # on the value decided by the original DataFlow.


### PR DESCRIPTION
In order to know the duration a frame will take, the camera component
must have all the VAs set. However, normally the spectrometer driver
only sets the VA just before the DataFlow is started. That's too late.
So, as a workaround, at least force the settings "flush" to also happen
when calling "synchronizedOn".

This at least allows to support our main use case of frameDuration,
which is to know the duration of the CCD while it's synchronized with
the e-beam scanner.