### PR TITLE
[TRCL-409][TRCL-410][TRCL-411][feat] Introduce more streak-cam automatic protection

### DIFF
--- a/src/odemis/acq/stream/_helper.py
+++ b/src/odemis/acq/stream/_helper.py
@@ -803,8 +803,13 @@ class SpectrumSettingsStream(CCDSettingsStream):
 
 class TemporalSpectrumSettingsStream(CCDSettingsStream):
     """
-    An streak camera stream, for a set of points (on the SEM).
+    A streak camera stream, for a set of points (on the SEM).
     The live view is just the raw readout camera image.
+    It has a few protections as the detector is very sensitive (to light):
+    * When active, disabling the streak mode, or setting the center wavelength to 0nm will reset the
+       MCPGain and activate the shutter.
+    * It's not possible to increase the MCPGain while the stream is paused.
+    * The MCPGain of the hardware is also always set to 0 when not playing.
     """
     def __init__(self, name, detector, dataflow, emitter, streak_unit, streak_delay,
                  streak_unit_vas, **kwargs):
@@ -812,7 +817,7 @@ class TemporalSpectrumSettingsStream(CCDSettingsStream):
         if "acq_type" not in kwargs:
             kwargs["acq_type"] = model.MD_AT_TEMPSPECTRUM
 
-        super(TemporalSpectrumSettingsStream, self).__init__(name, detector, dataflow, emitter, **kwargs)  # init of CCDSettingsStream
+        super().__init__(name, detector, dataflow, emitter, **kwargs)  # init of CCDSettingsStream
 
         self._active = False  # variable keep track if stream is active/inactive
 
@@ -826,7 +831,7 @@ class TemporalSpectrumSettingsStream(CCDSettingsStream):
         streak_unit_vas = self._duplicateVAs(streak_unit, "det", streak_unit_vas)
         self._det_vas.update(streak_unit_vas)
 
-        # whenever .streakMode changes
+        # Whenever .streakMode is disabled, or center wavelength is set to 0nm:
         # -> set .MCPGain = 0 and update .MCPGain.range
         # This is important for HW safety reasons to not destroy the streak unit,
         # when changing on of the VA while using a high MCPGain.
@@ -834,10 +839,14 @@ class TemporalSpectrumSettingsStream(CCDSettingsStream):
         # is limited to values <= current value to also prevent HW damage
         # when starting to play the stream again.
         try:
-            self.detStreakMode.subscribe(self._OnStreakSettings)
-            self.detMCPGain.subscribe(self._OnMCPGain)
+            self.detStreakMode.subscribe(self._on_streak_mode)
+            self.detMCPGain.subscribe(self._on_mcp_gain)
         except AttributeError:
             raise ValueError("Necessary HW VAs streakMode and MCPGain for streak camera was not provided")
+        try:
+            self.axisWavelength.subscribe(self._on_center_wavelength)
+        except AttributeError:
+            logging.info("No axis wavelength provided for stream %s, will not protect on wavelength change", name)
 
     # Override Stream.__find_metadata() in _base.py
     def _find_metadata(self, md):
@@ -845,7 +854,7 @@ class TemporalSpectrumSettingsStream(CCDSettingsStream):
         Find the useful metadata for a 2D spatial projection from the metadata of a raw image.
         :returns: (dict) Metadata dictionary (MD_* -> value).
         """
-        simple_md = super(TemporalSpectrumSettingsStream, self)._find_metadata(md)
+        simple_md = super()._find_metadata(md)
         if model.MD_TIME_LIST in md:
             simple_md[model.MD_TIME_LIST] = md[model.MD_TIME_LIST]
         if model.MD_WL_LIST in md:
@@ -860,7 +869,7 @@ class TemporalSpectrumSettingsStream(CCDSettingsStream):
         :param active: (boolean) True if stream is playing.
         :returns: (boolean) If stream is playing or not.
         """
-        self._active = super(TemporalSpectrumSettingsStream, self)._is_active_setter(active)
+        self._active = super()._is_active_setter(active)
 
         if self.is_active.value != self._active:  # changing from previous value?
             if self._active:
@@ -870,6 +879,9 @@ class TemporalSpectrumSettingsStream(CCDSettingsStream):
                 # Set HW MCPGain VA = 0, but keep GUI VA = previous value
                 try:
                     self.streak_unit.MCPGain.value = 0
