### PR TITLE
[refactor] No need to override inspect.getmembers() from Python 3.11

### DIFF
--- a/src/odemis/util/__init__.py
+++ b/src/odemis/util/__init__.py
@@ -24,23 +24,24 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 # Various helper functions that have a generic usefulness
 # Warning: do not put anything that has dependencies on non default python modules
 
-import queue
-from collections.abc import Mapping
-from concurrent.futures import CancelledError
-from decorator import decorator
-from functools import wraps
 import inspect
 import itertools
 import logging
 import math
-import numpy
+import queue
 import signal
 import sys
 import threading
 import time
-import weakref
 import types
+import weakref
+from collections.abc import Mapping
+from concurrent.futures import CancelledError
+from functools import wraps
 from typing import Iterable, Tuple, TypeVar
+
+import numpy
+from decorator import decorator
 
 from . import weak
 
@@ -605,57 +606,62 @@ def limit_invocation(delay_s):
     return li_dec
 
 
-def inspect_getmembers(object, predicate=None):
-    """
-    Fix for the corresponding function in inspect. If we modify __getattr__ of a function, inspect.getmembers()
-    doesn't work as intended (a TypeError is raised). The change consists of one line (highlighted below).
-    https://stackoverflow.com/questions/54478679/workaround-for-getattr-special-method-breaking-inspect-getmembers-in-pytho
-    """
-    # Line below adds inspect. reference to isclass()
-    if inspect.isclass(object):
-        # Line below adds inspect. reference to getmro()
-        mro = (object,) + inspect.getmro(object)
-    else:
-        mro = ()
-    results = []
-    processed = set()
-    names = dir(object)
-    # :dd any DynamicClassAttributes to the list of names if object is a class;
-    # this may result in duplicate entries if, for example, a virtual
-    # attribute with the same name as a DynamicClassAttribute exists
-    try:
-        for base in object.__bases__:
-            for k, v in base.__dict__.items():
-                if isinstance(v, types.DynamicClassAttribute):
-                    names.append(k)
-    #################################################################
-    ### Modification to inspect.getmembers: also catch TypeError here
-    #################################################################
-    except (AttributeError, TypeError):
-        pass
-    for key in names:
-        # First try to get the value via getattr.  Some descriptors don't
-        # like calling their __get__ (see bug #1785), so fall back to
-        # looking in the __dict__.
+# inspect.getmembers() in Python 3.10 and prior has an issue when __getattr__ is modified.
+if sys.version_info >= (3, 11):
+    def inspect_getmembers(object, predicate=None):
+        return inspect.getmembers(object, predicate)
+else:
+    def inspect_getmembers(object, predicate=None):
+        """
+        Fix for the corresponding function in inspect. If we modify __getattr__ of a function, inspect.getmembers()
+        doesn't work as intended (a TypeError is raised). The change consists of one line (highlighted below).
+        https://stackoverflow.com/questions/54478679/workaround-for-getattr-special-method-breaking-inspect-getmembers-in-pytho
+        """
+        # Line below adds inspect. reference to isclass()
+        if inspect.isclass(object):
+            # Line below adds inspect. reference to getmro()
+            mro = (object,) + inspect.getmro(object)
+        else:
+            mro = ()
+        results = []
+        processed = set()
+        names = dir(object)
+        # :dd any DynamicClassAttributes to the list of names if object is a class;
+        # this may result in duplicate entries if, for example, a virtual
+        # attribute with the same name as a DynamicClassAttribute exists
         try:
-            value = getattr(object, key)
-            # handle the duplicate key
-            if key in processed:
-                raise AttributeError
-        except AttributeError:
-            for base in mro:
-                if key in base.__dict__:
-                    value = base.__dict__[key]
-                    break
-            else:
-                # could be a (currently) missing slot member, or a buggy
-                # __dir__; discard and move on
-                continue
-        if not predicate or predicate(value):
-            results.append((key, value))
-        processed.add(key)
-    results.sort(key=lambda pair: pair[0])
-    return results
+            for base in object.__bases__:
+                for k, v in base.__dict__.items():
+                    if isinstance(v, types.DynamicClassAttribute):
+                        names.append(k)
+        #################################################################
+        ### Modification to inspect.getmembers: also catch TypeError here
+        #################################################################
+        except (AttributeError, TypeError):
+            pass
+        for key in names:
+            # First try to get the value via getattr.  Some descriptors don't
+            # like calling their __get__ (see bug #1785), so fall back to
+            # looking in the __dict__.
+            try:
+                value = getattr(object, key)
+                # handle the duplicate key
+                if key in processed:
+                    raise AttributeError
+            except AttributeError:
+                for base in mro:
+                    if key in base.__dict__:
+                        value = base.__dict__[key]
+                        break
+                else:
+                    # could be a (currently) missing slot member, or a buggy
+                    # __dir__; discard and move on
+                    continue
+            if not predicate or predicate(value):
+                results.append((key, value))
+            processed.add(key)
+        results.sort(key=lambda pair: pair[0])
+        return results
 
 class TimeoutError(Exception):
     pass

--- a/src/odemis/util/test/util_test.py
+++ b/src/odemis/util/test/util_test.py
@@ -657,11 +657,9 @@ class InspectGetMembersTestCase(unittest.TestCase):
     def test_inspect_get_members(self):
         """ Test the builtin inspect.getmembers raises a TypeError for the dummy class, and that
         util.inspect_getmembers has the correct output. """
-        with self.assertRaises(TypeError):
-            inspect.getmembers(InspectGetMembersDummy())
 
         res = util.inspect_getmembers(InspectGetMembersDummy())
-        self.assertEqual(len(res), 27)
+        self.assertGreater(len(res), 10)
 
 
 class InspectGetMembersDummy:


### PR DESCRIPTION
inspect.getmembers() in Python 3.10 and prior has an issue when __getattr__ is modified.
However, this is fixed in v3.11. So we can just use the standard code
(and avoid the risk of using an old version of getmembers() which is not
compatible with the newer Python anymore).

Also adjust the test case to not complain if Python works fine.