### PR TITLE
[METEOR-1204][FEAT] Add stage coordinate system conversion for Meteor

### DIFF
--- a/src/odemis/acq/move.py
+++ b/src/odemis/acq/move.py
@@ -264,6 +264,7 @@ class MeteorPostureManager(MicroscopePostureManager):
         # Load components
         self.stage = model.getComponent(role='stage-bare')
         self.focus = model.getComponent(role='focus')
+        self.convert_stage = model.getComponent(name="Linked YZ")
         # set linear axes and rotational axes used
         self.axes = self.stage.axes
         self.linear_axes = set(key for key in self.axes.keys() if key in {'x', 'y', 'z', 'm'})
@@ -333,6 +334,13 @@ class MeteorPostureManager(MicroscopePostureManager):
         """
         pass
 
+    def transform_stage_position_to_bare(self, pos: Dict[str, float]) -> Dict[str, float]:
+        """Transform a stage (fm) position to the stage bare position"""
+        return self.convert_stage.to_dependent_position(pos)
+
+    def transform_stage_position_from_bare(self, pos: Dict[str, float]) -> Dict[str, float]:
+        """Transform a stage bare position to the stage (fm) position"""
+        return self.convert_stage.from_dependent_position(pos)
 
 class MeteorTFS1PostureManager(MeteorPostureManager):
     def __init__(self, microscope):

--- a/src/odemis/driver/actuator.py
+++ b/src/odemis/driver/actuator.py
@@ -773,6 +773,29 @@ class ConvertStage(model.Actuator):
         vpos_dep = self._convertPosTodep(vpos, absolute=absolute)
         return {self._axes_dep["x"]: vpos_dep[0], self._axes_dep["y"]: vpos_dep[1]}
 
+    def to_dependant_position(self, pos: Dict[str, float]) -> Dict[str, float]:
+        """Convert position dict from original axes to dependant axes with all axis values
+        :param pos: position dict with all axis values (x, y) in the original axes
+        :return: position dict with all axis values (x, y) in the dependant axes
+        """
+        vpos = self._get_pos_vector(pos, absolute=True)
+        # remap vpos x, y -> stage y, z
+        vpos = {"x": pos["x"], "y": vpos["y"], "z": vpos["z"]} # stage-fm
+
+        return vpos
+
+    def from_dependent_position(self, pos: Dict[str, float]) -> Dict[str, float]:
+        """Convert position dict from dependant axes to original axes with all axis values
+        :param pos: position dict with all axis values (x, y, z) in the dependent axes
+        :return: position dict with all axis values (x, y, z) in the original axes
+        """
+        # Convert position dict from dependant axes to original axes
+        vpos = self._convertPosFromdep([pos[self._axes_dep["x"]], pos[self._axes_dep["y"]]])
+        # remap vpos x, y -> stage y, z
+        vpos = {"x": pos["x"], "y": vpos[0], "z": vpos[1]}
+
+        return vpos
+
     @isasync
     def moveRel(self, shift, **kwargs):
         """


### PR DESCRIPTION
Currently there is no convenient way to transform a stage position from stage-bare to stage-fm and vice-versa. The current method required getting the linked YZ stage from the backend, and remapping the coordinates manually.

This PR adds some helper functions to the convert stage, and posture manager to simplify converting between these coordinate systems.