### PR TITLE
[refactor] tiled area code to have more separation of concerns

### DIFF
--- a/src/odemis/acq/stitching/__init__.py
+++ b/src/odemis/acq/stitching/__init__.py
@@ -18,7 +18,7 @@ from odemis.acq.stitching._constants import REGISTER_GLOBAL_SHIFT, REGISTER_SHIF
     REGISTER_IDENTITY, WEAVER_MEAN, WEAVER_COLLAGE, WEAVER_COLLAGE_REVERSE
 from odemis.acq.stitching._tiledacq import (acquireTiledArea, acquireOverview, estimateOverviewTime,
                                             estimateTiledAcquisitionTime, estimateTiledAcquisitionMemory,
-                                            FocusingMethod, get_tiled_areas, get_zstack_levels)
+                                            FocusingMethod, get_zstack_levels, get_tiled_bboxes, get_stream_based_bbox)
 from odemis.acq.stitching._registrar import *
 from odemis.acq.stitching._weaver import *
 from odemis.acq.stitching._simple import register, weave

--- a/src/odemis/acq/stitching/test/tiledacq_test.py
+++ b/src/odemis/acq/stitching/test/tiledacq_test.py
@@ -18,6 +18,7 @@ You should have received a copy of the GNU General Public License along with
 Odemis. If not, see http://www.gnu.org/licenses/.
 """
 import logging
+import math
 import os
 import time
 import unittest
@@ -31,7 +32,8 @@ from odemis.acq import stream
 from odemis.acq.acqmng import SettingsObserver
 from odemis.acq.stitching import WEAVER_COLLAGE_REVERSE, REGISTER_IDENTITY, \
     WEAVER_MEAN, acquireTiledArea, FocusingMethod
-from odemis.acq.stitching._tiledacq import TiledAcquisitionTask, get_fov, get_tiled_areas, get_zstack_levels, compute_area_size, clip_tiling_area_to_range, SAMPLE_USABLE_BBOX_TEM_GRID
+from odemis.acq.stitching._tiledacq import (TiledAcquisitionTask, get_fov, get_zstack_levels, clip_tiling_bbox_to_range,
+                                            get_stream_based_bbox, get_tiled_bboxes, get_fov_based_bbox)
 from odemis.util import testing, img
 from odemis.util.comp import compute_camera_fov, compute_scanner_fov
 
@@ -581,7 +583,7 @@ class TiledAcqUtilTestCase(unittest.TestCase):
         focus_active_pos = self.focus.getMetadata()[model.MD_FAV_POS_ACTIVE]
         self.focus.moveAbsSync(focus_active_pos)
 
-    def test_get_tiled_areas(self):
+    def test_get_stream_based_bbox(self):
         # test when inside range, not whole grid
         pos = {"x": 0, "y": 0}
         streams = [self.fm_streams[0]]
@@ -589,56 +591,60 @@ class TiledAcqUtilTestCase(unittest.TestCase):
         rng = {"x": (-0.1, 0.1), "y": (-0.1, 0.1)}
         nx, ny = 5, 5
         overlap = 0.1
-        areas = get_tiled_areas(pos=pos,
-                                 streams=streams,
-                                 tiles_nx=nx, tiles_ny=ny,
-                                 tiling_rng=rng,
-                                 overlap=overlap,
-                                 whole_grid=False)
+        bbox = get_stream_based_bbox(
+            pos=pos,
+            streams=streams,
+            tiles_nx=nx,
+            tiles_ny=ny,
+            tiling_rng=rng,
+            overlap=overlap,
+        )
 
         w = nx * fov[0] * (1 - overlap)
         h = ny * fov[1] * (1 - overlap)
-        numpy.testing.assert_array_almost_equal(areas[0], [-w/2, -h/2, w/2, h/2])
+        numpy.testing.assert_array_almost_equal(bbox, [-w/2, -h/2, w/2, h/2])
 
         # test when outside range
         pos = {"x": 0.2, "y": 0.2}
-        area = get_tiled_areas(pos=pos,
-                                 streams=streams,
-                                 tiles_nx=nx, tiles_ny=ny,
-                                 tiling_rng=rng,
-                                 overlap=overlap,
-                                 whole_grid=False)
-        self.assertEqual(area, [])
+        bbox = get_stream_based_bbox(
+            pos=pos,
+            streams=streams,
+            tiles_nx=nx,
+            tiles_ny=ny,
+            tiling_rng=rng,
+            overlap=overlap,
+        )
+        self.assertEqual(bbox, None)
 
+    def test_get_tiled_bboxes(self):
         # test whole grid
         selected_grids = ["GRID 1", "GRID 2"]
         sample_centers_raw = self.stage_bare.getMetadata()[model.MD_SAMPLE_CENTERS]
-        sample_centers = {n: (v["x"], v["y"]) for n, v in sample_centers_raw.items()}
+        sample_centers = [(v["x"], v["y"]) for v in sample_centers_raw.values()]
+
+        SAMPLE_RADIUS_TEM_GRID = 1.25e-3
+        hwidth = SAMPLE_RADIUS_TEM_GRID / math.sqrt(2)
+        SAMPLE_USABLE_BBOX_TEM_GRID = (-hwidth, -hwidth, hwidth, hwidth)
         rel_bbox = SAMPLE_USABLE_BBOX_TEM_GRID
-        areas = get_tiled_areas(pos=pos,
-                                 streams=streams,
-                                 tiles_nx=nx, tiles_ny=ny,
-                                 tiling_rng=rng,
-                                 overlap=overlap,
-                                 whole_grid=True,
-                                 sample_centers=sample_centers,
-                                 rel_bbox=rel_bbox,
-                                 selected_grids=selected_grids,
+
+        areas = get_tiled_bboxes(
+            rel_bbox=rel_bbox,
+            sample_centers=sample_centers,
         )
 
         computed_areas = []
-        for name, center in sample_centers.items():
+        for center in sample_centers:
 
             computed_areas.append(
                 (center[0] + rel_bbox[0],
                  center[1] + rel_bbox[1],
                  center[0] + rel_bbox[2],
                  center[1] + rel_bbox[3])
-        )
+            )
         self.assertEqual(len(areas), len(selected_grids))
         numpy.testing.assert_array_almost_equal(areas, computed_areas)
 
-    def test_compute_area_size(self):
+    def test_get_fov_based_bbox(self):
 
         # test when inside range
         pos = {"x": 0, "y": 0}
@@ -647,42 +653,79 @@ class TiledAcqUtilTestCase(unittest.TestCase):
         rng = {"x": (-0.1, 0.1), "y": (-0.1, 0.1)}
         nx, ny = 5, 5
         overlap = 0.1
-        area = compute_area_size(pos=pos,
-                                 streams=streams,
-                                 tiles_nx=nx, tiles_ny=ny,
-                                 tiling_rng=rng,
-                                 overlap=overlap)
+        bbox = get_fov_based_bbox(
+            pos=pos,
+            fov=fov,
+            tiles_nx=nx,
+            tiles_ny=ny,
+            tiling_rng=rng,
+            overlap=overlap
+        )
 
         w = nx * fov[0] * (1 - overlap)
         h = ny * fov[1] * (1 - overlap)
-        numpy.testing.assert_array_almost_equal(area, [-w/2, -h/2, w/2, h/2])
+        numpy.testing.assert_array_almost_equal(bbox, [-w/2, -h/2, w/2, h/2])
 
         # test when outside range
         pos = {"x": 0.2, "y": 0.2}
-        area = compute_area_size(pos=pos,
-                                 streams=streams,
-                                 tiles_nx=nx, tiles_ny=ny,
-                                 tiling_rng=rng,
-                                 overlap=overlap)
-        self.assertEqual(area, None)
+        bbox = get_fov_based_bbox(
+            pos=pos,
+            fov=fov,
+            tiles_nx=nx,
+            tiles_ny=ny,
+            tiling_rng=rng,
+            overlap=overlap
+        )
+        self.assertEqual(bbox, None)
 
+        # test various horizontal and vertical repeats
+        pos = {"x": 0.0, "y": 0.0}
+        fov = (0.00017, 0.00017)  # Mock fov to be uniform
+        overlap = 0  # Set to zero, to make non-square comparison easier
+        test_repeat_cases = [
+            # Square case
+            {"nx": 5, "ny": 5},
+            # Non-square cases
+            {"nx": 5, "ny": 3},
+            {"nx": 5, "ny": 2},
+            {"nx": 5, "ny": 1}
+        ]
 
-    def test_clip_tiling_area_to_range(self):
+        for test_repeat_case in test_repeat_cases:
+            bbox = get_fov_based_bbox(
+                pos=pos,
+                fov=fov,
+                tiles_nx=test_repeat_case["nx"],
+                tiles_ny=test_repeat_case["ny"],
+                tiling_rng=rng,
+                overlap=overlap
+            )
+            x_size = bbox[2] - bbox[0]
+            y_size = bbox[3] - bbox[1]
+            # If we divide the size of the resulting bounding box by the repeat count,
+            # an identical size is expected
+            self.assertEqual(
+                x_size / test_repeat_case["nx"],
+                y_size / test_repeat_case["ny"],
+                test_repeat_case
+            )
+
+    def test_clip_tiling_bbox_to_range(self):
         # test area when inside range
         pos = {"x": 0, "y": 0}
         tiling_range = {"x": (-100, 100), "y": (-100, 100)}
         w, h = 50, 50
-        area = clip_tiling_area_to_range(w=w, h=h, pos=pos, tiling_rng=tiling_range)
+        area = clip_tiling_bbox_to_range(w=w, h=h, pos=pos, tiling_rng=tiling_range)
         numpy.testing.assert_array_almost_equal(area, [-25, -25, 25, 25])
 
         # test area when cliping to range
         pos = {"x": 0, "y": 0}
-        area = clip_tiling_area_to_range(w=500, h=500, pos=pos, tiling_rng=tiling_range)
+        area = clip_tiling_bbox_to_range(w=500, h=500, pos=pos, tiling_rng=tiling_range)
         numpy.testing.assert_array_almost_equal(area, [-100, -100, 100, 100])
 
         # test when outside of range
         pos = {"x": 500, "y": 500}
-        area = clip_tiling_area_to_range(w=100, h=100, pos=pos, tiling_rng=tiling_range)
+        area = clip_tiling_bbox_to_range(w=100, h=100, pos=pos, tiling_rng=tiling_range)
         self.assertEqual(area, None)
 
     def test_get_zstack_levels(self):

--- a/src/odemis/gui/win/test/acquisition_test.py
+++ b/src/odemis/gui/win/test/acquisition_test.py
@@ -24,14 +24,14 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 
 import unittest
 import logging
-from odemis.acq.stitching._tiledacq import clip_tiling_area_to_range
+from odemis.acq.stitching._tiledacq import clip_tiling_bbox_to_range
 
 logging.getLogger().setLevel(logging.DEBUG)
 
 
 class TestClipTilingArea(unittest.TestCase):
     """
