### PR TITLE
[legal] adjust name from "Delmic Acqusition Software" to Odemis

### DIFF
--- a/src/odemis/driver/test/xt_client_test.py
+++ b/src/odemis/driver/test/xt_client_test.py
@@ -7,17 +7,17 @@ Created on 16 Aug 2019
 
 Copyright © 2019-2021 Thera Pals, Delmic
 
-This file is part of Delmic Acquisition Software.
+This file is part of Odemis.
 
-Delmic Acquisition Software is free software: you can redistribute it and/or modify it under the terms of the GNU
+Odemis is free software: you can redistribute it and/or modify it under the terms of the GNU
 General Public License as published by the Free Software Foundation, either version 2 of the License, or (at your
 option) any later version.
 
-Delmic Acquisition Software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+Odemis is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
 the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
 more details.
 
-You should have received a copy of the GNU General Public License along with Delmic Acquisition Software. If not, see
+You should have received a copy of the GNU General Public License along with Odemis. If not, see
 http://www.gnu.org/licenses/.
 """
 import logging

--- a/src/odemis/driver/xt_client.py
+++ b/src/odemis/driver/xt_client.py
@@ -8,15 +8,15 @@ Copyright © 2019-2021 Thera Pals, Delmic
 
 This file is part of Odemis.
 
-Delmic Acquisition Software is free software: you can redistribute it and/or modify it under the terms of the GNU
+Odemis is free software: you can redistribute it and/or modify it under the terms of the GNU
 General Public License as published by the Free Software Foundation, either version 2 of the License, or (at your
 option) any later version.
 
-Delmic Acquisition Software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+Odemis is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
 the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
 more details.
 
-You should have received a copy of the GNU General Public License along with Delmic Acquisition Software. If not, see
+You should have received a copy of the GNU General Public License along with Odemis. If not, see
 http://www.gnu.org/licenses/.
 """
 import logging

--- a/src/odemis/odemisd/test/modelgen_test.py
+++ b/src/odemis/odemisd/test/modelgen_test.py
@@ -7,17 +7,17 @@ Created on 16 Dec 2020
 
 Copyright © 2019-2021 Kornee Kleijwegt, Delmic
 
-This file is part of Delmic Acquisition Software.
+This file is part of Odemis.
 
-Delmic Acquisition Software is free software: you can redistribute it and/or modify it under the terms of the GNU
+Odemis is free software: you can redistribute it and/or modify it under the terms of the GNU
 General Public License as published by the Free Software Foundation, either version 2 of the License, or (at your
 option) any later version.
 
-Delmic Acquisition Software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+Odemis is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
 the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
 more details.
 
-You should have received a copy of the GNU General Public License along with Delmic Acquisition Software. If not, see
+You should have received a copy of the GNU General Public License along with Odemis. If not, see
 http://www.gnu.org/licenses/.
 """
 import logging


### PR DESCRIPTION
The name "Delmic Acqusition Software" was used for just a few months, at
the very beginning of the project... but it somehow managed to sneak in.
=> Use Odemis everywhere.