### PR TITLE
[SDEV-1945] restructure calibration panel layout

### DIFF
--- a/src/odemis/acq/fastem.py
+++ b/src/odemis/acq/fastem.py
@@ -97,7 +97,6 @@ class FastEMCalibration(object):
         self.region = None  # FastEMROC
         self.is_done = model.BooleanVA(False)  # states if the calibration was done successfully or not
         self.sequence = model.ListVA([])  # list of calibrations that need to be run sequencially
-        self.button = None
         self.shape = None  # FastEMROCOverlay
         self.is_done.subscribe(self._on_done)
 

--- a/src/odemis/acq/fastem.py
+++ b/src/odemis/acq/fastem.py
@@ -114,15 +114,17 @@ class FastEMROC(object):
     scintillator is acquired and assigned with all ROAs on the respective scintillator.
     """
 
-    def __init__(self, name, coordinates=acqstream.UNDEFINED_ROI, colour="#FFA300"):
+    def __init__(self, name: str, scintillator_number: int, coordinates=acqstream.UNDEFINED_ROI, colour="#FFA300"):
         """
         :param name: (str) Name of the region of calibration (ROC).
+        :param scintillator_number: (int) The scintillator number of the region of calibration (ROC).
         :param coordinates: (float, float, float, float) left, top, right, bottom, Bounding box coordinates of the
                             ROC in [m]. The coordinates are in the sample carrier coordinate system, which
                             corresponds to the component with role='stage'.
         :param colour: The colour of the region of calibration (ROC).
         """
         self.name = model.StringVA(name)
+        self.scintillator_number = model.IntVA(scintillator_number)
         self.coordinates = model.TupleContinuous(coordinates,
                                                  range=((-1, -1, -1, -1), (1, 1, 1, 1)),
                                                  cls=(int, float),

--- a/src/odemis/acq/test/fastem_test.py
+++ b/src/odemis/acq/test/fastem_test.py
@@ -234,8 +234,8 @@ class TestFastEMROA(unittest.TestCase):
         ymax = res_y * px_size_y * y_fields
         coordinates = (0, 0, xmax, ymax)  # in m, don't change
         polygon = [(0, 0), (0, ymax - px_size_y), (xmax - px_size_x, 0)]
-        roc_2 = fastem.FastEMROC("roc_2", coordinates)
-        roc_3 = fastem.FastEMROC("roc_3", coordinates)
+        roc_2 = fastem.FastEMROC("roc_2", 0, coordinates)
+        roc_3 = fastem.FastEMROC("roc_3", 0, coordinates)
         roa_name = "test_megafield_id"
         roa = FastEMROA(shape=MockEditableShape(),
                         main_data=self.main_data,
@@ -392,8 +392,8 @@ class TestFastEMAcquisition(unittest.TestCase):
             (coordinates[0], coordinates[3]),  # xmin, ymax
             (coordinates[2], coordinates[3]),  # xmax, ymax
         ]
-        roc_2 = fastem.FastEMROC("roc_2", coordinates)
-        roc_3 = fastem.FastEMROC("roc_3", coordinates)
+        roc_2 = fastem.FastEMROC("roc_2", 0, coordinates)
+        roc_3 = fastem.FastEMROC("roc_3", 0, coordinates)
         roa_name = "test_megafield_id"
         roa = FastEMROA(shape=MockEditableShape(),
                         main_data=self.main_data,
@@ -439,8 +439,8 @@ class TestFastEMAcquisition(unittest.TestCase):
             (coordinates[0], coordinates[3]),  # xmin, ymax
             (coordinates[2], coordinates[3]),  # xmax, ymax
         ]
-        roc_2 = fastem.FastEMROC("roc_2", coordinates)
-        roc_3 = fastem.FastEMROC("roc_3", coordinates)
+        roc_2 = fastem.FastEMROC("roc_2", 0, coordinates)
+        roc_3 = fastem.FastEMROC("roc_3", 0, coordinates)
         roa_name = "test_megafield_id"
         roa = FastEMROA(shape=MockEditableShape(),
                         main_data=self.main_data,
@@ -485,8 +485,8 @@ class TestFastEMAcquisition(unittest.TestCase):
             (coordinates[0], coordinates[3]),  # xmin, ymax
             (coordinates[2], coordinates[3]),  # xmax, ymax
         ]
-        roc_2 = fastem.FastEMROC("roc_2", coordinates)
-        roc_3 = fastem.FastEMROC("roc_3", coordinates)
+        roc_2 = fastem.FastEMROC("roc_2", 0, coordinates)
+        roc_3 = fastem.FastEMROC("roc_3", 0, coordinates)
         roa_name = "test_megafield_id"
         roa = FastEMROA(shape=MockEditableShape(),
                         main_data=self.main_data,
@@ -531,8 +531,8 @@ class TestFastEMAcquisition(unittest.TestCase):
             (coordinates[0], coordinates[3]),  # xmin, ymax
             (coordinates[2], coordinates[3]),  # xmax, ymax
         ]
-        roc_2 = fastem.FastEMROC("roc_2", coordinates)
-        roc_3 = fastem.FastEMROC("roc_3", coordinates)
+        roc_2 = fastem.FastEMROC("roc_2", 0, coordinates)
+        roc_3 = fastem.FastEMROC("roc_3", 0, coordinates)
         roa_name = "test_megafield_id"
         roa = FastEMROA(shape=MockEditableShape(),
                         main_data=self.main_data,
@@ -587,8 +587,8 @@ class TestFastEMAcquisition(unittest.TestCase):
             (coordinates[0], coordinates[3]),  # xmin, ymax
             (coordinates[2], coordinates[3]),  # xmax, ymax
         ]
-        roc_2 = fastem.FastEMROC("roc_2", coordinates)
-        roc_3 = fastem.FastEMROC("roc_3", coordinates)
+        roc_2 = fastem.FastEMROC("roc_2", 0, coordinates)
+        roc_3 = fastem.FastEMROC("roc_3", 0, coordinates)
         roa_name = "test_megafield_id"
         roa = FastEMROA(shape=MockEditableShape(),
                         main_data=self.main_data,
@@ -654,8 +654,8 @@ class TestFastEMAcquisition(unittest.TestCase):
             (coordinates[0], coordinates[3]),  # xmin, ymax
             (coordinates[2], coordinates[3]),  # xmax, ymax
         ]
-        roc_2 = fastem.FastEMROC("roc_2", coordinates)
-        roc_3 = fastem.FastEMROC("roc_3", coordinates)
+        roc_2 = fastem.FastEMROC("roc_2", 0, coordinates)
+        roc_3 = fastem.FastEMROC("roc_3", 0, coordinates)
         roa_name = "test_megafield_id"
         roa = FastEMROA(shape=MockEditableShape(),
                         main_data=self.main_data,
@@ -1202,8 +1202,8 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
         settings_obs = SettingsObserver(model.getMicroscope(), model.getComponents())
 
         coordinates = (0, 0, 1e-8, 1e-8)  # in m
-        roc_2 = fastem.FastEMROC("roc_2", coordinates)
-        roc_3 = fastem.FastEMROC("roc_3", coordinates)
+        roc_2 = fastem.FastEMROC("roc_2", 0, coordinates)
+        roc_3 = fastem.FastEMROC("roc_3", 0, coordinates)
         points = [(0, 0), (0, 0), (0, 0), (0, 0)]
 
         roa = FastEMROA(shape=MockEditableShape(),
@@ -1368,8 +1368,8 @@ class TestFastEMAcquisitionTaskMock(TestFastEMAcquisitionTask):
     def test_save_full_cells(self):
         """Test saving fields with cell images of 900x900 px instead of 800x800 px"""
         coordinates = (0, 0, 1e-8, 1e-8)  # in m
-        roc_2 = fastem.FastEMROC("roc_2", coordinates)
-        roc_3 = fastem.FastEMROC("roc_3", coordinates)
+        roc_2 = fastem.FastEMROC("roc_2", 0, coordinates)
+        roc_3 = fastem.FastEMROC("roc_3", 0, coordinates)
         points = [(0, 0), (0.000001, 0), (0.000001, 0.000001), (0, 0.000001)]
 
         roa = FastEMROA(shape=MockEditableShape(),

--- a/src/odemis/gui/__init__.py
+++ b/src/odemis/gui/__init__.py
@@ -45,6 +45,9 @@ FG_COLOUR_ERROR = "#DD3939"      # Error text colour
 FG_COLOUR_RADIO_INACTIVE = "#111111"      # Text colour on radio button when inactive
 FG_COLOUR_RADIO_ACTIVE = "#106090"        # Text colour on radio button when active (same as BORDER_COLOUR_FOCUS)
 FG_COLOUR_BUTTON = "#999999"
+FG_COLOUR_BLIND_BLUE = "#648FFF"    # Colour-blind-friendly blue; choosen from IBM Design Library
+FG_COLOUR_BLIND_ORANGE = "#FFB000"  # Colour-blind-friendly orange; choosen from IBM Design Library
+FG_COLOUR_BLIND_PINK = "#DC267F"    # Colour-blind-friendly pink; choosen from IBM Design Library
 
 # Border colours for the viewports
 BORDER_COLOUR_FOCUS = "#127BA6"

--- a/src/odemis/gui/comp/overlay/fastem.py
+++ b/src/odemis/gui/comp/overlay/fastem.py
@@ -181,10 +181,11 @@ class FastEMROCOverlay(WorldSelectOverlay):
             b_start_pos = self.cnvs.phys_to_buffer(self.p_start_pos, offset)
             b_end_pos = self.cnvs.phys_to_buffer(self.p_end_pos, offset)
             b_start_pos, b_end_pos = self._normalize_rect(b_start_pos, b_end_pos)
-            pos = Vec(b_end_pos.x - 8, b_end_pos.y + 5)  # bottom left
+            pos = Vec(b_end_pos.x - 8, b_end_pos.y + 8)  # bottom left
 
             self.position_label.pos = pos
             self.position_label.text = "%s" % self.label
+            self.position_label.background = (0, 0, 0)  # black
             self.position_label.colour = self.colour
             self._write_labels(ctx)
 

--- a/src/odemis/gui/comp/settings.py
+++ b/src/odemis/gui/comp/settings.py
@@ -299,12 +299,17 @@ class SettingsPanel(wx.Panel):
         return lbl_ctrl, value_ctrl
 
     @control_bookkeeper
-    def add_checkbox_control(self, label_text, value=True, conf=None):
+    def add_checkbox_control(self, label_text, value=True, pos_col=1, span=wx.DefaultSpan, conf=None):
         """ Add a checkbox to the settings panel
 
         :param label_text: (str) Label text to display
         :param value: (bool) Value to display (True == checked)
         :param conf: (None or dict) Dictionary containing parameters for the control
