### PR TITLE
[feature] extend support for andor kymera 328i

### DIFF
--- a/src/odemis/driver/andorshrk.py
+++ b/src/odemis/driver/andorshrk.py
@@ -1127,7 +1127,7 @@ class Shamrock(model.Actuator):
     def GetFocusMirror(self):
         """
         Get the current position of the focus
-        return (0<=int<=maxsteps): absolute position (in steps)
+        return (0<int<=maxsteps): absolute position (in steps)
         """
         focus = c_int()
         with self._hw_access:
@@ -1138,6 +1138,8 @@ class Shamrock(model.Actuator):
     def GetFocusMirrorMaxSteps(self):
         """
         Get the maximum position of the focus
+        WARNING: the KY328 returns 550, but if going precisely to 550, it will raise a "communication
+        error" (while going out of the official range raises a "parameter invalid" error).
         return (0 <= int): absolute max position (in steps)
         """
         focus = c_int()
@@ -1545,6 +1547,7 @@ class Shamrock(model.Actuator):
                 userv = [k for k, v in FLIPPER_TO_PORT.items() if v == val][0]
                 pos[name] = userv
 
+        logging.debug("%s position updated to %s", self.name, pos)
         self.position._set_value(pos, must_notify=must_notify, force_write=True)
 
     def _storeFocus(self):
@@ -1562,6 +1565,7 @@ class Shamrock(model.Actuator):
             op = 0
         f = self.GetFocusMirror()
         self._go2focus[(g, op)] = f
+        logging.debug("Focus position for %s/%s stored to %d stp", g, op, f)
 
     def _restoreFocus(self):
         """

--- a/util/kymera-exchange-turret.sh
+++ b/util/kymera-exchange-turret.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Move the turret to the dedicated exchange position and back again
+# arg1: "<kymera serial number>" (eg KY-0523) to select the kymera if not running yet
+# arg2: "<odemis role>" (eg spectrograph-dedicated) to select the kymera if backend running
+# Example:
+# kymera-exchange-turret.sh KY-0523 spectrograph-dedicated
+
+WINDOW_TITLE="Turret exchange"
+ICON_PATH="$HOME/.local/share/icons/hicolor/128x128/apps/ky328-turret.png"
+
+# Check there is 2 arguments
+if [ "$#" -ne 2 ]; then
+    echo "Expected 2 arguments: serial number and odemis role"
+    exit 1
+fi
+
+serial_num=$1
+role=$2
+
+# Confirm the user really wants to change the turret
+zenity --title "$WINDOW_TITLE" --window-icon "$ICON_PATH" --question --text "Do you want to exchange the turret of the Kymera 328i?" --ok-label "Yes" --cancel-label "No"
+if [ $? -ne 0 ]; then
+    exit 0
+fi
+
+# Check if odemis is running
+odemis --check
+status=$?
+
+if [ $status = 0 ] || [ $status = 3 ] ; then  # Running or starting
+    select_args="--role $role"
+    # For safety, close the shutter of the streak cam (in case it's not already closed)
+    odemis --set-attr streak-ccd shutter True  # FIXME, check
+else
+    select_args="--serial $serial_num"
+fi
+
+# Move the turret to the exchange position
+shrkconfig --exchange-turret $select_args | zenity --title "$WINDOW_TITLE" --window-icon "$ICON_PATH" --progress --pulsate --no-cancel --text "Moving Kymera 328i turret..." --auto-close
+shkconfig_status=${PIPESTATUS[0]}
+if [ $shkconfig_status -ne 0 ]; then
+    zenity --title "$WINDOW_TITLE" --window-icon "$ICON_PATH" --error --text "Error moving Kymera 328i turret"
+    exit 1
+fi
+
+# Wait until the user has exchanged the turret
+zenity --title "$WINDOW_TITLE" --window-icon "$ICON_PATH" --info --text "You can now exchange the turret. Put back the cap, and then press OK when done."
+
+# Move the turret back to the original position
+shrkconfig --detect-turret $select_args | zenity --title "$WINDOW_TITLE" --window-icon "$ICON_PATH" --progress --pulsate --no-cancel --text "Moving Kymera 328i turret back..." --auto-close
+shkconfig_status=${PIPESTATUS[0]}
+if [ $shkconfig_status -ne 0 ]; then
+    zenity --title "$WINDOW_TITLE" --window-icon "$ICON_PATH" --error --text "Error moving back Kymera 328i turret. Trying turn off/on the spectrograph."
+    exit 1
+fi
+
+# Show a message to the user that's done
+if [ $status = 0 ] || [ $status = 3 ] ; then  # Running or starting
+    zenity --title "$WINDOW_TITLE" --window-icon "$ICON_PATH" --info --text "Spectrograph ready, you can now do full stop of Odemis, and restart it."
+else
+    zenity --title "$WINDOW_TITLE" --window-icon "$ICON_PATH" --info --text "Spectrograph ready, you can start Odemis"
+fi

--- a/util/shrkconfig
+++ b/util/shrkconfig
@@ -114,6 +114,35 @@ def set_szero(device, slit, offset):
     device._updatePosition()
 
 
+def exchange_turret(device: andorshrk.Shamrock) -> None:
+    """
+    Brings the turret (on a Kymera 328i) to the special exchange position.
+    Blocks until the turret is in position.
+    """
+    try:
+        device.ChangeTurret()
+    except AttributeError:
+        raise ValueError("This version of the Andor Shamrock library does not support changing the turret. "
+                         "Make sure you have at least version 2.104.30132")
+    logging.info("Turret is ready to be exchanged")
+
+
+def detect_turret(device: andorshrk.Shamrock) -> None:
+    """
+    Brings back the turret (on a Kymera 328i) to the standard position, and detects the turret number
+    (using the RFID tag).
+    Blocks until the turret is in position and the RFID is read.
+    """
+    try:
+        device.ReadTurretRFID()
+    except AttributeError:
+        raise ValueError("This version of the Andor Shamrock library does not support detecting the turret. "
+                         "Make sure you have at least version 2.104.30132")
+
+    turret = device.GetTurret()
+    logging.info("Detected turret is %s", turret)
+
+
 def main(args):
     """
     Handles the command line arguments
