### PR TITLE
[SDEV-1916] fix pre calibration failure stops the acquisition

### DIFF
--- a/src/odemis/acq/test/fastem_test.py
+++ b/src/odemis/acq/test/fastem_test.py
@@ -771,7 +771,7 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
                                           self.scan_stage, self.ccd, self.beamshift, self.lens, self.se_detector,
                                           self.ebeam_focus, roa, path=None, username="default", pre_calibrations=None,
                                           save_full_cells=False, settings_obs=None, spot_grid_thresh=0.5,
-                                          blank_beam=True, future=None)
+                                          blank_beam=True, stop_acq_on_failure=True, future=None)
 
             # Set the _pos_first_tile, which would normally be set in the run function.
             task._pos_first_tile = task.get_pos_first_tile()
@@ -859,7 +859,7 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
                                           self.scan_stage, self.ccd, self.beamshift, self.lens, self.se_detector,
                                           self.ebeam_focus, roa, path=None, username="default", pre_calibrations=None,
                                           save_full_cells=False, settings_obs=None, spot_grid_thresh=0.5,
-                                          blank_beam=True, future=None)
+                                          blank_beam=True, stop_acq_on_failure=True, future=None)
 
             # Set the _pos_first_tile, which would normally be set in the run function.
             task._pos_first_tile = task.get_pos_first_tile()
@@ -944,7 +944,7 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
                                       self.scan_stage, self.ccd, self.beamshift, self.lens, self.se_detector,
                                       self.ebeam_focus, roa, path=None, username="default", pre_calibrations=None,
                                       save_full_cells=True, settings_obs=None, spot_grid_thresh=0.5, blank_beam=True,
-                                      future=None)
+                                      stop_acq_on_failure=True, future=None)
 
         # Set the _pos_first_tile, which would normally be set in the run function.
         task._pos_first_tile = task.get_pos_first_tile()
@@ -1026,7 +1026,7 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
                                       self.scan_stage, self.ccd, self.beamshift, self.lens, self.se_detector,
                                       self.ebeam_focus, roa, path=None, username="default", pre_calibrations=None,
                                       save_full_cells=False, settings_obs=None, spot_grid_thresh=0.5, blank_beam=True,
-                                      future=None)
+                                      stop_acq_on_failure=True, future=None)
         # Set the _pos_first_tile, which would normally be set in the run function.
         task._pos_first_tile = task.get_pos_first_tile()
 
@@ -1085,7 +1085,7 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
                                       self.scan_stage, self.ccd, self.beamshift, self.lens, self.se_detector,
                                       self.ebeam_focus, roa, path=None, username="default", pre_calibrations=None,
                                       save_full_cells=False, settings_obs=None, spot_grid_thresh=0.5, blank_beam=True,
-                                      future=None)
+                                      stop_acq_on_failure=True, future=None)
 
         self.descanner.updateMetadata({model.MD_SCAN_GAIN: (5000, 5000)})
 
@@ -1144,7 +1144,7 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
                                           self.scan_stage, self.ccd, self.beamshift, self.lens, self.se_detector,
                                           self.ebeam_focus, roa, path=None, username="default", pre_calibrations=None,
                                           save_full_cells=False, settings_obs=None, spot_grid_thresh=0.5,
-                                          blank_beam=True, future=None)
+                                          blank_beam=True, stop_acq_on_failure=True, future=None)
 
             pos_first_tile_actual = task.get_pos_first_tile()
 
@@ -1177,7 +1177,7 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
                                       self.scan_stage, self.ccd, self.beamshift, self.lens, self.se_detector,
                                       self.ebeam_focus, roa, path=None, username="default", pre_calibrations=None,
                                       save_full_cells=False, settings_obs=settings_obs, spot_grid_thresh=0.5,
-                                      blank_beam=True, future=None)
+                                      blank_beam=True, stop_acq_on_failure=True, future=None)
 
         # Test that _create_acquisition_metadata() sets the settings from the selection
         acquisition_md = task._create_acquisition_metadata()
@@ -1224,7 +1224,7 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
                                       self.scan_stage, self.ccd, self.beamshift, self.lens, self.se_detector,
                                       self.ebeam_focus, roa, path="test-path", username="default",
                                       pre_calibrations=None, save_full_cells=False, settings_obs=settings_obs,
-                                      spot_grid_thresh=0.5, blank_beam=True, future=Mock())
+                                      spot_grid_thresh=0.5, blank_beam=True, stop_acq_on_failure=True, future=Mock())
         data, err = task.run()
         self.assertEqual(data[(0, 0)].shape, (6400, 6400))
 
