### PR TITLE
[fix] implement function to gradually move descanner axes to their full range

### DIFF
--- a/src/odemis/driver/technolution.py
+++ b/src/odemis/driver/technolution.py
@@ -429,12 +429,12 @@ class AcquisitionServer(model.HwComponent):
 
         total_line_scan_time = self._mppc.getTotalLineScanTime()
 
-        # get the scanner setpoints
-        x_descan_setpoints, y_descan_setpoints = self._mirror_descanner.getCalibrationSetpoints(total_line_scan_time)
-
         # get the descanner setpoints
+        x_descan_setpoints, y_descan_setpoints = descanner.getCalibrationSetpoints(total_line_scan_time)
+
+        # get the scanner setpoints
         x_scan_setpoints, y_scan_setpoints, scan_calibration_dwell_time_ticks = \
-            self._ebeam_scanner.getCalibrationSetpoints(total_line_scan_time)
+            scanner.getCalibrationSetpoints(total_line_scan_time)
 
         calibration_data = CalibrationLoopParameters(descanner.rotation.value,
                                                      0,  # Descan X offset parameter unused.
@@ -987,17 +987,25 @@ class MirrorDescanner(model.Emitter):
 
         return setpoints.tolist()
 
-    def getCalibrationSetpoints(self, total_line_scan_time):
+    def getCalibrationSetpoints(self, total_line_scan_time, sine_in_x=True, sine_in_y=False):
         """
         Calculate the setpoints for the descanner during calibration mode. The setpoints resemble a sine shape
-        in x and a flat line at zero in y.
+        on one axis and a flat line on the other or a sine in both directions.
 
         :param total_line_scan_time: (float) Total line scanning time in seconds including
-                                     overscanned pixels and flyback time. TODO do we need the flyback?
+                                     overscanned pixels and flyback time.
+        :param sine_in_x: (bool) If True, the setpoints in the x-direction will follow a sine wave.
+                                 if False, the setpoints in the x-direction will be a flat line.
+        :param sine_in_y: (bool) If True, the setpoints in the y-direction will follow a sine wave.
+                                 if False, the setpoints in the y-direction will be a flat line.
         :return:
                 x_setpoints (list of ints): The calibration setpoints in x direction in bits.
                 y_setpoints (list of ints): The calibration setpoints in y direction in bits.
         """
+        if not sine_in_x and not sine_in_y:
+            raise ValueError("Calibration set points require a sine wave in either the x or y axis, or both, "
+                             "not in neither direction.")
+
         # The calibration frequency is the inverse of the total line scan time.
         calibration_frequency = 1 / total_line_scan_time  # [1/sec]
 
@@ -1011,13 +1019,15 @@ class MirrorDescanner(model.Emitter):
 
         # convert offset and amplitude from [a.u.] to [bits]
         sine_offset = convertRange(self.scanOffset.value,
-                                   numpy.array(self.scanOffset.range)[:, 1], I16_SYM_RANGE)  # [bits]
+                                   numpy.array(self.scanOffset.range)[:, 1],
+                                   I16_SYM_RANGE)  # [bits]
         sine_amplitude = convertRange(self.scanAmplitude.value,
-                                      numpy.array(self.scanAmplitude.range)[:, 1], I16_SYM_RANGE)  # [bits]
+                                      numpy.array(self.scanAmplitude.range)[:, 1],
+                                      I16_SYM_RANGE)  # [bits]
 
         timestamps_setpoints = numpy.linspace(0, total_line_scan_time, number_setpoints)  # [sec]
-        # setpoints in x direction resemble a sine
-        # Note: There is not necessarily a setpoint at the max/min amplitude of the sine.
+        # Note: Due to the discrete nature of setpoints, there is not necessarily a setpoint
+        # exactly at the max/min amplitude of the sine.
         #
         # *               *  *
         #   *           *      *
