### PR TITLE
[fix] set pnl_projects and its sizeritem's option as 1 to share available space

### DIFF
--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -7268,12 +7268,14 @@ D\x02\x12\x0c/\x81\x10.\xc4\xcc\xb0\x8f\xa1\x9e\xa1\x81a/\x90\x05\x06\x8d\
                       <fg>#7F7F7F</fg>
                       <size>400,700</size>
                       <flag>wxTOP|wxEXPAND</flag>
+                      <option>1</option>
                     </object>
                   </object>
                 </object>
                 <bg>#4D4D4D</bg>
               </object>
               <flag>wxEXPAND</flag>
+              <option>1</option>
             </object>
             <object class="sizeritem">
               <object class="wxFlexGridSizer">

--- a/src/odemis/gui/xmlh/resources/panel_tab_fastem_acqui.xrc
+++ b/src/odemis/gui/xmlh/resources/panel_tab_fastem_acqui.xrc
@@ -26,12 +26,14 @@
                       <fg>#7F7F7F</fg>
                       <size>400,700</size>
                       <flag>wxTOP|wxEXPAND</flag>
+                      <option>1</option>
                     </object>
                   </object>
                 </object>
                 <bg>#4D4D4D</bg>
               </object>
               <flag>wxEXPAND</flag>
+              <option>1</option>
             </object>
             <object class="sizeritem">
               <object class="wxFlexGridSizer">


### PR DESCRIPTION
Expanding the log panel caused the acquisition START button to disappear. Using option as 1 along with wxEXPAND flag for pnl_projects and its sizer's allows the acquisition tab to share available space