### PR TITLE
[fix] clarify that fastem-sim microscope file can only be used as a b…

### DIFF
--- a/install/linux/usr/share/odemis/sim/fastem-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/fastem-sim.odm.yaml
@@ -1,4 +1,4 @@
-# Minimal configuration file to start the Fast-EM GUI
+# Minimal configuration file to start a simple Fast-EM backend without the ASM related functionality
 FASTEM-sim: {
     class: Microscope,
     role: mbsem,


### PR DESCRIPTION
…ackend not GUI

The microscope file fastem-sim.odm.yaml mentioned that it could be used to start a simple GUI. However it can only be used to start a simple backend without ASM related functionality. The comment has been fixed to clarify this.