@@ -1233,7 +1233,7 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
                                       self.scan_stage, self.ccd, self.beamshift, self.lens, self.se_detector,
                                       self.ebeam_focus, roa, path="test-path", username="default",
                                       pre_calibrations=None, save_full_cells=True, settings_obs=settings_obs,
-                                      spot_grid_thresh=0.5, blank_beam=True, future=Mock())
+                                      spot_grid_thresh=0.5, blank_beam=True, stop_acq_on_failure=True, future=Mock())
         data, err = task.run()
         self.assertEqual(data[(0, 0)].shape, (7200, 7200))
 
@@ -1255,7 +1255,7 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
                                       self.scan_stage, self.ccd, self.beamshift, self.lens, self.se_detector,
                                       self.ebeam_focus, roa, path=None, username="default", pre_calibrations=None,
                                       save_full_cells=False, settings_obs=None, spot_grid_thresh=0.5, blank_beam=True,
-                                      future=None)
+                                      stop_acq_on_failure=True, future=None)
         # When n_beamshifts=1, the beamshift correction should be applied for every field.
         # Therefore, the calculated indices should match the original field indices.
         beam_shift_indices = task._calculate_beam_shift_cor_indices(n_beam_shifts=1)
@@ -1397,7 +1397,7 @@ class TestFastEMAcquisitionTaskMock(TestFastEMAcquisitionTask):
                                       self.scan_stage, self.ccd, self.beamshift, self.lens, self.se_detector,
                                       self.ebeam_focus, roa, path="test-path", username="default",
                                       pre_calibrations=None, save_full_cells=False, settings_obs=None,
-                                      spot_grid_thresh=0.5, blank_beam=True, future=Mock())
+                                      spot_grid_thresh=0.5, blank_beam=True, stop_acq_on_failure=True, future=Mock())
 
         # image_received should be called as a side effect of calling data.next, this signals that the data is received
         def _image_received(*args, **kwargs):
@@ -1414,7 +1414,7 @@ class TestFastEMAcquisitionTaskMock(TestFastEMAcquisitionTask):
                                       self.scan_stage, self.ccd, self.beamshift, self.lens, self.se_detector,
                                       self.ebeam_focus, roa, path="test-path", username="default",
                                       pre_calibrations=None, save_full_cells=True, settings_obs=None,
-                                      spot_grid_thresh=0.5, blank_beam=True, future=Mock())
+                                      spot_grid_thresh=0.5, blank_beam=True, stop_acq_on_failure=True, future=Mock())
 
         data, err = task.run()
         self.assertEqual(data[(0, 0)].shape, (7200, 7200))

--- a/src/odemis/gui/comp/settings.py
+++ b/src/odemis/gui/comp/settings.py
@@ -264,34 +264,44 @@ class SettingsPanel(wx.Panel):
         return self._add_slider(UnitFloatSlider, label_text, value, conf)
 
     @control_bookkeeper
-    def add_int_field(self, label_text, value=None, conf=None):
+    def add_int_field(self, label_text, value=None, pos_col=1, span=wx.DefaultSpan, conf=None):
         """ Add an integer value field to the settings panel
 
         :param label_text: (str) Label text to display
         :param value: (None or int) Value to display
         :param conf: (None or dict) Dictionary containing parameters for the control
+        :param pos_col: (int) The column index in the grid layout where the int field will be placed.
+                        For example:
+                        - `pos_col=0` positions the int field in the first column.
+                        - `pos_col=1` positions it in the second column.
+        :param span: (tuple) the row and column spanning attributes of items in a GridBagSizer.
 
         """
 
-        return self._add_num_field(UnitIntegerCtrl, label_text, value, conf)
+        return self._add_num_field(UnitIntegerCtrl, label_text, value, pos_col, span, conf)
 
     @control_bookkeeper
-    def add_float_field(self, label_text, value=None, conf=None):
+    def add_float_field(self, label_text, value=None, pos_col=1, span=wx.DefaultSpan, conf=None):
         """ Add a float value field to the settings panel
 
         :param label_text: (str) Label text to display
         :param value: (None or float) Value to display
         :param conf: (None or dict) Dictionary containing parameters for the control
+        :param pos_col: (int) The column index in the grid layout where the float field will be placed.
+                        For example:
+                        - `pos_col=0` positions the float field in the first column.
+                        - `pos_col=1` positions it in the second column.
+        :param span: (tuple) the row and column spanning attributes of items in a GridBagSizer.
 
         """
 
