### PR TITLE
[fix] driver andorcam2 doesn't update frameDuration until first image

### DIFF
--- a/src/odemis/driver/andorcam2.py
+++ b/src/odemis/driver/andorcam2.py
@@ -876,6 +876,9 @@ class AndorCam2(model.DigitalCamera):
             else:
                 logging.info("Camera does not support external trigger")
 
+            # Start the acquisition thread immediately, as it also takes care of updating the
+            # frameDuration whenever some of the settings change.
+            self._ensure_acq_thread_is_running()
             logging.debug("Camera component ready to use.")
         except Exception as ex:
             logging.error("Failed to complete initialization (%s), will shutdown camera", ex)
@@ -2231,6 +2234,12 @@ class AndorCam2(model.DigitalCamera):
         The image are sent via the .data DataFlow
         """
         self._genmsg.put(GEN_START)
+        self._ensure_acq_thread_is_running()
+
+    def _ensure_acq_thread_is_running(self):
+        """
+        Start the acquisition thread if it's not already running
+        """
         if not self._acq_thread or not self._acq_thread.is_alive():
             logging.info("Starting acquisition thread")
             self._acq_thread = threading.Thread(target=self._acquire,
@@ -3349,8 +3358,10 @@ class FakeAndorV2DLL(object):
                 raise AndorV2Error(20024, "No new data, simulated acquisition aborted")
 
         elif self._trigger_mode == AndorV2DLL.TM_EXTERNAL:
-            # Pretends trigger immediately arrived, so acquisition starts just now
-            pass
+            # Pretends the trigger takes time to arrive on the first frame, and for the other frames
+            # it immediately arrives.
+            if self._first_frame == 0:
+                time.sleep(1.0)
             # Uncomment to simulate when hardware trigger is never received
             # time.sleep(timeout)
             # raise AndorV2Error(20024, "No new data, simulated acquisition aborted")

--- a/src/odemis/driver/test/andorcam2_test.py
+++ b/src/odemis/driver/test/andorcam2_test.py
@@ -234,7 +234,7 @@ class TestAndorCam2HwTrigger(unittest.TestCase):
         # a trigger just after waiting for the data. So the behaviour is actually
         # the same as no trigger.
         self.camera.data.synchronizedOn(self.camera.hardwareTrigger)
-        time.sleep(1)  # a couple of hw triggers coming in
+        time.sleep(3)  # a couple of hw triggers coming in
         self.assertGreater(len(self.rcv_dates), 1)
 
         self.camera.data.unsubscribe(self.receive_image)


### PR DESCRIPTION
The frameDuration is updated by the "acquisition" thread. However,
until now, the acquisition thread was only started on the first time an
acquisition was started. So, just after starting the back-end the
frameDuration would be incorrect.
That's actually not common on real systems, as the camera is almost
always first used before doing something relying on frameDuration, but
on test cases, this is very common.

Also adjust the simulator with the hardware trigger, to better simulate
external triggers typically don't arrive immediately when starting an
acquisition.