### PR TITLE
[feat] make fastem beam blanking in between fields optional

### DIFF
--- a/src/odemis/acq/test/fastem_test.py
+++ b/src/odemis/acq/test/fastem_test.py
@@ -767,13 +767,11 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
             # Give sometime for calculation of field_indices
             time.sleep(1)
 
-            task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner,
-                                          self.mppc, self.stage, self.scan_stage, self.ccd,
-                                          self.beamshift, self.lens,
-                                          self.se_detector, self.ebeam_focus,
-                                          roa, username="default", path=None, pre_calibrations=None,
-                                          save_full_cells=False, future=None,
-                                          settings_obs=None, spot_grid_thresh=0.5)
+            task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner, self.mppc, self.stage,
+                                          self.scan_stage, self.ccd, self.beamshift, self.lens, self.se_detector,
+                                          self.ebeam_focus, roa, path=None, username="default", pre_calibrations=None,
+                                          save_full_cells=False, settings_obs=None, spot_grid_thresh=0.5,
+                                          blank_beam=True, future=None)
 
             # Set the _pos_first_tile, which would normally be set in the run function.
             task._pos_first_tile = task.get_pos_first_tile()
@@ -857,13 +855,11 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
             # Give sometime for calculation of field_indices
             time.sleep(1)
 
-            task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner,
-                                          self.mppc, self.stage, self.scan_stage, self.ccd,
-                                          self.beamshift, self.lens,
-                                          self.se_detector, self.ebeam_focus,
-                                          roa, username="default", path=None, pre_calibrations=None,
-                                          save_full_cells=False, future=None,
-                                          settings_obs=None, spot_grid_thresh=0.5)
+            task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner, self.mppc, self.stage,
+                                          self.scan_stage, self.ccd, self.beamshift, self.lens, self.se_detector,
+                                          self.ebeam_focus, roa, path=None, username="default", pre_calibrations=None,
+                                          save_full_cells=False, settings_obs=None, spot_grid_thresh=0.5,
+                                          blank_beam=True, future=None)
 
             # Set the _pos_first_tile, which would normally be set in the run function.
             task._pos_first_tile = task.get_pos_first_tile()
@@ -944,13 +940,11 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
         # Give sometime for calculation of field_indices
         time.sleep(1)
 
-        task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner,
-                                      self.mppc, self.stage, self.scan_stage, self.ccd,
-                                      self.beamshift, self.lens,
-                                      self.se_detector, self.ebeam_focus,
-                                      roa, username="default", path=None, pre_calibrations=None,
-                                      save_full_cells=True, future=None,
-                                      settings_obs=None, spot_grid_thresh=0.5)
+        task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner, self.mppc, self.stage,
+                                      self.scan_stage, self.ccd, self.beamshift, self.lens, self.se_detector,
+                                      self.ebeam_focus, roa, path=None, username="default", pre_calibrations=None,
+                                      save_full_cells=True, settings_obs=None, spot_grid_thresh=0.5, blank_beam=True,
+                                      future=None)
 
         # Set the _pos_first_tile, which would normally be set in the run function.
         task._pos_first_tile = task.get_pos_first_tile()
@@ -1028,12 +1022,11 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
         # Give sometime for calculation of field_indices
         time.sleep(1)
 
-        task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner,
-                                      self.mppc, self.stage, self.scan_stage, self.ccd,
-                                      self.beamshift, self.lens,
-                                      self.se_detector, self.ebeam_focus,
-                                      roa, username="default", path=None, pre_calibrations=None,
-                                      save_full_cells=False, future=None, settings_obs=None, spot_grid_thresh=0.5)
+        task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner, self.mppc, self.stage,
+                                      self.scan_stage, self.ccd, self.beamshift, self.lens, self.se_detector,
+                                      self.ebeam_focus, roa, path=None, username="default", pre_calibrations=None,
+                                      save_full_cells=False, settings_obs=None, spot_grid_thresh=0.5, blank_beam=True,
+                                      future=None)
         # Set the _pos_first_tile, which would normally be set in the run function.
         task._pos_first_tile = task.get_pos_first_tile()
 