-        return self._add_num_field(UnitFloatCtrl, label_text, value, conf)
+        return self._add_num_field(UnitFloatCtrl, label_text, value, pos_col, span, conf)
 
-    def _add_num_field(self, klass, label_text, value, conf):
+    def _add_num_field(self, klass, label_text, value, pos_col, span, conf):
 
         lbl_ctrl = self._add_side_label(label_text)
         value_ctrl = klass(self, value=value, style=wx.NO_BORDER, **conf)
-        self.gb_sizer.Add(value_ctrl, (self.num_rows, 1),
+        self.gb_sizer.Add(value_ctrl, (self.num_rows, pos_col), span=span,
                           flag=wx.ALL | wx.EXPAND | wx.ALIGN_CENTER_VERTICAL, border=5)
         value_ctrl.SetForegroundColour(gui.FG_COLOUR_EDIT)
         value_ctrl.SetBackgroundColour(gui.BG_COLOUR_MAIN)

--- a/src/odemis/gui/cont/acquisition/fastem_acq.py
+++ b/src/odemis/gui/cont/acquisition/fastem_acq.py
@@ -561,14 +561,25 @@ class FastEMAcquiController(object):
             "Period for which to run autofocus, if the value is 5 it should run for "
             "ROAs with index 0, 5, 10, etc."
         )
