### PR TITLE
[fix] fix invalid detector settings offset position in metadata

### DIFF
--- a/src/odemis/dataio/test/tiff_test.py
+++ b/src/odemis/dataio/test/tiff_test.py
@@ -2159,7 +2159,8 @@ class TestTiffIO(unittest.TestCase):
                 model.MD_EXP_TIME: 1.2,  # s
                 model.MD_IN_WL: (500e-9, 522e-9),  # m
                 model.MD_OUT_WL: (400e-9, 450e-9),  # m
-                model.MD_LIGHT_POWER: 0.140,  # W
+                model.MD_LIGHT_POWER: 0.140,  # W,
+                model.MD_BASELINE: 400.0,
             },
             {model.MD_SW_VERSION: "1.0-test",
                 model.MD_HW_NAME: "fake hw",
@@ -2173,6 +2174,7 @@ class TestTiffIO(unittest.TestCase):
                 model.MD_IN_WL: (590e-9, 620e-9),  # m
                 model.MD_OUT_WL: (520e-9, 550e-9),  # m
                 model.MD_LIGHT_POWER: 0.240,  # W
+                model.MD_BASELINE: 400.0,
             },
             {model.MD_SW_VERSION: "1.0-test",
                 model.MD_HW_NAME: "fake hw",
@@ -2186,6 +2188,7 @@ class TestTiffIO(unittest.TestCase):
                 model.MD_IN_WL: (600e-9, 630e-9),  # m
                 model.MD_OUT_WL: (620e-9, 650e-9),  # m
                 model.MD_LIGHT_POWER: 0.350,  # W
+                model.MD_BASELINE: 400.0,
             },
             ]
         # create second group metadata (different position/lightpower)

--- a/src/odemis/dataio/tiff.py
+++ b/src/odemis/dataio/tiff.py
@@ -826,6 +826,10 @@ def _updateMDFromOME(root, das):
                     mdc[model.MD_EBEAM_VOLTAGE] = float(d_settings.attrib["Voltage"])
                 except (KeyError, ValueError):
                     pass
+                try:
+                    mdc[model.MD_BASELINE] = float(d_settings.attrib["Offset"])
+                except (KeyError, ValueError):
+                    pass
 
             # Get light source info
             ls_settings = che.find("LightSourceSettings")
@@ -1425,11 +1429,6 @@ def _addImageElement(root, das, ifd, rois, fname=None, fuuid=None):
         ose = ET.SubElement(ime, "ObjectiveSettings",
                             attrib={"ID": "Objective:%d" % ifd})
 
-    if model.MD_BASELINE in globalMD:
-        # add ref to Objective
-        dse = ET.SubElement(ime, "DetectorSettings",
-                            attrib={"ID": "Detector:%d" % ifd,
-                                    "Offset": "%.15f" % globalMD[model.MD_BASELINE]})
 
     # store the rotation, shear and extra settings in the StructuredAnnotations
     # as they are non-standard metadata
@@ -1658,6 +1657,8 @@ def _addImageElement(root, das, ifd, rois, fname=None, fuuid=None):
             if model.MD_EBEAM_VOLTAGE in da.metadata:
                 # Schema only mentions PMT, but we use it for the e-beam too
                 attrib["Voltage"] = "%.15f" % da.metadata[model.MD_EBEAM_VOLTAGE] # V
+            if model.MD_BASELINE in da.metadata:
+                attrib["Offset"] = "%.15f" % da.metadata[model.MD_BASELINE]
 
             if attrib:
                 # detector of the group has the same id as first IFD of the group

--- a/src/odemis/driver/simcam.py
+++ b/src/odemis/driver/simcam.py
@@ -130,7 +130,8 @@ class Camera(model.DigitalCamera):
 
         self._metadata = {model.MD_HW_NAME: "FakeCam",
                           model.MD_SENSOR_PIXEL_SIZE: spxs,
-                          model.MD_DET_TYPE: model.MD_DT_INTEGRATING}
+                          model.MD_DET_TYPE: model.MD_DT_INTEGRATING,
+                          model.MD_BASELINE: 100}
 
         try:
             focuser = dependencies["focus"]


### PR DESCRIPTION
From hardware testing:
An additional DetectorSettings with only the Offset value was placed in the Image part of the OME xml. This doesn't cause issues with odemis as the reader is custom, but is not valid OME for other readers and causes issues when reading externally. This wasn't picked up during previous testing because the simulator camera didn't have a MD_BASELINE so no Detector Offset was saved in the metadata. 

Changes:
- Migrate Detector Offset into Channel section of metadata as specified by OME
- Add MD_BASELINE to SimCam 

