### PR TITLE
[feat] small improvements to the SPARC abritrary scan order plugin

### DIFF
--- a/plugins/spectrum_arbscor.py
+++ b/plugins/spectrum_arbscor.py
@@ -22,18 +22,115 @@ You should have received a copy of the GNU General Public License along with Ode
 see http://www.gnu.org/licenses/.
 """
 import functools
+import inspect
 import logging
+from collections import OrderedDict
 from typing import Tuple, List
 
 import numpy
 
+import odemis
+from odemis import model
 from odemis.acq.stream import SEMSpectrumMDStream, SpectrumSettingsStream
+from odemis.gui.conf import data, util
 from odemis.gui.conf.data import get_local_vas
 from odemis.gui.plugin import Plugin
+
 
 # This plugin provides a new type of SpectrumStream. The implementation actually uses the
 # standard SpectrumSettingsStream, and only needs to provide a dedicated MDStream that overrides
 # the standard SEMSpectrumMDStream. It changes the e-beam position for each pixel.
+
+
+# Special functions to define the scan strategies: their name *must start with "scan_order_"*
+# The first line of the docstring will be the name as show in the GUI.
+
+def scan_order_checkerboard(rep: Tuple[int, int]) -> List[Tuple[int, int]]:
+    """
+    Checkerboard
+    First scan every odd pixel, and then every even pixel. Like first scanning the white
+    squares of a checkerboard, and then the black squares.
+    Example:
+    192.3.4.
+    .5.6.7.8
+    See _get_scan_order() for the parameter documentation
+    """
+    order = []
+    # Add odd pixels
+    for j in range(rep[1]):  # Y slow
+        for i in range(rep[0]):  # X fast
+            if (i + j) % 2 == 0:
+                order.append((i, j))
+
+    # Add even pixels
+    for j in range(rep[1]):
+        for i in range(rep[0]):
+            if (i + j) % 2 == 1:
+                order.append((i, j))
+
+    return order
+
+
+def scan_order_3x3(rep: Tuple[int, int]) -> List[Tuple[int, int]]:
+    """
+    3x3
+    Scan every 3 pixels, and then restart, but from a shift in the 3x3 initial point:
+    Example:
+    15926.
+    ......
+    ......
+    37.48.
+    See _get_scan_order() for the parameter documentation
+    """
+    return _scan_order_mxn(rep, (3, 3))
+
+
+def scan_order_4x4(rep: Tuple[int, int]) -> List[Tuple[int, int]]:
+    """
+    4x4
+    """
+    return _scan_order_mxn(rep, (4, 4))
+
+def _scan_order_mxn(rep: Tuple[int, int], skip: Tuple[int, int]) -> List[Tuple[int, int]]:
+    """
+    Scan every MxN pixels, and then restart, but from the next point (+1 in X, then +1 in Y)
+    in the MxN initial area.
+    skip: Tuple of 2 integers, the number of pixels to skip in X and Y between each point
+    See _get_scan_order() for the "rep" parameter documentation
+    """
+    order = []
+    # 3x3 base
+    for y_base in range(skip[1]):
+        for x_base in range(skip[0]):
+            # Every 3rd pixel (within the repetition)
+            for j in range(y_base, rep[1], skip[1]):  # Y slow
+                for i in range(x_base, rep[0], skip[0]):  # X fast
+                    order.append((i, j))
+
+    return order
+
+
+def _find_scan_order_strategies():
+    """
+    Find all functions that start with "scan_order_" and return them as a dictionary
+    """
+    strategies = {}
+    for name, func in globals().items():
+        if name.startswith("scan_order_") and callable(func):
+            # Name is the first line of the docstring
+            docstring = inspect.cleandoc(func.__doc__)
+            friendly_name = docstring.split("\n")[0].strip()
+            strategies[friendly_name] = func
+    return strategies
+
+
+class SpectrumArbitraryOrderSettingsStream(SpectrumSettingsStream):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._scan_strategies = _find_scan_order_strategies()
+        default_strategy = sorted(self._scan_strategies.keys())[0]
+        self.scanStrategy = model.VAEnumerated(default_strategy, choices=self._scan_strategies.keys())
 
 
 class SEMSpectrumArbitraryOrderMDStream(SEMSpectrumMDStream):
@@ -45,61 +142,15 @@ class SEMSpectrumArbitraryOrderMDStream(SEMSpectrumMDStream):
     call a different function that one of the two examples).
     """
 