+                    # TODO: Is it good for the shutter to be repeatedly opened/closed whenever playing/stopping?
+                    if model.hasVA(self.streak_unit, "shutter"):
+                        self.streak_unit.shutter.value = True
                 except Exception:
                     # Can happen if the hardware is not responding. In such case,
                     # let's still pause the stream.
@@ -877,24 +889,43 @@ class TemporalSpectrumSettingsStream(CCDSettingsStream):
 
                 # only allow values <= current MCPGain value for HW safety reasons when stream inactive
                 self.detMCPGain.range = (0, self.detMCPGain.value)
+                # TODO: also prevent the shutter from from closed -> open when not playing?
+                # It's actually harder to do that the gain, because it's a boolean... so for now we don't do that.
+
         return self._active
 
-    def _OnStreakSettings(self, value):
+    def _protect_detector(self) -> None:
         """
-        Callback, which sets MCPGain GUI VA = 0,
-        if .streakMode VA has changed.
+        Protect the streak camera by setting the MCPGain to 0 and activating the shutter.
         """
         self.detMCPGain.value = 0  # set GUI VA 0
-        self._OnMCPGain(value)  # update the .MCPGain VA
+        if hasattr(self, "detShutter"):
+            self.detShutter.value = True
 
-    def _OnMCPGain(self, _=None):
+    def _on_streak_mode(self, streak: bool) -> None:
+        """
+        Callback, to protect the camera if the streak mode is disabled (ie: all light on a single horizontal line)
+        """
+        if not streak:
+            self._protect_detector()
+
+    def _on_mcp_gain(self, gain: float) -> None:
         """
         Callback, which updates the range of possible values for MCPGain GUI VA if stream is inactive:
         only values <= current value are allowed.
         If stream is active the full range is available.
         """
         if not self._active:
-            self.detMCPGain.range = (0, self.detMCPGain.value)
+            self.detMCPGain.range = (0, gain)
+
+    def _on_center_wavelength(self, wl: float) -> None:
+        """
+        Callback, called when axisWavelength is changed, to automatically protect the camera if the
+        wavelength is set to 0nm (mirror mode), because all the light will be on a vertical line.
+        """
+        # If going from a spectrum mode to 0th order (mirror) mode, protect the streak camera
+        if wl < 10e-9:  # 0th order
+            self._protect_detector()
 
 
 class MonochromatorSettingsStream(RepetitionStream):

--- a/src/odemis/acq/stream/_sync.py
+++ b/src/odemis/acq/stream/_sync.py
@@ -3007,6 +3007,20 @@ class SEMTemporalSpectrumMDStream(SEMCCDMDStream):
     Data format: SEM (2D=XY) + TemporalSpectrum(4D=CT1YX).
     """
 
+    def _runAcquisition(self, future):
+        """
+        Acquires images from multiple detectors via software synchronisation.
+        Select whether the ebeam is moved for scanning or the sample stage.
+        :param future: Current future running for the whole acquisition.
+        """
+        try:
+            das = super()._runAcquisition(future)
+        finally:
+            # Make sure the streak-cam is protected
+            self._sccd._suspend()
+
+        return das
+
     def _assembleLiveData(self, n, raw_data, px_idx, px_pos, rep, pol_idx=0):
         """
         :param n: (int) number of the current stream

--- a/src/odemis/acq/test/stream_test.py
+++ b/src/odemis/acq/test/stream_test.py
@@ -2465,7 +2465,7 @@ class SPARC2StreakCameraTestCase(unittest.TestCase):
         streaks = stream.TemporalSpectrumSettingsStream("test streak cam", self.streak_ccd, self.streak_ccd.data,
                                                         self.ebeam, self.streak_unit, self.streak_delay,
                                                         detvas={"exposureTime", "readoutRate", "binning", "resolution"},
-                                                        streak_unit_vas={"timeRange", "MCPGain", "streakMode"})
+                                                        streak_unit_vas={"timeRange", "MCPGain", "streakMode", "shutter"})
 
         self._image = None
         streaks.image.subscribe(self._on_image)
@@ -2486,6 +2486,13 @@ class SPARC2StreakCameraTestCase(unittest.TestCase):
         # activate/play stream, optical path should be corrected immediately (no need to wait)
         streaks.is_active.value = True
 
+        # Disable the protections
+        streaks.detMCPGain.value = 10
+        streaks.detShutter.value = False
+        # Confirm they actually are applied on the hardware
+        self.assertEqual(self.streak_unit.MCPGain.value, 10)
+        self.assertFalse(self.streak_unit.shutter.value)
+
         time.sleep(2)
         streaks.is_active.value = False
 
