### PR TITLE
[DRAFT][METEOR-1203][FEAT] Import feature positions from autolamella

### DIFF
--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -228,6 +228,7 @@ class xrcfr_main(wx.Frame):
         self.menu_item_devmanual = self.GetMenuBar().FindItemById(xrc.XRCID("menu_item_devmanual"))
         self.menu_item_inspect = self.GetMenuBar().FindItemById(xrc.XRCID("menu_item_inspect"))
         self.menu_item_debug = self.GetMenuBar().FindItemById(xrc.XRCID("menu_item_debug"))
+        self.menu_item_import_from_autolamella = self.GetMenuBar().FindItemById(xrc.XRCID("menu_item_import_from_autolamella"))
         self.menu_item_bugreport = self.GetMenuBar().FindItemById(xrc.XRCID("menu_item_bugreport"))
         self.menu_item_update = self.GetMenuBar().FindItemById(xrc.XRCID("menu_item_update"))
         self.menu_item_about = self.GetMenuBar().FindItemById(xrc.XRCID("menu_item_about"))
@@ -2528,6 +2529,13 @@ b\xeb\x85\x9f\xb6B\x1d\x0cK\x17\xac\xf0\x12\xfe\xa0\xe5\xee\xe03\xb1\xfa\
             <label>Show log panel</label>
             <accel>Ctrl+D</accel>
             <checkable>1</checkable>
+            <XRCED>
+              <assign_var>1</assign_var>
+            </XRCED>
+          </object>
+            <object class="wxMenuItem" name="menu_item_import_from_autolamella">
+            <label>Import Features from AutoLamella</label>
+            <enabled>0</enabled>
             <XRCED>
               <assign_var>1</assign_var>
             </XRCED>

--- a/src/odemis/gui/win/acquisition.py
+++ b/src/odemis/gui/win/acquisition.py
@@ -27,7 +27,7 @@ import math
 import os.path
 from builtins import str
 from concurrent.futures._base import CancelledError
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 
 import odemis.gui.model as guimodel
 import wx
@@ -1390,15 +1390,16 @@ def ShowChamberFileDialog(parent, projectname):
     fn = dialog.GetFilename()
     return os.path.join(path, fn)
 
-def LoadProjectFileDialog(parent, projectname):
+def LoadProjectFileDialog(parent: wx.Frame, projectname: str, message: str = "Choose a project directory to load") -> Optional[str]:
     """
-    parent (wxframe): parent window
-    projectname (string): project name to propose by default
-    return (string or none): the project directory name to load (or the none if the user cancelled)
+    :param parent (wx.Frame): parent window
+    :param projectname (string): project name to propose by default
+    :param message (string): message to display in the dialog
+    :return (string or none): the project directory name to load (or the none if the user cancelled)
     """
     # current project name
     dialog = wx.DirDialog(parent,
-                           message="Choose a project directory to load",
+                           message=message,
                            defaultPath=projectname,
                            style=wx.DD_DEFAULT_STYLE | wx.DD_DIR_MUST_EXIST,
                            )

--- a/src/odemis/gui/xmlh/resources/frame_main.xrc
+++ b/src/odemis/gui/xmlh/resources/frame_main.xrc
@@ -183,6 +183,13 @@
               <assign_var>1</assign_var>
             </XRCED>
           </object>
+            <object class="wxMenuItem" name="menu_item_import_from_autolamella">
+            <label>Import Features from AutoLamella</label>
+            <enabled>0</enabled>
+            <XRCED>
+              <assign_var>1</assign_var>
+            </XRCED>
+          </object>
         </object>
         <object class="wxMenuItem" name="menu_item_bugreport">
           <label>Report a problem...</label>


### PR DESCRIPTION
Users have requested the ability to import feature positions from external software (autolamella and tfs maps), rather than having to select these coordinates on the fm overview themselves. In both cases, features are selected from the SEM overview, and need to be transformed into the stage-fm coordinate system (and position).

This PR adds the option to import feature positions from autolamella (stage-bare raw coordinates) and have the positions converted to the corresponding FM position as features.

The following PRs are related, but general functionality for this:
(https://github.com/delmic/odemis/pull/2875
https://github.com/delmic/odemis/pull/2874


Before merging, this PR will need to be updated to account for the difference between the raw-raw coordiantes system and the raw-offset-to-look-like-tfs-software coordinate system in [METEOR-590](https://github.com/delmic/odemis/pull/2751)

[METEOR-590]: https://delmic.atlassian.net/browse/METEOR-590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