### PR TITLE
[fix] estimate acquisition time calculation

### DIFF
--- a/src/odemis/acq/fastem.py
+++ b/src/odemis/acq/fastem.py
@@ -26,6 +26,7 @@ import math
 import os
 import threading
 import time
+from typing import Optional
 from concurrent.futures import CancelledError
 
 import numpy
@@ -131,7 +132,7 @@ class FastEMROC(object):
         self.colour = colour
 
 
-def estimate_acquisition_time(roa, pre_calibrations=None):
+def estimate_acquisition_time(roa, pre_calibrations=None, acq_dwell_time: Optional[float] = None):
     """
     Computes the approximate time it will take to run the ROA (megafield) acquisition including pre-calibrations
     if specified.
@@ -139,10 +140,11 @@ def estimate_acquisition_time(roa, pre_calibrations=None):
     :param roa: (FastEMROA) The acquisition region object to be acquired (megafield).
     :param pre_calibrations: (list[Calibrations]) List of calibrations that should be run before the ROA acquisition.
                              Default is None.
+    :param acq_dwell_time: (float or None) The acquisition dwell time.
 
     :return (0 <= float): The estimated time for the ROA (megafield) acquisition in s including pre-calibrations.
     """
-    tot_time = roa.estimate_acquisition_time()
+    tot_time = roa.estimate_acquisition_time(acq_dwell_time)
     if pre_calibrations:
         tot_time += estimate_calibration_time(pre_calibrations)
 
@@ -151,7 +153,7 @@ def estimate_acquisition_time(roa, pre_calibrations=None):
 
 def acquire(roa, path, username, scanner, multibeam, descanner, detector, stage, scan_stage, ccd, beamshift, lens,
             se_detector, ebeam_focus, pre_calibrations=None, save_full_cells=False, settings_obs=None,
-            spot_grid_thresh=0.5, blank_beam=True):
+            spot_grid_thresh=0.5, blank_beam=True, acq_dwell_time: Optional[float] = None):
     """
     Start a megafield acquisition task for a given region of acquisition (ROA).
 
@@ -186,6 +188,7 @@ def acquire(roa, path, username, scanner, multibeam, descanner, detector, stage,
         diagnostic camera image, calculated as `max(image) * spot_grid_thresh`.
     :param blank_beam: (bool) If true the beam will be blanked during stage moves, if false the beam remains
         un-blanked during stage moves.
+    :param acq_dwell_time: (float or None) The acquisition dwell time.
     :return: (ProgressiveFuture) Acquisition future object, which can be cancelled. The result of the future is
              a tuple that contains:
                 (model.DataArray): The acquisition data, which depends on the value of the detector.dataContent VA.
@@ -193,7 +196,7 @@ def acquire(roa, path, username, scanner, multibeam, descanner, detector, stage,
 
     """
 
-    est_dur = estimate_acquisition_time(roa, pre_calibrations)
+    est_dur = estimate_acquisition_time(roa, pre_calibrations, acq_dwell_time)
     f = model.ProgressiveFuture(start=time.time(), end=time.time() + est_dur)
 
     # TODO: pass path through attribute on ROA instead of argument?
@@ -281,6 +284,9 @@ class AcquisitionTask(object):
         self._settings_obs = settings_obs
         self._spot_grid_thresh = spot_grid_thresh
         self._blank_beam = blank_beam
+        self._total_roa_time = 0
+        if isinstance(future, model.ProgressiveFuture):
+            self._total_roa_time = future.end_time - future.start_time
 
         # save the initial multibeam resolution, because the resolution will get updated if save_full_cells is True
         self._old_res = self._multibeam.resolution.value
@@ -333,13 +339,10 @@ class AcquisitionTask(object):
         self._detector.updateMetadata({model.MD_SLICE_IDX: self._roa.slice_index.value})
         self._detector.updateMetadata({model.MD_USER: self._username})
 
-        # Get the estimated time for the roa.
-        total_roa_time = estimate_acquisition_time(self._roa, self._pre_calibrations)
-
         # No need to set the start time of the future: it's automatically done when setting its state to running.
         logging.info(
             "Starting acquisition of ROA %s, with expected duration of %f s, %s by %s fields and overlap %s.",
-            self._roa.shape.name.value, total_roa_time, self._roa.field_indices[-1][0] + 1, self._roa.field_indices[-1][1] + 1,
+            self._roa.shape.name.value, self._total_roa_time, self._roa.field_indices[-1][0] + 1, self._roa.field_indices[-1][1] + 1,
             self._roa.overlap,
         )
 

--- a/src/odemis/driver/technolution.py
+++ b/src/odemis/driver/technolution.py
@@ -30,6 +30,7 @@ import queue
 import re
 import threading
 import time
+from typing import Optional
 from io import BytesIO
 from urllib.parse import urlparse
 
@@ -1764,17 +1765,20 @@ class MPPC(model.Detector):
 
         return cellDarkOffset
 
-    def getTotalLineScanTime(self):
+    def getTotalLineScanTime(self, acq_dwell_time: Optional[float] = None):
         """
         Calculate the time for scanning one line (row) of pixels in a single field image including over-scanned
         pixels (cell complete resolution) and flyback time (time the descanner needs to move back to the start
         position for the next line scan).
+
+        :param acq_dwell_time: (float or None) The acquisition dwell time.
         :return: (float) Estimated time to scan a single line including overscanned pixels and the flyback
                  time in seconds.
         """
         descanner = self.parent._mirror_descanner
         scanner = self.parent._ebeam_scanner