@@ -1088,12 +1081,11 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
         # Give sometime for calculation of field_indices
         time.sleep(1)
 
-        task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner,
-                                      self.mppc, self.stage, self.scan_stage, self.ccd,
-                                      self.beamshift, self.lens,
-                                      self.se_detector, self.ebeam_focus,
-                                      roa, username="default", path=None, pre_calibrations=None,
-                                      save_full_cells=False, future=None, settings_obs=None, spot_grid_thresh=0.5)
+        task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner, self.mppc, self.stage,
+                                      self.scan_stage, self.ccd, self.beamshift, self.lens, self.se_detector,
+                                      self.ebeam_focus, roa, path=None, username="default", pre_calibrations=None,
+                                      save_full_cells=False, settings_obs=None, spot_grid_thresh=0.5, blank_beam=True,
+                                      future=None)
 
         self.descanner.updateMetadata({model.MD_SCAN_GAIN: (5000, 5000)})
 
@@ -1148,13 +1140,11 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
             # Give sometime for calculation of field_indices
             time.sleep(2)
 
-            task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner,
-                                          self.mppc, self.stage, self.scan_stage, self.ccd,
-                                          self.beamshift, self.lens,
-                                          self.se_detector, self.ebeam_focus,
-                                          roa, username="default", path=None, pre_calibrations=None,
-                                          save_full_cells=False, future=None,
-                                          settings_obs=None, spot_grid_thresh=0.5)
+            task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner, self.mppc, self.stage,
+                                          self.scan_stage, self.ccd, self.beamshift, self.lens, self.se_detector,
+                                          self.ebeam_focus, roa, path=None, username="default", pre_calibrations=None,
+                                          save_full_cells=False, settings_obs=None, spot_grid_thresh=0.5,
+                                          blank_beam=True, future=None)
 
             pos_first_tile_actual = task.get_pos_first_tile()
 
@@ -1183,13 +1173,11 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
         # Give sometime for calculation of field_indices
         time.sleep(1)
 
-        task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner,
-                                      self.mppc, self.stage, self.scan_stage, self.ccd,
-                                      self.beamshift, self.lens,
-                                      self.se_detector, self.ebeam_focus,
-                                      roa, username="default", path=None, pre_calibrations=None,
-                                      save_full_cells=False, future=None,
-                                      settings_obs=settings_obs, spot_grid_thresh=0.5)
+        task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner, self.mppc, self.stage,
+                                      self.scan_stage, self.ccd, self.beamshift, self.lens, self.se_detector,
+                                      self.ebeam_focus, roa, path=None, username="default", pre_calibrations=None,
+                                      save_full_cells=False, settings_obs=settings_obs, spot_grid_thresh=0.5,
+                                      blank_beam=True, future=None)
 
         # Test that _create_acquisition_metadata() sets the settings from the selection
         acquisition_md = task._create_acquisition_metadata()
@@ -1232,24 +1220,20 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
         time.sleep(1)
 
         # Acquire an image were the full cell images are cropped to 800x800px
-        task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner,
-                                      self.mppc, self.stage, self.scan_stage, self.ccd,
-                                      self.beamshift, self.lens,
-                                      self.se_detector, self.ebeam_focus,
-                                      roa, username="default", path="test-path", pre_calibrations=None,
-                                      save_full_cells=False, future=Mock(),
-                                      settings_obs=settings_obs, spot_grid_thresh=0.5)
+        task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner, self.mppc, self.stage,
+                                      self.scan_stage, self.ccd, self.beamshift, self.lens, self.se_detector,
+                                      self.ebeam_focus, roa, path="test-path", username="default",
+                                      pre_calibrations=None, save_full_cells=False, settings_obs=settings_obs,
+                                      spot_grid_thresh=0.5, blank_beam=True, future=Mock())
         data, err = task.run()
         self.assertEqual(data[(0, 0)].shape, (6400, 6400))
 
         # Acquire an image were the cell images are 900x900px
