### PR TITLE
[fix] kymera-exchange-turret fall back to direct connection if component not available on current back-end

### DIFF
--- a/util/kymera-exchange-turret.sh
+++ b/util/kymera-exchange-turret.sh
@@ -28,8 +28,15 @@ odemis --check
 status=$?
 
 if [ $status = 0 ] || [ $status = 3 ] ; then  # Running or starting
-    select_args="--role $role"
-    # For safety, close the shutter of the streak cam (in case it's not already closed)
+    # Check the back-end has the component
+    if odemis list-prop "$role" --machine > /dev/null; then
+        select_args="--role $role"
+    else
+        echo "Back-end running but component $role not available so will attempt direct connection"
+        select_args="--serial $serial_num"
+    fi
+
+    # For safety, if possible, close the shutter of the streak cam (in case it's not already closed)
     odemis --set-attr streak-unit shutter True
 else
     select_args="--serial $serial_num"


### PR DESCRIPTION
The script can connect to the spectrograph in two ways: either via the
running back-end (based on the role), or directly (based on a serial
number).

If a back-end is available, the script would only try to connect via the
back-end. However, it can be that the current back-end doesn't control
the specific spectrograph. In this case, it shouldn't fail, but just try
via the direct connection.

Note that this doesn't solve *every* case, as if the backend connects to
another spectrograph, it might have also claimed the spectrograph we are
interested in, because that's how the Andor SDK works. In such case, the
only option is to stop the back-end. It's not a big deal, as after
switching the turret, the back-end must be restarted anyway.