### PR TITLE
[TRCL-24] adjust streak cam alignment tab when using external spectrograph

### DIFF
--- a/src/odemis/acq/path.py
+++ b/src/odemis/acq/path.py
@@ -149,12 +149,18 @@ SPARC2_MODES = {
                  'lens-mover': {'x': "MD:" + model.MD_FAV_POS_ACTIVE},
                  'slit-in-big': {'x': 'off'},  # closed
                  'filter': {'band': BAND_PASS_THROUGH},
-                 'spectrograph': {'slit-in': 10e-6},  # slit to the minimum
+                 'spectrograph': {'slit-in': 10e-6, 'wavelength': 0},  # slit to the minimum
                  'chamber-light': {'power': 'off'},
                  'pol-analyzer': {'pol': MD_POL_NONE},
                  'light-aligner': {'x': "MD:" + model.MD_FAV_POS_ACTIVE,
                                    'z': "MD:" + model.MD_FAV_POS_ACTIVE},
                 }),
+            'streak-focus-ext': ("streak-ccd",  # same as spec-focus-ext, but with the streak-ccd
+                 {'spec-ded-aligner': {'z': "MD:" + model.MD_FAV_POS_ACTIVE},
+                  # slit to the minimum, wavelength to the zeroth order
+                  'spectrograph-dedicated': {'slit-in': 10e-6, 'wavelength': 0},
+                  'chamber-light': {'power': 'off'},
+                  }),
             'temporal-spectrum': ("streak-ccd",  # acquisition tab
                 {'lens-switch': {'x': ("MD:" + model.MD_FAV_POS_DEACTIVE, 'off')},
                  'lens-mover': {'x': "MD:" + model.MD_FAV_POS_ACTIVE},
@@ -257,7 +263,7 @@ SPARC2_MODES = {
                  # 'spec-selector' will depend on the affects
                  # for the spec-ded aligner only z axis positions are stored, currently for one WL
                  'spec-ded-aligner': {'z': "MD:" + model.MD_FAV_POS_ACTIVE},
-                 # for the spectrograph dedicated slit fully open and filter always on pass-through
+                 # slit to the minimum, wavelength to the zeroth order
                  'spectrograph-dedicated': {'slit-in': 10e-6, 'wavelength': 0},
                  # 'spec-ded-det-selector' will depend on the affects
                  }),

--- a/src/odemis/acq/test/path_test.py
+++ b/src/odemis/acq/test/path_test.py
@@ -1350,20 +1350,23 @@ class Sparc2TunnelLensAlignerTestCase(unittest.TestCase):
         assert_pos_as_in_mode(self, self.slit, "ar")
         assert_pos_as_in_mode(self, self.spectrograph, "ar")
 
-        # before switching 'accidentally' turn on the brightlight of the tunnel
-        self.brightlight_ext.power.value = [10]
         self.optmngr.setPath("tunnel-lens-align").result()
 
-        # assert the external calibration light is still on
-        self.assertEqual(self.brightlight_ext.power.value, list(self.brightlight_ext.power.range[1]))
         # assert that the specified actuators were moved according to mode given
-        self.assertEqual(self.spectrograph_ext.position.value["grating"], 2)
+        self.assertEqual(self.spectrograph_ext.position.value["grating"], 2)  # mirror
         self.assertEqual(self.spectrograph_ext.position.value["wavelength"], 0.0)
         self.assertEqual(self.spectrograph_ext.position.value["slit-in"], self.spectrograph_ext.axes["slit-in"].range[1])
         assert_pos_as_in_mode(self, self.spec_ded_aligner, "tunnel-lens-align")
-        # put the external calibration light off again
-        self.brightlight_ext.power.value = [0]
-        self.assertEqual(self.brightlight_ext.power.value, list(self.brightlight_ext.power.range[0]))
+
+        # Test the spec-focus-ext
+        # first move to a different grating and wavelength, to make it harder
+        self.spectrograph_ext.moveAbsSync({"grating": 1, "wavelength": 500e-9})
+
+        self.optmngr.setPath("spec-focus-ext").result()
+        # assert that the specified actuators were moved according to mode given
+        self.assertEqual(self.spectrograph_ext.position.value["grating"], 1)  # grating should not be changed
+        self.assertEqual(self.spectrograph_ext.position.value["wavelength"], 0.0)
+        self.assertEqual(self.spectrograph_ext.position.value["slit-in"], self.spectrograph_ext.axes["slit-in"].range[0])
 
 
 class SecomPathTestCase(unittest.TestCase):

--- a/src/odemis/gui/conf/data.py
+++ b/src/odemis/gui/conf/data.py
@@ -390,6 +390,9 @@ HW_SETTINGS_CONFIG = {
                            u"Be careful when setting the gain while operating the camera in focus-mode.",
                 "key_step": 1,
             }),
