### PR TITLE
[fix] SPARC2 GUI fail to start with streakcam if only one spectrograph available

### DIFF
--- a/src/odemis/gui/cont/tabs/sparc2_align_tab.py
+++ b/src/odemis/gui/cont/tabs/sparc2_align_tab.py
@@ -469,10 +469,10 @@ class Sparc2AlignTab(Tab):
                 hw_conf = get_hw_config(comp, main_data.hw_settings_config)
                 streak.add_axis_entry(axisname, comp, hw_conf.get(axisname))
 
-            # usually we only supported one dedicated internal spectrograph which the streak cam could connect to
-            # from now on we also want to support external spectrographs with the streak cam connected
-            spect = main_data.spectrograph
-            if main_data.streak_ccd.name in main_data.spectrograph_ded.affects.value:
+            # Find the spectrograph on which the streak cam is connected.
+            spect = main_data.spectrograph  # default
+            spect_ded = main_data.spectrograph_ded
+            if spect_ded and main_data.streak_ccd.name in spect_ded.affects.value:
                 spect = main_data.spectrograph_ded
                 self.panel.cmb_focus_detectors_ext.Append(main_data.streak_ccd.name)
 


### PR DESCRIPTION
The code somehow ended up assuming that there are always 2
spectrographs. Of course, that's not correct, and it possible that the
streakcam is connected on the only spectrograph present.