### PR TITLE
[TRCL-429] [fix] hamamatsurx: time metadata fails to load

### DIFF
--- a/src/odemis/driver/hamamatsurx.py
+++ b/src/odemis/driver/hamamatsurx.py
@@ -489,10 +489,10 @@ class ReadoutCamera(model.DigitalCamera):
             raise TimeoutError(f"Did not receive a scaling table: {ex}")
         logging.debug("Received scaling table for time axis of Hamamatsu streak camera.")
 
-        table = numpy.frombuffer(tab, dtype=numpy.float32)  # convert to array
+        table = numpy.frombuffer(tab, dtype=numpy.float32)  # convert to (read-only) array
         # The prefix unit varies depending on the time range (eg, ns, us), so need scale it, based
         # on the time range of the streak unit.
-        table *= self.parent._streakunit.timeRangeFactor
+        table = table * self.parent._streakunit.timeRangeFactor
 
         return table
 


### PR DESCRIPTION
Commit a1d777ee4 (driver hamamatsu: fixes & clean-up) introduced an
"optimisation" when reading the time metadata. However, as the data is
coming from a byte array, numpy considers it read-only. This causes such
error:

2024-08-14 17:34:21,071	ERROR	hamamatsurx:603:	Failed to get scaling table
Traceback (most recent call last):
  File "/home/sparc/development/odemis/src/odemis/driver/hamamatsurx.py", line 601, in _getDataFromBuffer
    self._metadata[model.MD_TIME_LIST] = self._get_time_scale()
  File "/home/sparc/development/odemis/src/odemis/driver/hamamatsurx.py", line 495, in _get_time_scale
    table *= self.parent._streakunit.timeRangeFactor
ValueError: output array is read-only

=> Revert to duplicating the array. As the original array is immediately
discarded, it's very minimal resource increase.