-    def _checkerboard_scan_order(self, rep: Tuple[int, int]) -> List[Tuple[int, int]]:
-        """
-        First scan every odd pixel, and then every even pixel. Like first scanning the white
-        squares of a checkerboard, and then the black squares.
-        Example:
-        192.3.4.
-        .5.6.7.8
-        See _get_scan_order() for the parameter documentation
-        """
-        order = []
-        # Add odd pixels
-        for j in range(rep[1]):  # Y slow
-            for i in range(rep[0]):  # X fast
-                if (i + j) % 2 == 0:
-                    order.append((i, j))
-
-        # Add even pixels
-        for j in range(rep[1]):
-            for i in range(rep[0]):
-                if (i + j) % 2 == 1:
-                    order.append((i, j))
-
-        return order
-
-    def _3x3_scan_order(self, rep: Tuple[int, int]) -> List[Tuple[int, int]]:
-        """
-        Scan every 3 pixels, and then restart, but from a shift in the 3x3 initial point:
-        Example:
-        15926.
-        ......
-        ......
-        37.48.
-        See _get_scan_order() for the parameter documentation
-        """
-        order = []
-        # 3x3 base
-        for y_base in range(3):
-            for x_base in range(3):
-                # Every 3rd pixel (within the repetition)
-                for j in range(y_base, rep[1], 3):  # Y slow
-                    for i in range(x_base, rep[0], 3):  # X fast
-                        order.append((i, j))
-
-        return order
-
     def _get_scan_order(self, rep: Tuple[int, int]) -> List[Tuple[int, int]]:
         """
         Computes the arbitrary scan order
         :param rep: x,y number of pixels to scan
         :return: list of positions (x, y) as indices to scan, in the scan order
         """
-        # Modify this function to call whichever function computes the scan order of your liking
-
-        # return self._checkerboard_scan_order(rep)
-        return self._3x3_scan_order(rep)
+        strategy = self._sccd.scanStrategy.value
+        strategy_func = self._sccd._scan_strategies[strategy]
+        return strategy_func(rep)
 
     def _getSpotPositions(self):
         """
@@ -183,6 +234,30 @@ class SpectrumArbitraryScanOrderPlugin(Plugin):
             act = functools.partial(self.add_stream, name=actname, detector=sptm)
             stctrl.add_action(actname, act)
 
+        # We "patch" the gui.conf.data for our special stream
+        data.STREAM_SETTINGS_CONFIG[SpectrumArbitraryOrderSettingsStream] = (
+            OrderedDict((
+                ("scanStrategy", {
+                    "label": "Scan strategy",
+                    "tooltip": "Select the scan strategy to use",
+                }),
+                ("wavelength", {
+                    "tooltip": "Center wavelength of the spectrograph",
+                    "control_type": odemis.gui.CONTROL_FLT,
+                    "range": (0.0, 1900e-9),
+                    "key_step_min": 1e-9,
+                }),
+                ("grating", {}),
+                ("slit-in", {
+                    "label": "Input slit",
+                    "tooltip": "Opening size of the spectrograph input slit.\nA wide opening means more light and a worse resolution.",
+                }),
+                ("filter", {  # from filter
+                    "choices": util.format_band_choices,
+                }),
+            ))
+        )
+
     def add_stream(self, name: str, detector: "Detector"):
         """
         Create a new spectrum stream and MDStream.
@@ -211,7 +286,7 @@ class SpectrumArbitraryScanOrderPlugin(Plugin):
                 axes["filter"] = ("band", fw)
                 break
 
-        sr_stream = SpectrumSettingsStream(
+        sr_stream = SpectrumArbitraryOrderSettingsStream(
             name,
             detector,
             detector.data,

--- a/plugins/spectrum_arbscor.py
+++ b/plugins/spectrum_arbscor.py
@@ -142,6 +142,16 @@ class SEMSpectrumArbitraryOrderMDStream(SEMSpectrumMDStream):
     call a different function that one of the two examples).
     """
 
+    # overrides SEMCCDStream method, to disable hardware sync
+    def _supports_hw_sync(self) -> bool:
+        # arbitrary scan order does not support hardware sync (at least for now)
+        return False
+
+    # overrides SEMCCDStream method, to disable scan stage acquisition
+    def _runAcquisitionScanStage(self, future):
+        # This could be implemented, by overriding _getScanStagePositions(), but that's not yet done
+        raise NotImplementedError("Arbitrary scan order does not support scan stage acquisition")
+
     def _get_scan_order(self, rep: Tuple[int, int]) -> List[Tuple[int, int]]:
         """
         Computes the arbitrary scan order


### PR DESCRIPTION
Add extra option to select the type of scanning strategy directly in the GUI.
Also fix the compatibility with the SPARC acquisition after it has been updated in commit 8cbd1090f372 (Support hardware synchronized acquisition on SPARC)