### PR TITLE
[TRCL-265] [feat] acq SPARC partial acquisition and streakcam live protection

### DIFF
--- a/install/linux/usr/share/odemis/sim/sparc2-streakcam-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/sparc2-streakcam-sim.odm.yaml
@@ -206,8 +206,9 @@
 #       device: 0,
         transp: [-1, 2], # if mirrored on X axis
     },
-#    dependencies: {spectrograph: "Spectrograph"},
-    # TODO does not work for now as modelgen says no component named spectrograph found
+    metadata: {
+        CALIB: {"intensity_limit": 50000},  # counts/s, high max to not trigger easily the safety check
+    },
 }
 
 "Streak Unit": {

--- a/src/odemis/acq/_futures.py
+++ b/src/odemis/acq/_futures.py
@@ -125,7 +125,7 @@ class SimpleStreamFuture(futures.Future):
                 l.next(self._stream.raw)
             l.complete(self._stream.raw)
 
-        return self._stream.raw # the acquisition data
+        return self._stream.raw, None # the acquisition data, and no (partial) error
 
     def _image_listener(self, image):
         """

--- a/src/odemis/acq/acqmng.py
+++ b/src/odemis/acq/acqmng.py
@@ -562,7 +562,7 @@ class AcquisitionTask(object):
 
                 # Wait for the acquisition to be finished.
                 # Will pass down exceptions, included in case it's cancelled
-                das = f.result()
+                das, acq_exp = f.result()
                 if not isinstance(das, Iterable):
                     logging.warning("Future of %s didn't return a list of DataArrays, but '%s'", s, das)
                     das = []
@@ -573,6 +573,10 @@ class AcquisitionTask(object):
                     for da in das:
                         da.metadata[model.MD_EXTRA_SETTINGS] = copy.deepcopy(settings)
                 raw_images[s] = das
+
+                # Now the data is stored, the exception handler will take care of the error
+                if acq_exp:
+                    raise acq_exp
 
                 # update the time left
                 expected_time -= self._streamTimes[s]

--- a/src/odemis/acq/stream/_helper.py
+++ b/src/odemis/acq/stream/_helper.py
@@ -26,7 +26,7 @@ import math
 import time
 
 import numbers
-from typing import Tuple, Any, Dict, Optional
+from typing import Tuple, Any, Dict, List, Optional, Callable
 
 import numpy
 
@@ -1727,7 +1727,7 @@ class OverlayStream(Stream):
         ovrl_future.result = self._result_wrapper(ovrl_future.result)
         return ovrl_future
 
-    def _result_wrapper(self, f):
+    def _result_wrapper(self, f) -> Callable:
         """
         Wraps the .result() return value of the Future provided
           by the FindOverlay function to make it return DataArrays, as a normal
@@ -1735,7 +1735,7 @@ class OverlayStream(Stream):
         """
 
         @wraps(f)
-        def result_as_da(timeout=None):
+        def result_as_da(timeout=None) -> Tuple[List[model.DataArray], Optional[Exception]]:
             trans_val, (opt_md, sem_md) = f(timeout)
             # In case the transformation values are extreme compared to the
             # calibration values just abort them
@@ -1787,7 +1787,7 @@ class OverlayStream(Stream):
             sem_md[model.MD_POS_COR] = (0, 0)
             opt_md[model.MD_SHEAR_COR] = 0
             # Create an empty DataArray with trans_md as the metadata
-            return [model.DataArray([], opt_md), model.DataArray([], sem_md)]
+            return [model.DataArray([], opt_md), model.DataArray([], sem_md)], None
 
         return result_as_da
 

--- a/src/odemis/acq/stream/_sync.py
+++ b/src/odemis/acq/stream/_sync.py
@@ -573,11 +573,14 @@ class MultipleDetectorStream(Stream, metaclass=ABCMeta):
         return pos
 
     @abstractmethod
-    def _runAcquisition(self, future):
+    def _runAcquisition(self, future) -> Tuple[List[model.DataArray], Optional[Exception]]:
         """
         Acquires images from the multiple detectors via software synchronisation.
         Warning: can be quite memory consuming if the grid is big
-        returns (list of DataArray): all the data acquired
+        :returns
+            list of DataArray: All the data acquired.
+            error: None if everything went fine, an Exception if an error happened, but some data has
+              already been acquired.
         raises:
           CancelledError() if cancelled
           Exceptions if error
@@ -1262,7 +1265,7 @@ class SEMCCDMDStream(MultipleDetectorStream):
 
         self._raw.append(da)
 
-    def _runAcquisition(self, future):
+    def _runAcquisition(self, future) -> Tuple[List[model.DataArray], Optional[Exception]]:
         """
         Acquires images from multiple detectors via software synchronisation.
         Select whether the ebeam is moved for scanning or the sample stage.
@@ -1361,7 +1364,7 @@ class SEMCCDMDStream(MultipleDetectorStream):
 
         return frame_duration_safe, integration_count
 
-    def _runAcquisitionHwSyncEbeam(self, future) -> List[model.DataArray]:
+    def _runAcquisitionHwSyncEbeam(self, future) -> Tuple[List[model.DataArray], Optional[Exception]]:
         """
         Acquires images from the multiple detectors by moving the ebeam, and triggering a CCD frame
         acquisition via hardware trigger connecting the e-beam scanner pixel position to the CCD.
@@ -1369,12 +1372,15 @@ class SEMCCDMDStream(MultipleDetectorStream):
         controlled by the e-beam scanner. In practice, typically there are just two streams: the SEM
         secondary electron detector and the CCD.
         :param future: Current future running for the whole acquisition.
-        :returns (list of DataArray): All the data acquired.
+        :returns
+            list of DataArray: All the data acquired.
+            error: None if everything went fine, an Exception if an error happened, but some data has
+              already been acquired.
         :raises:
           CancelledError() if cancelled
           Exceptions if error
         """
-
+        error = None
         try:
             self._acq_done.clear()
             # Configure the CCD to the defined exposure time, and hardware sync + get frame duration
@@ -1570,9 +1576,20 @@ class SEMCCDMDStream(MultipleDetectorStream):
             if not isinstance(exp, CancelledError) and self._acq_state == CANCELLED:
                 logging.warning("Converting exception to cancellation")
                 raise CancelledError()
-            raise
-        else:
-            return self.raw
+
+            # If it wasn't finalized yet, finalize the data
+            if not self._raw:
+                try:
+                    # Process all the (intermediary) ._live_data to the right shape/format for the final ._raw
+                    for stream_idx, das in enumerate(self._live_data):
+                        self._assembleFinalData(stream_idx, das)
+                except Exception:
+                    logging.warning("Failed to assemble the final data after exception in stream %s", self.name.value)
+
+            if not self._raw:
+                # No data -> just make it look like a "complete" exception
+                raise exp
+            error = exp
         finally:
             # In case of frame drop issue, create a ccd_dates list at the top of the function, and
             # uncomment the lines related to ccd_dates to analyse the timing:
@@ -1599,18 +1616,24 @@ class SEMCCDMDStream(MultipleDetectorStream):
             self._streams[0].raw = []
             self._streams[0].image.value = None
 
-    def _runAcquisitionEbeam(self, future):
+        return self.raw, error
+
+    def _runAcquisitionEbeam(self, future) -> Tuple[List[model.DataArray], Optional[Exception]]:
         """
         Acquires images from the multiple detectors via software synchronisation.
         Acquires images via moving the ebeam.
         Warning: can be quite memory consuming if the grid is big
         :param future: Current future running for the whole acquisition.
-        :returns (list of DataArray): All the data acquired.
+        :returns
+            list of DataArray: All the data acquired.
+            error: None if everything went fine, an Exception if an error happened, but some data has
+              already been acquired.
         :raises:
           CancelledError() if cancelled
-          Exceptions if error
+          Exceptions if error, and no data has been acquired
         """
         # TODO: handle better very large grid acquisition (than memory oops)
+        error = None
         try:
             self._acq_done.clear()
             img_time, integration_count = self._adjustHardwareSettings()
@@ -1813,14 +1836,27 @@ class SEMCCDMDStream(MultipleDetectorStream):
                 s._dataflow.unsubscribe(sub)
             self._ccd_df.synchronizedOn(None)
 
-            self._raw = []
-            self._anchor_raw = []
             if not isinstance(exp, CancelledError) and self._acq_state == CANCELLED:
+                # Reset data in case it was cancelled very late, to regain memory
+                self._raw = []
+                self._anchor_raw = []
                 logging.warning("Converting exception to cancellation")
                 raise CancelledError()
-            raise
-        else:
-            return self.raw
+
+            # If it wasn't finalized yet, finalize the data
+            if not self._raw:
+                try:
+                    # Process all the (intermediary) ._live_data to the right shape/format for the final ._raw
+                    for stream_idx, das in enumerate(self._live_data):
+                        self._assembleFinalData(stream_idx, das)
+                except Exception:
+                    logging.warning("Failed to assemble the final data after exception in stream %s", self.name.value)
+
+            if not self._raw:
+                # No data -> just make it look like a "complete" exception
+                raise exp
+
+            error = exp
         finally:
             self._current_scan_area = None  # Indicate we are done for the live (also in case of error)
             for s in self._streams:
@@ -1835,6 +1871,8 @@ class SEMCCDMDStream(MultipleDetectorStream):
             self._streams[0].raw = []
             self._streams[0].image.value = None
             self._img_intor = [None for _ in self._streams]
+
+        return self.raw, error
 
     def _waitForImage(self, img_time):
         """
@@ -1996,11 +2034,14 @@ class SEMCCDMDStream(MultipleDetectorStream):
         # TODO if image integration supported for scan stage, return both values
         return self._adjustHardwareSettings()[0]
 
-    def _runAcquisitionScanStage(self, future):
+    def _runAcquisitionScanStage(self, future) -> Tuple[List[model.DataArray], Optional[Exception]]:
         """
         Acquires images from the multiple detectors via software synchronisation, with a scan stage.
         Warning: can be quite memory consuming if the grid is big
-        returns (list of DataArray): all the data acquired
+        :returns
+            list of DataArray: All the data acquired.
+            error: None if everything went fine, an Exception if an error happened, but some data has
+              already been acquired.
         raises:
           CancelledError() if cancelled
           Exceptions if error
@@ -2031,6 +2072,7 @@ class SEMCCDMDStream(MultipleDetectorStream):
         orig_spos = sstage.position.value  # TODO: need to protect from the stage being outside of the axes range?
         scan_stage_is_stage = model.getComponent(role="stage").name in sstage.affects.value
 
+        error = None
         try:
             saxes = sstage.axes
             prev_spos = orig_spos.copy()
@@ -2260,14 +2302,25 @@ class SEMCCDMDStream(MultipleDetectorStream):
                 s._dataflow.unsubscribe(sub)
             self._ccd_df.synchronizedOn(None)
 
-            self._raw = []
-            self._anchor_raw = []
             if not isinstance(exp, CancelledError) and self._acq_state == CANCELLED:
+                self._raw = []
+                self._anchor_raw = []
                 logging.warning("Converting exception to cancellation")
                 raise CancelledError()
-            raise
-        else:
-            return self.raw
+
+            # If it wasn't finalized yet, finalize the data
+            if not self._raw:
+                try:
+                    # Process all the (intermediary) ._live_data to the right shape/format for the final ._raw
+                    for stream_idx, das in enumerate(self._live_data):
+                        self._assembleFinalData(stream_idx, das)
+                except Exception:
+                    logging.warning("Failed to assemble the final data after exception in stream %s", self.name.value)
+
+            if not self._raw:
+                # No data -> just make it look like a "complete" exception
+                raise exp
+            error = exp
         finally:
             self._current_scan_area = None  # Indicate we are done for the live (also in case of error)
             if sstage:
@@ -2295,6 +2348,7 @@ class SEMCCDMDStream(MultipleDetectorStream):
             self._streams[0].raw = []
             self._streams[0].image.value = None
 
+        return self.raw, error
 
 class SEMMDStream(MultipleDetectorStream):
     """
@@ -2414,15 +2468,19 @@ class SEMMDStream(MultipleDetectorStream):
 
         return n_y, n_x
 
-    def _runAcquisition(self, future):
+    def _runAcquisition(self, future) -> Tuple[List[model.DataArray], Optional[Exception]]:
         """
         Acquires images from the multiple detectors via software synchronisation.
         Warning: can be quite memory consuming if the grid is big
-        returns (list of DataArray): all the data acquired
+        :returns
+            list of DataArray: All the data acquired.
+            error: None if everything went fine, an Exception if an error happened, but some data has
+              already been acquired.
         raises:
           CancelledError() if cancelled
           Exceptions if error
         """
+        error = None
         try:
             self._acq_done.clear()
             # TODO: the real dwell time used depends on how many detectors are used, and so it can
@@ -2435,7 +2493,7 @@ class SEMMDStream(MultipleDetectorStream):
             pos_flat = spot_pos.reshape((-1, 2))  # X/Y together (X iterates first)
             rep = self.repetition.value
             self._acq_data = [[] for _ in self._streams]  # just to be sure it's really empty
-            self._live_data = [[] for s in self._streams]
+            self._live_data = [[] for _ in self._streams]
             self._current_scan_area = (0, 0, 0, 0)
             self._raw = []
             self._anchor_raw = []
@@ -2521,6 +2579,9 @@ class SEMMDStream(MultipleDetectorStream):
 
                 px_pos = (pos_lt[0] + px_idx[1] * self._pxs[0],
                           pos_lt[1] - px_idx[0] * self._pxs[1])  # Y is inverted
+
+
+                # FIXME: updateImage fails with index out of range: raw_data = self._live_data[stream_idx][-1]
 
                 # Wait for all the Dataflows to return the data. As all the
                 # detectors are linked together to the e-beam, they should all
@@ -2616,14 +2677,30 @@ class SEMMDStream(MultipleDetectorStream):
                 s._dataflow.unsubscribe(sub)
             self._df0.synchronizedOn(None)
 
-            self._raw = []
-            self._anchor_raw = []
             if not isinstance(exp, CancelledError) and self._acq_state == CANCELLED:
-                logging.warning("Converting exception to cancellation", exc_info=True)
+                # Reset data in case it was cancelled very late, to regain memory
+                self._raw = []
+                self._anchor_raw = []
+                logging.warning("Converting exception to cancellation")
                 raise CancelledError()
-            raise
-        else:
-            return self.raw
+
+            # If it wasn't finalized yet, finalize the data
+            if not self._raw:
+                try:
+                    # Process all the (intermediary) ._live_data to the right shape/format for the final ._raw
+                    for stream_idx, das in enumerate(self._live_data):
+                        if stream_idx == 0 and len(das) == 0:
+                            # It's OK to not have data for the SEM stream (e.g. Monochromator)
+                            continue
+                        self._assembleFinalData(stream_idx, das)
+                except Exception:
+                    logging.warning("Failed to assemble the final data after exception in stream %s", self.name.value)
+
+            if not self._raw:
+                # No data -> just make it look like a "complete" exception
+                raise exp
+
+            error = exp
         finally:
             self._current_scan_area = None  # Indicate we are done for the live (also in case of error)
             for s in self._streams:
@@ -2636,6 +2713,8 @@ class SEMMDStream(MultipleDetectorStream):
             self._dc_estimator = None
             self._current_future = None
             self._acq_done.set()
+
+        return self.raw, error
 
     def _updateImage(self):
         """
@@ -2776,7 +2855,10 @@ class SEMTemporalMDStream(MultipleDetectorStream):
 
         return px_time, ninteg
 
-    def _runAcquisition(self, future):
+    def _runAcquisition(self, future) -> Tuple[List[model.DataArray], Optional[Exception]]:
+        """
+        Overrides MultipleDetectorStream._runAcquisition. See that function for doc.
+        """
         self._raw = []
         self._anchor_raw = []
 
@@ -2872,9 +2954,8 @@ class SEMTemporalMDStream(MultipleDetectorStream):
             raise  # Just don't log the exception
         except Exception:
             logging.exception("Failure during Correlator acquisition")
+            # TODO: once live data is supported, return the partial data
             raise
-        else:
-            return self.raw
         finally:
             logging.debug("TC acquisition finished")
             self._acq_done.set()
@@ -2882,6 +2963,8 @@ class SEMTemporalMDStream(MultipleDetectorStream):
             # to subpixel drift correction)
             self._tc_stream._detector.dwellTime.value = tc_dt
             self._emitter.dwellTime.value = emitter_dt
+
+        return self.raw, None
 
     def _acquireImage(self, x, y, img_time):
         try:
@@ -3052,19 +3135,19 @@ class SEMTemporalSpectrumMDStream(SEMCCDMDStream):
     Data format: SEM (2D=XY) + TemporalSpectrum(4D=CT1YX).
     """
 
-    def _runAcquisition(self, future):
+    def _runAcquisition(self, future) -> Tuple[List[model.DataArray], Optional[Exception]]:
         """
         Acquires images from multiple detectors via software synchronisation.
         Select whether the ebeam is moved for scanning or the sample stage.
         :param future: Current future running for the whole acquisition.
         """
         try:
-            das = super()._runAcquisition(future)
+            das, error = super()._runAcquisition(future)
         finally:
             # Make sure the streak-cam is protected
             self._sccd._suspend()
 
-        return das
+        return das, error
 
     def _assembleLiveData(self, n: int, raw_data: model.DataArray,
                           px_idx: Tuple[int, int], px_pos: Tuple[float, float],
@@ -3258,11 +3341,13 @@ class ScannedFluoMDStream(MultipleDetectorStream):
             self._acq_complete[n].set()
             # TODO: unsubscribe here?
 
-    def _runAcquisition(self, future):
+    def _runAcquisition(self, future) -> Tuple[List[model.DataArray], Optional[Exception]]:
         """
         Acquires images from the multiple detectors via software synchronisation.
         Warning: can be quite memory consuming if the grid is big
-        returns (list of DataArray): all the data acquired
+        :returns
+            list of DataArray: All the data acquired.
+            error: None
         raises:
           CancelledError() if cancelled
           Exceptions if error
@@ -3327,8 +3412,6 @@ class ScannedFluoMDStream(MultipleDetectorStream):
                 logging.warning("Converting exception to cancellation")
                 raise CancelledError()
             raise
-        else:
-            return self.raw
         finally:
             for s in self._streams:
                 s._unlinkHwVAs()
@@ -3336,6 +3419,8 @@ class ScannedFluoMDStream(MultipleDetectorStream):
                 self._setting_stream.is_active.value = False
             self._current_future = None
             self._acq_done.set()
+
+        return self.raw, None
 
 
 class ScannedRemoteTCStream(LiveStream):
@@ -3471,7 +3556,7 @@ class ScannedRemoteTCStream(LiveStream):
 
         return scale, res, trans
 
-    def _runAcquisition(self, future):
+    def _runAcquisition(self, future) -> Tuple[List[model.DataArray], Optional[Exception]]:
         logging.debug("Starting FLIM acquisition")
         try:
             self._stream._linkHwVAs()
@@ -3544,7 +3629,7 @@ class ScannedRemoteTCStream(LiveStream):
                     raise CancelledError()
                 self._acq_state = FINISHED
 
-        return self.raw
+        return self.raw, None
 
     def _onAcqStop(self, dataflow, data):
         pass

--- a/src/odemis/acq/test/stream_test.py
+++ b/src/odemis/acq/test/stream_test.py
@@ -2908,9 +2908,9 @@ class SPARC2StreakCameraTestCase(unittest.TestCase):
         stss = stream.SEMTemporalSpectrumMDStream("test sem-temporal spectrum", [sems, streaks])
 
         streaks.detStreakMode.value = True
-        streaks.detExposureTime.value = 0.01  # 10ms
+        streaks.detExposureTime.value = 0.1  # 100ms
         # Disable the protections
-        streaks.detMCPGain.value = 10
+        streaks.detMCPGain.value = 5
         streaks.detShutter.value = False
 
         # # TODO use fixed repetition value -> set ROI?
@@ -3068,11 +3068,13 @@ class SPARC2StreakCameraTestCase(unittest.TestCase):
         streaks = stream.TemporalSpectrumSettingsStream("test streak cam", self.streak_ccd, self.streak_ccd.data,
                                                         self.ebeam, self.streak_unit, self.streak_delay,
                                                         detvas={"readoutRate", "binning", "resolution"},
-                                                        streak_unit_vas={"timeRange", "MCPGain", "streakMode"})
+                                                        streak_unit_vas={"timeRange", "MCPGain", "streakMode", "shutter"})
 
         stss = stream.SEMTemporalSpectrumMDStream("test sem-temporal spectrum", [sems, streaks])
 
         streaks.detStreakMode.value = True
+        streaks.detMCPGain.value = 10
+        streaks.detShutter.value = False
         sems.emtDwellTime.value = 1e-06
 
         # set a baseline, which does not effect data, but needed later to verify baseline is handled correctly
@@ -3170,11 +3172,13 @@ class SPARC2StreakCameraTestCase(unittest.TestCase):
         streaks = stream.TemporalSpectrumSettingsStream("test streak cam", self.streak_ccd, self.streak_ccd.data,
                                                         self.ebeam, self.streak_unit, self.streak_delay,
                                                         detvas={"readoutRate", "binning", "resolution"},
-                                                        streak_unit_vas={"timeRange", "MCPGain", "streakMode"})
+                                                        streak_unit_vas={"timeRange", "MCPGain", "streakMode", "shutter"})
 
         stss = stream.SEMTemporalSpectrumMDStream("test sem-temporal spectrum", [sems, streaks])
 
         streaks.detStreakMode.value = True
+        streaks.detMCPGain.value = 10
+        streaks.detShutter.value = False
         sems.emtDwellTime.value = 1e-06
 
         # set stream VAs

--- a/src/odemis/acq/test/stream_test.py
+++ b/src/odemis/acq/test/stream_test.py
@@ -821,7 +821,8 @@ class SECOMConfocalTestCase(unittest.TestCase):
         f.add_update_callback(self._on_progress_update)
         f.add_done_callback(self._on_done)
 
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
+        self.assertIsNone(exp)
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0].shape, exp_shape)
         self.assertGreaterEqual(self.updates, 1)  # at least 1 update
@@ -879,7 +880,8 @@ class SECOMConfocalTestCase(unittest.TestCase):
         f.add_update_callback(self._on_progress_update)
         f.add_done_callback(self._on_done)
 
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
+        self.assertIsNone(exp)
         self.assertEqual(len(data), len(self.photo_ds))
         for d in data:
             self.assertEqual(d.shape, exp_shape)
@@ -1027,7 +1029,8 @@ class SPARCTestCase(unittest.TestCase):
         f.add_update_callback(self.on_progress_update)
         f.add_done_callback(self.on_done)
 
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
+        self.assertIsNone(exp)
         self.assertEqual(len(data), num_ar + 1)
         self.assertEqual(data[0].shape, exp_shape)
         self.assertGreaterEqual(self.updates, 4)  # at least a couple of updates
@@ -1049,7 +1052,8 @@ class SPARCTestCase(unittest.TestCase):
         f.add_update_callback(self.on_progress_update)
         f.add_done_callback(self.on_done)
 
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
+        self.assertIsNone(exp)
         self.assertEqual(len(data), num_ar + 1)
         self.assertEqual(data[0].shape, exp_shape)
         self.assertGreaterEqual(self.updates, 5)  # at least a few updates
@@ -1144,10 +1148,11 @@ class SPARCTestCase(unittest.TestCase):
         f = sas.acquire()
 
         # wait until it's over
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
         dur = time.time() - start
         logging.debug("Acquisition took %g s", dur)
         self.assertTrue(f.done())
+        self.assertIsNone(exp)
         self.assertEqual(len(data), len(sas.raw))
         sem_da = sas.raw[0]
         self.assertEqual(sem_da.shape, exp_res[::-1])
@@ -1179,10 +1184,12 @@ class SPARCTestCase(unittest.TestCase):
         f = sas.acquire()
 
         # wait until it's over
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
         dur = time.time() - start
         logging.debug("Acquisition took %g s", dur)
         self.assertTrue(f.done())
+        self.assertIsNone(exp)
+
         self.assertEqual(len(data), len(sas.raw))
         sem_da = sas.raw[0]
         self.assertEqual(sem_da.shape, exp_res[::-1])
@@ -1230,10 +1237,11 @@ class SPARCTestCase(unittest.TestCase):
         testing.assert_array_not_equal(im1, im2)
 
         # wait until it's over
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
         dur = time.time() - start
         logging.debug("Acquisition took %g s", dur)
         self.assertTrue(f.done())
+        self.assertIsNone(exp)
         self.assertEqual(len(data), len(sps.raw))
         sem_da = sps.raw[0]
         self.assertEqual(sem_da.shape, exp_res[::-1])
@@ -1261,10 +1269,11 @@ class SPARCTestCase(unittest.TestCase):
         f = sps.acquire()
 
         # wait until it's over
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
         dur = time.time() - start
         logging.debug("Acquisition took %g s", dur)
         self.assertTrue(f.done())
+        self.assertIsNone(exp)
         self.assertEqual(len(data), len(sps.raw))
         sem_da = sps.raw[0]
         self.assertEqual(sem_da.shape, exp_res[::-1])
@@ -1307,10 +1316,11 @@ class SPARCTestCase(unittest.TestCase):
         f = sps.acquire()
 
         # wait until it's over
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
         dur = time.time() - start
         logging.debug("Acquisition took %g s", dur)
         self.assertTrue(f.done())
+        self.assertIsNone(exp)
         self.assertEqual(len(data), len(sps.raw))
         sem_da = sps.raw[0]
         # The SEM res should have at least 2x2 sub-pixels per pixel
@@ -1348,10 +1358,11 @@ class SPARCTestCase(unittest.TestCase):
         f = sps.acquire()
 
         # wait until it's over
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
         dur = time.time() - start
         logging.debug("Acquisition took %g s", dur)
         self.assertTrue(f.done())
+        self.assertIsNone(exp)
         self.assertEqual(len(data), len(sps.raw))
         sem_da = sps.raw[0]
         # The SEM res should have at least 2x2 sub-pixels per pixel
@@ -1409,12 +1420,13 @@ class SPARCTestCase(unittest.TestCase):
         f = sms.acquire()
 
         # wait until it's over
-        data = f.result()
+        data, exp = f.result()
         for l in sms.leeches:
             l.series_complete(data)
         dur = time.time() - start
         logging.debug("Acquisition took %g s", dur)
         self.assertTrue(f.done())
+        self.assertIsNone(exp)
         # No SEM data with monochromator (currently), so only PMT + anchor
         self.assertEqual(len(data), 2)
         mcsd = None
@@ -1449,12 +1461,13 @@ class SPARCTestCase(unittest.TestCase):
         f = sms.acquire()
 
         # wait until it's over
-        data = f.result()
+        data, exp = f.result()
         for l in sms.leeches:
             l.series_complete(data)
         dur = time.time() - start
         logging.debug("Acquisition took %g s", dur)
         self.assertTrue(f.done())
+        self.assertIsNone(exp)
         # No SEM data with monochromator (currently), so only PMT + anchor
         self.assertEqual(len(data), 2)
         mcsd = None
@@ -1635,10 +1648,11 @@ class SPARC2TestCase(unittest.TestCase):
         f = sms.acquire()
 
         # wait until it's over
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
         dur = time.time() - start
         logging.debug("Acquisition took %g s", dur)
         self.assertTrue(f.done())
+        self.assertIsNone(exp)
         self.assertEqual(len(data), len(sms.raw))
 
         # Both SEM and CL should have the same shape
@@ -1674,11 +1688,12 @@ class SPARC2TestCase(unittest.TestCase):
         f = sms.acquire()
 
         # wait until it's over
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
         dc.series_complete(data)
         dur = time.time() - start
         logging.debug("Acquisition took %g s", dur)
         self.assertTrue(f.done())
+        self.assertIsNone(exp)
         self.assertEqual(len(data), len(sms.raw))
         # Both SEM and CL should have the same shape (and last one is anchor region)
         self.assertEqual(len(sms.raw), 3)
@@ -1735,12 +1750,13 @@ class SPARC2TestCase(unittest.TestCase):
             f = sms.acquire()
 
         # Finally acquire something really, and check it worked
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
         for l in sms.leeches:
             l.series_complete(data)
         dur = time.time() - start
         logging.debug("Acquisition took %g s", dur)
         self.assertTrue(f.done())
+        self.assertIsNone(exp)
         self.assertEqual(len(data), len(sms.raw))
 
         # Both SEM and CL should have the same shape (and last one is anchor region)
@@ -1785,12 +1801,13 @@ class SPARC2TestCase(unittest.TestCase):
         f = sms.acquire()
 
         # wait until it's over
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
         for l in sms.leeches:
             l.series_complete(data)
         dur = time.time() - start
         logging.debug("Acquisition took %g s", dur)
         self.assertTrue(f.done())
+        self.assertIsNone(exp)
         self.assertEqual(len(data), len(sms.raw))
 
         # Both SEM and CL should have the same shape (and last one is anchor region)
@@ -1841,10 +1858,11 @@ class SPARC2TestCase(unittest.TestCase):
         f = sps.acquire()
 
         # wait until it's over
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
         dur = time.time() - start
         logging.debug("Acquisition took %g s (while expected %g s)", dur, estt)
         self.assertTrue(f.done())
+        self.assertIsNone(exp)
         self.assertEqual(len(data), len(sps.raw))
         sem_da = sps.raw[0]
         self.assertEqual(sem_da.shape, exp_res[::-1])
@@ -1879,10 +1897,11 @@ class SPARC2TestCase(unittest.TestCase):
         f = sps.acquire()
 
         # wait until it's over
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
         dur = time.time() - start
         logging.debug("Acquisition took %g s (while expected %g s)", dur, estt)
         self.assertTrue(f.done())
+        self.assertIsNone(exp)
         self.assertEqual(len(data), len(sps.raw))
         sem_da = sps.raw[0]
         self.assertEqual(sem_da.shape, exp_res[::-1])
@@ -1951,10 +1970,11 @@ class SPARC2TestCase(unittest.TestCase):
         f = sps.acquire()
 
         # wait until it's over
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
         dur = time.time() - start
         logging.debug("Acquisition took %g s (while expected %g s)", dur, estt)
         self.assertTrue(f.done())
+        self.assertIsNone(exp)
         self.assertEqual(len(data), len(sps.raw))
         sem_da = sps.raw[0]
         self.assertEqual(sem_da.shape, exp_res[::-1])
@@ -2016,12 +2036,13 @@ class SPARC2TestCase(unittest.TestCase):
         f = sps.acquire()
 
         # wait until it's over
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
         for l in sps.leeches:
             l.series_complete(data)
         dur = time.time() - start
         logging.debug("Acquisition took %g s (while expected %g s)", dur, estt)
         self.assertTrue(f.done())
+        self.assertIsNone(exp)
         self.assertEqual(len(data), len(sps.raw))
         sem_da = sps.raw[0]
         # The SEM res should have at least 2x2 sub-pixels per pixel
@@ -2067,12 +2088,13 @@ class SPARC2TestCase(unittest.TestCase):
         f = sps.acquire()
 
         # wait until it's over
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
         for l in sps.leeches:
             l.series_complete(data)
         dur = time.time() - start
         logging.debug("Acquisition took %g s (while expected %g s)", dur, estt)
         self.assertTrue(f.done())
+        self.assertIsNone(exp)
         sem_da = sps.raw[0]
         # The SEM res should have at least 2x2 sub-pixels per pixel
         self.assertGreaterEqual(sem_da.shape[1], exp_res[0] * 2)
@@ -2125,10 +2147,11 @@ class SPARC2TestCase(unittest.TestCase):
         f = sps.acquire()
 
         # wait until it's over
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
         dur = time.time() - start
         logging.debug("Acquisition took %g s", dur)
         self.assertTrue(f.done())
+        self.assertIsNone(exp)
         self.assertEqual(len(data), len(sps.raw))
         sem_da = sps.raw[0]
         self.assertEqual(sem_da.shape, exp_res[::-1])
@@ -2189,12 +2212,13 @@ class SPARC2TestCase(unittest.TestCase):
         f = sms.acquire()
 
         # wait until it's over
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
         for l in sms.leeches:
             l.series_complete(data)
         dur = time.time() - start
         logging.debug("Acquisition took %g s", dur)
         self.assertTrue(f.done())
+        self.assertIsNone(exp)
         self.assertEqual(len(data), len(sms.raw))
 
         # Both SEM and CL should have the same shape (and last one is anchor region)
@@ -2279,8 +2303,9 @@ class SPARC2TestCaseStageWrapper(unittest.TestCase):
         f.add_update_callback(self.on_progress_update)
         f.add_done_callback(self.on_done)
 
-        self.data = f.result()
+        self.data, exp = f.result()
         self.assertTrue(f.done())
+        self.assertIsNone(exp)
 
         # check if the ProgressiveFuture used to start the acquisition request is done
         time.sleep(0.1)  # wait a tiny bit to assert done status
@@ -2863,7 +2888,8 @@ class SPARC2StreakCameraTestCase(unittest.TestCase):
         im2 = streaks.image.value
 
         # wait until it's over
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
+        self.assertIsNone(exp)
 
         # Check if the image changed (live update is working)
         testing.assert_array_not_equal(im1, im2)
@@ -2903,10 +2929,11 @@ class SPARC2StreakCameraTestCase(unittest.TestCase):
         # data: array should contain same images as stss.raw
 
         # wait until it's over
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
         dur = time.time() - start
         logging.debug("Acquisition took %g s", dur)
         self.assertTrue(f.done())
+        self.assertIsNone(exp)
 
         # Confirm protections are applied on the hardware
         self.assertEqual(self.streak_unit.MCPGain.value, 0)
@@ -2948,10 +2975,11 @@ class SPARC2StreakCameraTestCase(unittest.TestCase):
         start = time.time()
         f = stss.acquire()  # calls acquire method in MultiDetectorStream in sync.py
         # wait until it's over
-        f.result(timeout2)
+        data, exp = f.result(timeout2)
         dur = time.time() - start
         logging.debug("Acquisition took %g s", dur)
         self.assertTrue(f.done())
+        self.assertIsNone(exp)
 
     def test_streak_acq_leech(self):
         """
@@ -2998,7 +3026,7 @@ class SPARC2StreakCameraTestCase(unittest.TestCase):
         # data: array should contain same images as stss.raw
 
         # wait until it's over
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
 
         for l in streaks.leeches:
             l.series_complete(data)
@@ -3006,6 +3034,7 @@ class SPARC2StreakCameraTestCase(unittest.TestCase):
         dur = time.time() - start
         logging.debug("Acquisition took %g s", dur)
         self.assertTrue(f.done())
+        self.assertIsNone(exp)
 
         # check if number of images in the received data (sem image + temporal spectrum images) is the same as
         # number of images stored in raw
@@ -3067,10 +3096,11 @@ class SPARC2StreakCameraTestCase(unittest.TestCase):
         # data: array should contain same images as stss.raw
 
         # wait until it's over
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
         dur = time.time() - start
         logging.debug("Acquisition took %g s", dur)
         self.assertTrue(f.done())
+        self.assertIsNone(exp)
 
         ts_da = data[1]  # temporal spectrum data array
         shape = ts_da.shape
@@ -3104,7 +3134,8 @@ class SPARC2StreakCameraTestCase(unittest.TestCase):
         timeout = 1.5 * stss.estimateAcquisitionTime()
         f = stss.acquire()  # calls acquire method in MultiDetectorStream in sync.py
         # wait until it's over
-        data2 = f.result(timeout)
+        data2, exp = f.result(timeout)
+        self.assertIsNone(exp)
         ts_da2 = data2[1]  # temporal spectrum data array
 
         # test that the values in the second acquisition are greater (integrationCount greater than first acq)
@@ -3119,7 +3150,8 @@ class SPARC2StreakCameraTestCase(unittest.TestCase):
         timeout = 1.5 * stss.estimateAcquisitionTime()
         f = stss.acquire()  # calls acquire method in MultiDetectorStream in sync.py
         # wait until it's over
-        data3 = f.result(timeout)
+        data3, exp = f.result(timeout)
+        self.assertIsNone(exp)
         ts_da3 = data3[1]  # temporal spectrum data array
 
         # check baseline is not multiplied by integrationCount (we keep only one baseline level for integrated img)
@@ -3175,7 +3207,7 @@ class SPARC2StreakCameraTestCase(unittest.TestCase):
         # data: array should contain same images as stss.raw
 
         # wait until it's over
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
 
         for l in streaks.leeches:
             l.series_complete(data)
@@ -3183,6 +3215,7 @@ class SPARC2StreakCameraTestCase(unittest.TestCase):
         dur = time.time() - start
         logging.debug("Acquisition took %g s", dur)
         self.assertTrue(f.done())
+        self.assertIsNone(exp)
 
         ts_da = data[1]  # temporal spectrum data array
         shape = ts_da.shape
@@ -3246,10 +3279,11 @@ class SPARC2StreakCameraTestCase(unittest.TestCase):
         f = sms.acquire()
 
         # wait until it's over
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
         dur = time.time() - start
         logging.debug("Acquisition took %g s", dur)
         self.assertTrue(f.done())
+        self.assertIsNone(exp)
         self.assertEqual(len(data), len(sms.raw))
 
         # Both SEM and the two CLs should have the same shape
@@ -3293,11 +3327,12 @@ class SPARC2StreakCameraTestCase(unittest.TestCase):
         f = sms.acquire()
 
         # wait until it's over
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
         dc.series_complete(data)
         dur = time.time() - start
         logging.debug("Acquisition took %g s", dur)
         self.assertTrue(f.done())
+        self.assertIsNone(exp)
         self.assertEqual(len(data), len(sms.raw))
         # Both SEM and CL should have the same shape (and last one is anchor region)
         self.assertEqual(len(sms.raw), 4)
@@ -3406,10 +3441,11 @@ class SPARC2HwSyncTestCase(unittest.TestCase):
         testing.assert_array_not_equal(im1, im2)
 
         # wait until it's over
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
         dur = time.time() - start
         logging.debug("Acquisition took %g s", dur)
         self.assertTrue(f.done())
+        self.assertIsNone(exp)
         self.assertEqual(len(data), len(sps.raw))
         sem_da = sps.raw[0]
         self.assertEqual(sem_da.shape, exp_res[::-1])
@@ -3437,10 +3473,11 @@ class SPARC2HwSyncTestCase(unittest.TestCase):
         f = sps.acquire()
 
         # wait until it's over
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
         dur = time.time() - start
         logging.debug("Acquisition took %g s", dur)
         self.assertTrue(f.done())
+        self.assertIsNone(exp)
         self.assertEqual(len(data), len(sps.raw))
         sem_da = sps.raw[0]
         self.assertEqual(sem_da.shape, exp_res[::-1])
@@ -3590,10 +3627,11 @@ class SPARC2PolAnalyzerTestCase(unittest.TestCase):
             # data: array should contain same images as sas.raw
 
             # wait until it's over
-            data = f.result(timeout)
+            data, exp = f.result(timeout)
             dur = time.time() - start
             logging.debug("Acquisition took %g s", dur)
             self.assertTrue(f.done())
+            self.assertIsNone(exp)
 
             # check if number of images in the received data (sem image + ar images) is the same as
             # number of images stored in raw
@@ -3673,13 +3711,14 @@ class SPARC2PolAnalyzerTestCase(unittest.TestCase):
         f = sas.acquire()
 
         # wait until it's over
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
 
         for l in sas.leeches:
             l.series_complete(data)
         dur = time.time() - start
         logging.debug("Acquisition took %g s", dur)
         self.assertTrue(f.done())
+        self.assertIsNone(exp)
 
         # check if number of images in the received data (sem image + ar images) is the same as
         # number of images stored in raw
@@ -3865,10 +3904,11 @@ class SPARC2PolAnalyzerTestCase(unittest.TestCase):
         # data: array should contain same images as sas.raw
 
         # wait until it's over
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
         dur = time.time() - start
         logging.debug("Acquisition took %g s", dur)
         self.assertTrue(f.done())
+        self.assertIsNone(exp)
 
         ar_da = data[1:]  # angle resolved data arrays
         # check that the number of acquired ar images matches the number of ebeam position
@@ -3901,8 +3941,9 @@ class SPARC2PolAnalyzerTestCase(unittest.TestCase):
         timeout = 1.5 * sas.estimateAcquisitionTime()
         f = sas.acquire()  # calls acquire method in MultiDetectorStream in sync.py
         # wait until it's over
-        data2 = f.result(timeout)
+        data2, exp = f.result(timeout)
         ar_da2 = data2[1:]  # angle resolved data arrays
+        self.assertIsNone(exp)
 
         # test that the values in the second acquisition are smaller
         numpy.testing.assert_array_less(ar_da2[0], ar_da[0])
@@ -3916,8 +3957,9 @@ class SPARC2PolAnalyzerTestCase(unittest.TestCase):
         timeout = 1.5 * sas.estimateAcquisitionTime()
         f = sas.acquire()  # calls acquire method in MultiDetectorStream in sync.py
         # wait until it's over
-        data3 = f.result(timeout)
+        data3, exp = f.result(timeout)
         ar_da3 = data3[1:]  # angle resolved data arrays
+        self.assertIsNone(exp)
 
         # check baseline is not multiplied by integrationCount (we keep only one baseline level for integrated img)
         self.assertEqual(ar_da3[0].metadata[model.MD_BASELINE], 100)
@@ -3971,7 +4013,7 @@ class SPARC2PolAnalyzerTestCase(unittest.TestCase):
         # data: array should contain same images as sas.raw
 
         # wait until it's over
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
 
         for l in ars.leeches:
             l.series_complete(data)
@@ -3979,6 +4021,7 @@ class SPARC2PolAnalyzerTestCase(unittest.TestCase):
         dur = time.time() - start
         logging.debug("Acquisition took %g s", dur)
         self.assertTrue(f.done())
+        self.assertIsNone(exp)
 
         ar_da = data[1:-1]  # angle resolved data arrays
         # check that the number of acquired angle resolved images matches the number of ebeam position
@@ -4093,10 +4136,11 @@ class SPARC2TestCaseFPLM(unittest.TestCase):
         self.assertEqual(self.light.power.value, [light_pwr])
 
         # wait until it's over
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
         dur = time.time() - start
         logging.debug("Acquisition took %g s", dur)
         self.assertTrue(f.done())
+        self.assertIsNone(exp)
         self.assertEqual(len(data), len(sps.raw))
 
         # The light should be off
@@ -4197,7 +4241,7 @@ class SPARC2TestCaseIndependentDetector(unittest.TestCase):
         ebics.roi.value = (0, 0.2, 0.3, 0.6)
 
         # dwell time of sems shouldn't matter
-        ebics.detDwellTime.value = 1e-6  # s
+        ebics.detDwellTime.value = 2e-6  # s
 
         ebics.repetition.value = (500, 700)
         exp_pos, exp_pxs, exp_res = roi_to_phys(ebics)
@@ -4208,10 +4252,11 @@ class SPARC2TestCaseIndependentDetector(unittest.TestCase):
         f = sms.acquire()
 
         # wait until it's over
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
         dur = time.time() - start
         logging.debug("Acquisition took %g s", dur)
         self.assertTrue(f.done())
+        self.assertIsNone(exp)
         self.assertEqual(len(data), len(sms.raw))
 
         # Both SEM and EBIC should have the same shape
@@ -4231,7 +4276,7 @@ class SPARC2TestCaseIndependentDetector(unittest.TestCase):
         dc = leech.AnchorDriftCorrector(self.ebeam, self.sed)
         dc.period.value = 1
         dc.roi.value = (0.525, 0.525, 0.6, 0.6)
-        dc.dwellTime.value = 2e-06
+        dc.dwellTime.value = 3e-06
         sems.leeches.append(dc)
 
         ebics.repetition.value = (1200, 1100)
@@ -4244,7 +4289,8 @@ class SPARC2TestCaseIndependentDetector(unittest.TestCase):
         f = sms.acquire()
 
         # wait until it's over
-        data = f.result(timeout)
+        data, exp = f.result(timeout)
+        self.assertIsNone(exp)
         dc.series_complete(data)
         dur = time.time() - start
         logging.debug("Acquisition took %g s", dur)
@@ -4328,7 +4374,8 @@ class TimeCorrelatorTestCase(unittest.TestCase):
         # the dwell time would be >> 1s.
         tc_stream.detDwellTime.value = 5e-3
         f = sem_tc_stream.acquire()
-        data = f.result()
+        data, exp = f.result()
+        self.assertIsNone(exp)
 
         self.assertEqual(len(data), 2)  # 1 array for se, the other for tc data
         for d in data:
@@ -4367,7 +4414,8 @@ class TimeCorrelatorTestCase(unittest.TestCase):
         self.assertEqual(self.time_correlator.dwellTime.value, 1)
         # SEM dwell time might be either 1s, or the drift correction dwell time
         self.assertIn(self.ebeam.dwellTime.value, (1, 1e-6))
-        data = f.result()
+        data, exp = f.result()
+        self.assertIsNone(exp)
         # Dwell time on detector and emitter should be back to normal
         self.assertEqual(self.time_correlator.dwellTime.value, 2)
         self.assertEqual(self.ebeam.dwellTime.value, 0.042)
@@ -4406,7 +4454,8 @@ class TimeCorrelatorTestCase(unittest.TestCase):
         im2 = tc_stream.image.value
 
         # wait until it's over
-        data = f.result()
+        data, exp = f.result()
+        self.assertIsNone(exp)
 
         # Check if the image changed (live update is working)
         testing.assert_array_not_equal(im1, im2)

--- a/src/odemis/driver/simstreakcam.py
+++ b/src/odemis/driver/simstreakcam.py
@@ -278,7 +278,13 @@ class ReadoutCamera(model.DigitalCamera):
             image[:] = 100  # Background level
             mx = 1000
         else:
-            mx = image.max()
+            mx = image.max() * 5
+
+        # Increase the image intensity based on the MCP gain.
+        # 0 -> x1
+        # 63 (max) -> x6.4
+        gain_factor = (self.parent._streakunit.MCPGain.value + 1) / 10
+        numpy.multiply(image, gain_factor, out=image, casting="unsafe")
 
         # Add some noise
         image += numpy.random.randint(0, 10, image.shape, dtype=image.dtype)


### PR DESCRIPTION
Every time an streakcam image is received, check that the intensity level is not too high. If too many pixels are too high, with a threshold defined in the microscope file, then the acquisition is stopped (and the data acquired so far is saved).

In order for the data to be still stored in case the acquisition is stopped in the middle, introduce for all SPARC acquisitions support for partial acquisition. => Change the API, in a similar way as the acqmng API: the Future always returns both the data acquired and the exception. If the acquisition went fine, the exception is None.
 
If an exception occurred, the GUI will show the error message, and store the data in a file named "filename-failed...", to make it clear it didn't work as expected.

