### PR TITLE
[fix] improve default settings for the SPARC autofocus

### DIFF
--- a/src/odemis/gui/cont/tabs/sparc2_align_tab.py
+++ b/src/odemis/gui/cont/tabs/sparc2_align_tab.py
@@ -1370,8 +1370,8 @@ class Sparc2AlignTab(Tab):
             )
             speclines.tint.value = odemis.gui.FOCUS_STREAM_COLOR
             # Fixed values, known to work well for autofocus
-            speclines.detExposureTime.value = speclines.detExposureTime.clip(0.2)
-            self._setFullFoV(speclines, (2, 2))
+            speclines.detExposureTime.value = speclines.detExposureTime.clip(0.1)
+            self._setFullFoV(speclines, (2, 16))
             if model.hasVA(speclines, "detReadoutRate"):
                 try:
                     speclines.detReadoutRate.value = speclines.detReadoutRate.range[1]


### PR DESCRIPTION
Use more vertical binning, to get more signal. This allows to have a
shorter exposure time (so shorter procedure), and even still have 4x
more signal, handy for systems wher the signal is very low (like on the
SPARCs with external spectrographs).

The vertical resolution doesn't really matter for spectrograph focus, so
it's fine to reduce it.