@@ -2504,7 +2511,84 @@ class SPARC2StreakCameraTestCase(unittest.TestCase):
         self.assertIn(model.MD_TIME_LIST, streaks.raw[0].metadata)
         self.assertIn(model.MD_WL_LIST, streaks.raw[0].metadata)
 
+        # Check the streak-cam protection is activated: MCPGain = 0 and shutter active
+        self.assertTrue(self.streak_unit.shutter.value)
+        self.assertEqual(self.streak_unit.MCPGain.value, 0)
+
         streaks.image.unsubscribe(self._on_image)
+
+    def test_streakcam_stream(self):
+        """Test playing StreakCamStream and check shape and MD for image received are correct."""
+
+        # Create the settings stream
+        streaks = stream.StreakCamStream("test streak cam", self.streak_ccd, self.streak_ccd.data,
+                                         self.ebeam, self.streak_unit, self.streak_delay,
+                                         detvas={"exposureTime", "readoutRate", "binning", "resolution"},
+                                         streak_unit_vas={"timeRange", "MCPGain", "streakMode", "shutter"})
+
+        self._image = None
+        streaks.image.subscribe(self._on_image)
+
+        # set GUI VAs
+        streaks.detExposureTime.value = 0.2  # s
+        streaks.detBinning.value = (2, 2)
+        streaks.detStreakMode.value = True
+        streaks.detTimeRange.value = find_closest(0.000000005, self.streak_unit.timeRange.choices)
+        streaks.detMCPGain.value = 0  # Note: cannot set any other value here as stream is inactive
+
+        # update stream (live)
+        streaks.should_update.value = True
+        # activate/play stream, optical path should be corrected immediately (no need to wait)
+        streaks.is_active.value = True
+
+        # Disable the protections
+        streaks.detMCPGain.value = 10
+        streaks.detShutter.value = False
+        # Confirm they actually are applied on the hardware
+        self.assertEqual(self.streak_unit.MCPGain.value, 10)
+        self.assertFalse(self.streak_unit.shutter.value)
+
+        # Disable the streak mode => it should trigger the protection
+        streaks.detStreakMode.value = False
+        self.assertEqual(self.streak_unit.MCPGain.value, 0)
+        self.assertTrue(self.streak_unit.shutter.value)
+
+        # Re-enable the settings: it should be allowed
+        streaks.detMCPGain.value = 10
+        streaks.detShutter.value = False
+        # Confirm they actually are applied on the hardware
+        self.assertEqual(self.streak_unit.MCPGain.value, 10)
+        self.assertFalse(self.streak_unit.shutter.value)
+
+        # Re-enable the streak mode: it should not change the settings (because this way is safe)
+        streaks.detStreakMode.value = True
+        self.assertEqual(self.streak_unit.MCPGain.value, 10)
+        self.assertFalse(self.streak_unit.shutter.value)
+
+        time.sleep(2)
+        streaks.is_active.value = False
+
+        self.assertIsNotNone(self._image, "No temporal spectrum received after 2s")
+        self.assertIsInstance(self._image, model.DataArray)
+        # .image should be a 2D temporal spectrum
+        self.assertEqual(self._image.shape[1::-1], streaks.detResolution.value)
+        # check if metadata is correctly stored
+        md = self._image.metadata
+        self.assertIn(model.MD_WL_LIST, md)
+        self.assertIn(model.MD_TIME_LIST, md)
+
+        # check raw image is a DataArray with right shape and MD
+        self.assertIsInstance(streaks.raw[0], model.DataArray)
+        self.assertEqual(streaks.raw[0].shape[1::-1], streaks.detResolution.value)
+        self.assertIn(model.MD_TIME_LIST, streaks.raw[0].metadata)
+        self.assertIn(model.MD_WL_LIST, streaks.raw[0].metadata)
+
+        # Check the streak-cam protection is activated: MCPGain = 0 and shutter active
+        self.assertEqual(self.streak_unit.MCPGain.value, 0)
+        self.assertTrue(self.streak_unit.shutter.value)
+
+        streaks.image.unsubscribe(self._on_image)
+
 
     def _on_image(self, im):
         self._image = im
@@ -2627,12 +2711,14 @@ class SPARC2StreakCameraTestCase(unittest.TestCase):
         self.assertNotEqual(streaks.detExposureTime.value, self.streak_ccd.exposureTime.value)
         self.assertNotEqual(streaks.detBinning.value, self.streak_ccd.binning.value)  # TODO check with real HW
 
