### PR TITLE
[fix] driver zeiss: SetMagnification() should pass a float (not just int)

### DIFF
--- a/src/odemis/driver/zeiss.py
+++ b/src/odemis/driver/zeiss.py
@@ -414,7 +414,7 @@ class SEM(model.HwComponent):
         """
         mag (float): magnification in MAGNIFICATION_RANGE
         """
-        self._SendCmd(b'MAG %d' % mag)
+        self._SendCmd(b'MAG %G' % mag)
 
     def SetFocus(self, foc):
         """


### PR DESCRIPTION
Everything indicates that the magnification is a float... but we used
%d, so this was rounded to an int. It sort of worked, but for large FoVs
(ie, small magnifications), this rounding caused unexpected limitations on which value
is allowed.