### PR TITLE
[SDEV-1938] make v em gui compatible with ubuntu 22

### DIFF
--- a/src/odemis/gui/cont/stream.py
+++ b/src/odemis/gui/cont/stream.py
@@ -36,6 +36,7 @@ from odemis import model, util
 from odemis.acq.stream import MeanSpectrumProjection
 from odemis.gui import (CONTROL_COMBO, CONTROL_FLT, FG_COLOUR_DIS,
                         FG_COLOUR_ERROR, FG_COLOUR_WARNING)
+from odemis.gui.comp.foldpanelbar import FoldPanelBar
 from odemis.gui.comp.overlay.repetition_select import RepetitionSelectOverlay
 from odemis.gui.comp.stream_panel import (OPT_BTN_PEAK, OPT_BTN_REMOVE, OPT_BTN_SHOW,
                                           OPT_BTN_TINT, OPT_BTN_UPDATE, OPT_FIT_RGB,
@@ -1386,12 +1387,36 @@ class FastEMStreamController(StreamController):
         assert isinstance(stream, acqstream.SEMStream)  # don't show for CCD stream
         self._add_fastem_ctrls()
 
+    def _create_immersion_mode_cbox(self):
+        # HACK manually create the checkbox using custom gb_sizer's pos and span
+        # The hack is needed because self.stream_paneladd_checkbox_control cannot be overridden,
+        # which has pos=(self.num_rows, 1) and span=(1, 2)
+        _ = self.stream_panel._add_side_label("Immersion Mode")
+        cbox_immersion_mode = wx.CheckBox(self.stream_panel._panel, wx.ID_ANY,
+                                          style=wx.ALIGN_RIGHT | wx.NO_BORDER)
+
+        self.stream_panel.gb_sizer.Add(cbox_immersion_mode, (self.stream_panel.num_rows, 2), span=(1, 1),
+                                       flag=wx.ALIGN_CENTRE_VERTICAL | wx.EXPAND | wx.TOP | wx.BOTTOM,
+                                       border=5)
+        cbox_immersion_mode.SetValue(self.stream.emitter.immersion.value)
+
+        if not self.stream_panel.gb_sizer.IsColGrowable(1):
+            self.stream_panel.gb_sizer.AddGrowableCol(1)
+
+        # Re-layout the FoldPanelBar parent
+        win = self.stream_panel
+        while not isinstance(win, FoldPanelBar):
+            win = win.Parent
+        win.Layout()
+        # Advance the row count for the next control
+        self.stream_panel.num_rows += 1
+        return cbox_immersion_mode
+
     def _add_fastem_ctrls(self):
         self.stream_panel.add_divider()
         # Create the immersion mode button
-        _, cbox_immersion_mode = self.stream_panel.add_checkbox_control(
-            label_text="Immersion Mode", value=self.stream.emitter.immersion.value
-        )
+        cbox_immersion_mode = self._create_immersion_mode_cbox()
+        # Create the buttons
         _, self.btn_optical_autofocus = self.stream_panel.add_run_btn(
             label_text="Optical autofocus", button_label="Run"
         )

--- a/src/odemis/gui/cont/tabs/fastem_main_tab.py
+++ b/src/odemis/gui/cont/tabs/fastem_main_tab.py
@@ -374,8 +374,14 @@ class FastEMMainTab(Tab):
             (-1, self.acquisition_tab.panel.Parent.GetSize().y)
         )
         self.setup_tab.panel.Layout()
+        self.setup_tab.active_scintillator_panel.Layout()
+        self.setup_tab.overview_acq_controller.overview_acq_panel.Layout()
+        self.setup_tab.calibration_controller.calibration_panel.Layout()
         self.acquisition_tab.panel.Layout()
         self.setup_tab.panel.Refresh()
+        self.setup_tab.active_scintillator_panel.Refresh()
+        self.setup_tab.overview_acq_controller.overview_acq_panel.Refresh()
+        self.setup_tab.calibration_controller.calibration_panel.Refresh()
         self.acquisition_tab.panel.Refresh()
 
     def _toggle_user_settings_panel(self, _):

--- a/src/odemis/gui/cont/tabs/fastem_project_settings_tab.py
+++ b/src/odemis/gui/cont/tabs/fastem_project_settings_tab.py
@@ -57,7 +57,7 @@ class FastEMProjectSettingsTab(Tab):
         self.dwell_time_acquisition_ctrl = None
 
         self.project_settings = SettingsPanel(
-            panel, size=(panel.Parent.Size[0] / 2.5, panel.Parent.Size[1] / 1.5)
+            panel, size=(int(panel.Parent.Size[0] / 2.5), int(panel.Parent.Size[1] / 1.5))
         )
 
         self._create_project_settings_entries()

