### PR TITLE
[fix] simstreakcam missed some of the time delay restructuring

### DIFF
--- a/src/odemis/driver/simstreakcam.py
+++ b/src/odemis/driver/simstreakcam.py
@@ -232,16 +232,12 @@ class ReadoutCamera(model.DigitalCamera):
         delay genereator and the metadata from the parent streak camera.
         :return: merged metadata
         """
-
-        md_devices = [self.parent._streakunit._metadata, self.parent._delaybox._metadata]
-
-        for md_dev in md_devices:
-            for key in md_dev.keys():
-                if key not in md:
-                    md[key] = md_dev[key]
-                elif key in (model.MD_HW_NAME, model.MD_HW_VERSION, model.MD_SW_VERSION):
-                    md[key] = md[key] + ", " + md_dev[key]
-
+        md_dev = self.parent._streakunit.getMetadata()
+        for key in md_dev.keys():
+            if key not in md:
+                md[key] = md_dev[key]
+            elif key in (model.MD_HW_NAME, model.MD_HW_VERSION, model.MD_SW_VERSION):
+                md[key] = ", ".join([md[key], md_dev[key]])
         return md
 
     def terminate(self):
@@ -415,17 +411,6 @@ class StreakUnit(model.HwComponent):
         """
         logging.debug("Reporting time range %s for streak unit.", value)
         self._metadata[model.MD_STREAK_TIMERANGE] = value
-
-        # set corresponding trigger delay
-        tr2d = self.parent._delaybox._metadata.get(model.MD_TIME_RANGE_TO_DELAY)
-        if tr2d:
-            key = util.find_closest(value, tr2d.keys())
-            if util.almost_equal(key, value):
-                self.parent._delaybox.triggerDelay.value = tr2d[key]
-            else:
-                logging.warning("Time range %s is not a key in MD for time range to "
-                                "trigger delay calibration" % value)
-
         return value
 
     def terminate(self):

--- a/src/odemis/driver/streak.py
+++ b/src/odemis/driver/streak.py
@@ -41,7 +41,7 @@ class DelayConnector(model.HwComponent):
         * streak-unit (optional): a component with a .timeRange, to be updated when the triggerDelay is changed
         according to the MD_TIME_RANGE_TO_DELAY metadata.
         """
-        super().__init__(name, role, **kwargs)
+        super().__init__(name, role, dependencies=dependencies, **kwargs)
 
         dependencies = dependencies or {}
         try:
@@ -56,7 +56,7 @@ class DelayConnector(model.HwComponent):
             self.triggerRate = model.FloatVA(0, unit="Hz", readonly=True)
             self._trigger.period.subscribe(self._on_trigger_period, init=True)
             if model.hasVA(self._trigger, "power"):
-                self._trigger.power.subscribe(self._on_trigger_period)
+                self._trigger.power.subscribe(self._on_trigger_power)
 
         if "streak-unit" in dependencies:
             self._streak_unit = dependencies["streak-unit"]


### PR DESCRIPTION
Commit 41c56883b29 (new DelayConnector Component wrapper) restructure the way the time delay is connected with the rest of the streak cam. Until now, the delayer was always part of the streak cam component, so the integration was straightforward. To support delayer components independent from the streak cam, the mdupdater must be involved.
Some of the changes required were only done on the hamamatsurx driver, but not on the simulator driver. This broke temporal spectrum acquisition on the simulator.