### PR TITLE
[DRAFT][METEOR-1186] [REFACTOR] Store feature stage position and focus position separately

### DIFF
--- a/install/linux/usr/share/odemis/sim/meteor-tfs2-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/meteor-tfs2-sim.odm.yaml
@@ -1,0 +1,208 @@
+# For now, this is esssentially just a FM microscope, as the FIB part is handled
+# separately by the SEM
+
+"METEOR TFSv2": {
+    class: Microscope,
+    role: meteor,
+    children: [
+        "Stage",
+        "Sample Stage",
+        "Optical Objective",
+        "Optical Focus",
+        "Light Source",
+        "Filter Wheel",
+        "Camera",
+        "EBeam",
+    ],
+}
+
+"SEM": {
+    class: simsem.SimSEM,
+    role: null,
+    init: {
+           image: "simsem-fake-output.h5", # any large 16 bit image is fine
+    },
+    children: {
+        scanner: "EBeam",
+        detector0: "SE Detector",
+        focus: "EBeam Focus",
+    }
+}
+
+"EBeam": {
+    # Internal child of SimSEM, so no class
+    role: e-beam,  # Not required for the meteor
+    init: {},
+    affects: ["SE Detector"],
+}
+
+"EBeam Focus": {
+    # role: ebeam-focus,
+    role: null,
+    init: {},
+    affects: ["EBeam"]
+}
+
+"SE Detector": {
+    # Internal child of SimSEM, so no class
+    # role: se-detector,
+    role: null,
+    init: {},
+}
+
+
+# Normally provided by the SEM
+"Stage": {
+    class: tmcm.TMCLController,
+    role: stage-bare,
+    init: {
+        port: "/dev/fake6",
+        address: null,
+        axes: ["x", "y", "z", "rx", "rz"],
+        ustepsize: [1.e-6, 1.e-6, 1.e-6, 1.2e-5, 1.2e-5], # unit/µstep
+        rng: [[-0.1, 0.1], [-0.05, 0.05], [-0.05, 0.1], [-2, 2], [0, 6.28]],
+        unit: ["m", "m", "m", "rad", "rad"],
+        refproc: "Standard",
+    },
+    metadata: {
+        # Loading position:
+        FAV_POS_DEACTIVE: { 'rx': 0, 'rz': 1.9076449, 'x': -0.01529, 'y': 0.0506, 'z': 29.e-3 },
+        # XYZ ranges for SEM & METEOR
+        SEM_IMAGING_RANGE: {"x": [-10.e-3, 10.e-3], "y": [-30.e-3, 25.e-3], "z": [15.e-3, 37.e-3]},
+        FM_IMAGING_RANGE: {"x": [0.040, 0.054], "y": [-30.e-3, 25.e-3], "z": [15.e-3, 34.e-3]},
+        # Grid centers in SEM range
+        # Adjusted so that at init (0,0,0), it's at the Grid 1.
+        SAMPLE_CENTERS: {"GRID 1": {'x': 0, 'y': 0, 'z': 32.e-3}, "GRID 2": {'x': 5.0e-3, 'y': 0, 'z': 32.e-3}},
+        # Mirroring values between SEM - METEOR
+        POS_COR: [0.0253126, 0.0024916],
+        CALIB: {"version": "tfs_2", 
+                "Sample pre-tilt":  0.6108652381980153},  # 35°
+        FAV_FM_POS_ACTIVE: {"rx": 0.12213888553625313  , "rz":  3.141592653589793}, # 7° - 270°
+        FAV_SEM_POS_ACTIVE: {"rx": 0.6108652381980153, "rz": 0},  # pre-tilt 35°
+        FAV_MILL_POS_ACTIVE: {"rx": 0.314159, "rz": 0},    # Note that milling angle (rx) can be changed per session  
+    },
+}
+
+"Light Source": {
+    class: omicronxx.HubxX,
+    role: light,
+    init: {
+        port: "/dev/fakehub", # Simulator
+        #port: "/dev/ttyFTDI*",
+        },
+    affects: ["Camera"],
+}
+
+"Optical Objective": {
+    class: static.OpticalLens,
+    role: lens,
+    init: {
+        mag: 84.0, # ratio, (actually of the complete light path)
+        na: 0.85, # ratio, numerical aperture
+        ri: 1.0, # ratio, refractive index
+    },
+    affects: ["Camera"]
+}
+
+# Normally a IDS uEye or Zyla
+# Axes: X is horizontal on screen (going left->right), physical: far->close when looking at the door
+#       Y is vertical on screen (going bottom->top), physical: left->right when looking at the door
+"Camera": {
+    class: simcam.Camera,
+    role: ccd,
+    dependencies: {focus: "Optical Focus"},
+    init: {
+        image: "andorcam2-fake-clara.tiff",
+        transp: [-1, 2], # To swap/invert axes
+    },
+    metadata: {
+        # To change what the "good" focus position is on the simulator
+        # It's needed for not using the initial value, which is at deactive position.
+         FAV_POS_ACTIVE: {'z': 1.7e-3},  # good focus position
+         ROTATION: -0.099484,  # [rad] (=-5.7°)
+    },
+}
+
+# Controller for the filter-wheel
+# DIP must be configured with address 7 (= 1110000)
+"Optical Actuators": {
+    class: tmcm.TMCLController,
+    role: null,
+    init: {
+        port: "/dev/fake6", # Simulator
+        address: null, # Simulator
+        axes: ["fw"],
+        ustepsize: [1.227184e-3], # [rad/µstep]  fake value for simulator
+        rng: [[-14, 7]], # rad, more than 0->2 Pi, in order to allow one extra rotation in both direction, when quickly switching
+        unit: ["rad"],
+        refproc: "Standard",
+        refswitch: {"fw": 0}, #digital output used to switch on/off sensor
+        inverted: ["fw"], # for the filter wheel, the direction doesn't matter, as long as the positions are correct
+    },
+}
+
+"AntiBacklash for Filter Wheel": {
+    class: actuator.AntiBacklashActuator,
+    role: null,
+    init: {
+        backlash: {
+            # Force every move to always finish in the same direction
+            "fw": 50.e-3,  # rad
+        },
+    },
+    dependencies: {"slave": "Optical Actuators"},
+}
+
+"Filter Wheel": {
+    class: actuator.FixedPositionsActuator,
+    role: filter,
+    dependencies: {"band": "AntiBacklash for Filter Wheel"},
+    init: {
+        axis_name: "fw",
+        # This filter-wheel is made so that the light goes through two "holes":
+        # the filter, and the opposite hole (left empty). So although it has 8
+        # holes, it only supports 4 filters (from 0° to 135°), and there is no
+        # "fast-path" between the last filter and the first one.
+        positions: {
+             # pos (rad) -> m,m
+             0.08: [414.e-9, 450.e-9], # FF01-432/36
+             0.865398: [500.e-9, 530.e-9], # FF01-515/30
+             1.650796: [579.5e-9, 610.5e-9], # FF01-595/31
+             2.4361944: [663.e-9, 733.e-9], # FF02-698/70
+        },
+        cycle: 6.283185, # position of ref switch (0) after a full turn
+    },
+    # TODO: a way to indicate the best filter to use during alignement and brightfield? via some metadata?
+    affects: ["Camera"],
+}
+
+# CLS3252dsc-1
+"Optical Focus": {
+    class: smaract.MCS2,
+    role: focus,
+    init: {
+        locator: "fake",
+        ref_on_init: True,
+        # TODO: check speed/accel
+        speed: 0.003,  # m/s
+        accel: 0.003,  # m/s²
+        #hold_time: 5 # s, default = infinite
+        # TODO: check the ranges, and the channel
+        axes: {
+            'z': {
+                # -11.5mm is safely parked (FAV_POS_DEACTIVE)
+                # 1.7mm is typically in focus (FAV_POS_ACTIVE)
+                range: [-15.e-3, 5.e-3],
+                unit: 'm',
+                channel: 0,
+            },
+        },
+    },
+    metadata: {
+        # Loading position to retract lens
+        FAV_POS_DEACTIVE: {'z': -11.5e-3},
+        # Initial active position (close from the sample, but not too close, for safety)
+        FAV_POS_ACTIVE: {'z': 1.69e-3}
+    },
+    affects: ["Camera"],
+}