-        # change .streakMode and/or .timeRange GUI VAs -> MCPGain GUI VA should be 0
+        # Change the settings VA, while not playing -> no effect on the hardware
         streaks.detStreakMode.value = True
+        self.assertNotEqual(streaks.detStreakMode.value, self.streak_unit.streakMode.value)
+
+        # change .streakMode from True to False -> MCPGain GUI VA should be 0
+        streaks.detStreakMode.value = False
         time.sleep(0.1)
         self.assertEqual(streaks.detMCPGain.value, 0)  # GUI VA should be 0 after changing .streakMode
-        # check GUI VA do not show same values as HW VAs
-        self.assertNotEqual(streaks.detStreakMode.value, self.streak_unit.streakMode.value)
         # value > current MCPGain GUI value while stream is not active shouldn't be possible
         # also checks if .MCPGain.range has been updated
         with self.assertRaises(IndexError):

--- a/src/odemis/gui/comp/popup.py
+++ b/src/odemis/gui/comp/popup.py
@@ -31,6 +31,9 @@ from wx.adv import NotificationMessage
 @call_in_wx_main
 def show_message(parent, title, message=None, timeout=3.0, level=logging.INFO):
     """ Show a small message popup for a short time
+    Note: on Ubuntu 22.04, the info level is shown only in the notification bar.
+    The warning level is shown in a popup window for a short while, and the error level
+    is shown in a popup window until the user closes it. The timeout has no effect.
 
     :param parent: (wxWindow or None)
     :param title: (str) The title of the message
@@ -49,3 +52,5 @@ def show_message(parent, title, message=None, timeout=3.0, level=logging.INFO):
 
     m = NotificationMessage(title, message, parent=parent, flags=flags)
     m.Show(int(timeout))
+
+    logging.debug("Notification: %s. %s", title, message or "")

--- a/src/odemis/gui/cont/menu.py
+++ b/src/odemis/gui/cont/menu.py
@@ -165,8 +165,17 @@ class MenuController(object):
 
     def on_stop_axes(self, evt):
         if self._main_data:
-            popup.show_message(self._main_frame, "Stopping motion on every axes", timeout=1)
             self._main_data.stopMotion()
+            self._main_data.protect_detectors()
+
+            # For each tab, let them know that hardware protection was triggered
+            # That allows to reset the settings of some streams, for instance
+            for tab in self._main_data.tab.choices:
+                tab.on_hardware_protect()
+
+            popup.show_message(self._main_frame, "Hardware protection activated",
+                               message="Stopped actuator motion and protected detectors on user request.",
+                               level=logging.WARNING)
         else:
             evt.Skip()
 

--- a/src/odemis/gui/cont/stream_bar.py
+++ b/src/odemis/gui/cont/stream_bar.py
@@ -1890,6 +1890,9 @@ class SparcStreamsController(StreamBarController):
             detvas=detvas,
             streak_unit_vas=get_local_vas(main_data.streak_unit, self._main_data_model.hw_settings_config))
         self._set_default_spectrum_axes(ts_stream)
+        # For safety, always start with the shutter closed.
+        if model.hasVA(ts_stream, "detShutter"):
+            ts_stream.detShutter.value = True
 
         # Create the equivalent MDStream
         sem_stream = self._tab_data_model.semStream

--- a/src/odemis/gui/cont/tabs/sparc2_align_tab.py
+++ b/src/odemis/gui/cont/tabs/sparc2_align_tab.py
@@ -449,9 +449,9 @@ class Sparc2AlignTab(Tab):
                                 "Calibration trigger delay for streak camera",
                                 main_data.streak_ccd,
                                 main_data.streak_ccd.data,
-                                main_data.streak_unit,
-                                main_data.streak_delay,
                                 emitter=None,
+                                streak_unit=main_data.streak_unit,
+                                streak_delay=main_data.streak_delay,
                                 detvas=get_local_vas(main_data.streak_ccd, main_data.hw_settings_config),
                                 streak_unit_vas=streak_unit_vas,
                                 forcemd={model.MD_POS: (0, 0),  # Just in case the stage is there

--- a/src/odemis/gui/cont/tabs/sparc2_align_tab.py
+++ b/src/odemis/gui/cont/tabs/sparc2_align_tab.py
@@ -43,6 +43,7 @@ import odemis.gui.model as guimod
 from odemis import model
 from odemis.acq.align.autofocus import GetSpectrometerFocusingDetectors
 from odemis.acq.align.autofocus import Sparc2AutoFocus, Sparc2ManualFocus
+from odemis.gui.comp import popup
 from odemis.gui.conf.data import get_local_vas, get_hw_config
 from odemis.gui.conf.util import create_axis_entry
 from odemis.gui.cont import settings
@@ -444,7 +445,7 @@ class Sparc2AlignTab(Tab):
             # Don't show the time range, as it's done by the StreakCamAlignSettingsController
             streak_unit_vas = (get_local_vas(main_data.streak_unit, main_data.hw_settings_config)
                                -{"timeRange"})
-            tsStream = acqstream.StreakCamStream(
+            ts_stream = acqstream.StreakCamStream(
                                 "Calibration trigger delay for streak camera",
                                 main_data.streak_ccd,
                                 main_data.streak_ccd.data,
@@ -457,10 +458,13 @@ class Sparc2AlignTab(Tab):
                                          model.MD_ROTATION: 0},  # Force the CCD as-is
                                 )
 
-            self._setFullFoV(tsStream, (2, 2))
-            self._ts_stream = tsStream
+            self._setFullFoV(ts_stream, (2, 2))
+            self._ts_stream = ts_stream
 
-            streak = self._stream_controller.addStream(tsStream,
+            if main_data.ebeam_blanker:
+                main_data.ebeam_blanker.power.subscribe(self._on_ebeam_blanker)
+
+            streak = self._stream_controller.addStream(ts_stream,
                              add_to_view=self.panel.vp_align_streak.view)
             streak.stream_panel.flatten()  # No need for the stream name
 
@@ -488,7 +492,7 @@ class Sparc2AlignTab(Tab):
 
             # To activate the SEM spot when the camera plays
             # (ebeam centered in image)
-            tsStream.should_update.subscribe(self._on_ccd_stream_play)
+            ts_stream.should_update.subscribe(self._on_ccd_stream_play)
 
         if "ek-align" in tab_data.align_mode.choices:
             detvas = get_local_vas(main_data.ccd, main_data.hw_settings_config)
@@ -1059,6 +1063,11 @@ class Sparc2AlignTab(Tab):
                 self._ts_stream.should_update.value = True
                 self._ts_stream.auto_bc.value = False  # default manual brightness/contrast
                 self._ts_stream.intensityRange.value = self._ts_stream.intensityRange.clip((100, 1000))  # default range
+                # Reset settings, for safety of the streak-unit
+                self._ts_stream.detMCPGain.value = 0
+                if hasattr(self._ts_stream, "detShutter"):
+                    self._ts_stream.detShutter.value = True
+
             if self._mirror_settings_controller:
                 self._mirror_settings_controller.enable(False)
             self.panel.pnl_mirror.Show(False)
@@ -2010,6 +2019,47 @@ class Sparc2AlignTab(Tab):
             fib_fav_pos["y"] = pos["y"]
             logging.debug("Updating the active fiber Y position to %s", fib_fav_pos)
             fiba.updateMetadata({model.MD_FAV_POS_ACTIVE: fib_fav_pos})
+
+    @call_in_wx_main
+    def _on_ebeam_blanker(self, blanked: bool) -> None:
+        """
+        Callback when the e-beam blanker is activated/deactivated. Used to protect the streak-cam
+        as a lot more light could be emitted when unblanking the e-beam.
+        :param blanked: True if the e-beam is (pulsed-)blanked, False if e-beam is active.
+        """
+        # Protect the streakcam in case the ebeam goes from blanked to unblanked, as suddenly a lot of light might be emitted
+        if blanked:  # just changed to blanked => no danger
+            return
+        if not self.IsShown():
+            return
+
+        # Reset settings, for safety of the streak-unit
+        protected = False
+        if self.tab_data_model.align_mode.value == "streak-align" and self._ts_stream:
+            if hasattr(self._ts_stream, "detMCPGain") and self._ts_stream.detMCPGain.value != 0:
+                self._ts_stream.detMCPGain.value = 0
+                protected = True
+            if hasattr(self._ts_stream, "detShutter") and not self._ts_stream.detShutter.value:
+                self._ts_stream.detShutter.value = True
+                protected = True
+
+        if protected:
+            popup.show_message(self.main_frame, "Streak camera protection",
+                               message="Streak camera settings were reset due to e-beam unblanking.",
+                               level=logging.WARNING)
+
+    def on_hardware_protect(self) -> None:
+        """
+        Called when the detector protection is activated (eg, by pressing the "Pause" button)
+        """
+        # In practice, for now the only thing which is done by the MainGUIData is to also reset the
+        # settings of the streak stream, mainly to make sure that the widgets are synchronized with
+        # the hardware state.
+        if self.tab_data_model.align_mode.value == "streak-align" and self._ts_stream:
+            # Reset settings, for safety of the streak-unit
+            self._ts_stream.detMCPGain.value = 0
+            if hasattr(self._ts_stream, "detShutter"):
+                self._ts_stream.detShutter.value = True
 
     def Show(self, show=True):
         Tab.Show(self, show=show)

--- a/src/odemis/gui/cont/tabs/tab.py
+++ b/src/odemis/gui/cont/tabs/tab.py
@@ -245,6 +245,12 @@ class Tab(object):
             self.button.highlight(on)
             self.highlighted = on
 
+    def on_hardware_protect(self) -> None:
+        """
+        Called when the detector protection is activated (eg, by pressing the "Pause" button)
+        """
+        pass
+
     @classmethod
     def get_display_priority(cls, main_data):
         """

