### PR TITLE
[TRCL-215] [feature] Show ebeam-blanker controls, if it's available

### DIFF
--- a/src/odemis/gui/conf/data.py
+++ b/src/odemis/gui/conf/data.py
@@ -235,6 +235,29 @@ HW_SETTINGS_CONFIG = {
                 "control_type": odemis.gui.CONTROL_NONE,
             }),
         )),
+    "ebeam-blanker":
+        OrderedDict((
+            ("period", {
+                "tooltip": "Duration of a blanking cycle.",
+                "range": (1e-16, 1),
+                "scale": "log",
+                "type": "float",
+                "accuracy": 3,
+                "event": wx.EVT_SCROLL_CHANGED,
+            }),
+            ("power", {
+                "label": "Blanking",
+                "tooltip": "Checked means the e-beam blanker is active (the e-beam is pulsed). \n"
+                           "Unchecked means the e-beam is constantly active.",
+            }),
+            ("dutyCycle", {
+                "tooltip": "Ratio of the forward sweep duration over the total blanking cycle.",
+                "event": wx.EVT_SCROLL_CHANGED,
+            }),
+            ("delay", {  # Should be shown on a separate component (ex: streak-delay)
+                "control_type": odemis.gui.CONTROL_NONE,
+            }),
+        )),
     "laser-mirror":
         OrderedDict((
             ("dwellTime", {

--- a/src/odemis/gui/cont/tabs/sparc2_align_tab.py
+++ b/src/odemis/gui/cont/tabs/sparc2_align_tab.py
@@ -47,6 +47,7 @@ from odemis.gui.conf.data import get_local_vas, get_hw_config
 from odemis.gui.conf.util import create_axis_entry
 from odemis.gui.cont import settings
 from odemis.gui.cont.actuators import ActuatorController
+from odemis.gui.cont.settings import EBeamBlankerSettingsController
 from odemis.gui.cont.stream_bar import StreamBarController
 from odemis.gui.cont.tabs._constants import MIRROR_ONPOS_RADIUS, MIRROR_POS_PARKED
 from odemis.gui.cont.tabs.tab import Tab
@@ -172,6 +173,9 @@ class Sparc2AlignTab(Tab):
         self.panel.vp_align_ek.view.show_pixelvalue.value = False
         self.panel.vp_align_streak.view.show_pixelvalue.value = True
         self.panel.vp_align_lens_ext.view.show_pixelvalue.value = False
+
+        # Will show the (pulsed) ebeam blanker settings, if available, otherwise will do nothing
+        self._ebeam_blanker_ctrl = EBeamBlankerSettingsController(panel, tab_data)
 
         # The streams:
         # * Alignment/AR CCD (ccd): Used to show CL spot during the alignment

--- a/src/odemis/gui/cont/tabs/sparc_acquisition_tab.py
+++ b/src/odemis/gui/cont/tabs/sparc_acquisition_tab.py
@@ -29,6 +29,7 @@ import wx
 from odemis import model
 import odemis.acq.stream as acqstream
 import odemis.gui.cont.acquisition as acqcont
+from odemis.gui.cont.settings import EBeamBlankerSettingsController
 from odemis.gui.cont.stream_bar import SparcStreamsController
 import odemis.gui.cont.views as viewcont
 import odemis.gui.model as guimod
@@ -240,6 +241,9 @@ class SparcAcquisitionTab(Tab):
 
         tab_data.tool.subscribe(self.on_tool_change)
 
+        # Will show the (pulsed) ebeam blanker settings, if available, otherwise will do nothing
+        self._ebeam_blanker_ctrl = EBeamBlankerSettingsController(panel, tab_data)
+
         # Create Stream Bar Controller
         self._stream_controller = SparcStreamsController(
             tab_data,
@@ -412,6 +416,7 @@ class SparcAcquisitionTab(Tab):
     def on_acquisition(self, is_acquiring):
         # TODO: Make sure nothing can be modified during acquisition
 
+        self._ebeam_blanker_ctrl.enable(not is_acquiring)
         self.tb.enable(not is_acquiring)
         self.panel.vp_sparc_tl.Enable(not is_acquiring)
         # TODO: Leave the canvas accessible, but only forbid moving the stage and

--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -1084,6 +1084,7 @@ class xrcpnl_tab_sparc2_align(wx.Panel):
         self.vp_align_fiber = xrc.XRCCTRL(self, "vp_align_fiber")
         self.vp_align_lens_ext = xrc.XRCCTRL(self, "vp_align_lens_ext")
         self.scr_win_right = xrc.XRCCTRL(self, "scr_win_right")
+        self.fp_settings_ebeam_blanker = xrc.XRCCTRL(self, "fp_settings_ebeam_blanker")
         self.pnl_streams = xrc.XRCCTRL(self, "pnl_streams")
         self.pnl_moi_settings = xrc.XRCCTRL(self, "pnl_moi_settings")
         self.btn_bkg_acquire = xrc.XRCCTRL(self, "btn_bkg_acquire")
@@ -1139,6 +1140,7 @@ class xrcpnl_tab_sparc_acqui(wx.Panel):
         self.vp_sparc_as = xrc.XRCCTRL(self, "vp_sparc_as")
         self.scr_win_right = xrc.XRCCTRL(self, "scr_win_right")
         self.fpb_settings = xrc.XRCCTRL(self, "fpb_settings")
+        self.fp_settings_ebeam_blanker = xrc.XRCCTRL(self, "fp_settings_ebeam_blanker")
         self.pnl_sparc_streams = xrc.XRCCTRL(self, "pnl_sparc_streams")
         self.txt_filename = xrc.XRCCTRL(self, "txt_filename")
         self.btn_sparc_change_file = xrc.XRCCTRL(self, "btn_sparc_change_file")
@@ -13619,6 +13621,15 @@ b\xeb\x85\x9f\xb6B\x1d\x0cK\x17\xac\xf0\x12\xfe\xa0\xe5\xee\xe03\xb1\xfa\
                 <object class="wxBoxSizer">
                   <object class="sizeritem">
                     <object class="FoldPanelBar">
+                      <object class="FoldPanelItem" name="fp_settings_ebeam_blanker">
+                        <label>EBEAM BLANKER</label>
+                        <hidden>1</hidden>
+                        <fg>#1A1A1A</fg>
+                        <bg>#555555</bg>
+                        <XRCED>
+                          <assign_var>1</assign_var>
+                        </XRCED>
+                      </object>
                       <object class="FoldPanelItem">
                         <object class="StreamBar" name="pnl_streams">
                           <size>300,-1</size>
@@ -14739,6 +14750,15 @@ D\x02\x12\x0c/\x81\x10.\xc4\xcc\xb0\x8f\xa1\x9e\xa1\x81a/\x90\x05\x06\x8d\
                   <orient>wxVERTICAL</orient>
                   <object class="sizeritem">
                     <object class="FoldPanelBar" name="fpb_settings">
+                      <object class="FoldPanelItem" name="fp_settings_ebeam_blanker">
+                        <label>EBEAM BLANKER</label>
+                        <hidden>1</hidden>
+                        <fg>#1A1A1A</fg>
+                        <bg>#555555</bg>
+                        <XRCED>
+                          <assign_var>1</assign_var>
+                        </XRCED>
+                      </object>
                       <object class="FoldPanelItem">
                         <object class="StreamBar" name="pnl_sparc_streams">
                           <size>300,-1</size>

--- a/src/odemis/gui/model/main_gui_data.py
+++ b/src/odemis/gui/model/main_gui_data.py
@@ -99,6 +99,7 @@ class MainGUIData(object):
         "pinhole": "pinhole",
         "stigmator": "stigmator",
         "ebeam-focus": "ebeam_focus",
+        "ebeam-blanker": "ebeam_blanker",
         "overview-focus": "overview_focus",
         "mirror": "mirror",
         "mirror-xy": "mirror_xy",
@@ -182,6 +183,7 @@ class MainGUIData(object):
         self.lens = None  # Optical lens for SECOM/focus lens for the SPARC
         self.ebeam = None
         self.ebeam_focus = None  # change the e-beam focus
+        self.ebeam_blanker = None  # for advanced blanker control (eg, pulsed)
         self.sed = None  # secondary electron detector
         self.bsd = None  # backscattered electron detector
         self.ebic = None  # electron beam-induced current detector

--- a/src/odemis/gui/xmlh/resources/panel_tab_sparc2_align.xrc
+++ b/src/odemis/gui/xmlh/resources/panel_tab_sparc2_align.xrc
@@ -2062,6 +2062,15 @@
                 <object class="wxBoxSizer">
                   <object class="sizeritem">
                     <object class="FoldPanelBar">
+                      <object class="FoldPanelItem" name="fp_settings_ebeam_blanker">
+                        <label>EBEAM BLANKER</label>
+                        <hidden>1</hidden>
+                        <fg>#1A1A1A</fg>
+                        <bg>#555555</bg>
+                        <XRCED>
+                          <assign_var>1</assign_var>
+                        </XRCED>
+                      </object>
                       <object class="FoldPanelItem">
                         <object class="StreamBar" name="pnl_streams">
                           <size>300,-1</size>

--- a/src/odemis/gui/xmlh/resources/panel_tab_sparc_acqui.xrc
+++ b/src/odemis/gui/xmlh/resources/panel_tab_sparc_acqui.xrc
@@ -240,6 +240,15 @@
                   <orient>wxVERTICAL</orient>
                   <object class="sizeritem">
                     <object class="FoldPanelBar" name="fpb_settings">
+                      <object class="FoldPanelItem" name="fp_settings_ebeam_blanker">
+                        <label>EBEAM BLANKER</label>
+                        <hidden>1</hidden>
+                        <fg>#1A1A1A</fg>
+                        <bg>#555555</bg>
+                        <XRCED>
+                          <assign_var>1</assign_var>
+                        </XRCED>
+                      </object>
                       <object class="FoldPanelItem">
                         <object class="StreamBar" name="pnl_sparc_streams">
                           <size>300,-1</size>


### PR DESCRIPTION
If the ebeam-blanker component is present, provide GUI controls to
change the (fast) blanker settings.
(For now, only one SPARC has this control, but there might be more coming)

=> Introduce a new EBeamBlankerSettingsController, and use it both in
Acquisition and Alignment tabs. If the component is not available, the
settings are automatically hidden.