### PR TITLE
[fix] GUI SPARC: allow a larger move on the Tunnel alignment lens

### DIFF
--- a/src/odemis/gui/model/tab_gui_data.py
+++ b/src/odemis/gui/model/tab_gui_data.py
@@ -573,7 +573,7 @@ class ActuatorGUIData(MicroscopyGUIData):
                   }
         if main.spec_ded_aligner:
             ss_def.update({
-                "spec_ded_aligner_xy": (5e-6, [100e-9, 1e-4], "spec_ded_aligner", {"x", "y"}),
+                "spec_ded_aligner_xy": (5e-6, [100e-9, 1e-3], "spec_ded_aligner", {"x", "y"}),
                 "spec_ded_aligner_z": (25e-6, [5e-6, 500e-6], "spec_ded_aligner", {"z"}),
             })
 


### PR DESCRIPTION
Requested by the users. Sometimes a large move of the lens is required.
Don't change the default step size of a move, but allow up to 1 mm per
step (instead of 100µm).