### PR TITLE
[fix] driver smaract: don't wait twice in a row for end of the move after referencing

### DIFF
--- a/src/odemis/driver/smaract.py
+++ b/src/odemis/driver/smaract.py
@@ -3676,7 +3676,7 @@ class MCS2(model.Actuator):
                         self._checkMoveAbs(deactive_pos)
                         self._doMoveAbs(future, self._applyInversion(deactive_pos))
 
-                self._waitEndMove(future, moving_channels, time.time() + 100)
+                    self._waitEndMove(future, moving_channels, time.time() + 100)
 
             except CancelledError:
                 # FIXME: if the referencing is stopped, the device refuses to


### PR DESCRIPTION
The MCS2 driver has a special option to move to a fixed position after
referencing. An indentation error caused the wait for end of that move to be
called even if the move wasn't done.

It didn't have much effect, just slowing down the referencing procedure
by a few milliseconds, and making the log quite confusing because it
seemed a second "ghost move" was done after referencing.