### PR TITLE
[fix] MeasureSpotsFocus() only worked with specific dtypes

### DIFF
--- a/.github/workflows/unit_tests_cloud.yml
+++ b/.github/workflows/unit_tests_cloud.yml
@@ -75,6 +75,12 @@ jobs:
         export PYTHONPATH="$PWD/src:$PYTHONPATH"
         python3 -m unittest src/odemis/util/test/fluo_test.py --verbose
 
+    - name: Run tests from odemis.util.focus
+      if: ${{ !cancelled() }}
+      run: |
+        export PYTHONPATH="$PWD/src:$PYTHONPATH"
+        python3 -m unittest src/odemis/util/test/focus_test.py --verbose
+
     - name: Run tests from odemis.util.graph
       if: ${{ !cancelled() }}
       run: |

--- a/src/odemis/util/focus.py
+++ b/src/odemis/util/focus.py
@@ -70,6 +70,12 @@ def MeasureOpticalFocus(image):
         # TODO find faster/better solution
         image = _convertRBGToGrayscale(image)
 
+    # TODO: maybe switch to scipy.ndimage.laplace ?
+    # OpenCV only supports int of 8 & 16 bits and float32/64 images. So if we get anything else,
+    # we first convert to float64, to make sure it's compatible.
+    if image.dtype not in (numpy.int8, numpy.uint8, numpy.int16, numpy.uint16, numpy.float32, numpy.float64):
+         image = image.astype(numpy.float64)
+
     return cv2.Laplacian(image, cv2.CV_64F).var()
 
 
@@ -120,6 +126,11 @@ def MeasureSpotsFocus(image):
     image (model.DataArray): Optical image
     returns (float): The focus level of the image (higher is better)
     """
+    # TODO: maybe switch to scipy.ndimage.sobel ?
+    # OpenCV only supports int of 8 & 16 bits and float32/64 images. So if we get anything else,
+    # we first convert to float64, to make sure it's compatible.
+    if image.dtype not in (numpy.int8, numpy.uint8, numpy.int16, numpy.uint16, numpy.float32, numpy.float64):
+         image = image.astype(numpy.float64)
     sobelx = cv2.Sobel(image, cv2.CV_64F, 1, 0, ksize=5)
     sobely = cv2.Sobel(image, cv2.CV_64F, 0, 1, ksize=5)
     sobel_image = sobelx ** 2 + sobely ** 2

--- a/src/odemis/util/test/focus_test.py
+++ b/src/odemis/util/test/focus_test.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on 24 January 2025
+
+@author: Éric Piel
+
+Copyright © 2025 Éric Piel, Delmic
+
+This file is part of Odemis.
+
+Odemis is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License version 2 as published by the Free Software Foundation.
+
+Odemis is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with Odemis. If not, see http://www.gnu.org/licenses/.
+"""
+
+import unittest
+import numpy
+
+from odemis.util.focus import MeasureSpotsFocus, MeasureOpticalFocus
+
+
+class TestMeasureOpticalFocus(unittest.TestCase):
+
+    def test_simple(self):
+        # Create a simple grayscale image
+        image = numpy.random.randint(200, 3000, (101, 512), dtype=numpy.uint16)
+        focus_level = MeasureOpticalFocus(image)
+        self.assertIsInstance(focus_level, float)
+        self.assertGreaterEqual(focus_level, 0)
+
+
+class TestMeasureSpotsFocus(unittest.TestCase):
+
+    def test_simple(self):
+        # Create a simple grayscale image
+        image = numpy.random.randint(200, 3000, (101, 512), dtype=numpy.uint16)
+        focus_level = MeasureSpotsFocus(image)
+        self.assertIsInstance(focus_level, float)
+        self.assertGreaterEqual(focus_level, 0)
+
+    def test_empty_image_uint8(self):
+        # Create a completely black image => focus level should be 0
+        image = numpy.zeros((2152, 3512), dtype=numpy.uint8)
+        focus_level = MeasureSpotsFocus(image)
+        self.assertIsInstance(focus_level, float)
+        self.assertEqual(focus_level, 0)
+
+    def test_uint32(self):
+        image = numpy.random.randint(200, 100000, (101, 512), dtype=numpy.uint32)
+        focus_level = MeasureSpotsFocus(image)
+        self.assertIsInstance(focus_level, float)
+        self.assertGreaterEqual(focus_level, 0)
+
+    def test_high_variance_image(self):
+        # Create an image with high variance
+        image = numpy.zeros((200, 512), dtype=numpy.uint16)
+        image[:] = 100 # background
+        image[100:120, 300:320] = 1000  # white rectangle in the middle of the image
+        focus_level = MeasureSpotsFocus(image)
+        self.assertIsInstance(focus_level, float)
+        self.assertGreater(focus_level, 1)  # Usually much higher than 1e12!
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
MeasureSpotsFocus() uses OpenCV functions, which only support some
specific dtypes. In particular, they don't handle uint32, which some
detectors generates.

In such case, this error happens (during autofocus):
```
File "/usr/lib/python3/dist-packages/odemis/util/focus.py", line 123, in MeasureSpotsFocus
    sobelx = cv2.Sobel(image, cv2.CV_64F, 1, 0, ksize=5)
cv2.error: OpenCV(4.5.4) :-1: error: (-5:Bad argument) in function 'Sobel'
> Overload resolution failed:
>  - src data type = 6 is not supported
>  - Expected Ptr<cv::UMat> for argument 'src'
```

=> Detect the image dtype is not supported and convert to float64 before
calling OpenCV.