--- a/src/odemis/acq/feature.py
+++ b/src/odemis/acq/feature.py
@@ -52,7 +52,7 @@ class CryoFeature(object):
         """
         self.name = model.StringVA(name)
         self.stage_position = model.VigilantAttribute(stage_position, unit="m") # stage-bare
-        self.fm_focus_pos = model.VigilantAttribute(fm_focus_position, unit="m")
+        self.fm_focus_position = model.VigilantAttribute(fm_focus_position, unit="m")
         self.posture = model.StringVA(posture)
         self.posture_positions: Dict[str, Dict[str, float]] = {} # positions for each posture
 

--- a/src/odemis/acq/move.py
+++ b/src/odemis/acq/move.py
@@ -35,6 +35,7 @@ import scipy
 from odemis import model, util
 from odemis.util import executeAsyncTask
 from odemis.util.driver import ATOL_ROTATION_POS, isNearPosition, isInRange
+from odemis.util.transform import RigidTransform
 
 MAX_SUBMOVE_DURATION = 90  # s
 
@@ -81,6 +82,8 @@ class MicroscopePostureManager:
                 return super().__new__(MeteorZeiss1PostureManager)
             elif stage_version == "tfs_1":
                 return super().__new__(MeteorTFS1PostureManager)
+            elif stage_version == "tfs_2":
+                return super().__new__(MeteorTFS2PostureManager)
             elif stage_version == "tescan_1":
                 return super().__new__(MeteorTescan1PostureManager)
             else:
@@ -195,6 +198,19 @@ class MicroscopePostureManager:
             missing_keys = required_keys - stage_md.keys()
             raise ValueError(f"Stage metadata is missing the following required keys: {missing_keys}.")
 
+    def check_calib_data(self, required_keys: set):
+        """
+        Checks the keys in the stage metadata MD_CALIB.
+        :param required_keys : A set of keys that must be present in the MD_CALIB metadata.
+        :raises ValueError: if the metadata does not have all required keys.
+        """
+        # Check for required keys in the given metadata
+        stage_md = self.stage.getMetadata()
+        calibrated_md = stage_md[model.MD_CALIB]
+        if not required_keys.issubset(calibrated_md.keys()):
+            missing_keys = required_keys - calibrated_md.keys()
+            raise ValueError(f"Stage metadata {model.MD_CALIB} is missing the following required keys: {missing_keys}.")
+
     def _cancelCryoMoveSample(self, future):
         """
         Canceller of _doCryoSwitchAlignPosition and _doCryoSwitchSamplePosition tasks
@@ -258,6 +274,13 @@ class MicroscopePostureManager:
             logging.info("Move procedure is cancelled after moving %s -> %s", component.name, sub_move)
             raise CancelledError()
 
+    def _update_posture(self, position: Dict[str, float]):
+        """
+        Update the current posture of the microscope
+        """
+        self.current_posture.value = self.getCurrentPostureLabel(position)
+
+        # TODO: update MD_POS on related components
 
 class MeteorPostureManager(MicroscopePostureManager):
     def __init__(self, microscope):
@@ -272,6 +295,9 @@ class MeteorPostureManager(MicroscopePostureManager):
         self.required_keys = {
             model.MD_FAV_POS_DEACTIVE, model.MD_FAV_SEM_POS_ACTIVE, model.MD_FAV_FM_POS_ACTIVE,
             model.MD_SAMPLE_CENTERS}
+        # current posture va
+        self.current_posture = model.VigilantAttribute(UNKNOWN)
+        self.stage.position.subscribe(self._update_posture, init=True)
 
     def getCurrentPostureLabel(self, pos: Dict[str, float] = None) -> int:
         """
@@ -295,6 +321,16 @@ class MeteorPostureManager(MicroscopePostureManager):
             return SEM_IMAGING
         # None of the above -> unknown position
         return UNKNOWN
+
+    def get_posture_orientation(self, posture: int) -> Dict[str, float]:
+        """Get the orientation of the stage for the given posture"""
+        stage_md = self.stage.getMetadata()
+        if posture == SEM_IMAGING:
+            return stage_md[model.MD_FAV_SEM_POS_ACTIVE]
+        elif posture == FM_IMAGING:
+            return stage_md[model.MD_FAV_FM_POS_ACTIVE]
+        elif posture == LOADING:
+            return stage_md[model.MD_FAV_POS_DEACTIVE]
 
     def getTargetPosition(self, target_pos_lbl: int) -> Dict[str, float]:
         """