--- a/src/odemis/gui/log.py
+++ b/src/odemis/gui/log.py
@@ -221,12 +221,12 @@ def observe_comp_state(comps):
             if component_state_value == ST_RUNNING:
                 show_message(wx.GetApp().main_frame, 'Recovered ' + component_name,
                              'Functionality of the "' + component_name + '" is recovered successfully.',
-                             timeout=3.0, level=logging.INFO)
+                             timeout=3.0, level=logging.WARNING)
                 logging.debug("Reporting recovery of %s", component_name)
 
             elif isinstance(component_state_value, HwError):
                 show_message(wx.GetApp().main_frame, 'Error in ' + component_name, str(component_state_value),
-                             timeout=5.0, level=logging.WARNING)
+                             timeout=5.0, level=logging.ERROR)
                 logging.debug("Reporting error in %s: %s", component_name, str(component_state_value))
 
         # Keep a reference to each subscriber function so they won't get dereferenced (because VA's use weakrefs)

--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -2423,7 +2423,7 @@ b\xeb\x85\x9f\xb6B\x1d\x0cK\x17\xac\xf0\x12\xfe\xa0\xe5\xee\xe03\xb1\xfa\
           </XRCED>
         </object>
         <object class="wxMenuItem" name="menu_item_halt">
-          <label>Stop all Axes</label>
+          <label>Emergency hardware protection</label>
           <accel>Pause</accel>
           <XRCED>
             <assign_var>1</assign_var>

