### PR TITLE
[refactor] remove use of deprecated threading API

### DIFF
--- a/src/odemis/driver/rigol.py
+++ b/src/odemis/driver/rigol.py
@@ -334,7 +334,6 @@ class FakeDG1000Z(object):
         self._shutdown_flag = threading.Event()
         self._listener_thread = threading.Thread(target=self._listen)
         self._listener_thread.daemon = True
-        # or listener_thread.setDaemon(True) for old versions of python
         self._listener_thread.start()
         # Wait a second to ensure the server is running
         time.sleep(1)

--- a/src/odemis/gui/test/comp_legend_test.py
+++ b/src/odemis/gui/test/comp_legend_test.py
@@ -69,7 +69,7 @@ class LegendTestCase(test.GuiTestCase):
         test.gui_loop(0.5)
 
         t = threading.Thread(target=set_range)
-        t.setDaemon(True)  # To automatically end when this main thread ends
+        t.daemon = True  # To automatically end when this main thread ends
         t.start()
 
         for i in range(30):  # Fail after 30s not yet finished

--- a/src/odemis/gui/test/comp_miccanvas_test.py
+++ b/src/odemis/gui/test/comp_miccanvas_test.py
@@ -226,7 +226,7 @@ class PlotCanvasTestCase(test.GuiTestCase):
 
         t = threading.Thread(target=rotate, args=(ys, ))
         # Setting Daemon to True, will cause the thread to exit when the parent does
-        t.setDaemon(True)
+        t.daemon = True
         t.start()
 
         for i in range(10):  # Fail after 10s not yet finished

--- a/src/odemis/gui/test/comp_viewport_test.py
+++ b/src/odemis/gui/test/comp_viewport_test.py
@@ -127,7 +127,7 @@ class ViewportTestCase(test.GuiTestCase):
 
         t = threading.Thread(target=rotate, args=(ys, vwp))
         # Setting Daemon to True, will cause the thread to exit when the parent does
-        t.setDaemon(True)
+        t.daemon = True
         t.start()
 
         for i in range(10):  # Fail after 10s not yet finished

--- a/src/odemis/gui/test/log_test.py
+++ b/src/odemis/gui/test/log_test.py
@@ -50,7 +50,7 @@ class TestLogWindow(test.GuiTestCase):
 
         t = threading.Thread(target=log_msg)
         # Setting Daemon to True, will cause the thread to exit when the parent does
-        t.setDaemon(True)
+        t.daemon = True
         t.start()
 
         test.gui_loop()

--- a/src/odemis/model/test/remote_test.py
+++ b/src/odemis/model/test/remote_test.py
@@ -1098,7 +1098,7 @@ class FakeDataFlow(model.DataFlow):
 
     # method for thread
     def generate(self):
-        while not self._stop.isSet():
+        while not self._stop.is_set():
             self.count += 1
             array = self._create_one(self.shape, self.bpp, self.count)
             if len(array):


### PR DESCRIPTION
Python 2.7 introduced a nicer API for the Thread & Event classes. 15 years later,
the old API is now deprecated, in Python 3.10.

setDaemon() -> daemon = ...
isSet() -> is_set()