### PR TITLE
[fix] kymera exchange turret used wrong component to close the shutter

### DIFF
--- a/util/kymera-exchange-turret.sh
+++ b/util/kymera-exchange-turret.sh
@@ -30,7 +30,7 @@ status=$?
 if [ $status = 0 ] || [ $status = 3 ] ; then  # Running or starting
     select_args="--role $role"
     # For safety, close the shutter of the streak cam (in case it's not already closed)
-    odemis --set-attr streak-ccd shutter True  # FIXME, check
+    odemis --set-attr streak-unit shutter True
 else
     select_args="--serial $serial_num"
 fi


### PR DESCRIPTION
The shutter is on the streak unit, not the streak ccd.