### PR TITLE
[fix] xt_client: shouldn't provide dwellTime when there is no detector

### DIFF
--- a/src/odemis/driver/test/xt_client_test.py
+++ b/src/odemis/driver/test/xt_client_test.py
@@ -632,6 +632,9 @@ class TestHelperMicroscope(TestMicroscope):
                 cls.chamber = child
 
     # Disable tests for anything related to the detector
+    def test_set_dwell_time(self):
+        self.skipTest("No detector to test.")
+
     def test_acquire(self):
         self.skipTest("No detector to test.")
 


### PR DESCRIPTION
When xt_client is used as a "beam control" in addition to the external
scan board, it doesn't make sense to provide access to the (internal)
dwell time.
=> Only provide .dwellTime if there is a detector child.