### PR TITLE
[fix] raise issue early if VAContinuous range has not the same length for min & max

### DIFF
--- a/src/odemis/model/_vattributes.py
+++ b/src/odemis/model/_vattributes.py
@@ -880,6 +880,10 @@ class Continuous(object):
             start = (start,)
             end = (end,)
 
+        if len(start) != len(end):
+            raise TypeError("Range min %s and max %s should have the same length." %
+                            (start, end))
+
         if any(mn > mx for mn, mx in zip(start, end)):
             raise TypeError("Range min %s should be smaller than max %s." %
                             (start, end))


### PR DESCRIPTION
If for example the min range has length 2, and max range has length 1,
an error would be raise at init... but confusingly complaining about the
value length.

=> Explicitly check that the range is sane.