### PR TITLE
[fix] newlines in ar csv export (Windows)

### DIFF
--- a/src/odemis/dataio/csv.py
+++ b/src/odemis/dataio/csv.py
@@ -276,7 +276,10 @@ def _export_angular_spectrum_data(data: model.DataArray, filename:str):
     headers = ["angle(" + unit_a + ")\\wavelength(" + unit_c + ")"] + spectrum_range
     rows = [(t,) + tuple(d) for t, d in zip(angle_range, data)]
 
-    with open(filename, 'w') as fd:
+    # Specifically set newline to an empty string, as described in the official documentation,
+    # as can be read here: https://docs.python.org/3/library/csv.html#csv.reader.
+    # This is more consistent since it overrides deviating operating system behavior.
+    with open(filename, 'w', newline='') as fd:
         csv_writer = csv.writer(fd)
         csv_writer.writerow(headers)
         csv_writer.writerows(rows)


### PR DESCRIPTION
On Windows, the default newline character is "\n" for exporting rows with csv writer.
Explicitly overwrite the newline character to be empty. This behavior never occurred on Linux due to a different newline convention.

Example of current behavior in Windows: 
![image](https://github.com/user-attachments/assets/38fe2a20-51f5-49e9-b3c2-8c472e3c2fc5)

