### PR TITLE
[TRCL-492] [fix] gui SPARC: time estimation should be updated when drift correction is adjusted

### DIFF
--- a/src/odemis/gui/cont/acquisition/sparc_acq.py
+++ b/src/odemis/gui/cont/acquisition/sparc_acq.py
@@ -123,10 +123,13 @@ class SparcAcquiController(object):
         # also listen to .semStream, which is not in .streams
         for va in self._get_settings_vas(tab_data.semStream):
             va.subscribe(self._onAnyVA)
+
         # Extra options affecting the acquisitions globally
         tab_data.pcdActive.subscribe(self._onAnyVA)
-        # TODO: should also listen to the VAs of the leeches on semStream
         tab_data.useScanStage.subscribe(self._onAnyVA)
+        tab_data.driftCorrector.roi.subscribe(self._onAnyVA)
+        tab_data.driftCorrector.period.subscribe(self._onAnyVA)
+        tab_data.driftCorrector.dwellTime.subscribe(self._onAnyVA)
 
         self._roa.subscribe(self._onROA, init=True)
 


### PR DESCRIPTION
When the drift correction is activated (ie, .roa goes from UNDEFINED_ROI to
another value), or the period is changed, the total acquisition time is
affected (a little bit). So need to automatically update it, like any
other VA affecting the acquisition.

Note that the dwell time is linked to the SEM survey dwell time. So in
theory, it's not really necessary to also listen to it, as the SEM dwell
time would already trigger the time estimation. However that's not a big
deal, and ensure that even if we change them to not be linked, the time
will still be correctly estimated.