### PR TITLE
[feature][meteor] now also log errors from the executed python script and log the output when using odemis-select-mic-start

### DIFF
--- a/install/linux/usr/bin/odemis-select-mic-start
+++ b/install/linux/usr/bin/odemis-select-mic-start
@@ -32,7 +32,12 @@ status=$?
 if [ $status == 0 ] || [ $status == 3 ] ; then
     # extract the running microscope file
     mic_name="$(odemis list --machine | head -1 | cut -d $'\t' -f 1)"
-    reply=$(zenity --info --title="Odemis backend already running" --text "Restart with new backend or start GUI only\n\nactive: $mic_name" --ok-label="Cancel" --extra-button="Restart" --extra-button="GUI only" --width=300 --height=100)
+    reply=$(zenity --info --title="Odemis backend already running" \
+        --text "Restart with new backend or start GUI only\n\nactive: $mic_name" \
+        --ok-label="Cancel" \
+        --extra-button="Restart" \
+        --extra-button="GUI only" \
+        --width=300 --height=100)
     if [ "$reply" == "Restart" ]; then
         echo "Trying to stop the backend"
         sudo odemis-stop
@@ -55,7 +60,10 @@ for fn in "${args[@]}"; do
     # add a new header to the logfile
     printf "$(date) Parsing file: $fn\n" >> $parse_logfile
     # extract the microscope name by using this small Python script
-    mic_name="$(python3 -c "import sys; import yaml; from odemis.odemisd import modelgen; f = open('$fn'); d = yaml.load(f, modelgen.SafeLoader); print(next(n for n, d in d.items() if d.get('class') == 'Microscope'))" 2>>$parse_logfile)"
+    mic_name="$(python3 -c "import sys; import yaml; from odemis.odemisd import modelgen; \
+        f = open('$fn'); \
+        d = yaml.load(f, modelgen.SafeLoader); \
+        print(next(n for n, d in d.items() if d.get('class') == 'Microscope'))" 2>>$parse_logfile)"
     mic_list+=("$fn")
     if test "$mic_name" == ""; then
         # save the file name in the error list
@@ -68,7 +76,11 @@ for fn in "${args[@]}"; do
 done
 
 # prompt the user with a list of microscope configurations to choose from
-selection="$(zenity --list --title "Odemis configuration starter" --list --text "Please select a configuration to start:" --column "" --column "" "${mic_list[@]}" --hide-header --width=300 --height=400 --hide-column 1 --print-column=1 2>/dev/null)"
+selection="$(zenity --list --title="Odemis configuration starter" \
+    --list --text "Please select a configuration to start:" \
+    --column "" --column "" "${mic_list[@]}" --hide-header \
+    --width=300 --height=400 \
+    --hide-column 1 --print-column=1 2>/dev/null)"
 
 # if one of the microscope names is selected which also contains an error, show the log file and stop the script
 for efn in "${error_filenames[@]}"; do

--- a/install/linux/usr/bin/odemis-select-mic-start
+++ b/install/linux/usr/bin/odemis-select-mic-start
@@ -46,16 +46,37 @@ if [ $status == 0 ] || [ $status == 3 ] ; then
 fi
 
 mic_list=()
+error_filenames=()
+mkdir $HOME/.local/share/odemis/log 2>/dev/null
+parse_logfile=$HOME/.local/share/odemis/log/odemis-select-mic-start-parse.log
+> $parse_logfile
+
 for fn in "${args[@]}"; do
+    # add a new header to the logfile
+    printf "$(date) Parsing file: $fn\n" >> $parse_logfile
     # extract the microscope name by using this small Python script
-    # note: does not check for errors when parsing
-    mic_name="$(python3 -c "import sys; import yaml; from odemis.odemisd import modelgen; f = open('$fn'); d = yaml.load(f, modelgen.SafeLoader); print(next(n for n, d in d.items() if d.get('class') == 'Microscope'))" 2>/dev/null)"
+    mic_name="$(python3 -c "import sys; import yaml; from odemis.odemisd import modelgen; f = open('$fn'); d = yaml.load(f, modelgen.SafeLoader); print(next(n for n, d in d.items() if d.get('class') == 'Microscope'))" 2>>$parse_logfile)"
     mic_list+=("$fn")
+    if test "$mic_name" == ""; then
+        # save the file name in the error list
+        error_filenames+=("$(basename ${fn})")
+        mic_name=">>ERROR parsing $(basename ${fn})"
+        # add a newline to the logfile
+        echo "" >> $parse_logfile
+    fi
     mic_list+=("$mic_name")
 done
 
 # prompt the user with a list of microscope configurations to choose from
 selection="$(zenity --list --title "Odemis configuration starter" --list --text "Please select a configuration to start:" --column "" --column "" "${mic_list[@]}" --hide-header --width=300 --height=400 --hide-column 1 --print-column=1 2>/dev/null)"
+
+# if one of the microscope names is selected which also contains an error, show the log file and stop the script
+for efn in "${error_filenames[@]}"; do
+    if test "$efn" == "$(basename ${selection})"; then
+        gedit $parse_logfile   
+        exit
+    fi
+done
 
 if test "$selection" != ""; then
     odemis-start "$selection"


### PR DESCRIPTION
Now also log errors from the executed python script and saves the output in $HOME/.local/share/odemis/log/odemis-select-mic-start-parse.log. Errors happening this way will display an error in the start window. This is to trace issues when the content of the config file is incorrect.