### PR TITLE
[FEAT] Add config file for odemis-advanced mode

### DIFF
--- a/src/odemis/gui/cont/acquisition/cryo_acq.py
+++ b/src/odemis/gui/cont/acquisition/cryo_acq.py
@@ -27,6 +27,7 @@ of microscope images.
 
 """
 
+import configparser
 import logging
 import math
 import os
@@ -63,7 +64,22 @@ ST_CANCELED = "CANCELED"
 
 # tmp flag for odemis advanced mode
 # TODO: remove and replace once the licenced version is released
-ODEMIS_ADVANCED_FLAG: bool = False
+def get_license_enabled() -> bool:
+    """
+    Temporary function to get the license status.
+    Allows to enable/disable without changing the code.
+    """
+    enabled  = False
+    odemis_advanced_config = os.path.abspath(os.path.join(conf.file.CONF_PATH, "odemis_advanced.config"))
+    if os.path.exists(odemis_advanced_config):
+        config = configparser.ConfigParser(interpolation=None)
+        config.read(odemis_advanced_config)
+        enabled = config["licence"].get("enabled", "False") == "True"
+
+    logging.debug(f"odemis-advanced mode is {'enabled' if enabled else 'disabled'}")
+    return enabled
+
+ODEMIS_ADVANCED_FLAG = get_license_enabled()
 
 
 class CryoAcquiController(object):


### PR DESCRIPTION
Change the odemis advanced flag to be read from a config file, rather than hardcoded in the code. This allows us to easily enable this for specific users without having to adjust the code (which requires installing a development version). 

This is temporary while we are testing the functionality which is hidden behind the flag