### PR TITLE
[SDEV-1947] estimating overview image tiled acquisition time

### DIFF
--- a/install/linux/usr/share/odemis/sim/fastem-sim-asm.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/fastem-sim-asm.odm.yaml
@@ -85,7 +85,7 @@ FASTEM-sim: {
         axes: {
             'x': {
                 axis_number: 1,
-                speed: 0.001, # m/s
+                speed: 0.005, # m/s
                 closed_loop: True,
                 range: [-25.e-3, 25.e-3],  # m
                 motorstep_resolution: 4.5e-6,  # m / step
@@ -93,7 +93,7 @@ FASTEM-sim: {
                 },
             'y': {
                 axis_number: 2,
-                speed: 0.001, # m/s
+                speed: 0.005, # m/s
                 closed_loop: True,
                 range: [-25.e-3, 25.e-3],  # m
                 motorstep_resolution: 4.5e-6,  # m / step

--- a/src/odemis/acq/fastem.py
+++ b/src/odemis/acq/fastem.py
@@ -826,8 +826,7 @@ def estimateTiledAcquisitionTime(stream, stage, area, dwell_time=None):
 
     :param stream: (SEMstream) The stream used for the acquisition.
     :param stage: (actuator.MultiplexActuator) The stage in the sample carrier coordinate system.
-        The x and y axes are aligned with the x and y axes of the ebeam scanner. UNUSED: Can be used to take
-        speed of axes into account for time estimation.
+        The x and y axes are aligned with the x and y axes of the ebeam scanner.
     :param area: (float, float, float, float) xmin, ymin, xmax, ymax coordinates of the overview region
         in the sample carrier coordinate system.
     :param dwell_time: (float) A user input dwell time to be used instead of the stream emitter's dwell time
@@ -837,26 +836,54 @@ def estimateTiledAcquisitionTime(stream, stage, area, dwell_time=None):
     """
     # get the resolution per tile used during overview imaging
     res = fastem_conf.SCANNER_CONFIG[fastem_conf.OVERVIEW_MODE]['resolution']
-    fov = fastem_conf.SCANNER_CONFIG[fastem_conf.OVERVIEW_MODE]['horizontalFoV']
+    fov_value = fastem_conf.SCANNER_CONFIG[fastem_conf.OVERVIEW_MODE]['horizontalFoV']
 
     # calculate area size
-    fov = (fov, fov * res[1] / res[0])
+    fov = (fov_value, fov_value * res[1] / res[0])
     acquisition_area = util.normalize_rect(area)  # make sure order is l, b, r, t
     area_size = (acquisition_area[2] - acquisition_area[0],
                  acquisition_area[3] - acquisition_area[1])
     # number of tiles
-    nx = math.ceil(abs(area_size[0] / fov[0]))
-    ny = math.ceil(abs(area_size[1] / fov[1]))
+    nx = math.ceil(abs(area_size[0] / fov[0]))  # Number of tiles horizontally
+    ny = math.ceil(abs(area_size[1] / fov[1]))  # Number of tiles vertically
 
-    # add some overhead per tile for e.g. stage movement
-    overhead = 1  # [s]
-    # time per tile
+    # Time for tile acquisition
     dwell_time_value = dwell_time if dwell_time is not None else stream.emitter.dwellTime.value
-    acq_time_tile = res[0] * res[1] * dwell_time_value + overhead  # [s]
-    # time for total overview image
-    acq_time_overview = nx * ny * acq_time_tile  # [s]
+    acq_time_tile = res[0] * res[1] * dwell_time_value
 
-    return acq_time_overview
+    # Total acquisition time for imaging (all tiles)
+    # add 2s to account for switching from one tile to next tile
+    # this time is added in TiledAcquisitionTask.estimateTime
+    acq_time = nx * ny * (acq_time_tile + 2)
+
+    # Stage movement time calculations
+    stage_speed_x = stage.speed.value['x']  # Speed of stage in x-direction [m/s]
+    stage_speed_y = stage.speed.value['y']  # Speed of stage in y-direction [m/s]
+
+    # Horizontal movement: Total time for moving across rows
+    time_x_per_row = (nx - 1) * (fov[0] / stage_speed_x)  # Moving (nx - 1) times per row
+    time_x = time_x_per_row * ny  # Repeated for each row
+
+    # Vertical movement: Time for repositioning to the next row
+    time_y_per_move = fov[1] / stage_speed_y  # Moving vertically between rows
+    time_y = time_y_per_move * (ny - 1)  # Moving (ny - 1) times
+
+    # Total stage movement time
+    stage_time = time_x + time_y
+
+    # The stage movement precision is quite good (just a few pixels). The stage's
+    # position reading is much better, and we can assume it's below a pixel.
+    # So as long as we are sure there is some overlap, the tiles will be positioned
+    # correctly and without gap.
+    overlap = STAGE_PRECISION / fov_value
+    # Estimate stitching time based on number of pixels in the overlapping part
+    max_pxs = res[0] * res[1]
+    stitch_time = (nx * ny * max_pxs * overlap) / 1e8  # 1e8 is stitching speed
+
+    # Combine imaging time, stage movement time and stitch time
+    total_time = acq_time + stage_time + stitch_time
+
+    return total_time
 
 
 class OverviewAcquisition(object):
@@ -902,16 +929,12 @@ class OverviewAcquisition(object):
         logging.debug("Overlap is %s%%", overlap * 100)  # normally < 1%
 
         def _pass_future_progress(sub_f, start, end):
-            self._future.set_progress(start, end)
+            self._future.set_progress(end=end)
 
         # Note, for debugging, it's possible to keep the intermediary tiles with log_path="./tile.ome.tiff"
         self._sub_future = stitching.acquireTiledArea([stream], stage, area, overlap, registrar=REGISTER_IDENTITY,
                                                       focusing_method=FocusingMethod.NONE)
-
-        # Connect the progress of the underlying future to the main future
-        # FIXME removed to provide better progress update in GUI
-        # When _tiledacq.py has proper time update implemented, add this line here again.
-        # self._sub_future.add_update_callback(_pass_future_progress)
+        self._sub_future.add_update_callback(_pass_future_progress)
 
         das = []
         try:

--- a/src/odemis/acq/stitching/__init__.py
+++ b/src/odemis/acq/stitching/__init__.py
@@ -18,7 +18,8 @@ from odemis.acq.stitching._constants import REGISTER_GLOBAL_SHIFT, REGISTER_SHIF
     REGISTER_IDENTITY, WEAVER_MEAN, WEAVER_COLLAGE, WEAVER_COLLAGE_REVERSE
 from odemis.acq.stitching._tiledacq import (acquireTiledArea, acquireOverview, estimateOverviewTime,
                                             estimateTiledAcquisitionTime, estimateTiledAcquisitionMemory,
-                                            FocusingMethod, get_zstack_levels, get_tiled_bboxes, get_stream_based_bbox)
+                                            FocusingMethod, get_zstack_levels, get_tiled_bboxes, get_stream_based_bbox,
+                                            STITCH_SPEED)
 from odemis.acq.stitching._registrar import *
 from odemis.acq.stitching._weaver import *
 from odemis.acq.stitching._simple import register, weave

--- a/src/odemis/acq/stitching/_tiledacq.py
+++ b/src/odemis/acq/stitching/_tiledacq.py
@@ -65,6 +65,7 @@ SAFE_REL_RANGE_DEFAULT = (-50e-6, 50e-6)  # m
 MAX_DISTANCE_FOCUS_POINTS = 450e-06  # in m
 
 DEFAULT_FOV = (100e-6, 100e-6) # m
+STITCH_SPEED = 1e8  # px/s
 
 class FocusingMethod(Enum):
     NONE = 0  # Never auto-focus
@@ -492,8 +493,6 @@ class TiledAcquisitionTask(object):
 
         return mem_sufficient, mem_est
 
-    STITCH_SPEED = 1e8  # px/s
-
     def estimateTime(self, remaining=None):
         """
         Estimates duration for acquisition and stitching.
@@ -522,7 +521,7 @@ class TiledAcquisitionTask(object):
                 if pxs > max_pxs:
                     max_pxs = pxs
 
-        stitch_time = (self._nx * self._ny * max_pxs * self._overlap) / self.STITCH_SPEED
+        stitch_time = (self._nx * self._ny * max_pxs * self._overlap) / STITCH_SPEED
         try:
             move_time = max(self._guessSmallestFov(self._streams)) * (remaining - 1) / self._move_speed
             # current tile is part of remaining, so no need to move there

--- a/src/odemis/acq/stitching/_tiledacq.py
+++ b/src/odemis/acq/stitching/_tiledacq.py
@@ -504,12 +504,12 @@ class TiledAcquisitionTask(object):
 
         acq_time = 0
         for stream in self._streams:
-            # add 1s to account for stage/objective movement time in z direction
-            acq_stream_time = acqmng.estimateTime([stream]) + 1
-            if stream.focuser is not None and len(self._zlevels) > 1:
-                # Acquisition time for each stream will be multiplied by the number of zstack levels
-                zlevels = [item for item in self._zlevels if item is not None]
-                acq_stream_time *= len(zlevels)
+            acq_stream_time = acqmng.estimateTime([stream])
+            # Acquisition time for each stream will be multiplied by the number of zstack levels
+            zlevels = [item for item in self._zlevels if item is not None]
+            if stream.focuser is not None and len(zlevels):
+                # add 1s to account for stage/objective movement time in z direction
+                acq_stream_time = (acq_stream_time + 1) * len(zlevels)
             # add 2 seconds to account for switching from one tile to next tile
             acq_time += acq_stream_time + 2
 


### PR DESCRIPTION
Fix includes:
- correctly estimating the stage movement time and adding it to the total time
- keeping the overhead time separate to overview acquisition time and stage time