@@ -333,6 +369,175 @@ class MeteorPostureManager(MicroscopePostureManager):
         """
         pass
 
+    def initialise_transformation(
+        self,
+        rotation: float = 0,
+        scale: tuple = (1, 1),
+        translation: tuple = (0, 0),
+        shear: tuple = (0, 0),
+    ):
+
+        self._transforms: Dict[int, numpy.ndarray] = {}     # transforms (to-sample-stage)
+        self._inv_transforms: Dict[int, numpy.ndarray] = {} # inverse transforms (from-sample-stage)
+
+        # FROM CONVERT STAGE
+        self._axes_dep = {"x": "y", "y": "z"}
+
+        self._metadata = {}
+        self._metadata[model.MD_POS_COR] = translation
+        self._metadata[model.MD_ROTATION_COR] = rotation
+        self._metadata[model.MD_PIXEL_SIZE_COR] = scale
+        self._metadata[model.MD_SHEAR_COR] = shear
+        self._updateConversion()
+
+    def _get_rot_matrix(self, invert=False):
+
+        rotation = self._metadata[model.MD_ROTATION_COR]
+        if invert:
+            rotation *= -1
+        return RigidTransform(rotation=rotation).matrix
+
+    def _updateConversion(self):
+        translation = self._metadata[model.MD_POS_COR]
+        scale = self._metadata[model.MD_PIXEL_SIZE_COR]
+        shear = self._metadata[model.MD_SHEAR_COR]
+
+        shear_matrix = numpy.array([[1, shear[0]], [shear[1], 1]])
+
+        # Scaling*Shearing*Rotation for convert back/forth between exposed and dep
+        scale_matrix = numpy.identity(len(scale)) * scale
+
+        # fm imaging
+        self._transforms[FM_IMAGING] = scale_matrix @ shear_matrix @ self._get_rot_matrix()
+        self._inv_transforms[FM_IMAGING] = numpy.linalg.inv(self._transforms[FM_IMAGING])
+
+        # sem imaging
+        self._transforms[SEM_IMAGING] = scale_matrix @ shear_matrix @ self._get_rot_matrix(invert=True)
+        self._inv_transforms[SEM_IMAGING] =  numpy.linalg.inv(self._transforms[SEM_IMAGING])
+
+        # add unknown as same as SEM IMAGING
+        self._transforms[UNKNOWN] = self._transforms[SEM_IMAGING]
+        self._inv_transforms[UNKNOWN] = self._inv_transforms[SEM_IMAGING]
+
+        # Offset between origins of the coordinate systems
+        self._O = numpy.array(translation, dtype=float)
+
+    def _convert_to_sample_stage_from_stage(self, pos_dep, absolute=True):
+        # Object lens position vector
+        Q = numpy.array(pos_dep, dtype=float)
+        # Transform to coordinates in the reference frame of the sample stage
+        posture = self.current_posture.value
+        p = self._inv_transforms[posture].dot(Q)
+        if absolute:
+            p -= self._O
+        return p.tolist()
+
+    def _convert_from_sample_stage_to_stage(self, pos, absolute=True):
+        # Sample stage position vector
+        P = numpy.array(pos, dtype=float)
+        if absolute:
+            P += self._O
+        # Transform to coordinates in the reference frame of the objective stage
+        posture = self.current_posture.value
+        q = self._transforms[posture].dot(P)
+        return q.tolist()
+
+    def _get_pos_vector(self, pos_val, absolute=True):
+        """ Convert position dict into dependant axes position dict"""
+        if absolute:
+            vpos = pos_val["x"], pos_val["y"]
+        else:
+            vpos = pos_val.get("x", 0), pos_val.get("y", 0)
+        vpos_dep = self._convert_from_sample_stage_to_stage(vpos, absolute=absolute)
+        return {self._axes_dep["x"]: vpos_dep[0], self._axes_dep["y"]: vpos_dep[1]}
+
+    def from_sample_stage_to_stage_movement(self, pos: Dict[str, float]) -> Dict[str, float]:
+        """Convert position dict from the sample-stage axes to the stage axes
+        Note: from sample-stage -> stage-bare (for relative movements)
+        :param pos: move dict with axis values (x, y, z) in the original axes. not all axes are required
+        :return: move dict with original axis values  in the dependant axes"""
+        # Convert position dict from original axes to dependant axes
+        vpos = self._get_pos_vector({"x": pos.get("y", 0), "y": pos.get("z", 0)}, absolute=False)
+
+        # return the new position
+        new_pos = pos.copy()
+        new_pos.update(vpos)
+        return new_pos
+
+    def from_sample_stage_to_stage_position(self, pos: Dict[str, float], posture: int = None) -> Dict[str, float]:
+        """Convert position dict from the sample-stage axes to the stage axes
+        Note: from sample-stage -> stage-bare
+        :param pos: position dict with all axis values (x, y) in the original axes
+        :param posture: (int) the posture of the stage
+        :return: position dict with all axis values (x, y) in the dependant axes
+        """
+        # Convert position dict from original axes to dependant axes
+        vpos = self._get_pos_vector({"x": pos["y"], "y": pos["z"]}, absolute=True)
+
+        # add rx, rz (orientation)
+        if posture is None:
+            posture = self.getCurrentPostureLabel()
+        orientation = self.get_posture_orientation(posture)
+
+        # return the new position
+        new_pos = pos.copy()
+        new_pos.update(orientation)
+        new_pos.update(vpos)
+        return new_pos
+
+    def to_sample_stage_from_stage_position(self, pos: Dict[str, float]) -> Dict[str, float]:
+        """Convert a stage position dict from the stage axes to the sample-stage axes
+        Note: from stage-bare -> sample stage
+        :param pos: position dict with all axis values (x, y, z) in the dependent axes
+        :return: position dict with all axis values (x, y, z) in the original axes
+        """
+        # Convert position dict from dependant axes to original axes
+        vpos = self._convert_to_sample_stage_from_stage([pos[self._axes_dep["x"]], pos[self._axes_dep["y"]]])
+        # remap vpos x, y -> stage y, z
+        vpos = {self._axes_dep["x"]: vpos[0], self._axes_dep["y"]: vpos[1]}
+
+        new_pos = pos.copy()
+        new_pos.update(vpos)
+        return new_pos
+
+    def to_posture(self, pos: Dict[str, float], posture: int) -> Dict[str, float]:
+        """Convert a stage position dict to the given posture
+        :param pos: position dict with all axis values in the stage axes
+        :param posture: (int) the target posture of the stage
+        :return: position dict with all axis values in the stage axes"""
+
+        position_posture = self.getCurrentPostureLabel(pos)
+
+        logging.info(f"Position Posture: {POSITION_NAMES[position_posture]}")
+        logging.info(f"Position: {pos}")
+        logging.info(f"Target Posture: {POSITION_NAMES[posture]}")
+
+        # TODO: what is the correct datastructure to store the different combinations of positions and transforms?
+
+        self._posture_transforms = {
+            FM_IMAGING: {
+                SEM_IMAGING: self._transformFromMeteorToSEM,
+            },
+            SEM_IMAGING: {
+                FM_IMAGING: self._transformFromSEMToMeteor,
+            },
+            UNKNOWN: {
+                UNKNOWN: lambda x: x
+         }
+        }
+        if position_posture == posture:
+            return pos
+
+        # validate the transformation
+        if position_posture not in self._posture_transforms:
+            raise ValueError(f"Position posture {position_posture} not supported")
+
+        if posture not in self._posture_transforms[position_posture]:
+            raise ValueError(f"Posture {posture} not supported for position posture {position_posture}")
+
+        tf = self._posture_transforms[position_posture][posture]
+
+        return tf(pos)
 
 class MeteorTFS1PostureManager(MeteorPostureManager):
     def __init__(self, microscope):
@@ -613,6 +818,31 @@ class MeteorTFS1PostureManager(MeteorPostureManager):
                     raise CancelledError()
                 future._task_state = FINISHED
 
+class MeteorTFS2PostureManager(MeteorTFS1PostureManager):
+    def __init__(self, microscope):
+        super().__init__(microscope)
+        # Check required metadata used during switching
+        self.required_keys.add(model.MD_POS_COR)
+        self.required_keys.add(model.MD_FAV_MILL_POS_ACTIVE)
+        self.required_keys.add(model.MD_CALIB)
+        self.check_stage_metadata(required_keys=self.required_keys)
+        self.check_calib_data(required_keys={model.MD_SAMPLE_PRE_TILT})
+        if not {"x", "y", "rz", "rx"}.issubset(self.stage.axes):
+            raise KeyError("The stage misses 'x', 'y', 'rx' or 'rz' axes")
+
+        # get the stage pre-tilt from the stage metadata
+        stage_md = self.stage.getMetadata()
+        pre_tilt = stage_md[model.MD_CALIB][model.MD_SAMPLE_PRE_TILT]
+
+        self.initialise_transformation(rotation=pre_tilt)
+        self.create_sample_stage()
+
+    def create_sample_stage(self):
+        from odemis.driver.actuator import SampleStage
+        self.sample_stage = SampleStage(name="Sample Stage",
+                                        role="stage",
+                                        dependencies={"under": self.stage},
+                                        posture_manager=self)
 
 class MeteorZeiss1PostureManager(MeteorPostureManager):
     def __init__(self, microscope):
@@ -1469,6 +1699,10 @@ class EnzelPostureManager(MicroscopePostureManager):
         stage_metadata = self.stage.getMetadata()
         if not {'x', 'y', 'z'}.issubset(stage_metadata[model.MD_POS_ACTIVE_RANGE]):
             raise ValueError('POS_ACTIVE_RANGE metadata should have values for x, y, z axes.')
+
+        # current posture va
+        self.current_posture = model.VigilantAttribute(UNKNOWN)
+        self.stage.position.subscribe(self._update_posture, init=True)
 
     def getTargetPosition(self, target_pos_lbl: int) -> Dict[str, float]:
         """

