### PR TITLE
[fix] Make project load message product agnostic

### DIFF
--- a/src/odemis/gui/cont/tabs/cryo_chamber_tab.py
+++ b/src/odemis/gui/cont/tabs/cryo_chamber_tab.py
@@ -942,8 +942,8 @@ class CryoChamberTab(Tab):
                 # Ask the user to create or load a project
                 box = wx.MessageDialog(
                     self.main_frame,
-                    message="Create or Load a Meteor Project?",
-                    caption="Meteor",
+                    message="Create or Load a project?",
+                    caption="Odemis Project",
                     style=wx.YES_NO | wx.ICON_QUESTION | wx.CENTER,
                 )
 


### PR DESCRIPTION
Make the message for creating /loading a project agnostic for meteor / enzel