### PR TITLE
[fix] hide fiber align control in SPARCv1 alignment tab if axes are not present

### DIFF
--- a/src/odemis/gui/cont/tabs/sparc_align_tab.py
+++ b/src/odemis/gui/cont/tabs/sparc_align_tab.py
@@ -167,6 +167,11 @@ class SparcAlignTab(Tab):
 
         tab_data.align_mode.subscribe(self._onAlignMode)
 
+        # Hide the fiber aligner panel if no hardware present (although the "fiber-align" mode may
+        # still be there, as it might be a manual fiber aligner)
+        showfib = ("fibaligner", "x") in tab_data.axes
+        panel.pnl_fibaligner.Show(showfib)
+
         self._actuator_controller = ActuatorController(tab_data, panel, "mirror_align_")
 
         # Bind keys


### PR DESCRIPTION
The ActuatorController used to do it. However, commit acb21edc45
(gui SPARC2 alignment tab: completly hide panels which cannot be used)
made it more "dynamic" by letting the tab controller do it.

The SPARCv2 alignment tab controller was updated, but we forgot to
update the SPARCv1 alignment tab.