-        task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner,
-                                      self.mppc, self.stage, self.scan_stage, self.ccd,
-                                      self.beamshift, self.lens,
-                                      self.se_detector, self.ebeam_focus,
-                                      roa, username="default", path="test-path", pre_calibrations=None,
-                                      save_full_cells=True, future=Mock(),
-                                      settings_obs=settings_obs, spot_grid_thresh=0.5)
+        task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner, self.mppc, self.stage,
+                                      self.scan_stage, self.ccd, self.beamshift, self.lens, self.se_detector,
+                                      self.ebeam_focus, roa, path="test-path", username="default",
+                                      pre_calibrations=None, save_full_cells=True, settings_obs=settings_obs,
+                                      spot_grid_thresh=0.5, blank_beam=True, future=Mock())
         data, err = task.run()
         self.assertEqual(data[(0, 0)].shape, (7200, 7200))
 
@@ -1267,13 +1251,11 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
                              (2, 1), (3, 1), (4, 1), (10, 1),
                              (1, 2), (2, 2), (3, 2), (4, 2),
                              (0, 3), (1, 3), (2, 3), (3, 3), (4, 3)]
-        task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner,
-                                      self.mppc, self.stage, self.scan_stage, self.ccd,
-                                      self.beamshift, self.lens,
-                                      self.se_detector, self.ebeam_focus,
-                                      roa, username="default", path=None, pre_calibrations=None,
-                                      save_full_cells=False, future=None,
-                                      settings_obs=None, spot_grid_thresh=0.5)
+        task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner, self.mppc, self.stage,
+                                      self.scan_stage, self.ccd, self.beamshift, self.lens, self.se_detector,
+                                      self.ebeam_focus, roa, path=None, username="default", pre_calibrations=None,
+                                      save_full_cells=False, settings_obs=None, spot_grid_thresh=0.5, blank_beam=True,
+                                      future=None)
         # When n_beamshifts=1, the beamshift correction should be applied for every field.
         # Therefore, the calculated indices should match the original field indices.
         beam_shift_indices = task._calculate_beam_shift_cor_indices(n_beam_shifts=1)
@@ -1404,13 +1386,11 @@ class TestFastEMAcquisitionTaskMock(TestFastEMAcquisitionTask):
         time.sleep(2)
 
         # Acquire an image were the full cell images are cropped to 800x800px
-        task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner,
-                                      self.mppc, self.stage, self.scan_stage, self.ccd,
-                                      self.beamshift, self.lens,
-                                      self.se_detector, self.ebeam_focus,
-                                      roa, username="default", path="test-path", pre_calibrations=None,
-                                      save_full_cells=False, future=Mock(),
-                                      settings_obs=None, spot_grid_thresh=0.5)
+        task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner, self.mppc, self.stage,
+                                      self.scan_stage, self.ccd, self.beamshift, self.lens, self.se_detector,
+                                      self.ebeam_focus, roa, path="test-path", username="default",
+                                      pre_calibrations=None, save_full_cells=False, settings_obs=None,
+                                      spot_grid_thresh=0.5, blank_beam=True, future=Mock())
 
         # image_received should be called as a side effect of calling data.next, this signals that the data is received
         def _image_received(*args, **kwargs):
@@ -1423,13 +1403,11 @@ class TestFastEMAcquisitionTaskMock(TestFastEMAcquisitionTask):
         self.assertEqual(data[(0, 0)].shape, (6400, 6400))
 
         # Acquire an image were the cell images are 900x900px
