### PR TITLE
[SDEV-1937] support importing greater than 2000 roas

### DIFF
--- a/src/odemis/gui/comp/fastem_project_manager_panel.py
+++ b/src/odemis/gui/comp/fastem_project_manager_panel.py
@@ -283,9 +283,7 @@ class ProjectManagerImportExport:
         if sample_data is None:
             raise ValueError(f"The JSON file is not for {sample_type}")
         projects_data = sample_data.get("projects", {})
-        roa_shapes = []
-        section_shapes = []
-        ribbon_shapes = []
+        new_shapes = []
         import_data: List[ImportData] = []
 
         shapes = self.project_manager.tab_data.shapes.value
@@ -346,7 +344,7 @@ class ProjectManagerImportExport:
                         grid=roas_grid,
                     )
                 )
-                roa_shapes.append(roa_row.roa.shape)
+                new_shapes.append(roa_row.roa.shape)
                 project_colour.add(roa["roa"]["shape"]["colour"])
 
             # Add sections
@@ -367,7 +365,7 @@ class ProjectManagerImportExport:
                         grid=sections_grid,
                     )
                 )
-                section_shapes.append(section_row.roa.shape)
+                new_shapes.append(section_row.roa.shape)
                 project_colour.add(section["roa"]["shape"]["colour"])
 
             # Add ribbons
@@ -386,7 +384,7 @@ class ProjectManagerImportExport:
                         grid=ribbons_grid,
                     )
                 )
-                ribbon_shapes.append(ribbon_row.roa.shape)
+                new_shapes.append(ribbon_row.roa.shape)
                 project_colour.add(ribbon["roa"]["shape"]["colour"])
 
             if len(project_colour) == 1:
@@ -419,9 +417,7 @@ class ProjectManagerImportExport:
         start_time = time.time()
         if projects_data:
             # Update the shapes
-            shapes.extend(roa_shapes)
-            shapes.extend(section_shapes)
-            shapes.extend(ribbon_shapes)
+            shapes.extend(new_shapes)
             self.project_manager.tab_data.shapes._set_value(shapes, must_notify=False)
             self.project_manager.previous_shapes = set(shapes)
             # Update the active_project_ctrl combobox

--- a/src/odemis/gui/cont/fastem_grid_base.py
+++ b/src/odemis/gui/cont/fastem_grid_base.py
@@ -380,8 +380,13 @@ class GridBase(Grid):
         else:
             evt.Skip()
 
-    def update_row(self, row: Row):
-        """Updates the specified row with new values and editors."""
+    def update_row(self, row: Row, autosize: bool = True):
+        """
+        Updates the specified row with new values and editors.
+
+        :param row: The Row object to add.
+        :param autosize: If True the size of the columns will be adjusted to the row data.
+        """
         for col in self.columns:
             if col.editor_cls != type(self.GetCellEditor(row.index, col.index)):
                 editor = col.editor_cls(**col.editor_args)
@@ -393,7 +398,8 @@ class GridBase(Grid):
                     )
             value = row.get_value(col.label)
             self.SetCellValue(row.index, col.index, str(value))
-        self.AutoSizeColumns()
+        if autosize:
+            self.AutoSizeColumns()
 
     def set_columns(self, columns: List[Column]):
         """
@@ -440,11 +446,12 @@ class GridBase(Grid):
         else:
             self.DeselectRow(row.index)
 
-    def add_row(self, row: Row):
+    def add_row(self, row: Row, autosize: bool = True):
         """
         Adds a new row to the grid.
 
         :param row: The Row object to add.
+        :param autosize: If True the size of the columns will be adjusted to the row data.
         """
         if len(row.data.keys()) != self.GetNumberCols():
             raise ValueError("Row data length does not match number of columns")
@@ -463,7 +470,7 @@ class GridBase(Grid):
         row_shape_selected_sub_callback = partial(self._on_row_shape_selected, row=row)
         self._row_shape_selected_sub_callback[row] = row_shape_selected_sub_callback
         row.roa.shape.selected.subscribe(row_shape_selected_sub_callback)
-        self.update_row(row)
+        self.update_row(row, autosize)
         event = RowChangedEvent(self.GetId(), row.index)
         wx.PostEvent(self, event)
 

--- a/src/odemis/gui/cont/fastem_project_tree.py
+++ b/src/odemis/gui/cont/fastem_project_tree.py
@@ -182,12 +182,12 @@ class FastEMTreeNode:
         if self._on_change_callback:
             self._on_change_callback(NodeChangeType.NAME_CHANGE, self)
 
-    def add_child(self, child, sort_order: bool = True):
+    def add_child(self, child, sort: bool = True):
         """
         Adds a child node to the current node.
 
         :param child: (FastEMTreeNode) The child node to add.
