### PR TITLE
[TRCL-41][feature] Add support for PicoQuant PH330

### DIFF
--- a/install/linux/usr/share/odemis/hwtest/ph330-only.odm.yaml
+++ b/install/linux/usr/share/odemis/hwtest/ph330-only.odm.yaml
@@ -1,0 +1,367 @@
+"SPARCv2 Time-correlator PH330": {
+    class: Microscope,
+    role: sparc2,
+}
+
+# Light (lamp with known spectrum)
+"Calibration Light": {
+    class: light.Light,
+    role: "brightlight",
+    power_supplier: "Power Control Unit",
+    affects: ["Camera", "VisNIR Spectrometer",
+              "Time Correlator", "Photon counter sync", "Photon counter signal"],
+}
+
+"Power Control Unit": {
+    class: powerctrl.PowerControlUnit,
+    role: "power-control",
+    init: {
+        port: "/dev/fake", # for simulator
+        pin_map: {
+            "Camera": 0,
+            "Spectrograph": 2,
+            "Optical Actuators": 4,
+            "Calibration Light": 6,
+        },
+        delay: { # Time it takes before a component is accessible
+            "Calibration Light": 1, # To turn on/off the light, with most bulbs it's very fast
+            "Camera": 1,
+            "Spectrograph": 1,
+            "Optical Actuators": 1,
+        },
+        init: { # Which component to power on from the very beginning (to save time)
+            "Calibration Light": True, # turn if on initially, to warm up. It will automatically be off when the component starts
+            "Camera": True,
+            "Spectrograph": True,
+            "Optical Actuators": True,
+        },
+        # List of EEPROM IDs (of the plates) which are required to start properly
+        # TODO: remove the one from the power control unit itself
+        ids: [],
+    }
+}
+
+# Quanta SEM driven via external X/Y connection, using a DAQ board
+"SEM Scan Interface": {
+    class: semcomedi.SEMComedi,
+    role: null,
+    init: {device: "/dev/comedi0"},
+    # more detectors can be added, if necessary
+    children: {
+       scanner: "SEM E-beam",
+       detector0: "SEM Detector",
+    }
+}
+
+# Connect:
+# X -> AO 0
+# Y -> AO 1
+# Ground -> AO GND
+"SEM E-beam": {
+    # Internal child of SEM ExtXY, so no class
+    role: e-beam,
+    init: {
+        channels: [1, 0],
+        limits: [[0, 5], [0, 5]],  # V
+        park: [0, 0], # V
+        # Digital output port mapping on the Delmic scanning box v2:
+        # 0 = Relay
+        # 1 = Open drain output (Y0.0)
+        # 2 = Digital Out 1
+        # 3 = Digital Out 0
+        # 4 = Status led
+        scanning_ttl: {4: True}, # output ports -> True (indicate scanning) or False (indicate parked)
+        settle_time: 5.e-6, # s
+        hfw_nomag: 0.14, # m
+    },
+    properties: {
+        scale: [8, 8], # (ratio) : start with a pretty fast scan
+        dwellTime: 10.e-6, # s
+        magnification: 100, # (ratio)
+    },
+    affects: ["SEM Detector", "VisNIR Spectrometer", "Camera",
+              "Time Correlator", "Photon counter sync", "Photon counter signal"] # affects the CCD in case of cathodoluminescence
+}
+
+# Must be connected on AI1/AI9 (differential)
+"SEM Detector": { # aka ETD
+    # Internal child of SEM Scan Interface, so no class
+    role: se-detector,
+    init: {
+        channel: 0, # 0-> sawtooth waves, 1-> square waves
+        limits: [-3, 3], # V
+    },
+}
+
+"Optical Path Properties": {
+    class: static.OpticalLens,
+    role: lens,
+    # Standard mirror config
+    init: {
+       mag: 0.31, # ratio
+       na: 0.2, # ratio, numerical aperture
+       ri: 1.0, # ratio, refractive index
+       pole_pos: [516, 634], # (px, px), position of the pole (aka the hole in the mirror)
+       x_max: 13.25e-3,  # m, the distance between the parabola origin and the cutoff position
+       hole_diam: 0.6e-3,  # m, diameter the hole in the mirror
+       focus_dist: 0.5e-3,  # m, the vertical mirror cutoff, iow the min distance between the mirror and the sample
+       parabola_f: 2.5e-3,  # m, parabola_parameter=1/4f
+       # TODO: update for the Quanta
+       rotation: -1.570796326795, # rad, 90° rotation between optical axis and SEM Y axis
+    },
+    affects: ["Camera", "VisNIR Spectrometer",
+              "Time Correlator", "Photon counter sync", "Photon counter signal"]
+}
+
+# Controller for the motors moving the various parts of the optical box
+# DIP must be configured with address 2 (= 0100000)
+"Optical Actuators": {
+    class: tmcm.TMCLController,
+    role: null,
+    power_supplier: "Power Control Unit",
+    init: {
+        port: "/dev/fake6",
+        address: null,
+        axes: ["l1", "l2", "spec-sel", "fiby", "slit"],
+        # These values only need to be roughly correct
+        ustepsize: [25.1e-6, 25.1e-6, 25.1e-6, 5.86e-6, 5.e-6], # m/µstep
+        rng: [[-0.001, 0.1], [-0.001, 0.1], [-0.001, 0.1], [-0.001, 0.01], [-0.01, 0.01]],  # very rough ranges, which should be correct for any module
+        unit: ["m", "m", "m", "m", "m"],
+        refproc: "Standard",
+        refswitch: {"l1": 0, "l2": 0, "spec-sel": 4, "fiby": 4},
+        inverted: ["l2"],
+    },
+}
+
+# The first lens of Plate 1, able to move along the whole range
+"Lens1 Mover": {
+    class: actuator.MultiplexActuator,
+    role: "lens-mover",
+    dependencies: {"x": "Optical Actuators"},
+    init: {
+        axes_map: {"x": "l1"},
+        ref_on_init: ["x"],
+    },
+    metadata: {
+        # Default position of the lens (can be improved by user)
+        FAV_POS_ACTIVE: {"x": 0.02637} # m
+    },
+    persistent: {
+        metadata: [FAV_POS_ACTIVE],
+    },
+    affects: ["Lens2 Switch"],
+}
+
+# The second lens of Plate 1, either to working or parking position
+"Lens2 Switch": {
+    class: actuator.FixedPositionsActuator,
+    role: "lens-switch",
+    dependencies: {"x": "Optical Actuators"},
+    init: {
+        axis_name: "l2",
+        positions: {
+            -0.049: "on",
+            0.0: "off", # completely out of the path
+        },
+    },
+    affects: ["Camera", "VisNIR Spectrometer",
+              "Time Correlator", "Photon counter sync", "Photon counter signal"],
+}
+
+# Control the slit position to either fully-open or small (dependent on the spectrometer slit-in)
+"Slit": {
+    class: actuator.FixedPositionsActuator,
+    role: "slit-in-big",
+    dependencies: {"x": "Optical Actuators"},
+    init: {
+        axis_name: "slit",
+        positions: {
+            0: "on", # fully opened
+            0.0012: "off", # opening based on the small slit
+        },
+    },
+    affects: ["Camera", "VisNIR Spectrometer"],
+}
+
+# Note that the next two components actually move the _same_ axis!
+# Mirror & Lens in Plate 2, to change X&Y of fiber alignment
+"Fiber align": {
+    class: actuator.MultiplexActuator,
+    role: "fiber-aligner",
+    dependencies: {"x": "Optical Actuators", "y": "Optical Actuators"},
+    init: {
+        axes_map: {"x": "spec-sel", "y": "fiby"},
+        ref_on_init: ["y"],
+    },
+    affects: ["Time Correlator", "Photon counter sync", "Photon counter signal"],
+}
+
+# For simulation, we use this component
+"Calibration Camera": {
+    class: andorcam2.AndorCam2,
+    role: ccd,
+    init: {
+       device: "fake",
+       image: "sparc-ar-mirror-align.h5", # only for simulator
+    },
+}
+
+"Time-Correlator Actuators": {
+    class: tmcm.TMCLController,
+    role: null,
+    init: {
+        port: "/dev/fake6",
+        address: null,
+        axes: ["od", "fw"],
+        # These values only need to be roughly correct
+        # od: 2.72e-5 rad/ustep, 0.04 -> 4 od = 270° (/360°) -> 2.286e-5 od/ustep
+        ustepsize: [2.286e-05, 3.392e-5], # od/µstep, rad/µstep
+        rng: [[-1.02, 2.94], [-14, 14]],
+        unit: ["od", "rad"],
+        refproc: "Standard",
+        refswitch: {"fw": 0, "od": 0},
+        inverted: ["od"],
+        do_axes: {
+            # channel -> axis name, reported position when high, reported position when low, transition period (s)
+            4: ["shutter0", 0, 1, 0.5], # high: open = 0
+            5: ["shutter1", 0, 1, 0.5], # low: closed = 1
+        },
+        # LED protection for digital output channels
+        led_prot_do: {
+            # VERY IMPORTANT TO GET THIS RIGHT, WRONG VALUE WILL DAMAGE INSTRUMENT!
+            4: 1,  # position when leds are on (1 = shutter closed)
+            5: 1
+        },
+    },
+}
+
+"TC Filter Wheel": {
+    class: actuator.FixedPositionsActuator,
+    role: "tc-filter",
+    dependencies: {"band": "Time-Correlator Actuators"},
+    init: {
+        axis_name: "fw",
+        # It supports up to 8 filters
+        positions: {
+            # pos (rad) -> m,m
+            0.027484197:       "pass-through",     # 1
+            0.81288236:        [375.e-9, 425.e-9], # 2
+            1.598280523:       [425.e-9, 475.e-9], # 3
+            2.383674197:       [475.e-9, 525.e-9], # 4
+            3.169074197:       [525.e-9, 575.e-9], # 5
+            3.954475014:       [575.e-9, 625.e-9], # 6
+            4.739874197:       [625.e-9, 675.e-9], # 7
+            5.525274197:       [675.e-9, 725.e-9], # 8
+        },
+        cycle: 6.283185, # position of ref switch (0) after a full turn
+    },
+    affects: ["Time Correlator", "Photon counter sync", "Photon counter signal"],
+}
+
+"TC Optical Density Filter": {
+    class: actuator.LinearActuator,
+    role: "tc-od-filter",
+    dependencies: {"density": "Time-Correlator Actuators"},
+    init: {
+        axis_name: "od",
+        # position when referenced (adjusted to be a multiple of the actuator stepsize)
+        offset: -2.98, # od
+        ref_start: 2.78, #  a little before the reference (inverted axis)
+        ref_period: null,  # (number of moves before forcing a referencing) never automatically reference the axis
+    },
+    affects: ["Time Correlator", "Photon counter sync", "Photon counter signal"],
+}
+
+"Time Correlator": {
+    class: picoquant.PH330,
+    role: time-correlator,
+    init: {
+#        device: "fake",
+#        device: "1051910", # put serial number, or it will pick the first one found
+        device: null,
+        shutter_axes: {
+        # internal child role of the actuator -> axis name, position when shutter is closed (ie, protected), position when opened (receiving light)
+            "shutter0": ["x", 1, 0],
+            "shutter1": ["x", 1, 0],
+        },
+    },
+    # These children allow to have access to the raw data on the PMTs
+    children: {
+        "detector0": "Photon counter sync",  # "Sync"
+        "detector1": "Photon counter signal"  # "Channel 1"
+    },
+    dependencies: {
+        "shutter0": "Shutter 0",
+        "shutter1": "Shutter 1",
+    },
+}
+
+# Should be connected to the "Sync" input
+"Photon counter sync": {
+    role: photo-detector1,
+    properties: {
+        triggerLevel: -50.e-3,  # V (-1.5 -> 0)
+        zeroCrossLevel: -10.e-3,  # V (-0.1 -> 0)
+    },
+}
+
+# Should be connected to the "Channel 1" input
+"Photon counter signal": {
+    role: photo-detector0, # det0, to be shown as main graph in GUI
+        properties: {
+        triggerLevel: -60.e-3,  # V
+        zeroCrossLevel: -15.e-3,  # V
+    },
+}
+
+"Shutter 0": {
+    class: actuator.MultiplexActuator,
+    role: "shutter0",
+    dependencies: {"x": "Time-Correlator Actuators"},
+    init: {
+        axes_map: {"x": "shutter0"},
+    },
+    affects: ["Time Correlator", "Photon counter sync"],
+}
+
+"Shutter 1": {
+    class: actuator.MultiplexActuator,
+    role: "shutter1",
+    dependencies: {"x": "Time-Correlator Actuators"},
+    init: {
+        axes_map: {"x": "shutter1"},
+    },
+    affects: ["Time Correlator", "Photon counter signal"],
+}
+
+# Controller for moving the 'Redux' stage
+# DIP must be configured with address 4 (= 0010000)
+"Mirror Actuators": {
+    class: tmcm.TMCLController,
+    role: "mirror",
+    init: {
+        port: "/dev/fake6",
+        address: null,
+        axes: ["l", "s"],
+        ustepsize: [2.e-6, 2.e-6], # m/µstep, for simulator
+        rng: [[0, 51.e-3], [-1.5e-3, 1.5e-3]],  # m, min/max
+        refproc: "Standard",
+        refswitch: {"s": 0, "l": 0},
+    },
+    metadata: {
+        # Default position of the mirror engaged (will be improved during alignment)
+        FAV_POS_ACTIVE: {"l": 0.048, "s": 0.0020},  # m, m
+    },
+}
+
+# Internal component to convert between the referential of the mirror actuators
+# and the X/Y referential of the SEM. Used by the mirror alignment functions.
+"Mirror Actuators in XY referential": {
+    class: actuator.ConvertStage,
+    role: "mirror-xy",
+    dependencies: {"orig": "Mirror Actuators"},
+    init: {
+        axes: ["l", "s"], # mapped respectively to X, Y
+        rotation: -1.0471975511965976, # rad (= 60°)
+    },
+}

