### PR TITLE
[fix] ShamrockBus with simulators fails to terminate

### DIFF
--- a/src/odemis/driver/andorshrk.py
+++ b/src/odemis/driver/andorshrk.py
@@ -2193,6 +2193,7 @@ class ShamrockBus(model.HwComponent):
             dev = Shamrock(device="fake", daemon=daemon, **ckwargs)
             self.children.value.add(dev)
 
+        self._dll = None
         if shamrocks:
             self._dll = ShamrockDLL()
             self.Initialize()
@@ -2233,7 +2234,11 @@ class ShamrockBus(model.HwComponent):
     def terminate(self):
         for c in self.children.value:
             c.terminate()
-        self.Close()
+
+        if self._dll:
+            self.Close()
+            self._dll = None
+
         super().terminate()
 
     def Initialize(self):


### PR DESCRIPTION
If using simulators, it doesn't instantiate a dll, so cannot close it.