### PR TITLE
[perf] Improve spot finding in estimate_grid_orientation_from_img

### DIFF
--- a/install/linux/usr/share/odemis/sim/fastem-sim-asm.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/fastem-sim-asm.odm.yaml
@@ -335,6 +335,7 @@ FASTEM-sim: {
             "percntl_im_rng": [1, 99],
             # List[int, int] min/max percentile of the dynamic range to which the histogram of the image will be stretched.
             "percntl_dyn_rng": [10, 90],
+            "pitch": 3.2e-6  # float [m], the expected pitch between two beamlets in meters
         },
     },
 }
@@ -366,7 +367,7 @@ FASTEM-sim: {
     class: static.OpticalLens,
     role: lens,
     init: {
-        mag: 60, # ratio, magnifying; higher magnification is a stronger simulated blur
+        mag: 40, # ratio, magnifying; higher magnification is a stronger simulated blur
         na: 0.95,  # numerical aperture
         ri: 1,  # refractive index
     },

--- a/scripts/spot-grid.py
+++ b/scripts/spot-grid.py
@@ -35,7 +35,8 @@ MAX_WIDTH = 2000  # px
 PIXEL_SIZE_SAMPLE_PLANE = 3.45e-6  # m
 DEFAULT_MAGNIFICATION = 40
 PIXEL_SIZE = PIXEL_SIZE_SAMPLE_PLANE / DEFAULT_MAGNIFICATION
-
+PITCH = 3.2e-6
+MIN_DIST_SPOTS = int(0.75 * PITCH / PIXEL_SIZE)
 
 class VideoDisplayerGrid(VideoDisplayer):
     """
@@ -68,6 +69,7 @@ class VideoDisplayerGrid(VideoDisplayer):
                 AffineTransform,
                 sigma=1.45,
                 threshold_rel=self.acqui_conf.spot_grid_threshold,
+                min_distance=MIN_DIST_SPOTS,
             )
             grid = unit_gridpoints(self.gridsize, mode="ji")
             self.app.spots = tform_ji.apply(grid)

--- a/src/odemis/acq/fastem.py
+++ b/src/odemis/acq/fastem.py
@@ -53,6 +53,8 @@ from odemis.util.transform import SimilarityTransform, to_physical_space
 # The executor is a single object, independent of how many times the module (fastem.py) is loaded.
 _executor = model.CancellableThreadPoolExecutor(max_workers=1)
 
+DEFAULT_PITCH = 3.2e-6  # distance between spots in m
+
 # TODO: Normally we do not use component names in code, only roles. Store in the roles in the SETTINGS_SELECTION,
 #  and at init lookup the role -> name conversion (using model.getComponent(role=role)).
 # Selection of components, VAs and values to save with the ROA acquisition, structured: {component: {VA: value}}
@@ -295,7 +297,7 @@ class AcquisitionTask(object):
         # Calculate the expected minimum distance between spots in the grid on the diagnostic camera
         detector_md = detector.getMetadata()
         ccd_md = ccd.getMetadata()
-        self._exp_pitch_m = detector_md.get(model.MD_CALIB, {}).get("pitch", 3.2e-6)  # m
+        self._exp_pitch_m = detector_md.get(model.MD_CALIB, {}).get("pitch", DEFAULT_PITCH)  # m
         lens_mag = ccd_md.get(model.MD_LENS_MAG)
         ccd_px_size = ccd_md.get(model.MD_SENSOR_PIXEL_SIZE)
         exp_pitch_px = self._exp_pitch_m * lens_mag / ccd_px_size[0]

--- a/src/odemis/acq/fastem.py
+++ b/src/odemis/acq/fastem.py
@@ -299,6 +299,7 @@ class AcquisitionTask(object):
         lens_mag = ccd_md.get(model.MD_LENS_MAG)
         ccd_px_size = ccd_md.get(model.MD_SENSOR_PIXEL_SIZE)
         exp_pitch_px = self._exp_pitch_m * lens_mag / ccd_px_size[0]
+        # 0.75 is a safety factor to allow for some variation in spot positions
         self._min_dist_spots = int(0.75 * exp_pitch_px)
 
         beam_shift_path = fastem_util.create_image_dir("beam-shift-correction")

--- a/src/odemis/acq/test/fastem_test.py
+++ b/src/odemis/acq/test/fastem_test.py
@@ -37,7 +37,7 @@ from odemis import model
 from odemis.acq import fastem, stream
 from odemis.acq.acqmng import SettingsObserver
 from odemis.acq.align.fastem import Calibrations
-from odemis.acq.fastem import SETTINGS_SELECTION
+from odemis.acq.fastem import DEFAULT_PITCH, SETTINGS_SELECTION
 from odemis.gui.comp.fastem_roa import FastEMROA
 from odemis.gui.comp.overlay.shapes import EditableShape
 from odemis.gui.model.main_gui_data import FastEMMainGUIData
@@ -1295,8 +1295,9 @@ class TestFastEMAcquisitionTaskMock(TestFastEMAcquisitionTask):
         cls.mppc.frameDuration.value = 0.1
         cls.mppc.cellCompleteResolution.value = (900, 900)
         cls.mppc.shape = (8, 8)
-        cls.mppc.configure_mock(**{"getMetadata.return_value": {model.MD_CALIB: {"pitch": 3.2e-6},
-                                                                }})
+        cls.mppc.configure_mock(
+            **{"getMetadata.return_value": {model.MD_CALIB: {"pitch": DEFAULT_PITCH},}}
+        )
 
         cls.multibeam = Mock()
         cls.multibeam.configure_mock(**{"getMetadata.return_value": {model.MD_SCAN_OFFSET_CALIB: [0.01, 0.01],

--- a/src/odemis/acq/test/fastem_test.py
+++ b/src/odemis/acq/test/fastem_test.py
@@ -757,10 +757,10 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
             # Create an ROA with the coordinates of the field.
             roa_name = "test_megafield_id"
             roa = FastEMROA(shape=MockEditableShape(),
-                        main_data=self.main_data,
-                        overlap=0.0,
-                        name=roa_name,
-                        slice_index=0)
+                            main_data=self.main_data,
+                            overlap=0.0,
+                            name=roa_name,
+                            slice_index=0)
             roa.shape._points = points
             roa.shape.points.value = points
 
@@ -845,10 +845,10 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
             # Create an ROA with the coordinates of the field.
             roa_name = "test_megafield_id"
             roa = FastEMROA(shape=MockEditableShape(),
-                        main_data=self.main_data,
-                        overlap=overlap,
-                        name=roa_name,
-                        slice_index=0)
+                            main_data=self.main_data,
+                            overlap=overlap,
+                            name=roa_name,
+                            slice_index=0)
             roa.shape._points = points
             roa.shape.points.value = points
 
@@ -1130,10 +1130,10 @@ class TestFastEMAcquisitionTask(unittest.TestCase):
             # Create an ROA with the coordinates of the field.
             roa_name = "test_megafield_id"
             roa = FastEMROA(shape=MockEditableShape(),
-                        main_data=self.main_data,
-                        overlap=0.0,
-                        name=roa_name,
-                        slice_index=0)
+                            main_data=self.main_data,
+                            overlap=0.0,
+                            name=roa_name,
+                            slice_index=0)
             roa.shape._points = points
             roa.shape.points.value = points
 
@@ -1295,6 +1295,8 @@ class TestFastEMAcquisitionTaskMock(TestFastEMAcquisitionTask):
         cls.mppc.frameDuration.value = 0.1
         cls.mppc.cellCompleteResolution.value = (900, 900)
         cls.mppc.shape = (8, 8)
+        cls.mppc.configure_mock(**{"getMetadata.return_value": {model.MD_CALIB: {"pitch": 3.2e-6},
+                                                                }})
 
         cls.multibeam = Mock()
         cls.multibeam.configure_mock(**{"getMetadata.return_value": {model.MD_SCAN_OFFSET_CALIB: [0.01, 0.01],
@@ -1328,7 +1330,11 @@ class TestFastEMAcquisitionTaskMock(TestFastEMAcquisitionTask):
         image[54:150:12, 54:150:12] = 1
         image = model.DataArray(input_array=image)
         cls.ccd.data.configure_mock(**{"get.return_value": image})
-        cls.ccd.configure_mock(**{"getMetadata.return_value": {model.MD_FAV_POS_ACTIVE: {"j": 100, "i": 100}}})
+        cls.ccd.configure_mock(**{"getMetadata.return_value": {
+            model.MD_FAV_POS_ACTIVE: {"j": 100, "i": 100},
+            model.MD_SENSOR_PIXEL_SIZE: (3.45e-6, 3.45e-6),
+            model.MD_LENS_MAG: 40,
+        }})
         cls.ccd.pointSpreadFunctionSize.value = 1
         cls.ccd.pixelSize.value = (1.0e-7, 1.0e-7)
 

--- a/src/odemis/util/peak_local_max.py
+++ b/src/odemis/util/peak_local_max.py
@@ -364,6 +364,7 @@ def peak_local_max(
     num_peaks: Optional[int] = None,
     footprint: Optional[np.ndarray] = None,
     p_norm: float = np.inf,
+    len_object: Optional[int] = None,
 ) -> np.ndarray:
     """
     Find peaks in an image as coordinate list.
@@ -378,7 +379,7 @@ def peak_local_max(
     image : ndarray
         Input image.
     min_distance : int, optional
-        The minimal allowed distance separating peaks. To find the
+        The minimal allowed distance in pixels separating peaks. To find the
         maximum number of peaks, use `min_distance=1`.
     threshold_abs : float, optional
         Minimum intensity of peaks. By default, the absolute threshold is
@@ -406,6 +407,12 @@ def peak_local_max(
         A finite large p may cause a ValueError if overflow can occur.
         ``inf`` corresponds to the Chebyshev distance and 2 to the
         Euclidean distance.
+    len_object : int, optional
+        The length of the object in pixels. This parameter is used to determine
+        the border width for peak exclusion when `exclude_border` is True. If
+        not provided, `min_distance` is used as the length of the object. This
+        can be useful when the object size is known and different from
+        `min_distance`.
 
     Returns
     -------
@@ -460,7 +467,10 @@ def peak_local_max(
             stacklevel=2,
         )
 
-    border_width = _get_excluded_border_width(image, min_distance, exclude_border)
+    if not len_object:
+        len_object = min_distance
+
+    border_width = _get_excluded_border_width(image, len_object, exclude_border)
 
     threshold = _get_threshold(image, threshold_abs, threshold_rel)
 

--- a/src/odemis/util/registration.py
+++ b/src/odemis/util/registration.py
@@ -532,6 +532,7 @@ def estimate_grid_orientation_from_img(
     threshold_abs: Optional[float] = None,
     threshold_rel: Optional[float] = None,
     num_spots: Optional[int] = None,
+    min_distance: Optional[int] = None,
 ) -> Tuple[T, float]:
     """
     Image based estimation of the orientation of a square grid of points.
@@ -559,6 +560,9 @@ def estimate_grid_orientation_from_img(
         `num_spots = shape[0] * shape[1]` as default when set to `None`. Set
         `num_spots = 0` to not impose a maximum. Note that this behavior is
         different from odemis.util.spot.find_spot_position().
+    min_distance : int, optional
+        The minimal allowed distance in pixels separating peaks. To find the
+        maximum number of peaks, use `min_distance=1`.
 
     Returns
     -------
@@ -578,5 +582,5 @@ def estimate_grid_orientation_from_img(
         num_spots = shape[0] * shape[1]
     elif num_spots == 0:
         num_spots = None
-    ji = find_spot_positions(image, sigma, threshold_abs, threshold_rel, num_spots)
+    ji = find_spot_positions(image, sigma, threshold_abs, threshold_rel, num_spots, min_distance)
     return estimate_grid_orientation(ji, shape, transform_type)

--- a/src/odemis/util/spot.py
+++ b/src/odemis/util/spot.py
@@ -369,6 +369,7 @@ def find_spot_positions(
     threshold_abs: Optional[float] = None,
     threshold_rel: Optional[float] = None,
     num_spots: Optional[int] = None,
+    min_distance: Optional[int] = None,
 ) -> numpy.ndarray:
     """
     Find the center coordinates of spots with the highest intensity in an
@@ -390,6 +391,9 @@ def find_spot_positions(
     num_spots : int, optional
         Maximum number of spots. When the number of spots exceeds `num_spots`,
         return `num_spots` peaks based on highest spot intensity.
+    min_distance : int, optional
+        The minimal allowed distance in pixels separating peaks. To find the
+        maximum number of peaks, use `min_distance=1`.
 
     Returns
     -------
@@ -399,15 +403,18 @@ def find_spot_positions(
 
     """
     size = int(round(3 * sigma))
-    min_distance = 2 * size
-    filtered = bandpass_filter(image, sigma, min_distance)
+    len_object = 2 * size  # typical length of a spot
+    min_distance = len_object if not min_distance else min_distance  # distance between spots
+    filtered = bandpass_filter(image, sigma, len_object)
     coordinates = peak_local_max(
         filtered,
         min_distance=min_distance,
         threshold_abs=threshold_abs,
         threshold_rel=threshold_rel,
+        exclude_border=False,
         num_peaks=num_spots,
         p_norm=2,
+        len_object=len_object,
     )
 
     # Improve coordinate estimate using radial symmetry center.

--- a/src/odemis/util/test/spot_test.py
+++ b/src/odemis/util/test/spot_test.py
@@ -339,6 +339,26 @@ class TestFindSpotPositions(unittest.TestCase):
         numpy.testing.assert_array_equal(sorted(indices), range(len(loc)))
         numpy.testing.assert_array_less(distances, 0.05)
 
+    def test_spots_close_to_edge(self):
+        """
+        `find_spot_positions` should find all spot positions in a generated
+        test image when the minimum distance between spots is larger than the
+        distance between the spots and the edge of the image.
+        """
+        # set a grid of 8 by 8 points to 1 at the top left of the image
+        image = numpy.zeros((256, 256))
+        image[4:100:12, 8:104:12] = 1
+        expected_ji = numpy.column_stack(numpy.where(image))
+
+        ji = spot.find_spot_positions(image, sigma=0.75, min_distance=12)
+
+        # Sort both arrays to ensure consistent ordering
+        expected_ji_sorted = expected_ji[numpy.lexsort((expected_ji[:, 1], expected_ji[:, 0]))]
+        ji_sorted = ji[numpy.lexsort((ji[:, 1], ji[:, 0]))]
+
+        # Check if the sorted arrays are equal
+        numpy.testing.assert_array_almost_equal(expected_ji_sorted, ji_sorted)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
[perf] Improve spot finding in when distance between spots >> spot size

Improved spot finding and grid fitting accuracy in `estimate_grid_orientation_from_img` and `find_spot_positions` by:
- Using a configurable minimum distance between spots during local maxima finding. This addresses issues when the intensity difference between spots is high and single bright spots could be detected twice, while less bright spots were not detected.
- Splitting `min_distance` and `len_object` parameters in `peak_local_max` and `find_spot_positions` to refine spot size calculation and edge exclusion relative to minimum spot distance.