+        :param pos_col: (int) The column index in the grid layout where the checkbox will be placed.
+                        For example:
+                        - `pos_col=0` positions the checkbox in the first column.
+                        - `pos_col=1` positions it in the second column.
+        :param span: (tuple) the row and column spanning attributes of items in a GridBagSizer.
 
         """
         if conf is None:
@@ -312,7 +317,7 @@ class SettingsPanel(wx.Panel):
 
         lbl_ctrl = self._add_side_label(label_text)
         value_ctrl = wx.CheckBox(self, wx.ID_ANY, style=wx.ALIGN_RIGHT | wx.NO_BORDER, **conf)
-        self.gb_sizer.Add(value_ctrl, (self.num_rows, 1),
+        self.gb_sizer.Add(value_ctrl, (self.num_rows, pos_col), span=span,
                           flag=wx.EXPAND | wx.TOP | wx.BOTTOM, border=5)
         value_ctrl.SetValue(value)
 

--- a/src/odemis/gui/comp/viewport.py
+++ b/src/odemis/gui/comp/viewport.py
@@ -58,8 +58,6 @@ from odemis.gui.comp.overlay.sample_background import SampleBackgroundOverlay
 from odemis.gui.comp.overlay.stage_point_select import StagePointSelectOverlay
 from odemis.gui.img import getBitmap
 from odemis.gui.model import (
-    CALIBRATION_2,
-    CALIBRATION_3,
     CHAMBER_UNKNOWN,
     CHAMBER_VACUUM,
     CryoChamberGUIData,
@@ -907,15 +905,14 @@ class FastEMMainViewport(MicroscopeViewport):
         # Add the scintillator background overlay
         self.canvas.add_background_overlay(self.scintillator)
 
-        # Add CALIBRATION_2 and CALIBRATION_3 boxes
-        for name, calib in self.scintillator.calibrations.items():
-            if name in [CALIBRATION_2, CALIBRATION_3]:
-                calib.shape = self.canvas.add_calibration_shape(
-                    calib.region.coordinates,
-                    calib.region.name.value,
-                    self.scintillator.shape.get_bbox(),
-                    calib.region.colour
-                )
+        # Add calibration boxes
+        for calib in self.scintillator.calibrations.values():
+            calib.shape = self.canvas.add_calibration_shape(
+                calib.region.coordinates,
+                calib.region.name.value,
+                self.scintillator.shape.get_bbox(),
+                calib.region.colour
+            )
 
         # Show a crosshair where the stage is
         self.cpol = CurrentPosCrossHairOverlay(self.canvas)

--- a/src/odemis/gui/cont/acquisition/fastem_acq.py
+++ b/src/odemis/gui/cont/acquisition/fastem_acq.py
@@ -749,7 +749,7 @@ class FastEMAcquiController(object):
                 roa = roa_window[0]
                 roc = roa.roc_2.value
                 if roc.coordinates.value == stream.UNDEFINED_ROI or not roc.parameters:
-                    undefined.add(roc.name.value)
+                    undefined.add(roc.scintillator_number.value)
         return sorted(undefined)
 
     def _get_undefined_calibrations_3(self):
@@ -762,7 +762,7 @@ class FastEMAcquiController(object):
                 roa = roa_window[0]
                 roc = roa.roc_3.value
                 if roc.coordinates.value == stream.UNDEFINED_ROI or not roc.parameters:
-                    undefined.add(roc.name.value)
+                    undefined.add(roc.scintillator_number.value)
         return sorted(undefined)
 
     @call_in_wx_main  # call in main thread as changes in GUI are triggered

--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -656,12 +656,16 @@ class xrcpnl_tab_fastem_setup(wx.Panel):
         self.bmp_acq_status_warn = xrc.XRCCTRL(self, "bmp_acq_status_warn")
         self.lbl_acq_estimate = xrc.XRCCTRL(self, "lbl_acq_estimate")
         self.gauge_acq = xrc.XRCCTRL(self, "gauge_acq")
-        self.btn_cancel = xrc.XRCCTRL(self, "btn_cancel")
+        self.btn_cancel_acq = xrc.XRCCTRL(self, "btn_cancel_acq")
         self.btn_acq = xrc.XRCCTRL(self, "btn_acq")
         self.pnl_calib = xrc.XRCCTRL(self, "pnl_calib")
         self.pnl_calib_status = xrc.XRCCTRL(self, "pnl_calib_status")
-        self.gauge_calib = xrc.XRCCTRL(self, "gauge_calib")
+        self.bmp_calib_status_info = xrc.XRCCTRL(self, "bmp_calib_status_info")
+        self.bmp_calib_status_warn = xrc.XRCCTRL(self, "bmp_calib_status_warn")
         self.lbl_calib = xrc.XRCCTRL(self, "lbl_calib")
+        self.gauge_calib = xrc.XRCCTRL(self, "gauge_calib")
+        self.btn_cancel_calib = xrc.XRCCTRL(self, "btn_cancel_calib")
+        self.btn_calib = xrc.XRCCTRL(self, "btn_calib")
 
 
 
@@ -8060,7 +8064,7 @@ N\x85iM\xfd\x1f\xfb\xdf\xeb\x83\xa5\x1cA\xadf,\xae\x27#\xa1\x8e\x85\xc1\
                               <border>16</border>
                             </object>
                             <object class="sizeritem">
-                              <object class="ImageTextButton" name="btn_cancel">
+                              <object class="ImageTextButton" name="btn_cancel_acq">
                                 <height>24</height>
                                 <face_colour>def</face_colour>
                                 <label>Cancel</label>
@@ -8120,43 +8124,116 @@ N\x85iM\xfd\x1f\xfb\xdf\xeb\x83\xa5\x1cA\xadf,\xae\x27#\xa1\x8e\x85\xc1\
                   </object>
                   <object class="sizeritem">
                     <object class="wxPanel" name="pnl_calib_status">
-                      <fg>#7F7F7F</fg>
                       <bg>#333333</bg>
-                      <size>400,40</size>
                       <object class="wxBoxSizer">
+                        <bg>#333333</bg>
+                        <orient>wxVERTICAL</orient>
                         <object class="sizeritem">
-                          <object class="wxGauge" name="gauge_calib">
-                            <size>250,10</size>
-                            <range>100</range>
-                            <value>0</value>
-                            <hidden>1</hidden>
-                            <style>wxGA_SMOOTH</style>
+                          <object class="wxPanel">
+                            <object class="wxBoxSizer">
+                              <orient>wxHORIZONTAL</orient>
+                              <object class="sizeritem">
+                                <object class="wxStaticBitmap" name="bmp_calib_status_info">
+                                  <bitmap>______img_icon_dialog_info_png</bitmap>
+                                  <hidden>1</hidden>
+                                  <XRCED>
+                                    <assign_var>1</assign_var>
+                                  </XRCED>
+                                </object>
+                                <flag>wxRIGHT</flag>
+                                <border>5</border>
+                              </object>
+                              <object class="sizeritem">
+                                <object class="wxStaticBitmap" name="bmp_calib_status_warn">
+                                  <bitmap>______img_icon_dialog_warning_png</bitmap>
+                                  <XRCED>
+                                    <assign_var>1</assign_var>
+                                  </XRCED>
+                                </object>
+                                <flag>wxRIGHT</flag>
+                                <border>5</border>
+                              </object>
+                              <object class="sizeritem">
+                                <object class="wxStaticText" name="lbl_calib">
+                                  <label>No calibration run</label>
+                                  <fg>#DDDDDD</fg>
+                                  <font>
+                                    <size>10</size>
+                                    <sysfont>wxSYS_DEFAULT_GUI_FONT</sysfont>
+                                  </font>
+                                  <XRCED>
+                                    <assign_var>1</assign_var>
+                                  </XRCED>
+                                </object>
+                              </object>
+                            </object>
+                            <bg>#333333</bg>
                             <XRCED>
                               <assign_var>1</assign_var>
                             </XRCED>
                           </object>
-                          <option>0</option>
-                          <flag>wxTOP|wxBOTTOM|wxLEFT|wxFIXED_MINSIZE</flag>
-                          <border>16</border>
-                        </object>
-                        <object class="sizeritem">
-                          <object class="wxStaticText" name="lbl_calib">
-                            <fg>#DDDDDD</fg>
-                            <label>No calibration run</label>
-                            <font>
-                              <sysfont>wxSYS_DEFAULT_GUI_FONT</sysfont>
-                            </font>
-                            <style>wxALIGN_RIGHT</style>
-                            <XRCED>
-                              <assign_var>1</assign_var>
-                            </XRCED>
-                          </object>
-                          <option>1</option>
-                          <flag>wxTOP|wxBOTTOM|wxRIGHT</flag>
+                          <flag>wxLEFT|wxTOP|wxBOTTOM|wxEXPAND</flag>
                           <border>12</border>
                         </object>
+                        <object class="sizeritem">
+                          <object class="wxBoxSizer">
+                            <object class="sizeritem">
+                              <object class="wxGauge" name="gauge_calib">
+                                <size>-1,10</size>
+                                <range>100</range>
+                                <value>0</value>
+                                <hidden>1</hidden>
+                                <style>wxGA_SMOOTH</style>
+                                <XRCED>
+                                  <assign_var>1</assign_var>
+                                </XRCED>
+                              </object>
+                              <option>1</option>
+                              <flag>wxTOP|wxBOTTOM|wxLEFT|wxEXPAND</flag>
+                              <border>16</border>
+                            </object>
+                            <object class="sizeritem">
+                              <object class="ImageTextButton" name="btn_cancel_calib">
+                                <height>24</height>
+                                <face_colour>def</face_colour>
+                                <label>Cancel</label>
+                                <hidden>1</hidden>
+                                <style>wxALIGN_CENTRE</style>
+                                <XRCED>
+                                  <assign_var>1</assign_var>
+                                </XRCED>
+                              </object>
+                              <flag>wxALL</flag>
+                              <border>10</border>
+                            </object>
+                            <orient>wxHORIZONTAL</orient>
+                          </object>
+                          <flag>wxEXPAND</flag>
+                        </object>
+                        <object class="sizeritem">
+                          <object class="ImageTextButton" name="btn_calib">
+                            <bg>#333333</bg>
+                            <height>48</height>
+                            <face_colour>blue</face_colour>
+                            <label>RUN</label>
+                            <fg>#FFFFFF</fg>
+                            <font>
+                              <size>15</size>
+                              <sysfont>wxSYS_DEFAULT_GUI_FONT</sysfont>
+                            </font>
+                            <style>wxALIGN_CENTRE</style>
+                            <XRCED>
+                              <assign_var>1</assign_var>
+                            </XRCED>
+                          </object>
+                          <flag>wxALL|wxEXPAND</flag>
+                          <border>10</border>
+                        </object>
                       </object>
+                      <bg>#333333</bg>
                     </object>
+                    <option>0</option>
+                    <flag>wxEXPAND</flag>
                   </object>
                 </object>
                 <bg>#4D4D4D</bg>

--- a/src/odemis/gui/model/main_gui_data.py
+++ b/src/odemis/gui/model/main_gui_data.py
@@ -32,7 +32,12 @@ from odemis.acq import acqmng, path
 from odemis.acq.align.fastem import Calibrations
 from odemis.acq.fastem import FastEMCalibration, FastEMROC
 from odemis.acq.move import MicroscopePostureManager
-from odemis.gui import FG_COLOUR_WARNING, conf
+from odemis.gui import (
+    FG_COLOUR_BLIND_BLUE,
+    FG_COLOUR_BLIND_ORANGE,
+    FG_COLOUR_BLIND_PINK,
+    conf,
+)
 from odemis.gui.conf.data import get_hw_settings_config
 from odemis.gui.log import observe_comp_state
 from odemis.gui.model import CALIBRATION_1, CALIBRATION_2, CALIBRATION_3
@@ -703,22 +708,32 @@ class FastEMMainGUIData(MainGUIData):
                     raise ValueError("Unknown scintillator shape dimensions")
 
                 scintillator = Scintillator(number=int(scintillator_number), shape=shape)
-                for calibration_name in [CALIBRATION_1, CALIBRATION_2, CALIBRATION_3]:
+                for calibration_name in (CALIBRATION_1, CALIBRATION_2, CALIBRATION_3):
                     calibration = FastEMCalibration(name=calibration_name)
+                    xmin = position[0] - 0.5 * sz[0]
+                    xmax = position[0] + 0.5 * sz[0]
+                    ymin = position[1] + 0.5 * sz[1]
+                    ymax = position[1] - 0.5 * sz[1]
                     if calibration_name == CALIBRATION_1:
+                        number = 1
+                        colour = FG_COLOUR_BLIND_BLUE
                         calibration.sequence.value = calib_1_calibrations
-                    elif calibration_name in [CALIBRATION_2, CALIBRATION_3]:
-                        if calibration_name == CALIBRATION_2:
-                            colour = FG_COLOUR_WARNING
-                            calibration.sequence.value = calib_2_calibrations
-                        elif calibration_name == CALIBRATION_3:
-                            colour = "#00ff00"  # green
-                            calibration.sequence.value = calib_3_calibrations
-                        xmin = position[0] - 0.5 * sz[0]
-                        ymin = position[1] + 0.5 * sz[1]
-                        xmax = position[0] + 0.5 * sz[0]
-                        ymax = position[1] - 0.5 * sz[1]
-                        calibration.region = FastEMROC(str(scintillator_number), coordinates=(xmin, ymin, xmax, ymax), colour=colour)
+                        # overlay location left on init
+                        xmin -= 1.2 * sz[0]
+                        xmax -= 1.2 * sz[0]
+                    elif calibration_name == CALIBRATION_2:
+                        number = 2
+                        colour = FG_COLOUR_BLIND_ORANGE
+                        calibration.sequence.value = calib_2_calibrations
+                        # overlay location middle on init
+                    elif calibration_name == CALIBRATION_3:
+                        number = 3
+                        colour = FG_COLOUR_BLIND_PINK
+                        calibration.sequence.value = calib_3_calibrations
+                        # overlay location right on init
+                        xmin += 1.2 * sz[0]
+                        xmax += 1.2 * sz[0]
+                    calibration.region = FastEMROC(str(number), coordinates=(xmin, ymin, xmax, ymax), colour=colour)
                     scintillator.calibrations[calibration_name] = calibration
                 self.samples.value[sample_type].scintillators[scintillator_number] = scintillator
 

--- a/src/odemis/gui/model/main_gui_data.py
+++ b/src/odemis/gui/model/main_gui_data.py
@@ -733,7 +733,9 @@ class FastEMMainGUIData(MainGUIData):
                         # overlay location right on init
                         xmin += 1.2 * sz[0]
                         xmax += 1.2 * sz[0]
-                    calibration.region = FastEMROC(str(number), coordinates=(xmin, ymin, xmax, ymax), colour=colour)
+                    calibration.region = FastEMROC(name=str(number),
+                                                   scintillator_number=int(scintillator_number),
+                                                   coordinates=(xmin, ymin, xmax, ymax), colour=colour)
                     scintillator.calibrations[calibration_name] = calibration
                 self.samples.value[sample_type].scintillators[scintillator_number] = scintillator
 

--- a/src/odemis/gui/xmlh/resources/panel_tab_fastem_setup.xrc
+++ b/src/odemis/gui/xmlh/resources/panel_tab_fastem_setup.xrc
@@ -181,7 +181,7 @@
                               <border>16</border>
                             </object>
                             <object class="sizeritem">
-                              <object class="ImageTextButton" name="btn_cancel">
+                              <object class="ImageTextButton" name="btn_cancel_acq">
                                 <height>24</height>
                                 <face_colour>def</face_colour>
                                 <label>Cancel</label>
@@ -241,43 +241,116 @@
                   </object>
                   <object class="sizeritem">
                     <object class="wxPanel" name="pnl_calib_status">
-                      <fg>#7F7F7F</fg>
                       <bg>#333333</bg>
-                      <size>400,40</size>
                       <object class="wxBoxSizer">
+                        <bg>#333333</bg>
+                        <orient>wxVERTICAL</orient>
                         <object class="sizeritem">
-                          <object class="wxGauge" name="gauge_calib">
-                            <size>250,10</size>
-                            <range>100</range>
-                            <value>0</value>
-                            <hidden>1</hidden>
-                            <style>wxGA_SMOOTH</style>
+                          <object class="wxPanel">
+                            <object class="wxBoxSizer">
+                              <orient>wxHORIZONTAL</orient>
+                              <object class="sizeritem">
+                                <object class="wxStaticBitmap" name="bmp_calib_status_info">
+                                  <bitmap>../../img/icon/dialog_info.png</bitmap>
+                                  <hidden>1</hidden>
+                                  <XRCED>
+                                    <assign_var>1</assign_var>
+                                  </XRCED>
+                                </object>
+                                <flag>wxRIGHT</flag>
+                                <border>5</border>
+                              </object>
+                              <object class="sizeritem">
+                                <object class="wxStaticBitmap" name="bmp_calib_status_warn">
+                                  <bitmap>../../img/icon/dialog_warning.png</bitmap>
+                                  <XRCED>
+                                    <assign_var>1</assign_var>
+                                  </XRCED>
+                                </object>
+                                <flag>wxRIGHT</flag>
+                                <border>5</border>
+                              </object>
+                              <object class="sizeritem">
+                                <object class="wxStaticText" name="lbl_calib">
+                                  <label>No calibration run</label>
+                                  <fg>#DDDDDD</fg>
+                                  <font>
+                                    <size>10</size>
+                                    <sysfont>wxSYS_DEFAULT_GUI_FONT</sysfont>
+                                  </font>
+                                  <XRCED>
+                                    <assign_var>1</assign_var>
+                                  </XRCED>
+                                </object>
+                              </object>
+                            </object>
+                            <bg>#333333</bg>
                             <XRCED>
                               <assign_var>1</assign_var>
                             </XRCED>
                           </object>
-                          <option>0</option>
-                          <flag>wxTOP|wxBOTTOM|wxLEFT|wxFIXED_MINSIZE</flag>
-                          <border>16</border>
-                        </object>
-                        <object class="sizeritem">
-                          <object class="wxStaticText" name="lbl_calib">
-                            <fg>#DDDDDD</fg>
-                            <label>No calibration run</label>
-                            <font>
-                              <sysfont>wxSYS_DEFAULT_GUI_FONT</sysfont>
-                            </font>
-                            <style>wxALIGN_RIGHT</style>
-                            <XRCED>
-                              <assign_var>1</assign_var>
-                            </XRCED>
-                          </object>
-                          <option>1</option>
-                          <flag>wxTOP|wxBOTTOM|wxRIGHT</flag>
+                          <flag>wxLEFT|wxTOP|wxBOTTOM|wxEXPAND</flag>
                           <border>12</border>
                         </object>
+                        <object class="sizeritem">
+                          <object class="wxBoxSizer">
+                            <object class="sizeritem">
+                              <object class="wxGauge" name="gauge_calib">
+                                <size>-1,10</size>
+                                <range>100</range>
+                                <value>0</value>
+                                <hidden>1</hidden>
+                                <style>wxGA_SMOOTH</style>
+                                <XRCED>
+                                  <assign_var>1</assign_var>
+                                </XRCED>
+                              </object>
+                              <option>1</option>
+                              <flag>wxTOP|wxBOTTOM|wxLEFT|wxEXPAND</flag>
+                              <border>16</border>
+                            </object>
+                            <object class="sizeritem">
+                              <object class="ImageTextButton" name="btn_cancel_calib">
+                                <height>24</height>
+                                <face_colour>def</face_colour>
+                                <label>Cancel</label>
+                                <hidden>1</hidden>
+                                <style>wxALIGN_CENTRE</style>
+                                <XRCED>
+                                  <assign_var>1</assign_var>
+                                </XRCED>
+                              </object>
+                              <flag>wxALL</flag>
+                              <border>10</border>
+                            </object>
+                            <orient>wxHORIZONTAL</orient>
+                          </object>
+                          <flag>wxEXPAND</flag>
+                        </object>
+                        <object class="sizeritem">
+                          <object class="ImageTextButton" name="btn_calib">
+                            <bg>#333333</bg>
+                            <height>48</height>
+                            <face_colour>blue</face_colour>
+                            <label>RUN</label>
+                            <fg>#FFFFFF</fg>
+                            <font>
+                              <size>15</size>
+                              <sysfont>wxSYS_DEFAULT_GUI_FONT</sysfont>
+                            </font>
+                            <style>wxALIGN_CENTRE</style>
+                            <XRCED>
+                              <assign_var>1</assign_var>
+                            </XRCED>
+                          </object>
+                          <flag>wxALL|wxEXPAND</flag>
+                          <border>10</border>
+                        </object>
                       </object>
+                      <bg>#333333</bg>
                     </object>
+                    <option>0</option>
+                    <flag>wxEXPAND</flag>
                   </object>
                 </object>
                 <bg>#4D4D4D</bg>


### PR DESCRIPTION
[feat] restructured calibration panel layout

Changes
- Calibration 1 also has a box
- Calibration 1, 2, 3 colour are choosen keeping colour blindness in mind
- Individual calibration Run button replaced with individual calibration checkbox and finally a single RUN button to run the checked and enabled calibrations
- Single cancel button to cancel running calibrations

![Screenshot from 2024-12-12 11-10-42](https://github.com/user-attachments/assets/7b05323d-2045-400a-946e-8de56098d6ea)

![Screenshot from 2024-12-12 11-11-20](https://github.com/user-attachments/assets/453a7f56-3c4a-40c5-92e2-c9075aa2039c)