@@ -1025,11 +1035,10 @@ class MirrorDescanner(model.Emitter):
         #     *      *           *
         #       *  *
         #
-        x_setpoints = sine_offset[0] + sine_amplitude[0] * \
-                      numpy.sin(2 * math.pi * calibration_frequency * timestamps_setpoints)  # [bits+bits*sec/sec=bits]
-
-        # setpoints in y direction are constant (=0)
-        y_setpoints = 0 * timestamps_setpoints  # [bits]
+        constant_setpoints = 0 * timestamps_setpoints  # a flat line [bits]
+        sine_wave = numpy.sin(2 * math.pi * calibration_frequency * timestamps_setpoints)  # [bits+bits*sec/sec=bits]
+        x_setpoints = sine_offset[0] + sine_amplitude[0] * sine_wave if sine_in_x else constant_setpoints
+        y_setpoints = sine_offset[1] + sine_amplitude[1] * sine_wave if sine_in_y else constant_setpoints
 
         # Setpoints need to be integers when send to the ASM. First round down found setpoints to next integer
         # then convert to int type.
@@ -1039,11 +1048,85 @@ class MirrorDescanner(model.Emitter):
         y_setpoints = numpy.floor(y_setpoints).astype(int)  # [bits]
 
         # mapping from a.u. to bits is symmetrically around 0, whereas the range in bits that is accepted by the ASM is
-        # not symetrically around 0 ([-32768, 32767]). Clip 2**15 = 32768 by one bit to 32767 bit.
+        # not symmetrically around 0 ([-32768, 32767]). Clip 2**15 = 32768 by one bit to 32767 bit.
         x_setpoints = numpy.minimum(x_setpoints, I16_SYM_RANGE[1] - 1)
         y_setpoints = numpy.minimum(y_setpoints, I16_SYM_RANGE[1] - 1)
 
         return x_setpoints.tolist(), y_setpoints.tolist()
+
+    def moveFullRange(self):
+        """
+        Moves the descanner x and y axes through their full range to minimize wear on the ball bearings,
+        which move only a small amount during acquisition. The movement is sinusoidal to ensure
+        gradual and complete coverage of the range.
+        """
+        # Store current parameters to restore them after moving the descanner through the full range
+        init_dwellTime = self.parent._ebeam_scanner.dwellTime.value
+        init_physicalFlybackTime = self.physicalFlybackTime.value
+        init_scanOffset = self.scanOffset.value
+        init_scanAmplitude = self.scanAmplitude.value
+        init_cellCompleteResolution = self.parent._mppc.cellCompleteResolution.value
+
+        # Set dwell time, flyback time, and resolution to maximum values to avoid moving the descanners too fast
+        self.parent._ebeam_scanner.dwellTime.value = self.parent._ebeam_scanner.dwellTime.range[-1]
+        self.physicalFlybackTime.value = self.physicalFlybackTime.range[-1]
+        self.parent._mppc.cellCompleteResolution.value = self.parent._mppc.cellCompleteResolution.range[-1]
+        self.scanOffset.value = (0.0, 0.0)
+        scan_amp_rng = self.scanAmplitude.range
+
+        # Set scan amplitude to cover the entire range
+        self.scanAmplitude.value = (scan_amp_rng[0][0], scan_amp_rng[-1][0])
+        total_line_scan_time = self.parent._mppc.getTotalLineScanTime()
+
+        # Generate descanner setpoints for sinusoidal movement in both x and y directions
+        x_descan_setpoints, y_descan_setpoints = self.getCalibrationSetpoints(
+            total_line_scan_time, sine_in_x=True, sine_in_y=True
+        )
+
+        # Generate scanner setpoints (note required by the ASM API, not needed for moving the descanners)
+        x_scan_setpoints, y_scan_setpoints, scan_calibration_dwell_time_ticks = \
+            self.parent._ebeam_scanner.getCalibrationSetpoints(total_line_scan_time)
+
+        # Prepare calibration data
+        calibration_data = CalibrationLoopParameters(self.rotation.value,
+                                                     0,  # Descan X offset parameter unused.
+                                                     x_descan_setpoints,
+                                                     0,  # Descan Y offset parameter unused.
+                                                     y_descan_setpoints,
+                                                     scan_calibration_dwell_time_ticks,
+                                                     self.parent._ebeam_scanner.rotation.value,
+                                                     self.parent._ebeam_scanner.getTicksScanDelay()[0],
+                                                     0.0,  # Scan X offset parameter unused.
+                                                     x_scan_setpoints,
+                                                     0.0,  # Scan Y offset parameter unused.
+                                                     y_scan_setpoints)
+
+        # Check if an acquisition is still in progress
+        if not self.parent._mppc.acq_queue.empty():
+            logging.error("There is still an unfinished acquisition in progress. "
+                          "Calibration mode cannot be started yet.")
+            return
+
+        # Stop the calibration loop if it's already running to restart it with new parameters
+        if self.parent.calibrationMode.value:
+            # Sending this command without the calibration loop being active might cause errors.
+            self.parent.asmApiPostCall("/scan/stop_calibration_loop", 204)
+
+        # Start the calibration loop with the new parameters
+        self.parent._calibrationParameters = calibration_data
+        self.parent.asmApiPostCall("/scan/start_calibration_loop",
+                                   204,
+                                   data=self.parent._calibrationParameters.to_dict())
+        time.sleep(total_line_scan_time * 10)
+        self.parent.asmApiPostCall("/scan/stop_calibration_loop", 204)
+
+        # Restore original parameters and clear calibration parameters
+        self.parent._calibrationParameters = None
+        self.parent._ebeam_scanner.dwellTime.value = init_dwellTime
+        self.physicalFlybackTime.value = init_physicalFlybackTime
+        self.scanOffset.value = init_scanOffset
+        self.scanAmplitude.value = init_scanAmplitude
+        self.parent._mppc.cellCompleteResolution.value = init_cellCompleteResolution
 
 
 class MPPC(model.Detector):
