### PR TITLE
[METEOR-1209][FIX] Invalid cached pyramids, broken correlation

### DIFF
--- a/src/odemis/acq/stream/_base.py
+++ b/src/odemis/acq/stream/_base.py
@@ -1100,8 +1100,8 @@ class Stream(object):
         return (DataArray): The merged image
         """
         # calculates the size of the merged image
-        width_zoomed = das.shape[1] / (2 ** z)
-        height_zoomed = das.shape[0] / (2 ** z)
+        width_zoomed = int(das.shape[1] / (2 ** z))
+        height_zoomed = int(das.shape[0] / (2 ** z))
         # calculates the number of tiles on both axes
         num_tiles_x = int(math.ceil(width_zoomed / das.tile_shape[1]))
         num_tiles_y = int(math.ceil(height_zoomed / das.tile_shape[0]))
@@ -1352,3 +1352,7 @@ class Stream(object):
         A list of metadata dicts is returned.
         """
         return [None if data is None else data.metadata for data in self.raw]
+
+    def force_image_update(self):
+        """Force the stream image to be updated"""
+        self._shouldUpdateImage()

--- a/src/odemis/acq/stream/_projection.py
+++ b/src/odemis/acq/stream/_projection.py
@@ -221,6 +221,17 @@ class RGBProjection(DataProjection):
         except Exception:
             logging.exception("Updating %s %s image", self.__class__.__name__, self.stream.name.value)
 
+    def force_image_update(self):
+        """Forces the image to be recomputed entirely, and invalidates the cache for tiled images"""
+
+        if hasattr(self, "_projectedTilesCache") and hasattr(self, "_rawTilesCache"):
+            # invalidate the raw and projectted tiles cache
+            self._projectedTilesCache = {}
+            self._rawTilesCache = {}
+            self._shouldUpdateImageEntirely()
+        else:
+            self._shouldUpdateImage()
+
 
 class ARProjection(RGBProjection):
     """
@@ -934,13 +945,11 @@ class RGBSpatialProjection(RGBProjection):
     def getBoundingBox(self):
         '''
         Get the bounding box of the whole image, whether it`s tiled or not.
+        Since the image can now be updated, the bounding box can change
+        so we need to get it from the stream directly.
         return (tuple of floats(minx, miny, maxx, maxy)): Tuple with the bounding box
         '''
-        if hasattr(self, 'rect'):
-            rng = self.rect.range
-            return rng[0][0], rng[0][1], rng[1][0], rng[1][1]
-        else:
-            return self.stream.getBoundingBox(self.image.value)
+        return self.stream.getBoundingBox()
 
     def _zFromMpp(self):
         """

--- a/src/odemis/gui/cont/correlation.py
+++ b/src/odemis/gui/cont/correlation.py
@@ -25,32 +25,37 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 import copy
 import logging
 import math
+from typing import List
+
 import wx
+
 # IMPORTANT: wx.html needs to be imported for the HTMLWindow defined in the XRC
 # file to be correctly identified. See: http://trac.wxwidgets.org/ticket/3626
 # This is not related to any particular wxPython version and is most likely permanent.
 import wx.html
+
 import odemis.acq.stream as acqstream
 import odemis.gui.model as guimod
 from odemis import model
-from odemis.acq.stream import RGBStream, StaticStream, StaticFluoStream, StaticSEMStream
-from odemis.gui.util import call_in_wx_main
+from odemis.acq.stream import RGBStream, StaticFluoStream, StaticSEMStream, StaticStream
 from odemis.gui.cont.tabs.localization_tab import LocalizationTab
+from odemis.gui.util import call_in_wx_main
+
 
 # TODO: move to more approprate location
-def update_image_in_views(s: StaticStream, views: list) -> None:
-    """Force update the static stream in the selected views
+def update_image_in_views(s: StaticStream, views: List[guimod.StreamView]) -> None:
+    """Force update the static stream in the selected views (forces image update)
     :param s: (StaticStream) the static stream to update
-    :param views: (list[View]) the list of views to update"""
-    v: guimod.View
+    :param views: (list[StreamView]) the list of views to update"""
+    v: guimod.StreamView
     for v in views:
         for sp in v.stream_tree.getProjections():  # stream or projection
-            if isinstance(sp, acqstream.DataProjection):
-                st = sp.stream
-            else:
-                st = sp
+            st = sp.stream if isinstance(sp, acqstream.DataProjection) else sp
+
+            # only update the selected stream
             if st is s:
-                sp._shouldUpdateImage()
+                sp.force_image_update()
+
 
 def convert_rgb_to_sem(rgb_stream: RGBStream) -> StaticSEMStream:
     """Convert an RGB stream to a SEM stream
@@ -77,6 +82,7 @@ def convert_rgb_to_sem(rgb_stream: RGBStream) -> StaticSEMStream:
     sem_stream.raw[0].metadata[model.MD_DIMS] = "YX"
 
     return sem_stream
+
 
 class CorrelationController(object):
 


### PR DESCRIPTION
User's reported that they were not able to correlate fm overview images, and that the images would not move. 

The data projection for overview images uses a cache to efficiently read/display tiled images. However, the projection assumed the image would never 'move', and there was no direct way to invalidate the cache to recompute the image. 
This PR adds a public method to force the projection to clear the cache and recompute the image. This allows user's to move the overviews (shadow-pyramids) correctly in the correlation tab.


- [Jira Issue](https://delmic.atlassian.net/browse/METEOR-1209)
- [Related](https://delmic.atlassian.net/browse/METEOR-1210)