--- a/src/odemis/acq/test/feature_test.py
+++ b/src/odemis/acq/test/feature_test.py
@@ -20,13 +20,12 @@ class TestFeatureEncoderDecoder(unittest.TestCase):
     """
     Test the json encoder and decoder of the CryoFeature class
     """
-    test_str = '{"feature_list": [{"name": "Feature-1", "status": "Active", "stage_position": {"x": 0, "y": 0, "z": 0}, "fm_focus_position": {"z": 0}, "posture": "FM"}, '+ \
-               '{"name": "Feature-2", "status": "Active", "stage_position": {"x": 0.001, "y": 0.001, "z": 0.001}, "fm_focus_position": {"z": 0.002}, "posture": "FM"}]}'
+    test_str = '{"feature_list": [{"name": "Feature-1", "status": "Active", "stage_position": {"x": 0, "y": 0, "z": 0}, "fm_focus_position": {"z": 0}, "posture": "FM", "posture_positions": {}}, '+ \
+               '{"name": "Feature-2", "status": "Active", "stage_position": {"x": 0.001, "y": 0.001, "z": 0.001}, "fm_focus_position": {"z": 0.002}, "posture": "FM", "posture_positions": {}}]}'
 
     def test_feature_encoder(self):
         feature1 = CryoFeature("Feature-1", stage_position={"x": 0, "y": 0, "z": 0}, fm_focus_position={"z": 0})
         feature2 = CryoFeature("Feature-2", stage_position={"x": 1e-3, "y": 1e-3, "z": 1e-3}, fm_focus_position={"z": 2e-3})
-
         features = [feature1, feature2]
         json_str = json.dumps(get_features_dict(features))
         self.assertEqual(json_str, self.test_str)

--- a/src/odemis/acq/test/feature_test.py
+++ b/src/odemis/acq/test/feature_test.py
@@ -20,12 +20,12 @@ class TestFeatureEncoderDecoder(unittest.TestCase):
     """
     Test the json encoder and decoder of the CryoFeature class
     """
-    test_str = '{"feature_list": [{"name": "Feature-1", "pos": [0, 0, 0], "status": "Active"}, '+ \
-               '{"name": "Feature-2", "pos": [0.001, 0.001, 0.002], "status": "Active"}]}'
+    test_str = '{"feature_list": [{"name": "Feature-1", "status": "Active", "stage_position": {"x": 0, "y": 0, "z": 0}, "fm_focus_position": {"z": 0}, "posture": "FM"}, '+ \
+               '{"name": "Feature-2", "status": "Active", "stage_position": {"x": 0.001, "y": 0.001, "z": 0.001}, "fm_focus_position": {"z": 0.002}, "posture": "FM"}]}'
 
     def test_feature_encoder(self):
-        feature1 = CryoFeature("Feature-1", 0, 0, 0)
-        feature2 = CryoFeature("Feature-2", 1e-3, 1e-3, 2e-3)
+        feature1 = CryoFeature("Feature-1", stage_position={"x": 0, "y": 0, "z": 0}, fm_focus_position={"z": 0})
+        feature2 = CryoFeature("Feature-2", stage_position={"x": 1e-3, "y": 1e-3, "z": 1e-3}, fm_focus_position={"z": 2e-3})
 
         features = [feature1, feature2]
         json_str = json.dumps(get_features_dict(features))
@@ -33,14 +33,15 @@ class TestFeatureEncoderDecoder(unittest.TestCase):
 
     def test_feature_decoder(self):
         features = json.loads(self.test_str, cls=FeaturesDecoder)
-        self.assertTrue(len(features), 2)
-        self.assertTrue(features[0].name.value, "Feature-1")
-        self.assertTrue(features[0].status.value, "Active")
-        self.assertTrue(features[1].pos.value, (1e-3, 1e-3, 2e-3))
+        self.assertEqual(len(features), 2)
+        self.assertEqual(features[0].name.value, "Feature-1")
+        self.assertEqual(features[0].status.value, "Active")
+        self.assertEqual(features[1].stage_position.value, {"x": 1e-3, "y": 1e-3, "z": 1e-3})
+        self.assertEqual(features[1].fm_focus_position.value, {"z": 2e-3})
 
     def test_save_read_features(self):
-        feature1 = CryoFeature("Feature-1", 0, 0, 0)
-        feature2 = CryoFeature("Feature-2", 1e-3, 1e-3, 2e-3)
+        feature1 = CryoFeature("Feature-1", stage_position={"x": 0, "y": 0, "z": 0}, fm_focus_position={"z": 0})
+        feature2 = CryoFeature("Feature-2", stage_position={"x": 1e-3, "y": 1e-3, "z": 1e-3}, fm_focus_position={"z": 2e-3})
 
         features = [feature1, feature2]
         save_features("", features)

--- a/src/odemis/driver/actuator.py
+++ b/src/odemis/driver/actuator.py
@@ -37,7 +37,7 @@ from odemis import model, util
 from odemis.model import (CancellableThreadPoolExecutor, CancellableFuture,
                           isasync, MD_PIXEL_SIZE_COR, MD_ROTATION_COR, MD_POS_COR, roattribute)
 from odemis.util.transform import RigidTransform