-        acq_dwell_time = scanner.dwellTime.value
+        if acq_dwell_time is None:
+            acq_dwell_time = scanner.dwellTime.value
 
         resolution_x = self.cellCompleteResolution.value[0]
         line_scan_time = acq_dwell_time * resolution_x
@@ -1800,14 +1804,16 @@ class MPPC(model.Detector):
         # Total line scan time is the period of the calibration signal.
         return numpy.round(line_scan_time + flyback_time, 9)  # Round to prevent floating point errors
 
-    def getTotalFieldScanTime(self):
+    def getTotalFieldScanTime(self, acq_dwell_time: Optional[float] = None):
         """
         Calculate the time for scanning a single field image including over-scanned pixels (cell complete resolution)
         and flyback time (time the descanner needs to move back to the start position for the next line scan).
+
+        :param acq_dwell_time: (float or None) The acquisition dwell time.
         :return: (float) Estimated time to scan a single field image including over-scanned pixels and the flyback
                  time in seconds.
         """
-        line_scan_time = self.getTotalLineScanTime()
+        line_scan_time = self.getTotalLineScanTime(acq_dwell_time)
         resolution_y = self.cellCompleteResolution.value[1]
         field_scan_time = line_scan_time * resolution_y
 

--- a/src/odemis/gui/comp/fastem_roa.py
+++ b/src/odemis/gui/comp/fastem_roa.py
@@ -20,7 +20,7 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 
 """
 import threading
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 
 import numpy
 from scipy.ndimage import binary_fill_holes
@@ -151,12 +151,14 @@ class FastEMROA:
             else:
                 self.calculate_field_indices()
 
-    def estimate_acquisition_time(self):
+    def estimate_acquisition_time(self, acq_dwell_time: Optional[float] = None):
         """
         Computes the approximate time it will take to run the ROA (megafield) acquisition.
+
+        :param acq_dwell_time: (float or None) The acquisition dwell time.
         :return (0 <= float): The estimated time for the ROA (megafield) acquisition in s.
         """
-        field_time = self._detector.frameDuration.value + 1.5  # there is about 1.5 seconds overhead per field
+        field_time = self._detector.getTotalFieldScanTime(acq_dwell_time) + 1.5  # there is about 1.5 seconds overhead per field
         tot_time = (len(self.field_indices) + 1) * field_time  # +1 because the first field is acquired twice
 
         return tot_time

--- a/src/odemis/gui/cont/tabs/fastem_project_settings_tab.py
+++ b/src/odemis/gui/cont/tabs/fastem_project_settings_tab.py
@@ -35,6 +35,7 @@ from odemis.gui.cont.tabs.tab import Tab
 
 class FastEMProjectSettingsTab(Tab):
     """A tab for managing project-specific settings."""
+
     def __init__(self, name, button, panel, main_frame, main_data, main_tab_data):
         """
         Initializes the FastEMProjectSettingsTab with the provided parameters.
@@ -74,7 +75,9 @@ class FastEMProjectSettingsTab(Tab):
         settings_data = self.main_tab_data.project_settings_data.value
         for project in settings_data.keys():
             settings_data[project][DWELL_TIME_ACQUISITION] = dwell_time
-        self.main_tab_data.project_settings_data.value = settings_data
+        self.main_tab_data.project_settings_data._set_value(
+            settings_data, must_notify=True
+        )
 
     def _on_current_project(self, current_project):
         """Updates the controls when the current project changes."""
@@ -122,9 +125,13 @@ class FastEMProjectSettingsTab(Tab):
             value = ctrl.GetValue()
             if entry == DWELL_TIME_ACQUISITION:
                 if len(self.main_tab_data.current_project.value) > 0:
-                    self.main_tab_data.project_settings_data.value[
-                        self.main_tab_data.current_project.value
-                    ][entry] = value
+                    settings_data = self.main_tab_data.project_settings_data.value
+                    settings_data[self.main_tab_data.current_project.value][
+                        entry
+                    ] = value
+                    self.main_tab_data.project_settings_data._set_value(
+                        settings_data, must_notify=True
+                    )
 
     def _bind_project_settings_control_events(self, ctrl, entry):
         """Binds the appropriate event handlers to the project settings controls."""

--- a/src/odemis/model/_futures.py
+++ b/src/odemis/model/_futures.py
@@ -387,6 +387,14 @@ class ProgressiveFuture(CancellableFuture):
         self._end_time = end or (self._start_time + 0.1)
         self.add_done_callback(self.__on_done)
 
+    @property
+    def start_time(self):
+        return self._start_time
+
+    @property
+    def end_time(self):
+        return self._end_time
+
     def __on_done(self, future):
         """
         Called when the future is over to report the update one last time


### PR DESCRIPTION
make use of acq_dwell_time arg to correctly calulate the fieldscan time using getTotalFieldScanTime()

In the vEM GUI projects can have their own acquisition dwell time. This is now taken into account and the acquisition time is estimated correctly for dwell time slider change.