@@ -1362,7 +1445,8 @@ class MPPC(model.Detector):
         """
         Puts the command 'next' field image scan on the queue with the appropriate field meta data model of the field
         image to be scanned. Can only be executed if it preceded by a 'start' mega field scan command on the queue.
-        The acquisition thread returns the acquired image to the provided notifier function added in the acquisition queue
+        The acquisition thread returns the acquired image to the provided notifier function added in the acquisition
+        queue
         with the "next" command. As notifier function the dataflow.notify is send. The returned image will be
         returned to the dataflow.notify which will provide the new data to all the subscribers of the dataflow.
 

--- a/src/odemis/driver/test/technolution_test.py
+++ b/src/odemis/driver/test/technolution_test.py
@@ -1151,18 +1151,18 @@ class TestMirrorDescanner(unittest.TestCase):
     def test_plot_getAcqSetpoints(self):
         """Plot the acquisition descan setpoint profiles."""
         self.ebeam_scanner.dwellTime.value = 5e-6  # Increase dwell time to see steps in the profile better
-        self.mirror_descanner.physicalFlybackTime.value = 25e-4  # Increase to see its effect in the profile better
+        self.mirror_descanner.physicalFlybackTime.value = 10e-4  # Increase to see its effect in the profile better
 
         x_descan_setpoints = self.mirror_descanner.getXAcqSetpoints()
         y_descan_setpoints = self.mirror_descanner.getYAcqSetpoints()
 
         fig, axs = plt.subplots(2)
         fig.tight_layout(pad=3.0)  # add some space between subplots so that the axes labels are not hidden
-        axs[0].plot(x_descan_setpoints, "xb", markersize=0.5,
+        axs[0].plot(x_descan_setpoints, "x", color="C0", markersize=1,
                     label="x descan setpoints (scanning of one row within a cell image)")
         axs[0].set_xlabel("overscanned cell image row plus flyback [us]")
         axs[0].set_ylabel("x setpoints [bits]")
-        axs[1].plot(y_descan_setpoints[::], "or", markersize=0.5,
+        axs[1].plot(y_descan_setpoints[::], "o", color="C1", markersize=1,
                     label="y descan setpoints (scanning of one column within a cell image)")
         axs[1].set_xlabel("overscanned cell image column [px]")
         axs[1].set_ylabel("y setpoints [bits]")
@@ -1229,13 +1229,11 @@ class TestMirrorDescanner(unittest.TestCase):
         x descanner: sine
         y descanner: flat line
         """