-
+from odemis.acq.move import MicroscopePostureManager, SEM_IMAGING, FM_IMAGING
 
 class MultiplexActuator(model.Actuator):
     """
@@ -3550,3 +3550,160 @@ class LinkedAxesActuator(model.Actuator):
     def reference(self, axes):
         """Reference the linked axes stage"""
         raise NotImplementedError("Referencing is currently not implemented.")
+
+
+
+# "Sample Stage": {
+#     class: actuator.SampleStage,
+#     role: "stage",
+#     dependencies: {
+#         "under": "Stage"
+#     },
+#     affects: ["Camera", "EBeam"],
+#     metadata: {
+#         # Typically, x range is the same as FM_IMAGING_RANGE, and Y has to be converted
+#         POS_ACTIVE_RANGE: {"x": [0.040, 0.054], "y": [-30.e-3, 30.e-3]}  # TODO: migrate this to stage-bare? I think it's only used for tiled acq?
+#     },
+#     init: {},
+# }
+
+class SampleStage(model.Actuator):
+    """
+    Stage wrapper component which converts the stage position to the sample stage position.
+    The sample stage coordinates system is along the sample-plane which is adjusted
+    according to the pre-tilt and other factors.
+    """
+
+    def __init__(self, name, role, dependencies, posture_manager: MicroscopePostureManager, **kwargs):
+        """
+        dependencies (dict str -> actuator): name to objective lens actuator
+        """
+        if len(dependencies) != 1:
+            raise ValueError("SampleStage needs 1 dependency")
+
+        self._dependency = list(dependencies.values())[0]
+
+        model.Actuator.__init__(self, name, role, dependencies=dependencies,
+                                axes=copy.deepcopy(self._dependency.axes), **kwargs)
+
+        # posture manager, to convert the positions
+        # self.pm: MicroscopePostureManager = MicroscopePostureManager(model.getMicroscope())
+        self.pm = posture_manager
+
+        # RO, as to modify it the client must use .moveRel() or .moveAbs()
+        self.position = model.VigilantAttribute({"x": 0, "y": 0, "z": 0, "rx": 0, "rz": 0},
+                                                unit=("m", "m", "m", "rad", "rad"),  readonly=True)
+        # it's just a conversion from the dep's position
+        self._dependency.position.subscribe(self._updatePosition, init=True)
+
+        if model.hasVA(self._dependency, "referenced"):
+            self.referenced = model.VigilantAttribute({}, readonly=True)
+            self._dependency.referenced.subscribe(self._updateReferenced, init=True)
+
+        if model.hasVA(self._dependency, "speed"):
+            speed_axes = set(self._dependency.speed.value.keys())
+            if set(self.axes) <= speed_axes:
+                self.speed = model.VigilantAttribute({}, readonly=True)
+                self._dependency.speed.subscribe(self._updateSpeed, init=True)
+            else:
+                logging.info("Axes %s of dependency are missing from .speed, so not providing it",
+                             set(self.axes) - speed_axes)
+
+        # TODO: correctly modify the reference, speed and axes range attributes
+
+    # def _updateAxesRange(self):
+    #     """
+    #     Calculate the axes range of position VA from the given range of dep's.
+    #     """
+    #     # Calculate rectangular border points on the given range
+    #     min_x, max_x = self.axes["x"].range
+    #     min_y, max_y = self.axes["y"].range
+    #     coordinates = [[min_x, min_y],
+    #                    [min_x, max_y],
+    #                    [max_x, min_y],
+    #                    [max_x, max_y]]
+
+    #     # Calculate range based on the conversion
+    #     new_coordinates = list(map(self._convertPosFromdep, coordinates))
+
+    #     # Update default axes range
+    #     new_range = numpy.array(new_coordinates, dtype=float)
+    #     self.axes["x"].range = (min(new_range[:, 0]), max(new_range[:, 0]))
+    #     self.axes["y"].range = (min(new_range[:, 1]), max(new_range[:, 1]))
+
+    def _updatePosition(self, pos_dep):
+        """
+        update the position VA when the dep's position is updated
+        """
+        # TODO: this should be posture converted to SEM posture
+        # pos_sem = self.pm.to_posture(pos_dep, SEM_IMAGING)
+        # pos = self.pm.to_sample_stage_from_stage_position(pos_sem)
+        # logging.warning(f"Converted position from {pos_dep} to {pos_sem}, Updating SampleStage position to {pos}")
+
+        pos = self.pm.to_sample_stage_from_stage_position(pos_dep)
+        # it's read-only, so we change it via _value
+        self.position._set_value(pos, force_write=True)
+
+        # update related MDs
+        affects = ["ccd", "e-beam"] # roles
+        for a in affects:
+            try:
+                comp = model.getComponent(role=a)
+                if comp:
+                    md_pos = pos.get("x", 0), pos.get("y", 0)
+                    comp.updateMetadata({model.MD_POS: md_pos})
+            except Exception as e:
+                logging.error("Failed to update %s with new position: %s", a, e)
+
+    def _updateSpeed(self, dep_speed):
+        """
+        update the speed VA based on the dependency's speed
+        """
+        # stage_speed = self.pm.to_sample_stage_from_stage_movement(dep_speed)
+        self.speed._set_value(dep_speed, force_write=True)
+
+    def _updateReferenced(self, dep_refd):
+        """
+        update the referenced VA
+        """
+        refd = {
+            ax: dep_refd[ad] for ax, ad in self.axes.items() if ad in dep_refd
+        }
+
+        self.referenced._set_value(refd, force_write=True)
+
+    @isasync
+    def moveRel(self, shift: Dict[str, float], **kwargs):
+        """
+        :param shift: The relative shift to be made
+        :param **kwargs: Mostly there to support "update" argument
+        """
+        # missing values are assumed to be zero
+        shift_stage = self.pm.from_sample_stage_to_stage_movement(shift)
+        logging.debug("converted relative move from %s to %s", shift, shift_stage)
+        return self._dependency.moveRel(shift_stage, **kwargs)
+
+    @isasync
+    def moveAbs(self, pos: Dict[str, float], **kwargs):
+        """
+        :param pos: The absolute position to be moved to
+        :param **kwargs: Mostly there to support "update" argument
+        """
+
+        # if key is missing from pos, fill it with the current position
+        for key in self.axes.keys():
+            if key not in pos:
+                pos[key] = self.position.value[key]
+
+        # pos is a position, so absolute conversion
+        pos_stage = self.pm.from_sample_stage_to_stage_position(pos)
+        logging.debug("converted absolute move from %s to %s", pos, pos_stage)
+        return self._dependency.moveAbs(pos_stage, **kwargs)
+
+    def stop(self, axes=None):
+        self._dependency.stop()
+
+    @isasync
+    def reference(self, axes):
+        dep_axes = {self._axes_dep[a] for a in axes}
+        return self._dependency.reference(dep_axes)

--- a/src/odemis/gui/comp/overlay/cryo_feature.py
+++ b/src/odemis/gui/comp/overlay/cryo_feature.py
@@ -132,7 +132,7 @@ class CryoFeatureOverlay(StagePointSelectOverlay, DragMixin):
                 logging.info("moving to feature {}".format(feature.name.value))
                 # convert from stage position to view position
                 view_pos = self.pm.to_sample_stage_from_stage_position(feature.stage_position.value)
-                self.cnvs.view.moveStageTo(view_pos)
+                self.cnvs.view.moveStageTo((view_pos["x"], view_pos["y"]))
                 self.tab_data.main.currentFeature.value = feature
             else:
                 # Move to selected point (if normally allowed to move)

--- a/src/odemis/gui/comp/overlay/cryo_feature.py
+++ b/src/odemis/gui/comp/overlay/cryo_feature.py
@@ -131,7 +131,7 @@ class CryoFeatureOverlay(StagePointSelectOverlay, DragMixin):
             if feature:
                 logging.info("moving to feature {}".format(feature.name.value))
                 # convert from stage position to view position
-                view_pos = self.pm.from_dependant_position(feature.stage_position.value)
+                view_pos = self.pm.to_sample_stage_from_stage_position(feature.stage_position.value)
                 self.cnvs.view.moveStageTo(view_pos)
                 self.tab_data.main.currentFeature.value = feature
             else:
@@ -207,7 +207,7 @@ class CryoFeatureOverlay(StagePointSelectOverlay, DragMixin):
 
         offset = self.cnvs.get_half_buffer_size()  # to convert physical feature positions to pixels
         for feature in self.tab_data.main.features.value:
-            view_pos = self.pm.from_dependant_position(feature.stage_position.value)
+            view_pos = self.pm.to_sample_stage_from_stage_position(feature.stage_position.value)
             fvsp = self.cnvs.phys_to_view((view_pos["x"], view_pos["y"]), offset)
             if in_radius(fvsp[0], fvsp[1], FEATURE_DIAMETER, v_pos[0], v_pos[1]):
                 return feature
