### PR TITLE
[TRCL-540] [fix] gui: improve tooltip about Streakcam MCPGain

### DIFF
--- a/src/odemis/gui/conf/data.py
+++ b/src/odemis/gui/conf/data.py
@@ -409,8 +409,9 @@ HW_SETTINGS_CONFIG = {
             ("MCPGain", {
                 "control_type": odemis.gui.CONTROL_INT,
                 "label": "MCP gain",
-                "tooltip": u"Microchannel plate gain of the streak unit.\n"
-                           u"Be careful when setting the gain while operating the camera in focus-mode.",
+                "tooltip": "Microchannel plate gain of the streak unit.\n"
+                           "Be careful when setting the gain while operating the camera in focus-mode.\n"
+                           "Only increase the gain while the stream is playing.",
                 "key_step": 1,
             }),
             ("shutter", {


### PR DESCRIPTION
The MCPGain has a special behaviour: for detector safety, it can only
be increased while the stream is playing (although it can be decreased at any time).
=> Warn about this behaviour in the tooltip, to avoid the chances the
user thinks it's a bug.