### PR TITLE
[fix][METEOR] prevent race condition if acquiring while streams are live

### DIFF
--- a/src/odemis/gui/cont/acquisition/cryo_acq.py
+++ b/src/odemis/gui/cont/acquisition/cryo_acq.py
@@ -200,7 +200,6 @@ class CryoAcquiController(object):
 
         # disable the streams settings while acquiring
         if is_acquiring:
-            self._tab.streambar_controller.pauseStreams()
             self._tab.streambar_controller.pause()
         else:
             self._tab.streambar_controller.resume()
@@ -217,6 +216,11 @@ class CryoAcquiController(object):
 
         # the acquisition is started
         self._tab_data.main.is_acquiring.value = True
+
+        # NOTE: acquisition manager expects all streams to be paused before starting.
+        # this cannot be done in the is_acquiring callback as it can be delayed
+        # until after the acquisition starts
+        self._tab.streambar_controller.pauseStreams()
 
         # acquire the data
         if self._zStackActive.value:
@@ -287,6 +291,11 @@ class CryoAcquiController(object):
 
         # the acquisition is started
         self._tab_data.main.is_acquiring.value = True
+
+        # NOTE: acquisition manager expects all streams to be paused before starting.
+        # this cannot be done in the is_acquiring callback as it can be delayed
+        # until after the acquisition starts
+        self._tab.streambar_controller.pauseStreams()
 
         zparams: dict = {}
         if self._zStackActive.value:


### PR DESCRIPTION
There is a race condition on the is_acquiring/_on_acquisition callback, if the stream is playing, the callback has to wait for the main ui thread to be available to start, while the acquisition can just start. the callback will pause the stream, and the acquisition will timeout. We add a synchronous pause of the streams to prevent this from occurring. synchronously here. 

Currently this completely breaks imaging on the meteor, so needs to be fixed urgently