+            ("shutter", {
+                "tooltip": "Checked means the shutter is closed, and protects the camera from the light.",
+            }),
         )),
     r"spectrometer.*":
         OrderedDict((

--- a/src/odemis/gui/cont/settings.py
+++ b/src/odemis/gui/cont/settings.py
@@ -908,18 +908,22 @@ class StreakCamAlignSettingsController(SettingsBarController):
         entry_triggerDelay.value_ctrl.SetBackgroundColour(odemis.gui.BG_COLOUR_PANEL)
         self.ctrl_triggerDelay = entry_triggerDelay.value_ctrl
 
-        entry_magnification = create_setting_entry(self.panel_streak, "Magnification",
-                                                   self.streak_lens.magnification,
-                                                   self.streak_lens,
-                                                   conf={"control_type": odemis.gui.CONTROL_COMBO,
-                                                         "label": "Magnification",
-                                                         "tooltip": "Change the magnification of the input"
-                                                                    "optics for the streak camera system. \n"
-                                                                    "Values < 1: De-magnifying \n"
-                                                                    "Values > 1: Magnifying"})
+        if (self.streak_lens
+            and hasattr(self.streak_lens.magnification, "choices")
+            and len(self.streak_lens.magnification.choices) > 1
+           ):
+            entry_magnification = create_setting_entry(self.panel_streak, "Magnification",
+                                                       self.streak_lens.magnification,
+                                                       self.streak_lens,
+                                                       conf={"control_type": odemis.gui.CONTROL_COMBO,
+                                                             "label": "Magnification",
+                                                             "tooltip": "Change the magnification of the input"
+                                                                        "optics for the streak camera system. \n"
+                                                                        "Values < 1: De-magnifying \n"
+                                                                        "Values > 1: Magnifying"})
 
-        entry_magnification.value_ctrl.SetBackgroundColour(odemis.gui.BG_COLOUR_PANEL)
-        self.combo_magnification = entry_magnification.value_ctrl
+            entry_magnification.value_ctrl.SetBackgroundColour(odemis.gui.BG_COLOUR_PANEL)
+            self.combo_magnification = entry_magnification.value_ctrl
 
         # remove border
         self.panel_streak.GetSizer().GetItem(0).SetBorder(0)

--- a/src/odemis/gui/cont/tabs/sparc2_align_tab.py
+++ b/src/odemis/gui/cont/tabs/sparc2_align_tab.py
@@ -105,16 +105,12 @@ class Sparc2AlignTab(Tab):
 
         if main_data.streak_ccd:
             self._streak_settings_controller = settings.StreakCamAlignSettingsController(panel, tab_data)
-            self.streak_ccd = main_data.streak_ccd
-            self.streak_delay = main_data.streak_delay
-            self.streak_unit = main_data.streak_unit
-            self.streak_lens = main_data.streak_lens
 
             # !!Note: In order to make sure the default value shown in the GUI corresponds
             # to the correct trigger delay from the MD, we call the setter of the .timeRange VA,
             # which sets the correct value for the .triggerDelay VA from MD-lookup
             # Cannot be done in the driver, as MD from yaml is updated after initialization of HW!!
-            self.streak_unit.timeRange.value = self.streak_unit.timeRange.value
+            main_data.streak_unit.timeRange.value = main_data.streak_unit.timeRange.value
 
         # Create stream & view
         self._stream_controller = StreamBarController(

--- a/src/odemis/gui/cont/tabs/sparc2_align_tab.py
+++ b/src/odemis/gui/cont/tabs/sparc2_align_tab.py
@@ -482,7 +482,8 @@ class Sparc2AlignTab(Tab):
 
             add_axis("grating", spect)
             add_axis("wavelength", spect)
-            add_axis("x", main_data.slit_in_big)
+            if main_data.streak_ccd.name in main_data.slit_in_big.affects.value:
+                add_axis("x", main_data.slit_in_big)
             add_axis("slit-in", spect)
 
             # To activate the SEM spot when the camera plays


### PR DESCRIPTION
Many small fixes, related to the streakcam alignment tab when the streakcam is not the "standard" spectrograph, but on the "spectrograph-dedicated".