-        task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner,
-                                      self.mppc, self.stage, self.scan_stage, self.ccd,
-                                      self.beamshift, self.lens,
-                                      self.se_detector, self.ebeam_focus,
-                                      roa, username="default", path="test-path", pre_calibrations=None,
-                                      save_full_cells=True, future=Mock(),
-                                      settings_obs=None, spot_grid_thresh=0.5)
+        task = fastem.AcquisitionTask(self.scanner, self.multibeam, self.descanner, self.mppc, self.stage,
+                                      self.scan_stage, self.ccd, self.beamshift, self.lens, self.se_detector,
+                                      self.ebeam_focus, roa, path="test-path", username="default",
+                                      pre_calibrations=None, save_full_cells=True, settings_obs=None,
+                                      spot_grid_thresh=0.5, blank_beam=True, future=Mock())
 
         data, err = task.run()
         self.assertEqual(data[(0, 0)].shape, (7200, 7200))

--- a/src/odemis/gui/cont/acquisition/fastem_acq.py
+++ b/src/odemis/gui/cont/acquisition/fastem_acq.py
@@ -540,7 +540,7 @@ class FastEMAcquiController(object):
         self.bmp_acq_status_warn = self._tab_panel.bmp_acq_status_warn
         self.bmp_acq_status_info = self._tab_panel.bmp_acq_status_info
         self.chk_ebeam_off = self._tab_panel.chk_ebeam_off
-        self.chk_beam_blank = self._tab_panel.chk_beam_blank
+        self.chk_beam_blank_off = self._tab_panel.chk_beam_blank_off
         self.acq_future = None  # ProgressiveBatchFuture
         self._fs_connector = None  # ProgressiveFutureConnector
         self.save_full_cells = model.BooleanVA(
@@ -842,7 +842,7 @@ class FastEMAcquiController(object):
             f"and autofocus every {autofocus_period} sections."
         )
         username = self._main_data_model.current_user.value
-        blank_beam = not self.chk_beam_blank.IsChecked()
+        blank_beam = not self.chk_beam_blank_off.IsChecked()
 
         total_t = 0
         project_names = list(self.project_roas.keys())

--- a/src/odemis/gui/cont/acquisition/fastem_acq.py
+++ b/src/odemis/gui/cont/acquisition/fastem_acq.py
@@ -540,6 +540,7 @@ class FastEMAcquiController(object):
         self.bmp_acq_status_warn = self._tab_panel.bmp_acq_status_warn
         self.bmp_acq_status_info = self._tab_panel.bmp_acq_status_info
         self.chk_ebeam_off = self._tab_panel.chk_ebeam_off
+        self.chk_beam_blank = self._tab_panel.chk_beam_blank
         self.acq_future = None  # ProgressiveBatchFuture
         self._fs_connector = None  # ProgressiveFutureConnector
         self.save_full_cells = model.BooleanVA(
@@ -841,6 +842,7 @@ class FastEMAcquiController(object):
             f"and autofocus every {autofocus_period} sections."
         )
         username = self._main_data_model.current_user.value
+        blank_beam = not self.chk_beam_blank.IsChecked()
 
         total_t = 0
         project_names = list(self.project_roas.keys())
@@ -884,6 +886,7 @@ class FastEMAcquiController(object):
                     save_full_cells=self.save_full_cells.value,
                     settings_obs=self._main_data_model.settings_obs,
                     spot_grid_thresh=acqui_conf.spot_grid_threshold,
+                    blank_beam=blank_beam
                 )
                 # If this is the last ROA in the current project, set the dwell time for the next project
                 # on completion of current project's future

--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -562,6 +562,7 @@ class xrcpnl_tab_fastem_acqui(wx.Panel):
         self.pnl_projects_header = xrc.XRCCTRL(self, "pnl_projects_header")
         self.pnl_projects = xrc.XRCCTRL(self, "pnl_projects")
         self.chk_ebeam_off = xrc.XRCCTRL(self, "chk_ebeam_off")
+        self.chk_beam_blank = xrc.XRCCTRL(self, "chk_beam_blank")
         self.txt_num_roas = xrc.XRCCTRL(self, "txt_num_roas")
         self.bmp_acq_status_info = xrc.XRCCTRL(self, "bmp_acq_status_info")
         self.bmp_acq_status_warn = xrc.XRCCTRL(self, "bmp_acq_status_warn")
