### PR TITLE
[fix] DigitalCamera depthOfField formula error

### DIFF
--- a/src/odemis/model/_components.py
+++ b/src/odemis/model/_components.py
@@ -670,7 +670,7 @@ class DigitalCamera(Detector, metaclass=ABCMeta):
 
         try:
             # from https://www.microscopyu.com/articles/formulas/formulasfielddepth.html
-            dof = (l * ri) / na ** 2 + (ri * pxs_sensor) / (mag - na)
+            dof = (l * ri) / na ** 2 + (ri * pxs_sensor) / (mag * na)
             try:
                 self.depthOfField._set_value(dof, force_write=True)
             except (IndexError, TypeError):


### PR DESCRIPTION
The code references a website with a formula, but that formula was
incorrectly copied: "mag - na", instead of the correct "mag * na".
For large, standard values, like mag = 60, na = 0.9, this has
surprisingly little effect, as the first part of the formula is the
main contributor. However, for values found on the SPARC like mag = 0.3,
this can have very strong effect. In particular, this could even lead to
impossible negative values.