-        _, self.chk_beam_blank_off = self.acq_panel.add_checkbox_control(
+        chk_beam_blank_off_lbl, self.chk_beam_blank_off = self.acq_panel.add_checkbox_control(
             "Do not blank beam in between fields", value=False, pos_col=2, span=(1, 1)
         )
-        _, self.chk_stop_acq_on_failure = self.acq_panel.add_checkbox_control(
+        chk_beam_blank_off_lbl.SetToolTip(
+            "Reduces the acquisition time by keeping the e-beam active between fields instead "
+            "of blanking it."
+        )
+        chk_stop_acq_on_failure_lbl, self.chk_stop_acq_on_failure = self.acq_panel.add_checkbox_control(
             "Stop acquisition on failure", value=True, pos_col=2, span=(1, 1)
         )
-        _, self.chk_ebeam_off = self.acq_panel.add_checkbox_control(
+        chk_stop_acq_on_failure_lbl.SetToolTip(
+            "Stop the entire acquisition if a ROA acquisition fails. If unselected, skip the failed ROA "
+            "and continue the acquisition for subsequent ROAs."
+        )
+        chk_ebeam_off_lbl, self.chk_ebeam_off = self.acq_panel.add_checkbox_control(
             "Turn off e-beam after acquisition", value=True, pos_col=2, span=(1, 1)
+        )
+        chk_ebeam_off_lbl.SetToolTip(
+            "Automatically turned off the e-beam after acquisition is complete."
         )
 
         # ROA count

--- a/src/odemis/gui/cont/fastem_project_tree.py
+++ b/src/odemis/gui/cont/fastem_project_tree.py
@@ -419,15 +419,15 @@ class NodeWindow(wx.Window):
         self.checkbox = wx.CheckBox(self, label="")
         self.item_label = wx.StaticText(self, label=node.name)
         self.gauge = wx.Gauge(self, range=100, size=(100, 16))
-        self.open_text = wx.StaticText(self, label="Open")
-        self.open_text.SetForegroundColour(FG_COLOUR_DIS)
+        self.status_text = wx.StaticText(self, label="Open")
+        self.status_text.SetForegroundColour(FG_COLOUR_DIS)
 
         # Bind the checkbox event
         self.checkbox.Bind(wx.EVT_CHECKBOX, self.on_checkbox)
 
         if node.type in [NodeType.ALL_PROJECTS, NodeType.PROJECT, NodeType.RIBBON]:
             self.gauge.Hide()
-            self.open_text.Hide()
+            self.status_text.Hide()
         # Layout widgets
         self._layout_widgets()
 
@@ -441,7 +441,7 @@ class NodeWindow(wx.Window):
         self.main_sizer.Add(self.left_sizer, 0, wx.ALIGN_LEFT)
         self.main_sizer.AddStretchSpacer(1)
         self.right_sizer.Add(self.gauge, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 10)
-        self.right_sizer.Add(self.open_text, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 10)
+        self.right_sizer.Add(self.status_text, 0, wx.ALIGN_CENTER_VERTICAL | wx.LEFT, 10)
 
         self.main_sizer.Add(self.right_sizer, 0, wx.ALIGN_RIGHT)
         self.SetSizer(self.main_sizer)

--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -561,8 +561,7 @@ class xrcpnl_tab_fastem_acqui(wx.Panel):
         # Define variables for the controls, bind event handlers
         self.pnl_projects_header = xrc.XRCCTRL(self, "pnl_projects_header")
         self.pnl_projects = xrc.XRCCTRL(self, "pnl_projects")
-        self.chk_ebeam_off = xrc.XRCCTRL(self, "chk_ebeam_off")
-        self.chk_beam_blank_off = xrc.XRCCTRL(self, "chk_beam_blank_off")
+        self.pnl_acq = xrc.XRCCTRL(self, "pnl_acq")
         self.txt_num_roas = xrc.XRCCTRL(self, "txt_num_roas")
         self.bmp_acq_status_info = xrc.XRCCTRL(self, "bmp_acq_status_info")
         self.bmp_acq_status_warn = xrc.XRCCTRL(self, "bmp_acq_status_warn")
@@ -7319,18 +7318,13 @@ D\x02\x12\x0c/\x81\x10.\xc4\xcc\xb0\x8f\xa1\x9e\xa1\x81a/\x90\x05\x06\x8d\
                       <object class="wxBoxSizer">
                         <orient>wxVERTICAL</orient>
                         <object class="sizeritem">
-                          <object class="wxCheckBox" name="chk_ebeam_off">
-                            <label>Turn off e-beam after acquisition</label>
+                          <object class="wxPanel" name="pnl_acq">
+                            <bg>#333333</bg>
+                            <fg>#7F7F7F</fg>
+                            <size>400,140</size>
+                            <flag>wxTOP|wxEXPAND</flag>
+                            <option>1</option>
                           </object>
-                          <flag>wxALL|wxEXPAND</flag>
-                          <border>10</border>
-                        </object>
-                        <object class="sizeritem">
-                          <object class="wxCheckBox" name="chk_beam_blank_off">
-                            <label>Do not blank beam in between fields</label>
-                          </object>
-                          <flag>wxALL|wxEXPAND</flag>
-                          <border>10</border>
                         </object>
                         <object class="sizeritem">
                           <object class="wxFlexGridSizer">

--- a/src/odemis/gui/xmlh/resources/panel_tab_fastem_acqui.xrc
+++ b/src/odemis/gui/xmlh/resources/panel_tab_fastem_acqui.xrc
@@ -68,18 +68,13 @@
                       <object class="wxBoxSizer">
                         <orient>wxVERTICAL</orient>
                         <object class="sizeritem">
-                          <object class="wxCheckBox" name="chk_ebeam_off">
-                            <label>Turn off e-beam after acquisition</label>
+                          <object class="wxPanel" name="pnl_acq">
+                            <bg>#333333</bg>
+                            <fg>#7F7F7F</fg>
+                            <size>400,140</size>
+                            <flag>wxTOP|wxEXPAND</flag>
+                            <option>1</option>
                           </object>
-                          <flag>wxALL|wxEXPAND</flag>
-                          <border>10</border>
-                        </object>
-                        <object class="sizeritem">
-                          <object class="wxCheckBox" name="chk_beam_blank_off">
-                            <label>Do not blank beam in between fields</label>
-                          </object>
-                          <flag>wxALL|wxEXPAND</flag>
-                          <border>10</border>
                         </object>
                         <object class="sizeritem">
                           <object class="wxFlexGridSizer">


### PR DESCRIPTION
NOTE: This PR depends on https://github.com/delmic/odemis/pull/2972

[feat] allow skipping roa acquisition in case of failure
    
Updates:
- The status text in the ROA window of the project tree will show "Open", "Skipped", "Failed" and respective colour
- Added autostigmation and autofocus period in the Acquisition panel; previously it was in the acquisition.config file
- Added a checkbox `Stop acquisition on failure` which helps is skipping roa acquisition in case of failure
    
![Screenshot from 2024-12-20 09-37-59](https://github.com/user-attachments/assets/ee1976df-dd03-4913-8a22-fa2d6318fb39)

Cancelled
![Screenshot from 2024-12-20 09-40-53](https://github.com/user-attachments/assets/d03911d3-2546-48a7-af28-8f83da108e87)

Stop acquisition on failure checked (Exception is raised in autostigmation)
![Screenshot from 2024-12-20 09-44-16](https://github.com/user-attachments/assets/898f803e-cc49-4a13-a60b-9391d1f45691)

Stop acquisition on failure un-checked (Exception is raised in autostigmation)
![Screenshot from 2024-12-20 09-46-38](https://github.com/user-attachments/assets/93859252-349f-4c19-8721-a53163a9afa0)



