### PR TITLE
[fix] Handle floating point error when computing axes ticks in gui.img.calculate_ticks()

### DIFF
--- a/src/odemis/gui/util/img.py
+++ b/src/odemis/gui/util/img.py
@@ -1055,7 +1055,7 @@ def calculate_ticks(value_range, client_size, orientation, tick_spacing):
                   value_step, value_space, tick_spacing)
 
     # Find the smallest value multiple of value_step, which is within the range
-    first_val = math.ceil(min_val / value_step) * value_step
+    first_val = max(min_val, math.ceil(min_val / value_step) * value_step)  # Clamp to min_val for floating point errors
     # logging.debug("Setting first tick at value %s", first_val)
 
     tick_values = [min_val] if min_val == 0 else []

--- a/src/odemis/gui/util/test/img_test.py
+++ b/src/odemis/gui/util/test/img_test.py
@@ -124,6 +124,7 @@ class TestCalculateTicks(unittest.TestCase):
     def test_simple(self):
         # Various "simple" inputs which should return a couple of ticks with a value to pixel ratio > 0
         ranges = [(100, 1000), (0, 9500), (1e-3, 8e-3), (-5, 6), (-2, -1000)]
+        ranges += [(400e-9 + 5e-23, 500e-9)]  # floating point error would causes first tick < range[0]
 
         csize = (500, 600)
         for rng in ranges:


### PR DESCRIPTION
For some very specific ranges, the calculation of the first tick value
would end up being very slightly less than the first value of the range
(eg, 1e-18 less). That would confuse the assertion later that all ticks
are within the range.
=> Make sure that the first tick is at least as big as the first value
in the range.

This avoids such error messages:
2024-07-12 15:39:59,308 ERROR   main:411:       Traceback (most recent call last):
  File "odemis/src/odemis/gui/comp/legend.py", line 495, in on_paint
    self._tick_list = calculate_ticks(self._value_range, csize, self._orientation, self._tick_spacing)
  File "odemis/src/odemis/gui/util/img.py", line 1077, in calculate_ticks
    pixel = value_to_pixel(tick_value, pixel_space, value_range, orientation)
  File "odemis/src/odemis/gui/util/img.py", line 899, in value_to_pixel
    assert value_range_finite[0] <= value <= value_range_finite[-1] or value_range_finite[-1] <= value <= value_range_finite[0]
AssertionError