### PR TITLE
[fix] Run image translation before and after running image rotation

### DIFF
--- a/src/odemis/gui/model/main_gui_data.py
+++ b/src/odemis/gui/model/main_gui_data.py
@@ -643,11 +643,14 @@ class FastEMMainGUIData(MainGUIData):
             calib_3_calibrations = [Calibrations.OPTICAL_AUTOFOCUS,
                                     Calibrations.IMAGE_TRANSLATION_PREALIGN]
         else:
+            # Run image translation before image rotation to ensure the pattern is fully on the mppc, run it again
+            # after image rotation because the pattern is not rotated exactly around its own center.
             calib_1_calibrations = [Calibrations.OPTICAL_AUTOFOCUS,
                                     Calibrations.IMAGE_ROTATION_PREALIGN,
                                     Calibrations.SCAN_ROTATION_PREALIGN,
                                     Calibrations.DESCAN_GAIN_STATIC,
                                     Calibrations.IMAGE_TRANSLATION_PREALIGN,
+                                    Calibrations.IMAGE_TRANSLATION_FINAL,
                                     Calibrations.IMAGE_ROTATION_FINAL,
                                     Calibrations.IMAGE_TRANSLATION_FINAL]
             calib_2_calibrations = [Calibrations.OPTICAL_AUTOFOCUS,


### PR DESCRIPTION
For reasons unknown it can happen that the image translation pre-alignment does not fully center the pattern on the mppc. The result is that when we try to run the image rotation alignment, not all squares are visible in the image and the fit fails (see image below). By first running the image translation alignment we ensure that all squares are visible in the image. But because the image rotation does not rotate the pattern exactly around the center of the pattern we will have to run the image translation again afterwards. So the order will be: image translation → image rotation → image translation.