### PR TITLE
[METEOR-1202][FEAT] Add option to autofocus before acquiring at feature positions

### DIFF
--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -763,6 +763,7 @@ class xrcpnl_tab_localization(wx.Panel):
         self.btn_cryosecom_acqui_cancel = xrc.XRCCTRL(self, "btn_cryosecom_acqui_cancel")
         self.btn_acquire_overview = xrc.XRCCTRL(self, "btn_acquire_overview")
         self.btn_acquire_features = xrc.XRCCTRL(self, "btn_acquire_features")
+        self.chk_use_autofocus_acquire_features = xrc.XRCCTRL(self, "chk_use_autofocus_acquire_features")
         self.pnl_cryosecom_acquired = xrc.XRCCTRL(self, "pnl_cryosecom_acquired")
         self.btn_mill_active_features = xrc.XRCCTRL(self, "btn_mill_active_features")
         self.txt_milling_est_time = xrc.XRCCTRL(self, "txt_milling_est_time")
@@ -9287,6 +9288,19 @@ D\xc48\xc6qd\x1b\xed\x886\x1a\xa5\x00\x00D0\xc6\x181?\x03\x96\xf6I\x16\
                               </object>
                               <option>0</option>
                               <flag>wxTOP|wxBOTTOM|wxLEFT</flag>
+                              <border>10</border>
+                            </object>
+                            <object class="sizeritem">
+                              <object class="wxCheckBox" name="chk_use_autofocus_acquire_features">
+                                <label>Use AutoFocus</label>
+                                <fg>#E5E5E5</fg>
+                                <checked>0</checked>
+                                <flag>wxVERTICAL</flag>
+                                <border>10</border>
+                                <XRCED>
+                                  <assign_var>1</assign_var>
+                                </XRCED>
+                              </object>
                               <border>10</border>
                             </object>
                             <orient>wxVERTICAL</orient>

--- a/src/odemis/gui/xmlh/resources/panel_tab_localization.xrc
+++ b/src/odemis/gui/xmlh/resources/panel_tab_localization.xrc
@@ -823,6 +823,19 @@
                               <flag>wxTOP|wxBOTTOM|wxLEFT</flag>
                               <border>10</border>
                             </object>
+                            <object class="sizeritem">
+                              <object class="wxCheckBox" name="chk_use_autofocus_acquire_features">
+                                <label>Use AutoFocus</label>
+                                <fg>#E5E5E5</fg>
+                                <checked>0</checked>
+                                <flag>wxVERTICAL</flag>
+                                <border>10</border>
+                                <XRCED>
+                                  <assign_var>1</assign_var>
+                                </XRCED>
+                              </object>
+                              <border>10</border>
+                            </object>
                             <orient>wxVERTICAL</orient>
                           </object>
                           <size>400,-1</size>


### PR DESCRIPTION
This PR adds the option to the user interface to run autofocus before running multi-feature acquisition. This was requested by a user and is on the roadmap for future. Assuming the autofocus works correctly, we should be able to select acquisition sites without having to move and focus beforehand. At the very least, it should serve as an initial coarse screening.

This also contains a small refactor of the zlevels calculation for the multi feature acquisition. Previously, the zlevels were calculated before starting acquisition which meant they were constant for all the features (even if they had different focus positions). Now, instead of passing in the zlevels directly, we pass in the parameters required to calculate zlevels (zmin, zmax, zstep and focus.position). 

This was also required for the autofocus to work correctly with z-stack acquisition as the autofocus changes the focus position after these were previously calculated.

This PR is dependant on: https://github.com/delmic/odemis/pull/2837