### PR TITLE
[fix] simulated stage could take very long doing an absolute move to 0

### DIFF
--- a/src/odemis/driver/test/simulated_test.py
+++ b/src/odemis/driver/test/simulated_test.py
@@ -105,6 +105,24 @@ class ActuatorTest(object):
         f.result()  # wait
         testing.assert_pos_almost_equal(move, self.dev.position.value, atol=1e-7)
 
+        # Move to 0 (int), which used to cause a bug in the speed computation
+        speed = {}
+        for axis in self.dev.axes:
+            rng = self.dev.axes[axis].range
+            move[axis] = rng[0]
+            print(rng)
+            speed[axis] = (rng[1] - rng[0]) / 1  # 1 s to go to whole range
+        self.dev.moveAbsSync(move)
+        logging.info("Updating speed to %s", speed)
+        self.dev.speed.value = speed
+
+        # Should take ~1s (used to take 5s)
+        move = {a: 0 for a in self.dev.axes}
+        t_start = time.time()
+        self.dev.moveAbsSync(move)
+        t_end = time.time()
+        self.assertLess(t_end - t_start, 2)
+
     def test_moveRel(self):
         prev_pos = self.dev.position.value
         move = {}


### PR DESCRIPTION
When asking a moveAbs() to position 0, which is usually the center of
the axis, the code would detect it's not a float, and concider it as a
"arbitrary move". If the speed was set to something "reasonable" like
1 mm/s, that would cause a 100 s move.

=> detect it's a arbitrary move by the presence of .choices