### PR TITLE
[fix] GUI shows checkbox unaligned

### DIFF
--- a/src/odemis/gui/comp/stream_panel.py
+++ b/src/odemis/gui/comp/stream_panel.py
@@ -1128,7 +1128,7 @@ class StreamPanel(wx.Panel):
         value_ctrl = wx.CheckBox(self._panel, wx.ID_ANY,
                                  style=wx.ALIGN_RIGHT | wx.NO_BORDER,
                                  **conf)
-        self.gb_sizer.Add(value_ctrl, (self.num_rows, 2), span=(1, 1),
+        self.gb_sizer.Add(value_ctrl, (self.num_rows, 1), span=(1, 2),
                           flag=wx.ALIGN_CENTRE_VERTICAL | wx.EXPAND | wx.TOP | wx.BOTTOM, border=5)
         value_ctrl.SetValue(value)
 


### PR DESCRIPTION
For the FASTEM GUI vEM (commit 42efe0cb6a), the checkbox position
in the size was changed. It seems this was to accomodate better the
calibration buttons.
However, this breaks the checkbox position on the SPARC (and METEOR)
streams.
=> Put back the checkbox positioning as before.

If the FASTEM GUI needs larger calibration buttons, then these buttons
should have the positionning adjusted.