### PR TITLE
[fix] Display SPARC Monochromator stream filters in user-friendly way

### DIFF
--- a/src/odemis/gui/conf/data.py
+++ b/src/odemis/gui/conf/data.py
@@ -994,6 +994,9 @@ STREAM_SETTINGS_CONFIG = {
                 "label": "Det. slit",
                 "tooltip": u"Opening size of the detector slit.\nThe wider, the larger the wavelength bandwidth.",
             }),
+            ("filter", {  # filter.band axis
+                "choices": util.format_band_choices,
+            }),
         )),
     stream.ARSettingsStream:
         OrderedDict((


### PR DESCRIPTION
Use the same display as for the spectrum and AR stream to show nicely
the filter bands.