### PR TITLE
[fix] limit how quickly turnOnLight() acquires images

### DIFF
--- a/src/odemis/acq/align/light.py
+++ b/src/odemis/acq/align/light.py
@@ -19,12 +19,14 @@ PARTICULAR  PURPOSE. See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along with
 Odemis. If not, see http://www.gnu.org/licenses/.
 """
-
-from concurrent.futures._base import CancelledError, CANCELLED, FINISHED, RUNNING
-from odemis.model import CancellableFuture, logging
-import numpy
-from odemis.util import executeAsyncTask, img
 import threading
+import time
+from concurrent.futures._base import CancelledError, CANCELLED, FINISHED, RUNNING
+
+import numpy
+
+from odemis.model import CancellableFuture, logging
+from odemis.util import executeAsyncTask, img
 
 
 def turnOnLight(bl, ccd):
@@ -80,6 +82,7 @@ def _doTurnOnLight(f, bl, ccd):
         # Turn the light on, full power!
         bl.power.value = bl.power.range[1]
         while True:
+            time.sleep(0.1)
             img2 = ccd.data.get()
             try:
                 new_img = img.Subtract(img2, img_light_off)

--- a/src/odemis/acq/align/test/autofocus_test.py
+++ b/src/odemis/acq/align/test/autofocus_test.py
@@ -56,20 +56,9 @@ class TestAutofocus(unittest.TestCase):
     """
     Test autofocus functions
     """
-    backend_was_running = False
-
     @classmethod
     def setUpClass(cls):
-
-        try:
-            testing.start_backend(SECOM_CONFIG)
-        except LookupError:
-            logging.info("A running backend is already found, skipping tests")
-            cls.backend_was_running = True
-            return
-        except IOError as exp:
-            logging.error(str(exp))
-            raise
+        testing.start_backend(SECOM_CONFIG)
 
         # find components by their role
         cls.ebeam = model.getComponent(role="e-beam")
@@ -83,17 +72,6 @@ class TestAutofocus(unittest.TestCase):
         # The good focus positions are at the start up positions
         cls._opt_good_focus = cls.focus.position.value["z"]
         cls._sem_good_focus = cls.efocus.position.value["z"]
-
-    @classmethod
-    def tearDownClass(cls):
-        if cls.backend_was_running:
-            return
-        testing.stop_backend()
-
-    def setUp(self):
-
-        if self.backend_was_running:
-            self.skipTest("Running backend found")
 
     def test_measure_focus(self):
         """
