### PR TITLE
[ci] Add cloud hosted CI on Ubuntu 24.04

### DIFF
--- a/.github/workflows/unit_tests_cloud_ubuntu24.yml
+++ b/.github/workflows/unit_tests_cloud_ubuntu24.yml
@@ -1,0 +1,189 @@
+# This workflow will install Python dependencies, and run a selection of tests from the Odemis repository.
+# The selection is picked such that they do not require a back-end and are known to pass with this github workflow.
+# Test cases that will pass with this workflow can be added to this document.
+# It uses the python 3 system interpreter to run test cases.
+# NOTE: this workflow only runs the test cases on Ubuntu 24.04 and will not send a notification on failure.
+# TODO: When all test cases pass successfully on Ubuntu 24.04, testing on Ubuntu 24.04 can be added to
+#   unit_tests_cloud.yml.
+
+name: Unit testing Ubuntu 24.04
+
+on:
+  [push, pull_request]
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    continue-on-error: true  # This ensures there is no notification when the test cases fail
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install Odemis dependencies
+      run: |
+        sudo add-apt-repository ppa:delmic-soft/odemis
+        sudo apt-get -y update
+
+        sudo apt-get -y install python3-pil python3-yaml python3-serial python3-zmq \
+        python3-scipy python3-decorator \
+        python3-libtiff python3-comedilib python3-h5py libtiff5-dev python3-future \
+        python3-pkg-resources python3-netifaces python3-cairo python3-numpy python3-scipy \
+        python3-decorator python3-xdg python3-suds python3-matplotlib python3-opencv \
+        python3-wxgtk4.0 python3-serial python3-evdev python3-notify2 python3-psutil \
+        graphicsmagick cgroup-tools authbind python3-setuptools cython3 python3-pyro4-delmic
+
+        sudo mkdir /var/run/odemisd
+        sudo chmod a+rw /var/run/odemisd
+
+        python3 setup.py build_ext --inplace
+
+    - name: Run tests from odemis.dataio
+      run: |
+        export PYTHONPATH="$PWD/src:$PYTHONPATH"
+        python3 -m unittest discover -s src/odemis/dataio/test -p "*_test.py" --verbose
+
+    - name: Run tests from odemis.acq.drift
+      # Run this step if the previous step passed or failed, but not if it was canceled.
+      # continue-on-error prevents the pipeline from failing, with this `if` the pipeline
+      # still reports a fail, and the next steps are also executed.
+      if: ${{ !cancelled() }}
+      run: |
+        export PYTHONPATH="$PWD/src:$PYTHONPATH"
+        python3 -m unittest discover -s src/odemis/acq/drift/test -p "*_test.py" --verbose
+
+    - name: Run tests from odemis.util.conversion
+      if: ${{ !cancelled() }}
+      run: |
+        export PYTHONPATH="$PWD/src:$PYTHONPATH"
+        python3 -m unittest src/odemis/util/test/conversion_test.py --verbose
+
+    - name: Run tests from odemis.util.dataio
+      if: ${{ !cancelled() }}
+      run: |
+        export PYTHONPATH="$PWD/src:$PYTHONPATH"
+        python3 -m unittest src/odemis/util/test/dataio_test.py --verbose
+
+    - name: Run tests from odemis.util.filename
+      if: ${{ !cancelled() }}
+      run: |
+        export PYTHONPATH="$PWD/src:$PYTHONPATH"
+        python3 -m unittest src/odemis/util/test/filename_test.py --verbose
+
+    - name: Run tests from odemis.util.fluo
+      if: ${{ !cancelled() }}
+      run: |
+        export PYTHONPATH="$PWD/src:$PYTHONPATH"
+        python3 -m unittest src/odemis/util/test/fluo_test.py --verbose
+
+    - name: Run tests from odemis.util.graph
+      if: ${{ !cancelled() }}
+      run: |
+        export PYTHONPATH="$PWD/src:$PYTHONPATH"
+        python3 -m unittest src/odemis/util/test/graph_test.py --verbose
+
+    - name: Run tests from odemis.util.img
+      if: ${{ !cancelled() }}
+      run: |
+        export PYTHONPATH="$PWD/src:$PYTHONPATH"
+        python3 -m unittest src/odemis/util/test/img_test.py --verbose
+
+    - name: Run tests from odemis.util.linalg
+      if: ${{ !cancelled() }}
+      run: |
+        export PYTHONPATH="$PWD/src:$PYTHONPATH"
+        python3 -m unittest src/odemis/util/test/linalg_test.py --verbose
+
+    - name: Run tests from odemis.util.peak_local_max
+      if: ${{ !cancelled() }}
+      run: |
+        export PYTHONPATH="$PWD/src:$PYTHONPATH"
+        python3 -m unittest src/odemis/util/test/peak_local_max_test.py --verbose
+
+    - name: Run tests from odemis.util.peak
+      if: ${{ !cancelled() }}
+      run: |
+        export PYTHONPATH="$PWD/src:$PYTHONPATH"
+        python3 -m unittest src/odemis/util/test/peak_test.py --verbose
+
+    - name: Run tests from odemis.util.registration
+      if: ${{ !cancelled() }}
+      run: |
+        export PYTHONPATH="$PWD/src:$PYTHONPATH"
+        python3 -m unittest src/odemis/util/test/registration_test.py --verbose
+
+    - name: Run tests from odemis.util.spectrum
+      if: ${{ !cancelled() }}
+      run: |
+        export PYTHONPATH="$PWD/src:$PYTHONPATH"
+        python3 -m unittest src/odemis/util/test/spectrum_test.py --verbose
+
+    - name: Run tests from odemis.util.transform
+      if: ${{ !cancelled() }}
+      run: |
+        export PYTHONPATH="$PWD/src:$PYTHONPATH"
+        python3 -m unittest src/odemis/util/test/transform_test.py --verbose
+
+    - name: Run tests from odemis.util.units
+      if: ${{ !cancelled() }}
+      run: |
+        export PYTHONPATH="$PWD/src:$PYTHONPATH"
+        python3 -m unittest src/odemis/util/test/units_test.py --verbose
+
+    - name: Run tests from odemis.util.__init__.py
+      if: ${{ !cancelled() }}
+      run: |
+        export PYTHONPATH="$PWD/src:$PYTHONPATH"
+        python3 -m unittest src/odemis/util/test/util_test.py --verbose
+
+    - name: Run tests from odemis.acq.stitching except tiled_acq
+      if: ${{ !cancelled() }}
+      run: |
+        export PYTHONPATH="$PWD/src:$PYTHONPATH"
+        python3 -m unittest src/odemis/acq/stitching/test/registrar_test.py --verbose
+        python3 -m unittest src/odemis/acq/stitching/test/stitching_test.py --verbose
+        python3 -m unittest src/odemis/acq/stitching/test/weaver_test.py --verbose
+
+    - name: Run tests from odemis.acq.calibration
+      if: ${{ !cancelled() }}
+      run: |
+        export PYTHONPATH="$PWD/src:$PYTHONPATH"
+        python3 -m unittest src/odemis/acq/test/calibration_test.py --verbose
+
+    - name: Run tests from odemis.acq.feature
+      if: ${{ !cancelled() }}
+      run: |
+        export PYTHONPATH="$PWD/src:$PYTHONPATH"
+        python3 -m unittest src/odemis/acq/test/feature_test.py --verbose
+
+    - name: Run tests from odemis.gui.conf
+      if: ${{ !cancelled() }}
+      run: |
+        export PYTHONPATH="$PWD/src:$PYTHONPATH"
+        python3 -m unittest src.odemis.gui.conf.test.conf_test.AcquisitionConfigTest --verbose
+        python3 -m unittest src.odemis.gui.conf.test.conf_test.CalibrationConfigTest --verbose
+        python3 -m unittest src.odemis.gui.conf.test.conf_test.GeneralConfigTest.test_save --verbose
+        python3 -m unittest src.odemis.gui.conf.test.conf_test.GeneralConfigTest.test_save_unicode --verbose
+        python3 -m unittest src.odemis.gui.conf.test.conf_test.GeneralConfigTest.test_simple --verbose
+        # test_default fails on CI, because the manual path does not exist on the server
+        # python3 -m unittest src.odemis.gui.conf.test.conf_test.GeneralConfigTest.test_default --verbose
+
+    - name: Run tests from odemis.gui.util.conversion
+      if: ${{ !cancelled() }}
+      run: |
+        export PYTHONPATH="$PWD/src:$PYTHONPATH"
+        python3 -m unittest src/odemis/gui/util/test/conversion_test.py --verbose
+
+    - name: Run tests from odemis.gui.win
+      if: ${{ !cancelled() }}
+      run: |
+        export PYTHONPATH="$PWD/src:$PYTHONPATH"
+        python3 -m unittest src/odemis/gui/win/test/acquisition_test.py --verbose
+
+    - name: Run mocked tests from odemis.acq.fastem
+      if: ${{ !cancelled() }}
+      run: |
+        export PYTHONPATH="$PWD/src:$PYTHONPATH"
+        python3 -m unittest src.odemis.acq.test.fastem_test.TestFastEMAcquisitionTaskMock --verbose


### PR DESCRIPTION
The unit tests do not pass yet on Ubuntu 24.04. This ci-workflow can be used to figure out what we need to test and verify fixes. It will not send a notification for a failed run, but if you click on the specific github action you will see a failure for the specific build. I created a separate workflow, because it is not possible to integrate in the regular workflow such that you get a notification for failures on Ubuntu 20/22 but not on Ubuntu 24.