### PR TITLE
[METEOR-1210][FIX] Fix image pyramid tile read calculation and projection cache invalidation 

### DIFF
--- a/src/odemis/gui/cont/correlation.py
+++ b/src/odemis/gui/cont/correlation.py
@@ -25,33 +25,35 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 import copy
 import logging
 import math
+from typing import List
+
 import wx
+
 # IMPORTANT: wx.html needs to be imported for the HTMLWindow defined in the XRC
 # file to be correctly identified. See: http://trac.wxwidgets.org/ticket/3626
 # This is not related to any particular wxPython version and is most likely permanent.
 import wx.html
+
 import odemis.acq.stream as acqstream
 import odemis.gui.model as guimod
 from odemis import model
-from odemis.acq.stream import RGBStream, StaticStream, StaticFluoStream, StaticSEMStream
-from odemis.gui.util import call_in_wx_main
+from odemis.acq.stream import RGBStream, StaticFluoStream, StaticSEMStream, StaticStream
 from odemis.gui.cont.tabs.localization_tab import LocalizationTab
+from odemis.gui.util import call_in_wx_main
 
 # TODO: move to more approprate location
-def update_image_in_views(s: StaticStream, views: list) -> None:
-    """Force update the static stream in the selected views
+def update_image_in_views(s: StaticStream, views: List[guimod.StreamView]) -> None:
+    """Force update the static stream in the selected views (forces image update)
     :param s: (StaticStream) the static stream to update
-    :param views: (list[View]) the list of views to update"""
-    v: guimod.View
+    :param views: (list[StreamView]) the list of views to update"""
+    v: guimod.StreamView
     for v in views:
         for sp in v.stream_tree.getProjections():  # stream or projection
-            if isinstance(sp, acqstream.DataProjection):
-                st = sp.stream
-            else:
-                st = sp
-            if st is s:
-                sp._shouldUpdateImage()
+            st = sp.stream if isinstance(sp, acqstream.DataProjection) else sp
 
+            # only update the selected stream
+            if st is s:
+                sp.force_image_update()
 def convert_rgb_to_sem(rgb_stream: RGBStream) -> StaticSEMStream:
     """Convert an RGB stream to a SEM stream
     :param rgb_stream: (RGBStream) the RGB stream to convert


### PR DESCRIPTION
User's reported that they were not able to correlate fm overview images, and that the images would not move.  They also reported that some overviews wouldn't load. These two issues were interrelated:

1. [METEOR-1210](https://delmic.atlassian.net/browse/METEOR-1210) Tiled imaged reads were failing for specific resolution / tile size combinations due to inconsistencies and rounding issues in the tile calculation. Made all tile reads use the same code, and fixed the rounding issues. 

2. [ METEOR-1209](https://delmic.atlassian.net/browse/METEOR-1209) The data projection for overview images uses a cache to efficiently read/display tiled images. However, the projection assumed the image would never 'move', and there was no direct way to invalidate the cache to recompute the image. 
This PR adds a public method to force the projection to clear the cache and recompute the image. This allows user's to move the overviews (shadow-pyramids) correctly in the correlation tab. It also correctly now recalculates the image rect when moving the image.

Now when moving an image, the caller is required to call force_image_update which will:
1. Invalidate any cached tiles (projected and raw)
2. Recompute the image rect (view)
3. Request image re-computation

[METEOR-1210]: https://delmic.atlassian.net/browse/METEOR-1210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