### PR TITLE
[testing] extend acq.leech test and run in CI

### DIFF
--- a/.github/workflows/unit_tests_cloud.yml
+++ b/.github/workflows/unit_tests_cloud.yml
@@ -154,6 +154,12 @@ jobs:
         export PYTHONPATH="$PWD/src:$PYTHONPATH"
         python3 -m unittest src/odemis/acq/test/feature_test.py --verbose
 
+    - name: Run tests from odemis.acq.leech
+      if: ${{ !cancelled() }}
+      run: |
+        export PYTHONPATH="$PWD/src:$PYTHONPATH"
+        python3 -m unittest src/odemis/acq/test/leech_test.py --verbose
+
     - name: Run tests from odemis.gui.conf
       if: ${{ !cancelled() }}
       run: |


### PR DESCRIPTION
Add an explicit test for `acq.leech.get_next_rectangle()`, and also run the test cases for leech in the CI, as it doesn't need the back-end.