@@ -140,7 +169,10 @@ def main(args):
     parser.add_argument('--szero', dest="szero", nargs=2, type=int,
                         metavar=("<slit>", "<offset>"),
                         help="Changes the zero position (-200 → 0) for the given slit. (1 step ≈ 5µm)")
-    # TODO: allow to change the current turret?
+    parser.add_argument('--exchange-turret', dest="exchange_turret", action="store_true",
+                        help="Brings the turret to the exchange position")
+    parser.add_argument('--detect-turret', dest="detect_turret", action="store_true",
+                        help="Brings back the turret and detect the turret number")
 
     parser.add_argument('--serial', dest="serial", default=0,
                         help="Serial number of the device (by default, it will pick the one connected). Odemis must not be running.")
@@ -164,6 +196,9 @@ def main(args):
         else:
             dev = andorshrk.Shamrock("test", "test", options.serial)
 
+        if options.exchange_turret and options.detect_turret:
+            raise ValueError("Cannot exchange and detect the turret at the same time.")
+
         if options.read:
             read_all(dev)
         if options.turret:
@@ -174,6 +209,12 @@ def main(args):
             set_doffset(dev, *options.doffset)
         if options.szero:
             set_szero(dev, *options.szero)
+        if options.exchange_turret:
+            exchange_turret(dev)
+        if options.detect_turret:
+            detect_turret(dev)
+            if options.role:
+                logging.warning("Odemis back-end must be restarted to update the grating information.")
 
         if not options.role:
             dev.terminate()


### PR DESCRIPTION
The main goal is to add support for exchanging the turret on the Kymera 328. These changes also improve the support when having multiple Andor spectrographs (as the Kymera 328 is used in addition to the Kymera 193), and support reconnection even if the spectrograph power cannot be controlled (because we don't have power control for the Kymera 328).