### PR TITLE
[fix] andorcam2 don't call PrepareAcquisition, as it sometimes fails

### DIFF
--- a/src/odemis/driver/andorcam2.py
+++ b/src/odemis/driver/andorcam2.py
@@ -2531,9 +2531,9 @@ class AndorCam2(model.DigitalCamera):
                     # Trigger received => start the acquisition
                     self.atcore.SendSoftwareTrigger()
                 elif trigger_mode == TRIG_FAKE:
-                    # In theory, it's supposed to make the StartAcquisition(). In practice, it doesn't
-                    # seem to help much, but we still do it just in case it helps a little bit.
-                    self.atcore.PrepareAcquisition()
+                    # In theory, we could call PrepareAcquisition(), as it's supposed to make the StartAcquisition().
+                    # In practice, it doesn't seem to help much, and even more annoyingly, it sometimes fails
+                    # claiming that the (previous) acquisition is still running.
 
                     # Wait for trigger
                     msg = self._acq_wait_trigger()


### PR DESCRIPTION
The idea of PrepareAcquisition() was that it'd help the camera to start
more quickly when receiving a trigger. However, on the Newton without
software triggers, sometimes the camera would reject the call, because
it thinks it's not done with the acquisition yet (although it did
receive the frame already). As it's not clear whether it was ever
helpful, let's just drop this "potential improvement", and make sure
it's reliable.