### PR TITLE
[fix] SPARC acq: handle floating point error in comparison

### DIFF
--- a/src/odemis/acq/stream/_sync.py
+++ b/src/odemis/acq/stream/_sync.py
@@ -2429,7 +2429,7 @@ class SEMMDStream(MultipleDetectorStream):
             # only be known once we start acquiring. One way would be to set a synchronization, and
             # then subscribe all the detectors, and finally check the dwell time.
             px_time = self._adjustHardwareSettings()
-            if self._emitter.dwellTime.value != px_time:
+            if not almost_equal(self._emitter.dwellTime.value, px_time):
                 raise IOError("Expected hw dt = %f but got %f" % (px_time, self._emitter.dwellTime.value))
             spot_pos = self._getSpotPositions()
             pos_flat = spot_pos.reshape((-1, 2))  # X/Y together (X iterates first)


### PR DESCRIPTION
In some very rare cases, comparing the dwell time of the emitter with
the dwell time of the stream wouldn't perfectly match, with confusing
error messages like this:
Traceback (most recent call last):
  File "/home/sparc/development/odemis/src/odemis/acq/stream/_sync.py", line 2433, in _runAcquisition
    raise IOError("Expected hw dt = %f but got %f" % (px_time, self._emitter.dwellTime.value))
OSError: Expected hw dt = 0.000100 but got 0.000100

That was due to floating point error. => Change to an almost equal test.