### PR TITLE
[fix] SPARCv2 alignment tab should show shutter minimum period for sp-ccd too

### DIFF
--- a/src/odemis/gui/conf/data.py
+++ b/src/odemis/gui/conf/data.py
@@ -653,6 +653,16 @@ HW_SETTINGS_CONFIG_PER_ROLE = {
                 "control_type": odemis.gui.CONTROL_SLIDER,
             },
         },
+        r"sp-ccd.*":
+        {
+            "resolution":  # Read-only it shouldn't be changed by the user
+                {
+                    "control_type": odemis.gui.CONTROL_READONLY,
+                },
+            "shutterMinimumPeriod": {  # Only on the SPARC
+                "control_type": odemis.gui.CONTROL_SLIDER,
+            },
+        },
         "e-beam":
         {
             "dwellTime":


### PR DESCRIPTION
By default, the shutter minimum period is hidden on all the detectors.
On the SPARCv2, we have to explicitly show it. It was done for the ccd
and spectrometers, but we forgot the sp-ccd's.