### PR TITLE
[test] [SWM-145] Fix numpy deprecation warning

### DIFF
--- a/src/odemis/acq/stitching/test/registrar_test.py
+++ b/src/odemis/acq/stitching/test/registrar_test.py
@@ -68,7 +68,7 @@ class TestIdentityRegistrar(unittest.TestCase):
         # and tile sizes
         shifts = [(0, 0), (10, 10), (0, 10), (8, 5), (-6, 5)]
         t_sizes = [(500, 500), (300, 400), (500, 200)]
-        dtypes = [numpy.int8, numpy.int16]
+        dtypes = [numpy.uint8, numpy.uint16]
 
         for shift in shifts:
             for size in t_sizes:
@@ -308,7 +308,7 @@ class TestShiftRegistrar(unittest.TestCase):
         # sizes
         shifts = [(0, 0), (10, 10), (0, 10), (8, 5), (6, -5)]
         img_sizes = [(500, 500), (300, 400), (500, 200)]
-        dtypes = [numpy.int8, numpy.int16]
+        dtypes = [numpy.uint8, numpy.uint16]
         px_size = (1e-6, 1e-6)
 
         for shift in shifts:
@@ -322,12 +322,14 @@ class TestShiftRegistrar(unittest.TestCase):
                         if is_vertical:
                             # Draw a vertical line
                             x = random.randint(0, img_size[0])
-                            color = random.randint(1, 256)
+                            # Give the line a random non-zero color in the uint8 range (also in bounds of uint16)
+                            color = random.randint(1, 255)
                             img[x:x + 2, :] = color
                         else:
                             # Draw a horizontal line
                             y = random.randint(0, img_size[1])
-                            color = random.randint(1, 256)
+                            # Give the line a random non-zero color in the uint8 range (also in bounds of uint16)
+                            color = random.randint(1, 255)
                             img[:, y: y + 2] = color
 
                     # Crop two tiles from the full image
@@ -618,7 +620,7 @@ class TestGlobalShiftRegistrar(unittest.TestCase):
         # sizes
         shifts = [(0, 0), (10, 10), (0, 10), (8, 5), (6, -5)]
         img_sizes = [(500, 500), (300, 400), (500, 200)]
-        dtypes = [numpy.int8, numpy.int16]
+        dtypes = [numpy.uint8, numpy.uint16]
         px_size = (1e-6, 1e-6)
 
         for shift in shifts:
@@ -632,12 +634,12 @@ class TestGlobalShiftRegistrar(unittest.TestCase):
                         if is_vertical:
                             # Draw a vertical line
                             x = random.randint(0, img_size[0])
-                            color = random.randint(1, 256)
+                            color = random.randint(1, 255)
                             img[x:x + 2, :] = color
                         else:
                             # Draw a horizontal line
                             y = random.randint(0, img_size[1])
-                            color = random.randint(1, 256)
+                            color = random.randint(1, 255)
                             img[:, y: y + 2] = color
 
                     # Crop two tiles from the full image

--- a/src/odemis/acq/stitching/test/registrar_test.py
+++ b/src/odemis/acq/stitching/test/registrar_test.py
@@ -68,6 +68,7 @@ class TestIdentityRegistrar(unittest.TestCase):
         # and tile sizes
         shifts = [(0, 0), (10, 10), (0, 10), (8, 5), (-6, 5)]
         t_sizes = [(500, 500), (300, 400), (500, 200)]
+        # Use uint over int since negative values for images are not commonly used.
         dtypes = [numpy.uint8, numpy.uint16]
 
         for shift in shifts:
@@ -308,6 +309,7 @@ class TestShiftRegistrar(unittest.TestCase):
         # sizes
         shifts = [(0, 0), (10, 10), (0, 10), (8, 5), (6, -5)]
         img_sizes = [(500, 500), (300, 400), (500, 200)]
+        # Use uint over int since negative values for images are not commonly used.
         dtypes = [numpy.uint8, numpy.uint16]
         px_size = (1e-6, 1e-6)
 
@@ -322,13 +324,13 @@ class TestShiftRegistrar(unittest.TestCase):
                         if is_vertical:
                             # Draw a vertical line
                             x = random.randint(0, img_size[0])
-                            # Give the line a random non-zero color in the uint8 range (also in bounds of uint16)
+                            # Give the line a random non-zero color in the uint8 range (also in bounds of uint16).
                             color = random.randint(1, 255)
                             img[x:x + 2, :] = color
                         else:
                             # Draw a horizontal line
                             y = random.randint(0, img_size[1])
-                            # Give the line a random non-zero color in the uint8 range (also in bounds of uint16)
+                            # Give the line a random non-zero color in the uint8 range (also in bounds of uint16).
                             color = random.randint(1, 255)
                             img[:, y: y + 2] = color
 
@@ -620,6 +622,7 @@ class TestGlobalShiftRegistrar(unittest.TestCase):
         # sizes
         shifts = [(0, 0), (10, 10), (0, 10), (8, 5), (6, -5)]
         img_sizes = [(500, 500), (300, 400), (500, 200)]
+        # Use uint over int since negative values for images are not commonly used.
         dtypes = [numpy.uint8, numpy.uint16]
         px_size = (1e-6, 1e-6)
 
@@ -634,11 +637,13 @@ class TestGlobalShiftRegistrar(unittest.TestCase):
                         if is_vertical:
                             # Draw a vertical line
                             x = random.randint(0, img_size[0])
+                            # Give the line a random non-zero color in the uint8 range (also in bounds of uint16).
                             color = random.randint(1, 255)
                             img[x:x + 2, :] = color
                         else:
                             # Draw a horizontal line
                             y = random.randint(0, img_size[1])
+                            # Give the line a random non-zero color in the uint8 range (also in bounds of uint16).
                             color = random.randint(1, 255)
                             img[:, y: y + 2] = color
 


### PR DESCRIPTION
This PR changes 
- the dtype in `registrar_test.py` to use `uint` over `int`.
- the `random.randint` call to be in bound for an image of the `uint8` dtype.

To exemplify: before the suggested change, the `high` argument was set to 256, which allows integers above 127 (which is the upper bound of int8). This triggered a warning for the latest Numpy version compatible with Ubuntu 24. Now `high` is set to 255, which is the upper bound of `uint8`.