@@ -242,7 +242,7 @@ class CryoFeatureOverlay(StagePointSelectOverlay, DragMixin):
 
         # Show each feature icon and label if applicable
         for feature in self.tab_data.main.features.value:
-            view_pos = self.pm.from_dependant_position(feature.stage_position.value)
+            view_pos = self.pm.to_sample_stage_from_stage_position(feature.stage_position.value)
             half_size_offset = self.cnvs.get_half_buffer_size()
 
             # convert physical position to buffer 'world' coordinates
@@ -278,5 +278,5 @@ class CryoFeatureOverlay(StagePointSelectOverlay, DragMixin):
             "y": p_pos[1],
             "z": self.tab_data.main.stage.position.value["z"],  #NOTE: we cannot use cnvs.view._stage, because the acquired cnvs does not have a _stage....? why?
         }
-        pos = self.pm.to_dependant_position(new_pos)
+        pos = self.pm.from_sample_stage_to_stage_position(new_pos)
         return pos

--- a/src/odemis/gui/cont/acquisition/cryo_acq.py
+++ b/src/odemis/gui/cont/acquisition/cryo_acq.py
@@ -298,7 +298,7 @@ class CryoAcquiController(object):
                        "zstep": self._tab_data.zStep.value}
 
         filename = self._filename.value
-        stage = self._tab_data.main.stage
+        stage = self._tab_data.main.stage_bare
         focus = self._tab_data.main.focus
         features = self._tab_data.main.features.value
 

--- a/src/odemis/gui/cont/acquisition/cryo_z_localization.py
+++ b/src/odemis/gui/cont/acquisition/cryo_z_localization.py
@@ -198,7 +198,7 @@ class CryoZLocalizationController(object):
         feature = self._tab_data.main.currentFeature.value
         if feature is None:
             raise ValueError("Select a feature first to specify the Z localization in X/Y")
-        pos = self._tab_data.main.posture_manager.from_dependant_position(feature.stage_position.value)
+        pos = self._tab_data.main.posture_manager.to_sample_stage_from_stage_position(feature.stage_position.value)
 
         # Disable the GUI and show the progress bar
         self._tab.streambar_controller.pauseStreams()

--- a/src/odemis/gui/cont/acquisition/cryo_z_localization.py
+++ b/src/odemis/gui/cont/acquisition/cryo_z_localization.py
@@ -198,7 +198,7 @@ class CryoZLocalizationController(object):
         feature = self._tab_data.main.currentFeature.value
         if feature is None:
             raise ValueError("Select a feature first to specify the Z localization in X/Y")
-        pos = feature.pos.value[:2]
+        pos = self._tab_data.main.posture_manager.from_dependant_position(feature.stage_position.value)
 
         # Disable the GUI and show the progress bar
         self._tab.streambar_controller.pauseStreams()
@@ -217,7 +217,7 @@ class CryoZLocalizationController(object):
         # The angles of stigmatorAngle should come from MD_CALIB, so it's relatively safe
         angle = self._tab_data.stigmatorAngle.value
 
