### PR TITLE
[FEAT] add correlation tab to odemis viewer

### DIFF
--- a/src/odemis/gui/cont/correlation.py
+++ b/src/odemis/gui/cont/correlation.py
@@ -71,7 +71,9 @@ class CorrelationController(object):
         # disable if no streams are present
         self._tab_data_model.streams.subscribe(self._on_correlation_streams_change, init=True)
         self._tab_data_model.streams.subscribe(self._update_correlation_cmb, init=True)
-        self._tab_data_model.streams.subscribe(self.add_to_localization_tab, init=False)
+        if not self._main_data_model.is_viewer:
+            # localisation tab doesn't exist in viewer
+            self._tab_data_model.streams.subscribe(self.add_to_localization_tab, init=False)
 
         # connect the correlation streams to the tab data
         self._panel.cmb_correlation_stream.Bind(wx.EVT_COMBOBOX, self._on_selected_stream_change)
@@ -334,7 +336,8 @@ class CorrelationController(object):
         self.fit_correlation_views_to_content()
 
         # update the localization tab
-        self.update_localization_tab(s)
+        if not self._main_data_model.is_viewer:
+            self.update_localization_tab(s)
 
     def fit_correlation_views_to_content(self, force: bool = False) -> None:
         # TODO: be more selective about which viewports to fit

--- a/src/odemis/gui/cont/menu.py
+++ b/src/odemis/gui/cont/menu.py
@@ -149,6 +149,15 @@ class MenuController(object):
         # /Help/About
         main_frame.Bind(wx.EVT_MENU, self._on_about, id=main_frame.menu_item_about.GetId())
 
+        # add a toggle for correlation tab in viewer mode
+        if main_data.is_viewer:
+            main_frame.Bind(wx.EVT_MENU, self._on_show_correlation, id=main_frame.menu_item_show_correlation.GetId())
+        else:
+            # remove the menu item
+            menu = main_frame.menu_item_show_correlation.GetMenu()
+            menu.Remove(main_frame.menu_item_show_correlation)
+            main_frame.menu_item_show_correlation.Destroy()
+
     def _on_update(self, evt):
         import odemis.gui.util.updater as updater
         u = updater.WindowsUpdater()