-        self.ebeam_scanner.dwellTime.value = 5e-6
+        self.ebeam_scanner.dwellTime.value = 4e-5
         self.mirror_descanner.scanOffset.value = (0.1, 0.0)  # center of the sine on x; y flat line
-        self.mirror_descanner.scanAmplitude.value = (0.5, 0.0)  # amplitude of the sine on x; y flat line
-
+        self.mirror_descanner.scanAmplitude.value = (0.5, 0.5)  # amplitude of the sine on x; y flat line
         # Total line scan time is equal to period of the calibration signal, the frequency is the inverse
         total_line_scan_time = self.mppc.getTotalLineScanTime()
-        # TODO Do we need the flyback included for calibration of the scan delay?
 
         x_descan_setpoints, y_descan_setpoints = self.mirror_descanner.getCalibrationSetpoints(total_line_scan_time)
 
@@ -1245,9 +1243,9 @@ class TestMirrorDescanner(unittest.TestCase):
         timestamps_descanner = numpy.arange(0, total_line_scan_time, self.mirror_descanner.clockPeriod.value)
 
         fig, axs = plt.subplots(1)
-        axs.plot(timestamps_descanner, x_descan_setpoints, "ro", markersize=0.5,
+        axs.plot(timestamps_descanner, x_descan_setpoints, "o", markersize=1,
                  label="Descanner x setpoints")
-        axs.plot(timestamps_descanner, y_descan_setpoints, "bo", markersize=0.5,
+        axs.plot(timestamps_descanner, y_descan_setpoints, "o", markersize=1,
                  label="Descanner y setpoints")
         axs.set_xlabel("scanning time [sec]")
         axs.set_ylabel("setpoints [bits]")

--- a/src/odemis/gui/cont/acquisition/fastem_acq.py
+++ b/src/odemis/gui/cont/acquisition/fastem_acq.py
@@ -525,12 +525,9 @@ class FastEMAcquiController(object):
         self.gauge_acq.Value = 0
 
         # During acquisition the galvo's only move a very small amount. To reduce the wearing of the ball bearing,
-        # the galvo's are moved to their extrema at the start of every acquisition.
-        logging.debug("Move the galvo's to their extrema.")
-        for scan_offset in [[-1, -1], [1, 1]]:  # [a.u.]
-            self._main_data_model.descanner.scanAmplitude.value = (0, 0)
-            self._main_data_model.descanner.scanOffset.value = scan_offset
-            self._main_data_model.mppc.data.get(dataContent="empty")
+        # the galvo's are moved to their full range at the start of every acquisition.
+        logging.debug("Move the galvo's to their full range.")
+        self._main_data_model.descanner.moveFullRange()
 
         # The user should focus manually before an acquisition, thus the current
         # position is saved as "good focus"


### PR DESCRIPTION
The previous implementation moved them very quickly, this caused problems with the hardware. The new movement is sinusoidal to ensure gradual and complete coverage of the range.

This commit includes the following:
* add a function to the technolution descanner class to move the axes along the full range
* use that function at the start of the acquisition
* update MirrorDescanner.getCalibrationSetpoints to support a sine function in x as well as in y
* clean up test code plots, used for debugging the setpoints; ensure values used for physical flyback time and dwell time are within range and update plots to use latest matplotlib colors