--- a/src/odemis/driver/picoquant.py
+++ b/src/odemis/driver/picoquant.py
@@ -2049,17 +2049,6 @@ class HH400(model.Detector):
                 # Open protection shutters
                 self._toggle_shutters(self._shutters.keys(), True)
 
-                # The demo code prints these out
-                syncrate = self.GetSyncRate()
-                # logging.debug("Sync rate: %d cnt/s", syncrate)
-                for i in range(0, self._numinput):
-                    count = self.GetCountRate(i)
-                    # logging.debug("Count rate for input %d: %d cnt/s", i, count)
-                # Check for warnings after getting count rates
-                warnings = self.GetWarnings()
-                if warnings != 0:
-                    logging.warning(self.GetWarningsText(warnings))
-
                 # Stop measurement if any bin fills up
                 self.SetStopOverflow(True, HH_STOPCNTMAX)
                 # Odemis waits a while to keep acquiring even after overflow


### PR DESCRIPTION
The PicoHarp 330 is half-way between the PicoHarp 300 and the HydraHarp 400. => Reuse most of the code.
    
Also add support to change dynamically the trigger level and zero-crossing level, for all devices (via VigilanteAttributes). Still keep the old arguments for the old devices allowed, to not break the current installations.

Also add support for event synchronization on the DataFlow.
    
This involves a major refactoring to share code similar between the 3 devices. The main refactoring is kept separate, in the second commit.