@@ -7309,6 +7310,13 @@ D\x02\x12\x0c/\x81\x10.\xc4\xcc\xb0\x8f\xa1\x9e\xa1\x81a/\x90\x05\x06\x8d\
                         <object class="sizeritem">
                           <object class="wxCheckBox" name="chk_ebeam_off">
                             <label>Turn off e-beam after acquisition</label>
+                          </object>
+                          <flag>wxALL|wxEXPAND</flag>
+                          <border>10</border>
+                        </object>
+                        <object class="sizeritem">
+                          <object class="wxCheckBox" name="chk_beam_blank">
+                            <label>Turn off beam blanking in between fields</label>
                           </object>
                           <flag>wxALL|wxEXPAND</flag>
                           <border>10</border>

--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -562,7 +562,7 @@ class xrcpnl_tab_fastem_acqui(wx.Panel):
         self.pnl_projects_header = xrc.XRCCTRL(self, "pnl_projects_header")
         self.pnl_projects = xrc.XRCCTRL(self, "pnl_projects")
         self.chk_ebeam_off = xrc.XRCCTRL(self, "chk_ebeam_off")
-        self.chk_beam_blank = xrc.XRCCTRL(self, "chk_beam_blank")
+        self.chk_beam_blank_off = xrc.XRCCTRL(self, "chk_beam_blank_off")
         self.txt_num_roas = xrc.XRCCTRL(self, "txt_num_roas")
         self.bmp_acq_status_info = xrc.XRCCTRL(self, "bmp_acq_status_info")
         self.bmp_acq_status_warn = xrc.XRCCTRL(self, "bmp_acq_status_warn")
@@ -7315,8 +7315,8 @@ D\x02\x12\x0c/\x81\x10.\xc4\xcc\xb0\x8f\xa1\x9e\xa1\x81a/\x90\x05\x06\x8d\
                           <border>10</border>
                         </object>
                         <object class="sizeritem">
-                          <object class="wxCheckBox" name="chk_beam_blank">
-                            <label>Turn off beam blanking in between fields</label>
+                          <object class="wxCheckBox" name="chk_beam_blank_off">
+                            <label>Do not blank beam in between fields</label>
                           </object>
                           <flag>wxALL|wxEXPAND</flag>
                           <border>10</border>

--- a/src/odemis/gui/xmlh/resources/panel_tab_fastem_acqui.xrc
+++ b/src/odemis/gui/xmlh/resources/panel_tab_fastem_acqui.xrc
@@ -73,6 +73,13 @@
                           <border>10</border>
                         </object>
                         <object class="sizeritem">
+                          <object class="wxCheckBox" name="chk_beam_blank">
+                            <label>Turn off beam blanking in between fields</label>
+                          </object>
+                          <flag>wxALL|wxEXPAND</flag>
+                          <border>10</border>
+                        </object>
+                        <object class="sizeritem">
                           <object class="wxFlexGridSizer">
                             <object class="sizeritem">
                               <object class="wxStaticText">

--- a/src/odemis/gui/xmlh/resources/panel_tab_fastem_acqui.xrc
+++ b/src/odemis/gui/xmlh/resources/panel_tab_fastem_acqui.xrc
@@ -73,8 +73,8 @@
                           <border>10</border>
                         </object>
                         <object class="sizeritem">
-                          <object class="wxCheckBox" name="chk_beam_blank">
-                            <label>Turn off beam blanking in between fields</label>
+                          <object class="wxCheckBox" name="chk_beam_blank_off">
+                            <label>Do not blank beam in between fields</label>
                           </object>
                           <flag>wxALL|wxEXPAND</flag>
                           <border>10</border>


### PR DESCRIPTION
For some samples the beam damage is minimal when the beam is left unblanked during stage moves. As beam blanking and unblanking takes ~0.16 s, this feature makes beam blanking optional to increase throughput.