@@ -475,3 +484,18 @@ class MenuController(object):
         """
         # TODO: use event?
         self._main_data.debug.value = self._main_frame.menu_item_debug.IsChecked()
+
+    def _on_show_correlation(self, evt):
+        """ Toggle display of the correlation tab and tab buttons """
+
+        show = self._main_frame.menu_item_show_correlation.IsChecked()
+
+        if show:
+            self._main_frame.pnl_tabbuttons.Show()
+            tab = self._main_data.getTabByName("meteor-correlation")
+        else:
+            self._main_frame.pnl_tabbuttons.Hide()
+            tab = self._main_data.getTabByName("analysis")
+
+        self._main_data.tab.value = tab
+        self._main_frame.Layout()

--- a/src/odemis/gui/cont/tabs/analysis_tab.py
+++ b/src/odemis/gui/cont/tabs/analysis_tab.py
@@ -821,6 +821,9 @@ class AnalysisTab(Tab):
 
     @classmethod
     def get_display_priority(cls, main_data):
+        # high priority for viewer
+        if main_data.is_viewer:
+            return 1
         # Don't display tab for FastEM
         if main_data.role in ("mbsem",):
             return None

--- a/src/odemis/gui/cont/tabs/correlation_tab.py
+++ b/src/odemis/gui/cont/tabs/correlation_tab.py
@@ -242,6 +242,8 @@ class CorrelationTab(Tab):
 
     @classmethod
     def get_display_priority(cls, main_data) -> Optional[int]:
+        if main_data.is_viewer:
+            return 0 # low priority in viewer
         if main_data.role == "meteor":
             return 1
         else:

--- a/src/odemis/gui/cont/tabs/tab_bar_controller.py
+++ b/src/odemis/gui/cont/tabs/tab_bar_controller.py
@@ -192,7 +192,8 @@ class TabBarController(TabController):
             if b not in buttons:
                 b.Hide()
 
-        if len(tabs) <= 1:  # No need for tab buttons at all
+        # hide tab buttons for viewer
+        if main_data.is_viewer:
             main_frame.pnl_tabbuttons.Hide()
 
         return tabs, default_tab

--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -221,6 +221,7 @@ class xrcfr_main(wx.Frame):
         self.menu_item_cross = self.GetMenuBar().FindItemById(xrc.XRCID("menu_item_cross"))
         self.menu_item_interpolation = self.GetMenuBar().FindItemById(xrc.XRCID("menu_item_interpolation"))
         self.menu_item_rawpixel = self.GetMenuBar().FindItemById(xrc.XRCID("menu_item_rawpixel"))
+        self.menu_item_show_correlation = self.GetMenuBar().FindItemById(xrc.XRCID("menu_item_show_correlation"))
         self.menu_item_manual = self.GetMenuBar().FindItemById(xrc.XRCID("menu_item_manual"))
         self.menu_item_devmanual = self.GetMenuBar().FindItemById(xrc.XRCID("menu_item_devmanual"))
         self.menu_item_inspect = self.GetMenuBar().FindItemById(xrc.XRCID("menu_item_inspect"))
@@ -2456,6 +2457,14 @@ b\xeb\x85\x9f\xb6B\x1d\x0cK\x17\xac\xf0\x12\xfe\xa0\xe5\xee\xe03\xb1\xfa\
           <accel>Ctrl+U</accel>
           <checkable>1</checkable>
           <enabled>0</enabled>
+          <XRCED>
+            <assign_var>1</assign_var>
+          </XRCED>
+        </object>
+            <object class="wxMenuItem" name="menu_item_show_correlation">
+          <label>Show Correlation Tab</label>
+          <enabled>1</enabled>
+          <checkable>1</checkable>
           <XRCED>
             <assign_var>1</assign_var>
           </XRCED>

--- a/src/odemis/gui/model/main_gui_data.py
+++ b/src/odemis/gui/model/main_gui_data.py
@@ -386,6 +386,9 @@ class MainGUIData(object):
         # do directly access additional GUI information.
         self.tab = model.VAEnumerated(None, choices={None: ""})
 
+        # Indicate whether the gui is loaded as viewer
+        self.is_viewer = self.microscope is None
+
     def stopMotion(self):
         """
         Stops immediately every axis

--- a/src/odemis/gui/model/tab_gui_data.py
+++ b/src/odemis/gui/model/tab_gui_data.py
@@ -217,7 +217,7 @@ class CryoGUIData(MicroscopyGUIData):
     Represents an interface for handling cryo microscopes.
     """
     def __init__(self, main):
-        if main.role not in ("enzel", "meteor", "mimas"):
+        if not main.is_viewer and main.role not in ("enzel", "meteor", "mimas"):
             raise ValueError(
                 "Expected a microscope role of 'enzel', 'meteor', or 'mimas' but found it to be %s." % main.role)
         super().__init__(main)

--- a/src/odemis/gui/xmlh/resources/frame_main.xrc
+++ b/src/odemis/gui/xmlh/resources/frame_main.xrc
@@ -140,6 +140,14 @@
             <assign_var>1</assign_var>
           </XRCED>
         </object>
+            <object class="wxMenuItem" name="menu_item_show_correlation">
+          <label>Show Correlation Tab</label>
+          <enabled>1</enabled>
+          <checkable>1</checkable>
+          <XRCED>
+            <assign_var>1</assign_var>
+          </XRCED>
+        </object>
         <label>View</label>
       </object>
       <object class="wxMenu">


### PR DESCRIPTION
Users have requested the ability to use the correlation tools (stitching and correlating) overviews in the odemis viewer without being connected to a microscope. This PR adds:

Features:
- Enable the use of the correlation tab in the odemis viewer. 

