### PR TITLE
[feat] Fastem acquisitions: Reduce the number of times the beamshift …

### DIFF
--- a/src/odemis/acq/fastem.py
+++ b/src/odemis/acq/fastem.py
@@ -491,7 +491,10 @@ class AcquisitionTask(object):
         # save the initial multibeam resolution, because the resolution will get updated if save_full_cells is True
         self._old_res = self._multibeam.resolution.value
 
-        self.path = fastem_util.create_image_dir("beam-shift-correction")
+        path = fastem_util.create_image_dir("beam-shift-correction")
+        # The path should be [image-dir]/beam-shift-correction/[timestamp]/[roa-name]
+        self.path = os.path.join(path, self._roa.name.value)
+        os.makedirs(self.path, exist_ok=True)
 
         # Dictionary containing the single field images with index as key: e.g. {(0,1): DataArray}.
         self.megafield = {}
@@ -535,8 +538,8 @@ class AcquisitionTask(object):
         self._future.set_progress(end=time.time() + total_roa_time)  # provide end time to future
         logging.info(
             "Starting acquisition of ROA %s, with expected duration of %f s, %s by %s fields and overlap %s.",
-            self._roa.name, total_roa_time, self._roa.field_indices[-1][0] + 1, self._roa.field_indices[-1][1] + 1,
-            self._roa.overlap,
+            self._roa.name.value, total_roa_time, self._roa.field_indices[-1][0] + 1,
+            self._roa.field_indices[-1][1] + 1, self._roa.overlap,
         )
 
         # Update the position of the first tile.
@@ -920,7 +923,7 @@ class AcquisitionTask(object):
         Example: If the beam shift correction should run every 3 sections for the indices [(1, 0), (2, 0), (8, 0)],
         it should run for indices (1, 0) and (8, 0).
 
-        :param n_beam_shifts: (int) Every how many sections the beam shift correction should run.
+        :param n_beam_shifts: (int) Number of sections after which the beam shift correction should run.
         """
         # Sort indices by row first and then by column to enable row-wise processing
         field_indices = sorted(self._roa.field_indices, key=lambda x: (x[1], x[0]))

--- a/src/odemis/acq/fastem.py
+++ b/src/odemis/acq/fastem.py
@@ -653,9 +653,10 @@ class AcquisitionTask(object):
                 try:
                     new_beam_shift = self.correct_beam_shift()
                     # The difference in x or y should not be larger than 2 micrometers
-                    if any(map(lambda x, y: abs(x - y) > 2e-6, new_beam_shift, prev_beam_shift)):
+                    if any(map(lambda n, p: abs(n - p) > 2e-6, new_beam_shift, prev_beam_shift)):
                         raise ValueError(
-                            "Difference in beam shift is larger than 2 µm, therefore it most likely failed."
+                            f"Difference in beam shift is larger than 2 µm, therefore it most likely failed. "
+                            f"Previous beam shift: {prev_beam_shift}, new beam shift: {new_beam_shift}"
                         )
                     beam_shift_failed = False
                 except Exception:
@@ -929,10 +930,10 @@ class AcquisitionTask(object):
         field_indices = sorted(self._roa.field_indices, key=lambda x: (x[1], x[0]))
 
         beam_shift_indices = []
-        current_row = -1  # Initialize with an invalid row number to handle the first row properly
+        current_row = -1  # Initialize with -1 to handle the first row (row 0) properly
         for idx in field_indices:
             col, row = idx  # field indices are saved (col, row)
-            if row == current_row + 1:
+            if row > current_row:
                 # Always apply beam shift correction at the start of a new row
                 beam_shift_indices.append(idx)
                 current_row = row


### PR DESCRIPTION
…correction runs

The beamshift correction was running for every field, it takes about 0.46s to run, so reducing the number of times it runs increases the throughput significantly.