### PR TITLE
[feat] SPARC alignment slit overlay hightlight low signal

### DIFF
--- a/src/odemis/gui/cont/tabs/sparc2_align_tab.py
+++ b/src/odemis/gui/cont/tabs/sparc2_align_tab.py
@@ -1417,6 +1417,8 @@ class Sparc2AlignTab(Tab):
                 acq_type=model.MD_AT_SLIT,
             )
             speclines.tint.value = odemis.gui.FOCUS_STREAM_COLOR
+            # Show most of the image (compared to the standard 100/256 %), to see the potential faint parts of the line
+            speclines.auto_bc_outliers.value = 0.001  # %
             # Fixed values, known to work well for autofocus
             speclines.detExposureTime.value = speclines.detExposureTime.clip(0.1)
             self._setFullFoV(speclines, (2, 16))


### PR DESCRIPTION
During spectorgraph focusing, the slit image is a single line over a complete black background.
That line represents a small propotion of the pixels, so the standard
outliers percentage (1/256) could sometimes end-up hiding a part of the line.
=> Reduce the outlier percentage to highlight the line.

This doesn't change the autofocus behaviour, but helps manual
calibration.