### PR TITLE
[fix] cl_acquisition: e-beam scan settings could be sometimes incorrect

### DIFF
--- a/scripts/cl_acquisition.py
+++ b/scripts/cl_acquisition.py
@@ -255,8 +255,8 @@ class Acquirer(object):
         self.escan.dwellTime.value = self.escan.dwellTime.clip(exp)
 
         # Configure the SEM to spot mode
-        self.escan.resolution.value = (1, 1)
         self.escan.scale.value = (1, 1)  # to be certain we can easily move the spot anywhere
+        self.escan.resolution.value = (1, 1)
         spot_pos = self.get_spot_positions()
         logging.debug("Generating %dx%d spots for %g s",
                       spot_pos.shape[1], spot_pos.shape[0], exp)


### PR DESCRIPTION
Scale must always be set before resolution, as it adjusts the resolution
to keep the same FoV.