### PR TITLE
[fix] test_det_external will now use the right alignment mode for external auto-focus testing

### DIFF
--- a/src/odemis/acq/align/test/autofocus_test.py
+++ b/src/odemis/acq/align/test/autofocus_test.py
@@ -249,7 +249,7 @@ class TestSparc2AutoFocus(unittest.TestCase):
         new_img = img.ensure2DImage(data[0])
         self.spccd.set_image(new_img)
 
-        f = Sparc2AutoFocus("tunnel-lens-align", self.optmngr, [self.specline_spccd_ext], True)
+        f = Sparc2AutoFocus("spec-focus-ext", self.optmngr, [self.specline_spccd_ext], True)
 
         data = tiff.read_data(os.path.join(TEST_IMAGE_PATH, "brightlight-on-slit-spccd-simple.ome.tiff"))
         new_img = img.ensure2DImage(data[0])


### PR DESCRIPTION
test_det_external in autofocus_test.py would fail with a ValueError stating the given alignment mode tunnel-lens-align does not exist. This was indeed changed in the latest master and now changed to the right amode.