-        self._acq_future = z_localization.measure_z(self._stigmator, angle, pos, s, logpath=fn)
+        self._acq_future = z_localization.measure_z(self._stigmator, angle, (pos["x"], pos["y"]), s, logpath=fn)
         self._panel.btn_z_localization.SetLabel("Cancel")
 
         self._acq_future_connector = ProgressiveFutureConnector(self._acq_future,
@@ -248,8 +248,7 @@ class CryoZLocalizationController(object):
 
             # Update the feature Z pos, and move there
             feature = self._tab_data.main.currentFeature.value
-            pos = feature.pos.value[:2]
-            feature.pos.value = pos + (zpos,)
+            feature.fm_focus_position.value = {"z": zpos}
             if warning:
                 # Update the Z pos, but do not move there.
                 logging.warning("Z pos shift detected of %s, but not going there as it had warning %s", zshift, warning)

--- a/src/odemis/gui/cont/tabs/cryo_chamber_tab.py
+++ b/src/odemis/gui/cont/tabs/cryo_chamber_tab.py
@@ -95,10 +95,10 @@ class CryoChamberTab(Tab):
         # via a dialog, until a project is created or loaded.
         self._is_initial_project_ready: bool = False
 
-        self._cancel = False
+        self._move_cancelled = False
 
-        self._current_position = UNKNOWN  # position of the sample (regularly updated)
-        self._target_position = None  # when moving, move POSITION to be reached, otherwise None
+        self._current_posture = UNKNOWN  # position of the sample (regularly updated)
+        self._target_posture = None  # when moving, move POSITION to be reached, otherwise None
 
         if self._role == 'enzel':
             # get the stage and its meta data
@@ -201,7 +201,7 @@ class CryoChamberTab(Tab):
 
         # Show current position of the stage via the progress bar
         self._stage.position.subscribe(self._update_progress_bar, init=False)
-        self._stage.position.subscribe(self._on_stage_pos, init=True)
+        self.posture_manager.current_posture.subscribe(self._on_posture, init=True)
         self._show_warning_msg(None)
 
         # Show temperature control, if available
@@ -490,21 +490,12 @@ class CryoChamberTab(Tab):
         self.panel.gauge_move.Refresh()
 
     @call_in_wx_main
-    def _on_stage_pos(self, pos):
-        """ Called every time the stage moves, to update the state of the chamber tab buttons. """
-        # Don't update the buttons while the stage is going to a new position
-        if not self._move_future.done():
-            return
-
-        self._update_movement_controls()
-
-    def _control_warning_msg(self):
+    def _control_warning_msg(self, posture: int):
         # show/hide the warning msg
-        current_pos_label = self.posture_manager.getCurrentPostureLabel()
-        if self._cancel:
+        if self._move_cancelled:
             txt_msg = self._get_cancel_warning_msg()
             self._show_warning_msg(txt_msg)
-        elif current_pos_label == UNKNOWN:
+        elif posture == UNKNOWN and self._move_future.done(): # unknown position and not moving
             txt_warning = "To enable buttons, please move away from unknown position."
             self._show_warning_msg(txt_warning)
         else:
@@ -517,9 +508,9 @@ class CryoChamberTab(Tab):
         return (str): the cancel message. It returns None if the target position is None.
         """
         # Show warning message if target position is indicated
-        if self._target_position is not None:
-            current_label = POSITION_NAMES[self._current_position]
-            target_label = POSITION_NAMES[self._target_position]
+        if self._target_posture is not None:
+            current_label = POSITION_NAMES[self._current_posture]
+            target_label = POSITION_NAMES[self._target_posture]
             return "Stage stopped between {} and {} positions".format(
                 current_label, target_label
             )
@@ -559,30 +550,30 @@ class CryoChamberTab(Tab):
         Enable/disable chamber move controls (position and stage) based on current move
         """
         # Get current movement (including unknown and on the path)
-        self._current_position = self.posture_manager.getCurrentPostureLabel()
-        self._enable_position_controls(self._current_position)
+        self._current_posture = self.posture_manager.current_posture.value
+        self._enable_position_controls(self._current_posture)
         if self._role == 'enzel':
             # Enable stage advanced controls on sem imaging
-            self._enable_advanced_controls(self._current_position == SEM_IMAGING)
-        elif self._role == 'meteor':
-            self._control_warning_msg()
+            self._enable_advanced_controls(self._current_posture == SEM_IMAGING)
+        elif self._role == "meteor":
+            self._control_warning_msg(self._current_posture)
         elif self._role == 'mimas':
             pass
 
-    def _enable_position_controls(self, current_position):
+    def _enable_position_controls(self, current_posture: int):
         """
         Enable/disable switching position button based on current move
-        current_position (acq.move constant): as reported by getCurrentPositionLabel()
+        current_posture (acq.move constant): as reported by getCurrentPositionLabel()
         """
         if self._role == 'enzel':
             # Define which button to disable in respect to the current move
             disable_buttons = {LOADING: (), THREE_BEAMS: (), ALIGNMENT: (), COATING: (),
                                SEM_IMAGING: (), LOADING_PATH: (ALIGNMENT, COATING, SEM_IMAGING)}
             for movement, button in self.position_btns.items():
-                if current_position == UNKNOWN:
+                if current_posture == UNKNOWN:
                     # If at unknown position, only allow going to LOADING position
                     button.Enable(movement == LOADING)
-                elif movement in disable_buttons[current_position]:
+                elif movement in disable_buttons[current_posture]:
                     button.Disable()
                 else:
                     button.Enable()
@@ -591,8 +582,8 @@ class CryoChamberTab(Tab):
             # How can this help the user?
 
             # The move button should turn green only if current move is known and not cancelled
-            if current_position in self.position_btns and not self._cancel:
-                btn = self.position_btns[current_position]
+            if current_posture in self.position_btns and not self._move_cancelled:
+                btn = self.position_btns[current_posture]
                 # btn.icon_on = img.getBitmap(self.btn_toggle_icons[btn][1])
                 btn.SetValue(2)  # Complete
                 self._toggle_switch_buttons(btn)
@@ -602,17 +593,17 @@ class CryoChamberTab(Tab):
         elif self._role == 'meteor':
             # enabling/disabling meteor buttons
             for button in self.position_btns.values():
-                button.Enable(current_position != UNKNOWN)
+                button.Enable(current_posture != UNKNOWN)
 
             # turn on (green) the current position button green
-            btn = self.position_btns.get(current_position)
+            btn = self.position_btns.get(current_posture)
             self._toggle_switch_buttons(btn)
 
             # It's a common mistake that the stage.POS_ACTIVE_RANGE is incorrect.
             # If so, the sample moving will be very odd, as the move is clipped to
             # the range. So as soon as we reach FM_IMAGING, we check that at the
             # current position is within range, if not, most likely that range is wrong.
-            if current_position == FM_IMAGING:
+            if current_posture == FM_IMAGING:
                 imaging_stage = self.tab_data_model.main.stage
                 stage_pos = imaging_stage.position.value
                 imaging_rng = imaging_stage.getMetadata().get(model.MD_POS_ACTIVE_RANGE, {})
@@ -631,14 +622,14 @@ class CryoChamberTab(Tab):
         elif self._role == 'mimas':
             # enabling/disabling mimas buttons
             for movement, button in self.position_btns.items():
-                if current_position == UNKNOWN:
+                if current_posture == UNKNOWN:
                     # If at unknown position, only allow going to LOADING position
                     button.Enable(movement == LOADING)
                 else:
                     button.Enable(True)
 
             # turn on (green) the current position button green
-            btn = self.position_btns.get(current_position)
+            btn = self.position_btns.get(current_posture)
             self._toggle_switch_buttons(btn)
 
     def _enable_advanced_controls(self, enable=True):
@@ -710,7 +701,7 @@ class CryoChamberTab(Tab):
         """
         Event handling for the position panel buttons
         """
-        self._cancel = False
+        self._move_cancelled = False
         target_button = evt.theButton
         move_future = self._perform_switch_position_movement(target_button)
         if move_future is None:
@@ -759,7 +750,7 @@ class CryoChamberTab(Tab):
 
         # After the movement is done, set start, end and target position to None
         # That way any stage moves from outside the chamber tab are not considered
-        self._target_position = None
+        self._target_posture = None
         self._start_pos = None
         self._end_pos = None
 
@@ -770,7 +761,7 @@ class CryoChamberTab(Tab):
         # Cancel the running move
         self._move_future.cancel()
         self.panel.btn_cancel.Disable()
-        self._cancel = True
+        self._move_cancelled = True
         self._update_movement_controls()
         logging.info("Stage move cancelled.")
 
@@ -785,17 +776,17 @@ class CryoChamberTab(Tab):
             return
 
         # Get the required target_position from the pressed button
-        self._target_position = next((m for m in self.position_btns.keys() if target_button == self.position_btns[m]),
+        self._target_posture = next((m for m in self.position_btns.keys() if target_button == self.position_btns[m]),
                                      None)
-        if self._target_position is None:
+        if self._target_posture is None:
             logging.error("Unknown target button: %s", target_button)
             return None
 
         # define the start position
         self._start_pos = self._stage.position.value
-        current_posture = self.posture_manager.getCurrentPostureLabel()
+        current_posture = self.posture_manager.current_posture.value
         # determine the end position for the gauge
-        end_pos = self.posture_manager.getTargetPosition(self._target_position)
+        end_pos = self.posture_manager.getTargetPosition(self._target_posture)
 
         if self._role == 'enzel':
             if (
@@ -806,14 +797,18 @@ class CryoChamberTab(Tab):
 
         elif self._role == 'meteor':
             if (
-                self._target_position in [FM_IMAGING, SEM_IMAGING]
+                self._target_posture in [FM_IMAGING, SEM_IMAGING]
                 and current_posture in [LOADING, SEM_IMAGING, FM_IMAGING]
                 and not self._display_meteor_pos_warning_msg(end_pos)
             ):
                 return None
 
         self._end_pos = end_pos
-        return self.posture_manager.cryoSwitchSamplePosition(self._target_position)
+        return self.posture_manager.cryoSwitchSamplePosition(self._target_posture)
+
+    def _on_posture(self, posture: int) -> None:
+        logging.info(f"Stage posture changed to {POSITION_NAMES[posture]}")
+        self._update_movement_controls()
 
     def _display_insertion_stick_warning_msg(self) -> bool:
         box = wx.MessageDialog(self.main_frame, "The sample will be loaded. Please make sure that the sample is properly set and the insertion stick is removed.",
@@ -969,9 +964,9 @@ class CryoChamberTab(Tab):
         Called to perform action prior to terminating the tab
         :return: (bool) True to proceed with termination, False for canceling
         """
-        if self._current_position is LOADING:
+        if self._current_posture is LOADING:
             return True
-        if self._move_future.running() and self._target_position is LOADING:
+        if self._move_future.running() and self._target_posture is LOADING:
             return self._confirm_terminate_dialog(
                 "The sample is still moving to the loading position, are you sure you want to close Odemis?"
             )

--- a/src/odemis/gui/model/main_gui_data.py
+++ b/src/odemis/gui/model/main_gui_data.py
@@ -314,6 +314,10 @@ class MainGUIData(object):
             elif self.role == "mbsem":
                 required_roles += ["e-beam", "stage"]
 
+            if microscope.name == "METEOR TFSv2" and self.role == "meteor":
+                # remove stage from required roles for METEOR TFSv2
+                required_roles.remove("stage")
+
             for crole in required_roles:
                 attrname = self._ROLE_TO_ATTR[crole]
                 if getattr(self, attrname) is None:
@@ -508,6 +512,8 @@ class CryoMainGUIData(MainGUIData):
 
         # Controls the stage movement based on the imaging mode
         self.posture_manager = MicroscopePostureManager(microscope)
+        if self.role == "meteor":
+            self.stage = self.posture_manager.sample_stage
 
         # stage.MD_SAMPLE_CENTERS contains the date in almost the right format, but the
         # position is a dict instead of a tuple. => Convert it, while checking the data.
@@ -536,6 +542,9 @@ class CryoMainGUIData(MainGUIData):
         self.sample_radius = self.SAMPLE_RADIUS_TEM_GRID
         # Bounding-box of the "useful area" relative to the center of a grid
         self.sample_rel_bbox = self.SAMPLE_USABLE_BBOX_TEM_GRID
+
+
+
 
 
 class ScintillatorShape(metaclass=ABCMeta):

--- a/src/odemis/gui/model/stream_view.py
+++ b/src/odemis/gui/model/stream_view.py
@@ -441,7 +441,10 @@ class StreamView(View):
         if not self._stage:
             return None
 
-        move = self.clipToStageLimits({"x": pos[0], "y": pos[1]})
+        if isinstance(pos, dict):
+            pos = (pos["x"], pos["y"]) # tmp compatibility with old code
+        if isinstance(pos, tuple):
+            move = self.clipToStageLimits({"x": pos[0], "y": pos[1]})
 
         logging.debug("Requesting stage to move to %s mm in x direction and %s mm in y direction",
                       move["x"] * 1e3, move["y"] * 1e3)
@@ -732,6 +735,8 @@ class FeatureOverviewView(FeatureView):
         self.show_crosshair.value = False
         self.mpp.value = 10e-6
         self.mpp.range = (1e-10, 1)
+
+        # add stage-bare, convert-stage here, so we can convert the stage coordinates?
 
     def _on_stage_pos(self, pos):
         # we DON'T want to recenter the viewports whenever the stage moves

--- a/src/odemis/gui/model/stream_view.py
+++ b/src/odemis/gui/model/stream_view.py
@@ -25,6 +25,7 @@ import math
 import queue
 import threading
 import time
+from typing import Tuple
 
 from odemis import model
 from odemis.acq.stream import DataProjection, RGBSpatialProjection, Stream, StreamTree
@@ -431,7 +432,7 @@ class StreamView(View):
         shift = (view_pos[0] - prev_pos["x"], view_pos[1] - prev_pos["y"])
         return self.moveStageBy(shift)
 
-    def moveStageTo(self, pos):
+    def moveStageTo(self, pos: Tuple[float, float]):
         """
         Request an absolute move of the stage to a given position
 
@@ -441,8 +442,6 @@ class StreamView(View):
         if not self._stage:
             return None
 
-        if isinstance(pos, dict):
-            pos = (pos["x"], pos["y"]) # tmp compatibility with old code
         if isinstance(pos, tuple):
             move = self.clipToStageLimits({"x": pos[0], "y": pos[1]})
 

--- a/src/odemis/gui/model/tab_gui_data.py
+++ b/src/odemis/gui/model/tab_gui_data.py
@@ -273,7 +273,7 @@ class CryoGUIData(MicroscopyGUIData):
 
         def dist_to_pos(feature):
             pm = self.main.posture_manager
-            pos = pm.from_dependant_position(feature.stage_position.value)
+            pos = pm.to_sample_stage_from_stage_position(feature.stage_position.value)
             return math.hypot(pos["x"] - current_position["x"],
                               pos["y"] - current_position["y"])
 

--- a/src/odemis/gui/test/comp_overlay_test.py
+++ b/src/odemis/gui/test/comp_overlay_test.py
@@ -503,8 +503,8 @@ class OverlayTestCase(test.GuiTestCase):
         cryofeature_overlay.active.value = True
 
         # Add features to the tab's features list
-        tab_mod.add_new_feature(0, 0)
-        tab_mod.add_new_feature(0.001, 0.001)
+        tab_mod.add_new_feature(stage_position={"x": 0, "y": 0, "z": 0}, fm_focus_position={"z": 0})
+        tab_mod.add_new_feature(stage_position={"x":0.001, "y":0.001, "z":0.001}, fm_focus_position={"z": 0.001})
         # Execute the gui loop, so that the buffer contains the features
         test.gui_loop(0.1)
         cnvs._dc_buffer.SelectObject(wx.NullBitmap)  # Flush the buffer

--- a/src/odemis/gui/win/acquisition.py
+++ b/src/odemis/gui/win/acquisition.py
@@ -821,9 +821,10 @@ class OverviewAcquisitionDialog(xrcfr_overview_acq):
                 "y": self.stage.axes["y"].range
             }
 
-            stage_md = self.stage.getMetadata()
-            if imaging_range in stage_md:
-                self._tiling_rng.update(stage_md[imaging_range])
+            # tmp disable until consolidate to sem posture range
+            # stage_md = self.stage.getMetadata()
+            # if imaging_range in stage_md:
+                # self._tiling_rng.update(stage_md[imaging_range])
         except (KeyError, IndexError):
             raise ValueError(f"Failed to find stage {imaging_range} with x and y range")
 

--- a/src/odemis/model/_metadata.py
+++ b/src/odemis/model/_metadata.py
@@ -228,6 +228,8 @@ MD_SEM_IMAGING_RANGE = "SEM imaging range"  # dict str → [float, float] defini
 MD_FM_IMAGING_RANGE = "FM imaging range"  # dict str → [float, float] defining the volume of the FM imaging area, along x, y and z axes.
 MD_FAV_FM_POS_ACTIVE = "Favourite FM position active"  # dict str->float representing the position required for FM imaging
 MD_FAV_SEM_POS_ACTIVE = "Favourite SEM position active"  # dict -> float representing the position required for SEM imaging
+MD_FAV_FIB_POS_ACTIVE = "Favourite FIB position active"  # dict -> float representing the position required for FIB imaging
+MD_FAV_MILL_POS_ACTIVE = "Favourite Milling position active"  # dict -> float representing the position required for milling
 
 # The following metadata is used to store the destination components of the
 # specific known positions for the actuators.

--- a/src/odemis/odemisd/mdupdater.py
+++ b/src/odemis/odemisd/mdupdater.py
@@ -148,6 +148,7 @@ class MetadataUpdater(model.Component):
         return bool: True if will actually update the affected component,
                      False if the affect is not supported (here)
         """
+        # TODO: write a special updater for the posture adjusted position
 
         # we need to keep the information on the detector to update
         def updateStagePos(pos, comp_affected=comp_affected):


### PR DESCRIPTION

Previously for meteor, the stage position and focus position were stored as a single 3D tuple (stage_x, stage_y, focus_z)
This behaviour was different on enzel, where the pos was (stage_x, stage_y, stage_z). 

This difference in behaviour was confusing, and the meteor position lacked information required to transform stage positions (stage_z). 

This refactor separates the stage position and focus position explicitly, and stores them as dictionaries to match the underlying hw components more closely (e.g. stage.position). We should also store a coordinate system for the stage to retain which stage's coordinate it is (stage-fm, stage-bare)