-        :param sort_order: (bool) Sort the order of FastEMTreeNode's children.
+        :param sort: (bool) Sort the order of FastEMTreeNode's children.
         :raises ValueError: If the child type is not allowed under the current node's type.
         """
         if self.can_have_child(child.type):
@@ -195,26 +195,26 @@ class FastEMTreeNode:
             child.parent_node = self  # Set child's parent node to current node
             if self._on_change_callback:
                 self._on_change_callback(NodeChangeType.ADD_CHILD, child)
-                if sort_order:
+                if sort:
                     self.sort_children_recursively()
         else:
             raise ValueError(
                 f"Cannot add child of type {child.type} to parent of type {self.type}"
             )
 
-    def remove_child(self, child, sort_order: bool = True):
+    def remove_child(self, child, sort: bool = True):
         """
         Removes a child node from the current node.
 
         :param child: (FastEMTreeNode) The child node to remove.
-        :param sort_order: (bool) Sort the order of FastEMTreeNode's children.
+        :param sort: (bool) Sort the order of FastEMTreeNode's children.
         :raises ValueError: If the child is not found in the current node's children.
         """
         if child in self.children:
             self.children.remove(child)
             if self._on_change_callback:
                 self._on_change_callback(NodeChangeType.REMOVE_CHILD, child)
-                if sort_order:
+                if sort:
                     self.sort_children_recursively()
         else:
             raise ValueError("Child not found in the node's children")

--- a/src/odemis/gui/cont/fastem_project_tree.py
+++ b/src/odemis/gui/cont/fastem_project_tree.py
@@ -182,11 +182,12 @@ class FastEMTreeNode:
         if self._on_change_callback:
             self._on_change_callback(NodeChangeType.NAME_CHANGE, self)
 
-    def add_child(self, child):
+    def add_child(self, child, sort_order: bool = True):
         """
         Adds a child node to the current node.
 
         :param child: (FastEMTreeNode) The child node to add.
+        :param sort_order: (bool) Sort the order of FastEMTreeNode's children.
         :raises ValueError: If the child type is not allowed under the current node's type.
         """
         if self.can_have_child(child.type):
@@ -194,24 +195,27 @@ class FastEMTreeNode:
             child.parent_node = self  # Set child's parent node to current node
             if self._on_change_callback:
                 self._on_change_callback(NodeChangeType.ADD_CHILD, child)
-                self.sort_children_recursively()
+                if sort_order:
+                    self.sort_children_recursively()
         else:
             raise ValueError(
                 f"Cannot add child of type {child.type} to parent of type {self.type}"
             )
 
-    def remove_child(self, child):
+    def remove_child(self, child, sort_order: bool = True):
         """
         Removes a child node from the current node.
 
         :param child: (FastEMTreeNode) The child node to remove.
