### PR TITLE
[feat] Store more component information in hardware settings metadata

### DIFF
--- a/src/odemis/acq/acqmng.py
+++ b/src/odemis/acq/acqmng.py
@@ -20,7 +20,6 @@ You should have received a copy of the GNU General Public License along with
 Odemis. If not, see http://www.gnu.org/licenses/.
 
 """
-
 # Everything related to high-level image acquisition on the microscope.
 
 
@@ -28,7 +27,9 @@ from collections import OrderedDict
 from collections.abc import Iterable
 from concurrent.futures import CancelledError
 import logging
+import os
 import threading
+from typing import Set
 
 from odemis import model
 from odemis.acq import _futures
@@ -698,13 +699,22 @@ class SettingsObserver(object):
     at the end of an acquisition.
     """
 
-    def __init__(self, components):
+    def __init__(self, microscope: model.HwComponent, components: Set[model.HwComponent]):
         """
-        components (set of HwComponents): component which should be observed
+        microscope: the "root" component
+        components: components which should be observed
         """
         self._all_settings = {}
         self._components = components  # keep a reference to the components, so they are not garbage collected
         self._va_updaters = []  # keep a reference to the subscribers so they are not garbage collected
+
+        # Store very generic (and static) information about the whole microscope
+        self._all_settings["Microscope"] = {
+            "Manufacturer": ("Delmic", None),  #  None == No unit
+            "Name": (microscope.name, None),
+            "Model": (microscope.role, None),
+            "Serial number": (os.uname().nodename, None),
+        }
 
         for comp in components:
             self._all_settings[comp.name] = {}

--- a/src/odemis/acq/stitching/test/tiledacq_test.py
+++ b/src/odemis/acq/stitching/test/tiledacq_test.py
@@ -264,7 +264,7 @@ class CRYOSECOMTestCase(unittest.TestCase):
        Test the whole procedure (acquire compressed zstack + stitch) of acquireTiledArea function
        """
         # With fm streams
-        settings_obs = SettingsObserver([self.stage])
+        settings_obs = SettingsObserver(self.microscope, [self.stage])
         fm_fov = compute_camera_fov(self.ccd)
         # Using "songbird-sim-ccd.h5" in simcam with tile max_res: (260, 348)
         area = (0, 0, fm_fov[0] * 2, fm_fov[1] * 2)  # left, top, right, bottom
@@ -288,7 +288,7 @@ class CRYOSECOMTestCase(unittest.TestCase):
         Test the whole procedure (acquire + stitch) of acquireTiledArea function
         """
         # With fm streams
-        settings_obs = SettingsObserver([self.stage])
+        settings_obs = SettingsObserver(self.microscope, [self.stage])
 
         fm_fov = compute_camera_fov(self.ccd)
         # Using "songbird-sim-ccd.h5" in simcam with tile max_res: (260, 348)
@@ -443,7 +443,7 @@ class CRYOSECOMTestCase(unittest.TestCase):
         """
         Test the focusing methods ALWAYS
         """
-        settings_obs = SettingsObserver([self.stage])
+        settings_obs = SettingsObserver(self.microscope, [self.stage])
         self._focuser_pos = []  # List of focuser positions
         # Note: we assume it doesn't randomly changes if not explicitly moving,
         # which is normally correct on the simulator.

--- a/src/odemis/acq/test/fastem_test.py
+++ b/src/odemis/acq/test/fastem_test.py
@@ -1069,7 +1069,7 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
         original_md = self.mppc.getMetadata().get(model.MD_EXTRA_SETTINGS, "")
 
         # Create the settings observer to store the settings on the metadata
-        settings_obs = SettingsObserver(model.getComponents())
+        settings_obs = SettingsObserver(model.getMicroscope(), model.getComponents())
         points = [(0, 0), (0, 0), (0, 0), (0, 0)]
 
         roa = fastem.FastEMROA("roa_name", None, None,
@@ -1104,7 +1104,7 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
         self.mppc.dataContent.value = "full"
 
         # Create the settings observer to store the settings on the metadata
-        settings_obs = SettingsObserver(model.getComponents())
+        settings_obs = SettingsObserver(model.getMicroscope(), model.getComponents())
 
         coordinates = (0, 0, 1e-8, 1e-8)  # in m
         roc_2 = fastem.FastEMROC("roc_2", coordinates)
@@ -1260,9 +1260,6 @@ class TestFastEMAcquisitionTaskMock(TestFastEMAcquisitionTask):
 
     def test_save_full_cells(self):
         """Test saving fields with cell images of 900x900 px instead of 800x800 px"""
-        # Create the settings observer to store the settings on the metadata
-        settings_obs = SettingsObserver({})
-
         coordinates = (0, 0, 1e-8, 1e-8)  # in m
         roc_2 = fastem.FastEMROC("roc_2", coordinates)
         roc_3 = fastem.FastEMROC("roc_3", coordinates)
@@ -1280,7 +1277,7 @@ class TestFastEMAcquisitionTaskMock(TestFastEMAcquisitionTask):
                                       self.se_detector, self.ebeam_focus,
                                       roa, path="test-path", pre_calibrations=None,
                                       save_full_cells=False, future=Mock(),
-                                      settings_obs=settings_obs, spot_grid_thresh=0.5)
+                                      settings_obs=None, spot_grid_thresh=0.5)
 
         # image_received should be called as a side effect of calling data.next, this signals that the data is received
         def _image_received(*args, **kwargs):
@@ -1299,7 +1296,7 @@ class TestFastEMAcquisitionTaskMock(TestFastEMAcquisitionTask):
                                       self.se_detector, self.ebeam_focus,
                                       roa, path="test-path", pre_calibrations=None,
                                       save_full_cells=True, future=Mock(),
-                                      settings_obs=settings_obs, spot_grid_thresh=0.5)
+                                      settings_obs=None, spot_grid_thresh=0.5)
 
         data, err = task.run()
         self.assertEqual(data[(0, 0)].shape, (7200, 7200))

--- a/src/odemis/gui/model/main_gui_data.py
+++ b/src/odemis/gui/model/main_gui_data.py
@@ -250,10 +250,11 @@ class MainGUIData(object):
             for c in components:
                 if c.role is None:
                     continue
+
+                comps_with_role.append(c)
                 try:
                     attrname = self._ROLE_TO_ATTR[c.role]
                     setattr(self, attrname, c)
-                    comps_with_role.append(c)
                 except KeyError:
                     pass
 

--- a/src/odemis/gui/model/main_gui_data.py
+++ b/src/odemis/gui/model/main_gui_data.py
@@ -349,7 +349,7 @@ class MainGUIData(object):
                 self.currentFeature = model.VigilantAttribute(None)
             # Initialize settings observer to keep track of all relevant settings that should be
             # stored as metadata
-            self.settings_obs = acqmng.SettingsObserver(comps_with_role)
+            self.settings_obs = acqmng.SettingsObserver(microscope, comps_with_role)
 
             # There are two kinds of SEM (drivers): the one that are able to
             # control the magnification, and the one that cannot. The former ones


### PR DESCRIPTION
This ensures that every component with a role is stored in the MD_EXTRA_SETTINGS info (not just the ones that are explicitly controlled by the GUI). Also adds info about the microscope itself.