@@ -159,20 +137,9 @@ class TestSparc2AutoFocus(unittest.TestCase):
         Test Sparc2Autofocus for sp-ccd
         backend : SPARC2_FOCUS_CONFIG
     """
-    backend_was_running = False
-
     @classmethod
     def setUpClass(cls):
-
-        try:
-            testing.start_backend(SPARC2_FOCUS_CONFIG)
-        except LookupError:
-            logging.info("A running backend is already found, skipping tests")
-            cls.backend_was_running = True
-            return
-        except IOError as exp:
-            logging.error(str(exp))
-            raise
+        testing.start_backend(SPARC2_FOCUS_CONFIG)
 
         # find components by their role
         cls.ccd = model.getComponent(role="ccd")
@@ -197,21 +164,12 @@ class TestSparc2AutoFocus(unittest.TestCase):
         # The good focus position is the start up position
         cls._good_focus = cls.focus.position.value["z"]
 
-    @classmethod
-    def tearDownClass(cls):
-        if cls.backend_was_running:
-            return
-        testing.stop_backend()
-
     def setUp(self):
-        if self.backend_was_running:
-            self.skipTest("Running backend found")
         self.opm = acq.path.OpticalPathManager(model.getMicroscope())
 
         # Speed it up
         self.ccd.exposureTime.value = self.ccd.exposureTime.range[0]
         self.spccd.exposureTime.value = self.spccd.exposureTime.range[0]
-
 
     @timeout(1000)
     def test_one_det(self):
@@ -318,25 +276,15 @@ class TestSparc2AutoFocus(unittest.TestCase):
         # We expect an entry for each combination grating/detector
         self.assertEqual(len(res.keys()), len(self.spgr.axes["grating"].choices))
 
+
 class TestSparc2AutoFocus_2(unittest.TestCase):
     """
     Test Sparc2Autofocus for ccd
     backend : SPARC2_FOCUS_CONFIG
     """
-    backend_was_running = False
-
     @classmethod
     def setUpClass(cls):
-
-        try:
-            testing.start_backend(SPARC2_FOCUS_CONFIG)
-        except LookupError:
-            logging.info("A running backend is already found, skipping tests")
-            cls.backend_was_running = True
-            return
-        except IOError as exp:
-            logging.error(str(exp))
-            raise
+        testing.start_backend(SPARC2_FOCUS_CONFIG)
 
         # find components by their role
         cls.ccd = model.getComponent(role="ccd")
@@ -353,20 +301,11 @@ class TestSparc2AutoFocus_2(unittest.TestCase):
         # The good focus position is the start up position
         cls._good_focus = cls.focus.position.value["z"]
 
-    @classmethod
-    def tearDownClass(cls):
-        if cls.backend_was_running:
-            return
-        testing.stop_backend()
-
     def setUp(self):
-        if self.backend_was_running:
-            self.skipTest("Running backend found")
         self.opm = acq.path.OpticalPathManager(model.getMicroscope())
         # Speed it up
         self.ccd.exposureTime.value = self.ccd.exposureTime.range[0]
         self.spccd.exposureTime.value = self.spccd.exposureTime.range[0]
-
 
     @timeout(1000)
     def test_one_det(self):
@@ -446,25 +385,15 @@ class TestSparc2AutoFocus_2(unittest.TestCase):
         # We expect an entry for each combination grating/detector
         self.assertEqual(len(res.keys()), len(self.spgr_ded.axes["grating"].choices))
 
+
 class TestSparc2AutoFocus_3(unittest.TestCase):
     """
     Test Sparc2Autofocus for in case of 4 detectors
     backend : SPARC2_FOCUS2_CONFIG
     """
-    backend_was_running = False
-
     @classmethod
     def setUpClass(cls):
-
-        try:
-            testing.start_backend(SPARC2_FOCUS2_CONFIG)
-        except LookupError:
-            logging.info("A running backend is already found, skipping tests")
-            cls.backend_was_running = True
-            return
-        except IOError as exp:
-            logging.error(str(exp))
-            raise
+        testing.start_backend(SPARC2_FOCUS2_CONFIG)
 
         # find components by their role
         cls.ccd = model.getComponent(role="ccd0")
@@ -481,20 +410,11 @@ class TestSparc2AutoFocus_3(unittest.TestCase):
         # The good focus position is the start up position
         cls._good_focus = cls.focus.position.value["z"]
 
-    @classmethod
-    def tearDownClass(cls):
-        if cls.backend_was_running:
-            return
-        testing.stop_backend()
-
     def setUp(self):
-        if self.backend_was_running:
-            self.skipTest("Running backend found")
         self.opm = acq.path.OpticalPathManager(model.getMicroscope())
         # Speed it up
         self.ccd.exposureTime.value = self.ccd.exposureTime.range[0]
         self.spccd.exposureTime.value = self.spccd.exposureTime.range[0]
-
 
     @timeout(1000)
     def test_spectrograph(self):
@@ -541,20 +461,9 @@ class TestAutofocusSpectrometer(unittest.TestCase):
     """
     Test autofocus spectrometer function
     """
-    backend_was_running = False
-
     @classmethod
     def setUpClass(cls):
-
-        try:
-            testing.start_backend(SPARC_CONFIG)
-        except LookupError:
-            logging.info("A running backend is already found, skipping tests")
-            cls.backend_was_running = True
-            return
-        except IOError as exp:
-            logging.error(str(exp))
-            raise
+        testing.start_backend(SPARC_CONFIG)
 
         # find components by their role
         cls.ccd = model.getComponent(role="ccd")
@@ -567,16 +476,7 @@ class TestAutofocusSpectrometer(unittest.TestCase):
         # The good focus position is the start up position
         cls._good_focus = cls.focus.position.value["z"]
 
-    @classmethod
-    def tearDownClass(cls):
-        if cls.backend_was_running:
-            return
-        testing.stop_backend()
-
     def setUp(self):
-        if self.backend_was_running:
-            self.skipTest("Running backend found")
-
         # Speed it up
         self.ccd.exposureTime.value = self.ccd.exposureTime.range[0]
         self.spccd.exposureTime.value = self.spccd.exposureTime.range[0]


### PR DESCRIPTION
turnOnLight() would continuously acquire images until it detects light.
This is a little over the top, as it can take several seconds and it's
really not in a rush. If the CCD is set to short exposure times, that
could lead to 100 fps, which causes high CPU usage, with no advantage.

=> wait at least 100ms per frame, so at most it will be 10fps.

As a side effect, that will help some test cases which were setting
the exposure time to the minimum, and which relied on andorcam2. That
driver seems to have a memory leak when doing many DataFlow.get() in a
row.

Also simplify the code of autofocus_test.