+        :param sort_order: (bool) Sort the order of FastEMTreeNode's children.
         :raises ValueError: If the child is not found in the current node's children.
         """
         if child in self.children:
             self.children.remove(child)
             if self._on_change_callback:
                 self._on_change_callback(NodeChangeType.REMOVE_CHILD, child)
-                self.sort_children_recursively()
+                if sort_order:
+                    self.sort_children_recursively()
         else:
             raise ValueError("Child not found in the node's children")
 

--- a/src/odemis/gui/cont/tabs/fastem_project_ribbons_tab.py
+++ b/src/odemis/gui/cont/tabs/fastem_project_ribbons_tab.py
@@ -265,6 +265,21 @@ class FastEMProjectRibbonsTab(Tab):
 
         self.panel.Bind(wx.EVT_SIZE, self._on_panel_size)
 
+    def create_grid(self) -> GridBase:
+        """
+        Creates and configures a new grid for displaying data.
+
+        :return: (GridBase) A configured instance of the grid.
+
+        Note:
+            The grid is not displayed immediately but is prepared for further manipulation
+            or data population before being shown.
+        """
+        grid = GridBase(self.panel, size=self.panel.Parent.Size)
+        grid.set_columns(self.columns)
+        grid.Hide()
+        return grid
+
     def Show(self, show=True):
         super().Show(show)
 

--- a/src/odemis/gui/cont/tabs/fastem_project_roas_tab.py
+++ b/src/odemis/gui/cont/tabs/fastem_project_roas_tab.py
@@ -336,6 +336,33 @@ class FastEMProjectROAsTab(Tab):
 
         self.panel.Bind(wx.EVT_SIZE, self._on_panel_size)
 
+    def create_grid(self) -> GridBase:
+        """
+        Creates and configures a new grid for displaying data.
+
+        :return: (GridBase) A configured instance of the grid.
+
+        Note:
+            The grid is not displayed immediately but is prepared for further manipulation
+            or data population before being shown.
+        """
+        grid = GridBase(self.panel, size=self.panel.Parent.Size)
+        grid.set_columns(self.columns)
+        grid.Hide()
+        return grid
+
+    def update_sections_grid(self, sections_grid):
+        """
+        Updates the sections grid and binds relevant event handlers.
+
+        :param sections_grid: (GridBase) The grid to be set as the sections grid.
+        """
+        self.sections_grid = sections_grid
+        self.sections_grid.Bind(
+            EVT_GRID_CELL_CHANGING, self._on_sections_grid_cell_changing
+        )
+        self.sections_grid.Bind(EVT_GRID_ROW_CHANGED, self._on_sections_row_changed)
+
     def _on_sections_grid_cell_changing(self, evt):
         """Handles changes in the sections grid cell values and updates the parent column in the ROA grid."""
         name_col = self.sections_grid.get_column_by_label(SectionColumnNames.NAME.value)

--- a/src/odemis/gui/cont/tabs/fastem_project_sections_tab.py
+++ b/src/odemis/gui/cont/tabs/fastem_project_sections_tab.py
@@ -292,6 +292,33 @@ class FastEMProjectSectionsTab(Tab):
 
         self.panel.Bind(wx.EVT_SIZE, self._on_panel_size)
 
+    def create_grid(self) -> GridBase:
+        """
+        Creates and configures a new grid for displaying data.
+
+        :return: (GridBase) A configured instance of the grid.
+
+        Note:
+            The grid is not displayed immediately but is prepared for further manipulation
+            or data population before being shown.
+        """
+        grid = GridBase(self.panel, size=self.panel.Parent.Size)
+        grid.set_columns(self.columns)
+        grid.Hide()
+        return grid
+
+    def update_ribbons_grid(self, ribbons_grid):
+        """
+        Updates the ribbons grid and binds relevant event handlers.
+
+        :param ribbons_grid: (GridBase) The grid to be set as the ribbons grid.
+        """
+        self.ribbons_grid = ribbons_grid
+        self.ribbons_grid.Bind(
+            EVT_GRID_CELL_CHANGING, self._on_ribbon_grid_cell_changing
+        )
+        self.ribbons_grid.Bind(EVT_GRID_ROW_CHANGED, self._on_ribbon_row_changed)
+
     def _on_ribbon_grid_cell_changing(self, evt):
         """Handles changes in the ribbons grid cell values and updates the parent column in the section grid."""
         name_col = self.ribbons_grid.get_column_by_label(RibbonColumnNames.NAME.value)


### PR DESCRIPTION
[perf] optimize ProjectManagerImportExport's _apply_project_data function to import projects data faster

The following high level changes have been made:
- Extend tab_data shapes list and set the update value without notifying to avoid unnecessary subscriber's callback
- Add child to a node without sorting; instead call tab_data.projects_tree.sort_children_recursively() in the end
- Separate creating/gathering all projects data and adding grid rows/children of all projects, because the later takes more time because it has functions which have wx.PostEvent triggering GUI changes
- Created a smart way of switching ribbons, sections, roas grid for projects, the projects grid data is now stored in a A dict where key is the project name and value is the project grid's data, the project's grid data again is a dict where key is the name of the grid's tab and value is the grid object