### PR TITLE
[METEOR-1163][FEAT] Add changeable autofocus distance for overview acquisition

### DIFF
--- a/src/odemis/acq/stitching/_tiledacq.py
+++ b/src/odemis/acq/stitching/_tiledacq.py
@@ -967,7 +967,8 @@ def estimateOverviewTime(*args, **kwargs):
 
 
 def acquireOverview(streams, stage, areas, focus, detector, overlap=0.2, settings_obs=None, log_path=None, zlevels=None,
-                    registrar=REGISTER_GLOBAL_SHIFT, weaver=WEAVER_MEAN, focusing_method=FocusingMethod.NONE, use_autofocus: bool = False):
+                    registrar=REGISTER_GLOBAL_SHIFT, weaver=WEAVER_MEAN, focusing_method=FocusingMethod.NONE,
+                    use_autofocus: bool = False, focus_points_dist: float = MAX_DISTANCE_FOCUS_POINTS):
     """
     Start autofocus and tiled acquisition tasks for each area in the list of area which is
     given by the input argument areas.
@@ -997,7 +998,7 @@ def acquireOverview(streams, stage, areas, focus, detector, overlap=0.2, setting
     future = model.ProgressiveFuture()
     task = AcquireOverviewTask(streams, stage, areas, focus, detector, future, overlap, settings_obs,
                                log_path, zlevels,
-                               registrar, weaver, focusing_method, use_autofocus)
+                               registrar, weaver, focusing_method, use_autofocus, focus_points_dist)
     future.task_canceller = task.cancel  # let the future cancel the task
 
     future.set_progress(end=task.estimate_time() + time.time())
@@ -1015,7 +1016,8 @@ class AcquireOverviewTask(object):
     def __init__(self, streams, stage, areas, focus, detector, future=None,
                  overlap=0.2, settings_obs=None, log_path=None,
                  zlevels=None, registrar=REGISTER_GLOBAL_SHIFT, weaver=WEAVER_MEAN,
-                 focusing_method=FocusingMethod.NONE, use_autofocus: bool = False):
+                 focusing_method=FocusingMethod.NONE, use_autofocus: bool = False,
+                 focus_points_dist: float = MAX_DISTANCE_FOCUS_POINTS):
         # site and feature means the same
         self._stage = stage
         self._future = future
@@ -1042,7 +1044,7 @@ class AcquireOverviewTask(object):
         self._focus_points = []  # list of focus points per each area in areas
         self._total_nb_focus_points = 0
         for area in areas:
-            focus_points = generate_triangulation_points(MAX_DISTANCE_FOCUS_POINTS, area)
+            focus_points = generate_triangulation_points(focus_points_dist, area)
             self._total_nb_focus_points += len(focus_points)
             self._focus_points.append(focus_points)
         self._overlap = overlap

--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -124,6 +124,8 @@ class xrcfr_overview_acq(wx.Dialog):
         self.selected_grid_pnl_holder = xrc.XRCCTRL(self, "selected_grid_pnl_holder")
         self.area_size_txt = xrc.XRCCTRL(self, "area_size_txt")
         self.autofocus_chkbox = xrc.XRCCTRL(self, "autofocus_chkbox")
+        self.focus_points_dist_lbl = xrc.XRCCTRL(self, "focus_points_dist_lbl")
+        self.focus_points_dist_ctrl = xrc.XRCCTRL(self, "focus_points_dist_ctrl")
         self.gauge_acq = xrc.XRCCTRL(self, "gauge_acq")
         self.lbl_acqestimate = xrc.XRCCTRL(self, "lbl_acqestimate")
         self.btn_cancel = xrc.XRCCTRL(self, "btn_cancel")
@@ -1931,7 +1933,7 @@ b\xeb\x85\x9f\xb6B\x1d\x0cK\x17\xac\xf0\x12\xfe\xa0\xe5\xee\xe03\xb1\xfa\
                   </object>
                   <object class="sizeritem">
                     <object class="wxCheckBox" name="autofocus_chkbox">
-                      <label>Run autofocus</label>
+                      <label>Run AutoFocus</label>
                       <fg>#E5E5E5</fg>
                       <XRCED>
                         <assign_var>1</assign_var>
@@ -1939,6 +1941,42 @@ b\xeb\x85\x9f\xb6B\x1d\x0cK\x17\xac\xf0\x12\xfe\xa0\xe5\xee\xe03\xb1\xfa\
                     </object>
                     <flag>wxLEFT</flag>
                     <border>10</border>
+                  </object>
+                  <object class="sizeritem">
+                    <object class="wxBoxSizer">
+                      <orient>wxHORIZONTAL</orient>
+                      <object class="sizeritem">
+                        <object class="wxStaticText" name="focus_points_dist_lbl">
+                          <label>Distance between Focus Points</label>
+                          <fg>#DDDDDD</fg>
+                          <font>
+                            <size>9</size>
+                          </font>
+                          <XRCED>
+                            <assign_var>1</assign_var>
+                          </XRCED>
+                        </object>
+                        <flag>wxLEFT</flag>
+                        <border>10</border>
+                      </object>
+                      <object class="sizeritem">
+                        <object class="UnitFloatCtrl" name="focus_points_dist_ctrl">
+                          <size>-1,15</size>
+                          <unit>m</unit>
+                          <accuracy>4</accuracy>
+                          <font>
+                            <size>9</size>
+                            <encoding>UTF-8</encoding>
+                          </font>
+                          <style>wxBORDER_NONE</style>
+                          <XRCED>
+                            <assign_var>1</assign_var>
+                          </XRCED>
+                        </object>
+                        <flag>wxLEFT|wxRIGHT|wxEXPAND</flag>
+                        <border>10</border>
+                      </object>
+                    </object>
                   </object>
                 </object>
                 <size>400,-1</size>

--- a/src/odemis/gui/xmlh/resources/dialog_overview_acq.xrc
+++ b/src/odemis/gui/xmlh/resources/dialog_overview_acq.xrc
@@ -308,7 +308,7 @@
                   </object>
                   <object class="sizeritem">
                     <object class="wxCheckBox" name="autofocus_chkbox">
-                      <label>Run autofocus</label>
+                      <label>Run AutoFocus</label>
                       <fg>#E5E5E5</fg>
                       <XRCED>
                         <assign_var>1</assign_var>
@@ -316,6 +316,42 @@
                     </object>
                     <flag>wxLEFT</flag>
                     <border>10</border>
+                  </object>
+                  <object class="sizeritem">
+                    <object class="wxBoxSizer">
+                      <orient>wxHORIZONTAL</orient>
+                      <object class="sizeritem">
+                        <object class="wxStaticText" name="focus_points_dist_lbl">
+                          <label>Distance between Focus Points</label>
+                          <fg>#DDDDDD</fg>
+                          <font>
+                            <size>9</size>
+                          </font>
+                          <XRCED>
+                            <assign_var>1</assign_var>
+                          </XRCED>
+                        </object>
+                        <flag>wxLEFT</flag>
+                        <border>10</border>
+                      </object>
+                      <object class="sizeritem">
+                        <object class="UnitFloatCtrl" name="focus_points_dist_ctrl">
+                          <size>-1,15</size>
+                          <unit>m</unit>
+                          <accuracy>4</accuracy>
+                          <font>
+                            <size>9</size>
+                            <encoding>UTF-8</encoding>
+                          </font>
+                          <style>wxBORDER_NONE</style>
+                          <XRCED>
+                            <assign_var>1</assign_var>
+                          </XRCED>
+                        </object>
+                        <flag>wxLEFT|wxRIGHT|wxEXPAND</flag>
+                        <border>10</border>
+                      </object>
+                    </object>
                   </object>
                 </object>
                 <size>400,-1</size>


### PR DESCRIPTION
Allow the user to change the distance between autofocus for overview acquisition. 

Previously this was hardcoded at 450um, which meant that for overviews smaller than that only a single autofocus in the centre of the image was done. This was particularly bad on systems with 100x mag