-    This test case is to test the method clip_tiling_area_to_range()
+    This test case is to test the method clip_tiling_bbox_to_range()
     """
     def test_clipping_is_performed_same_width_and_height(self):
         # move the stage close to the bottom left corner of the active range (200 micrometers
@@ -42,7 +42,7 @@ class TestClipTilingArea(unittest.TestCase):
         ovv_rng = {'x': [-1e-3, 1e-3], 'y': [-1.1e-3, 1.1e-3]}
         pos = {"x": ovv_rng["x"][0] + 200e-6,
                "y": ovv_rng["y"][0] + 200e-6}
-        rect_pts = clip_tiling_area_to_range(w, h, pos, ovv_rng)
+        rect_pts = clip_tiling_bbox_to_range(w, h, pos, ovv_rng)
         # Note: the return rect_pts is LBRT assuming y axis upwards, or LTRB assuming y axis downwards.
         # check if the intersection happened
         self.assertAlmostEqual(rect_pts[0], ovv_rng["x"][0])
@@ -59,7 +59,7 @@ class TestClipTilingArea(unittest.TestCase):
         ovv_rng = {'x': [-1e-3, 1e-3], 'y': [-1.1e-3, 1.1e-3]}
         pos = {"x": ovv_rng["x"][0] + 200e-6,
                "y": ovv_rng["y"][0] + 200e-6}
-        rect_pts = clip_tiling_area_to_range(w, h, pos, ovv_rng)
+        rect_pts = clip_tiling_bbox_to_range(w, h, pos, ovv_rng)
         # Note: the return rect_pts is LBRT assuming y axis upwards, or LTRB assuming y axis downwards.
         # check if the intersection happened
         self.assertAlmostEqual(rect_pts[0], ovv_rng["x"][0])
@@ -76,7 +76,7 @@ class TestClipTilingArea(unittest.TestCase):
         ovv_rng = {'x': [-1e-3, 1e-3], 'y': [-1.1e-3, 1.1e-3]}
         pos = {"x": sum(ovv_rng["x"]) / 2,
                "y": sum(ovv_rng["y"]) / 2}
-        rect_pts = clip_tiling_area_to_range(w, h, pos, ovv_rng)
+        rect_pts = clip_tiling_bbox_to_range(w, h, pos, ovv_rng)
         # Note: the return rect_pts is LBRT assuming y axis upwards, or LTRB assuming y axis downwards.
         # check if the intersection area is the same as the tl and br of the requested area.
         # tl and br are found by the current position +/- half of the width and height
@@ -94,7 +94,7 @@ class TestClipTilingArea(unittest.TestCase):
         ovv_rng = {'x': [-1e-3, 1e-3], 'y': [-1.1e-3, 1.1e-3]}
         pos = {"x": sum(ovv_rng["x"]) / 2,
                "y": sum(ovv_rng["y"]) / 2}
-        rect_pts = clip_tiling_area_to_range(w, h, pos, ovv_rng)
+        rect_pts = clip_tiling_bbox_to_range(w, h, pos, ovv_rng)
         # Note: the return rect_pts is LBRT assuming y axis upwards, or LTRB assuming y axis downwards.
         # check if the intersection area is the same as the tl and br of the requested area.
         # tl and br are found by the current position +/- half of the width and height


### PR DESCRIPTION
This PR proposes a solution to resolve the bounding box related bug found during integration testing. After inspection, the bug was always there, but it only reached the surface after Patrick's PR (https://github.com/delmic/odemis/pull/2798).  Changes:

- The `get_tiled_areas` function is now too convoluted in my opinion (it has two responsibilities), making it unnecessarily complex to read it and to unit test it. My proposal is to separate concerns, and split the original function into two functions and handle the paths on a higher level. 
- The original fallback was heuristic. I removed the fallback and raise an error instead, so the developer will be forced to investigate if the bounding box is applicable to the specific use case and set it accordingly (like @nandishjpatel did in `CryoMainGUIData`).
- Fixed a [bug](https://github.com/delmic/odemis/blob/6a5a9d93ed824dde9ce6907ee7efa7cf15014895/src/odemis/acq/stitching/_tiledacq.py#L1303C1-L1304C42) where the y tiling used the x repetition number. Probably never reached the surface, since a symmetrical grid is probably most often used. A regression test is added accordingly.
- Naming: the variable name `area` is ambiguous. It was now used for a bounding box, but it is easily mixed up with "surface area". I refactored most lower level functions to use `bbox` now.

TODO:
- [x] Fix lint
- [x] Update tests to reflect new functions
- [x] Publish PR
- [x] Check if Cryo workflow still works as intended. After testing: Even though Cryo ("meteor", "enzel", "mimas") has a potential path where the alternative custom bbox function is used, it is not tested by the simulator (self.stage.getMetadata().get(model.MD_SAMPLE_CENTERS) is None). It would be nice to have both paths tested in the GUI. At least we have unit tests.
- [x] Add regression test for non-square grid