--- a/src/odemis/gui/model/main_gui_data.py
+++ b/src/odemis/gui/model/main_gui_data.py
@@ -395,6 +395,31 @@ class MainGUIData(object):
         # Indicate whether the gui is loaded as viewer
         self.is_viewer = self.microscope is None
 
+    def protect_detectors(self):
+        """
+        Put all the potentially damageable detectors to a safe mode.
+        """
+        if self.streak_unit:
+            # Note that in the SPARC acquisition tab, pausing the TemporalSpectrumSettingsStream
+            # should have the same effect. However, in case an acquisition is running, or another
+            # tab is active, the safest option is to directly set the streak camera to a safe state.
+            try:
+                if model.hasVA(self.streak_unit, "MCPGain"):
+                    self.streak_unit.MCPGain.value = 0
+            except Exception:
+                logging.exception("Failed to reset the streak-unit MCPGain")
+
+            try:
+                if model.hasVA(self.streak_unit, "shutter"):
+                    self.streak_unit.shutter.value = True
+            except Exception:
+                logging.exception("Failed to activate the streak-unit shutter")
+
+            logging.info("Set streak-unit to a safe state")
+
+        # TODO: add more detectors here
+        # Example time-correlator shutter
+
     def stopMotion(self):
         """
         Stops immediately every axis

--- a/src/odemis/gui/xmlh/resources/frame_main.xrc
+++ b/src/odemis/gui/xmlh/resources/frame_main.xrc
@@ -47,7 +47,7 @@
           </XRCED>
         </object>
         <object class="wxMenuItem" name="menu_item_halt">
-          <label>Stop all Axes</label>
+          <label>Emergency hardware protection</label>
           <accel>Pause</accel>
           <XRCED>
             <assign_var>1</assign_var>


### PR DESCRIPTION
Improves the automatic protection of the streak-cam in various ways:
* Pause key also protects the streak-cam
* Protection not only sets the MCP Gain to 0, but also closes the shutter, if available
* The change of the wavelength or e-beam blanker also trigger the protection
* In the SPARC alignment tab, the "dangerous" settings are always reset when going back to the tab.