--- a/src/odemis/gui/cont/tabs/fastem_setup_tab.py
+++ b/src/odemis/gui/cont/tabs/fastem_setup_tab.py
@@ -135,7 +135,7 @@ class FastEMSetupTab(Tab):
         )  # enable/disable button if calibrating
 
         # Acquisition controller
-        self._acquisition_controller = FastEMOverviewAcquiController(
+        self.overview_acq_controller = FastEMOverviewAcquiController(
             self.tab_data,
             self.main_tab_data,
             panel,
@@ -244,7 +244,7 @@ class FastEMSetupTab(Tab):
         enable = not mode
         self.active_scintillator_ctrl.Enable(enable)
         self.sem_stream_cont.stream_panel.Enable(enable)
-        self._acquisition_controller.overview_acq_panel.Enable(enable)
+        self.overview_acq_controller.overview_acq_panel.Enable(enable)
         self.btn_optical_autofocus.Enable(enable)
         self.btn_sem_autofocus.Enable(enable)
         self.btn_autobc.Enable(enable)

--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -7464,6 +7464,7 @@ D\x02\x12\x0c/\x81\x10.\xc4\xcc\xb0\x8f\xa1\x9e\xa1\x81a/\x90\x05\x06\x8d\
                     <border>10</border>
                   </object>
                 </object>
+                <bg>#4D4D4D</bg>
               </object>
               <flag>wxEXPAND</flag>
             </object>
@@ -8136,7 +8137,7 @@ N\x85iM\xfd\x1f\xfb\xdf\xeb\x83\xa5\x1cA\xadf,\xae\x27#\xa1\x8e\x85\xc1\
                           </object>
                           <option>0</option>
                           <flag>wxTOP|wxBOTTOM|wxLEFT|wxFIXED_MINSIZE</flag>
-                          <border>18</border>
+                          <border>16</border>
                         </object>
                         <object class="sizeritem">
                           <object class="wxStaticText" name="lbl_calib">
@@ -8152,7 +8153,7 @@ N\x85iM\xfd\x1f\xfb\xdf\xeb\x83\xa5\x1cA\xadf,\xae\x27#\xa1\x8e\x85\xc1\
                           </object>
                           <option>1</option>
                           <flag>wxTOP|wxBOTTOM|wxRIGHT</flag>
-                          <border>14</border>
+                          <border>12</border>
                         </object>
                       </object>
                     </object>

--- a/src/odemis/gui/xmlh/resources/panel_tab_fastem_acqui.xrc
+++ b/src/odemis/gui/xmlh/resources/panel_tab_fastem_acqui.xrc
@@ -222,6 +222,7 @@
                     <border>10</border>
                   </object>
                 </object>
+                <bg>#4D4D4D</bg>
               </object>
               <flag>wxEXPAND</flag>
             </object>

--- a/src/odemis/gui/xmlh/resources/panel_tab_fastem_setup.xrc
+++ b/src/odemis/gui/xmlh/resources/panel_tab_fastem_setup.xrc
@@ -258,7 +258,7 @@
                           </object>
                           <option>0</option>
                           <flag>wxTOP|wxBOTTOM|wxLEFT|wxFIXED_MINSIZE</flag>
-                          <border>18</border>
+                          <border>16</border>
                         </object>
                         <object class="sizeritem">
                           <object class="wxStaticText" name="lbl_calib">
@@ -274,7 +274,7 @@
                           </object>
                           <option>1</option>
                           <flag>wxTOP|wxBOTTOM|wxRIGHT</flag>
-                          <border>14</border>
+                          <border>12</border>
                         </object>
                       </object>
                     </object>


### PR DESCRIPTION
Fixed:

In xrc file `<bg>#4D4D4D</bg>` (The bg of CaptionBar and acq button was missing)
![Screenshot from 2024-12-06 08-24-31](https://github.com/user-attachments/assets/b07748de-736b-4308-99cb-60025d57dd6c)

In xrc file `<border>` (No calibration run text was cropped)
![Screenshot from 2024-12-06 08-24-06](https://github.com/user-attachments/assets/5c71aa39-191d-4f0b-ac18-a06550f39ab9)

Settings dwell time (The slider was cropped)
![Screenshot from 2024-12-06 08-26-36](https://github.com/user-attachments/assets/4eacc6b6-d1be-4271-8252-4ef71471a491)

Immersion mode cbox (the cbox position not aligned properly)
![Screenshot from 2024-12-06 08-23-46](https://github.com/user-attachments/assets/cc95715a-236e-4d8b-ae75-c5df6297c395)



