### PR TITLE
[feat] andorshrk: also allow shutter control on the KY328i

### DIFF
--- a/src/odemis/driver/andorshrk.py
+++ b/src/odemis/driver/andorshrk.py
@@ -618,7 +618,7 @@ class Shamrock(model.Actuator):
                                      pos, allowed_pos))
 
             if self.ShutterIsPresent():
-                if drives_shutter and not self._model == MODEL_KY193:
+                if drives_shutter and self._model == MODEL_SR303:
                     raise ValueError("Device doesn't support BNC mode for shutter")
                 if "flip-out" in axes:
                     val = self.GetFlipperMirror(OUTPUT_FLIPPER)


### PR DESCRIPTION
So far only the KY193 supported the shutter control, and the SR303 not.
Now that we have added support for the KY328, which also can control the
shutter, we need to invert the logic to just say "SR303" doesn't support
shutter control (and every else does).