### PR TITLE
[refactor]: convert numpy.fromstring() -> numpy.frombuffer()

### DIFF
--- a/src/odemis/driver/semcomedi.py
+++ b/src/odemis/driver/semcomedi.py
@@ -2371,7 +2371,7 @@ class MMapReader(Reader):
         # mmap_action = copy to numpy array
         offset = self.buf_offset / self.buf.itemsize
         s = read_size / self.buf.itemsize
-        self.buf[offset:offset + s] = numpy.fromstring(self.mmap.read(read_size),
+        self.buf[offset:offset + s] = numpy.frombuffer(self.mmap.read(read_size),
                                                        dtype=self.dtype)
         comedi.mark_buffer_read(self._device, self._subdevice, read_size)
         if wrap:

--- a/src/odemis/util/angleres.py
+++ b/src/odemis/util/angleres.py
@@ -605,7 +605,7 @@ def _figure2data(figure):
     figure.canvas.draw()
 
     w, h = figure.canvas.get_width_height()
-    image = numpy.fromstring(figure.canvas.tostring_rgb(), dtype=numpy.uint8)
+    image = numpy.frombuffer(figure.canvas.tostring_rgb(), dtype=numpy.uint8)
     image.shape = (h, w, 3)
 
     return image


### PR DESCRIPTION
.fromstring() is deprecated, and replaced by various functions.
In our case, all calls are equivalent to .frombuffer().