### PR TITLE
[SDEV-1958] extend tiled acquisition code to be able to acquire non rectangular shapes

### DIFF
--- a/.github/workflows/unit_tests_cloud.yml
+++ b/.github/workflows/unit_tests_cloud.yml
@@ -154,6 +154,7 @@ jobs:
         python3 -m unittest src/odemis/acq/stitching/test/registrar_test.py --verbose
         python3 -m unittest src/odemis/acq/stitching/test/stitching_test.py --verbose
         python3 -m unittest src/odemis/acq/stitching/test/weaver_test.py --verbose
+        python3 -m unittest src.odemis.acq.stitching.test.tiledacq_test.TiledAcquisitionTaskTestCase --verbose
 
     - name: Run tests from odemis.acq.calibration
       if: ${{ !cancelled() }}
@@ -209,3 +210,9 @@ jobs:
       run: |
         export PYTHONPATH="$PWD/src:$PYTHONPATH"
         python3 -m unittest src.odemis.acq.test.fastem_test.TestFastEMAcquisitionTaskMock --verbose
+
+    - name: Run tests from odemis.util.raster
+      if: ${{ !cancelled() }}
+      run: |
+        export PYTHONPATH="$PWD/src:$PYTHONPATH"
+        python3 -m unittest src/odemis/util/test/raster_test.py --verbose

--- a/src/odemis/acq/stitching/_tiledacq.py
+++ b/src/odemis/acq/stitching/_tiledacq.py
@@ -25,26 +25,45 @@ import statistics
 import threading
 import time
 from concurrent.futures import CancelledError, TimeoutError
-from concurrent.futures._base import RUNNING, FINISHED, CANCELLED
+from concurrent.futures._base import CANCELLED, FINISHED, RUNNING
 from enum import Enum
-from typing import List, Tuple, Optional, Dict
+from itertools import groupby
+from typing import Dict, List, Optional, Tuple, Union
 
 import numpy
 import psutil
+from scipy.ndimage import binary_fill_holes
 from scipy.spatial import Delaunay
+from shapely.geometry import Polygon, box
 
-from odemis import model, dataio
+from odemis import dataio, model
 from odemis.acq import acqmng
-from odemis.acq.align.autofocus import AutoFocus, MTD_EXHAUSTIVE
-from odemis.util.focus import MeasureOpticalFocus
-from odemis.acq.align.roi_autofocus import autofocus_in_roi, estimate_autofocus_in_roi_time
-from odemis.acq.stitching._constants import WEAVER_MEAN, REGISTER_IDENTITY, REGISTER_GLOBAL_SHIFT
+from odemis.acq.align.autofocus import MTD_EXHAUSTIVE, AutoFocus
+from odemis.acq.align.roi_autofocus import (
+    autofocus_in_roi,
+    estimate_autofocus_in_roi_time,
+)
+from odemis.acq.stitching._constants import (
+    REGISTER_GLOBAL_SHIFT,
+    REGISTER_IDENTITY,
+    WEAVER_MEAN,
+)
 from odemis.acq.stitching._simple import register, weave
-from odemis.acq.stream import Stream, EMStream, ARStream, \
-    SpectrumStream, FluoStream, MultipleDetectorStream, util, executeAsyncTask, \
-    CLStream
+from odemis.acq.stream import (
+    ARStream,
+    CLStream,
+    EMStream,
+    FluoStream,
+    MultipleDetectorStream,
+    SpectrumStream,
+    Stream,
+    executeAsyncTask,
+    util,
+)
 from odemis.model import DataArray
-from odemis.util import dataio as udataio, img, linalg, rect_intersect
+from odemis.util import dataio as udataio
+from odemis.util import img, linalg, rect_intersect
+from odemis.util.focus import MeasureOpticalFocus
 from odemis.util.img import assembleZCube
 from odemis.util.linalg import generate_triangulation_points
 from odemis.util.raster import point_in_polygon
@@ -81,13 +100,15 @@ class TiledAcquisitionTask(object):
     The goal of this task is to acquire a set of tiles then stitch them together
     """
 
-    def __init__(self, streams, stage, area, overlap, settings_obs=None, log_path=None, future=None, zlevels=None,
+    def __init__(self, streams, stage, region, overlap, settings_obs=None, log_path=None, future=None, zlevels=None,
                  registrar=REGISTER_GLOBAL_SHIFT, weaver=WEAVER_MEAN, focusing_method=FocusingMethod.NONE,
                  focus_points=None, focus_range=None):
         """
         :param streams: (list of Streams) the streams to acquire
         :param stage: (Actuator) the sample stage to move to the possible tiles locations
-        :param area: (float, float, float, float) left, top, right, bottom points of acquisition area
+        :param region: Either:
+            - (Tuple[float, float, float, float]) Bounding box as (xmin, ymin, xmax, ymax)
+            - (List[Tuple[float, float]]) List of (x, y) points defining a polygon
         :param overlap: (float) the amount of overlap between each acquisition
         :param settings_obs: (SettingsObserver or None) class that contains a list of all VAs
             that should be saved as metadata
@@ -111,19 +132,16 @@ class TiledAcquisitionTask(object):
         self._focus_range = focus_range
         # Average time taken for each tile acquisition
         self.average_acquisition_time = None
+        self._overlap = overlap
+        self._polygon = None
         if future is not None:
             self._future.running_subf: future.Future = model.InstantaneousFuture()
             self._future._task_lock = threading.Lock()
-        # Get total area as a tuple of width, height from ltrb area points
-        normalized_area = util.normalize_rect(area)
-        if area[0] != normalized_area[0] or area[1] != normalized_area[1]:
-            logging.warning("Acquisition area {} rearranged into {}".format(area, normalized_area))
 
-        self._area = normalized_area
-        height = normalized_area[3] - normalized_area[1]
-        width = normalized_area[2] - normalized_area[0]
-        self._area_size = (width, height)
-        self._overlap = overlap
+        # Normalize the region input into a polygon
+        self._polygon = self._normalize_region_to_polygon(region)
+        xmin, ymin, xmax, ymax = self._polygon.bounds
+        self._area_size = (xmax - xmin, ymax - ymin)
 
         # Note: we used to change the stream horizontalFoV VA to the max, if available (eg, SEM).
         # However, it's annoying if the caller actually cares about the FoV (eg,
@@ -138,7 +156,8 @@ class TiledAcquisitionTask(object):
         self._sfov = self._guessSmallestFov(streams)
         logging.debug("Smallest FoV: %s", self._sfov)
 
-        (self._nx, self._ny), self._starting_pos = self._getNumberOfTiles()
+        self._number_of_tiles, self._starting_pos, self._tile_indices = self._getNumberOfTiles()
+        logging.debug("Calculated number of tiles %s", self._number_of_tiles)
 
         # save actual time take for tile acquisition, stage movement from one tile to another
         # and stitching time for each tile. The keys tell the action, i.e. move or stitch and the time
@@ -222,6 +241,35 @@ class TiledAcquisitionTask(object):
         self._weaver = weaver
         self._focus_plane = {}
 
+    def _normalize_region_to_polygon(
+            self,
+            region: Union[Tuple[float, float, float, float], List[Tuple[float, float]]]
+        ) -> Polygon:
+        """
+        Normalize the region input into a polygon.
+        :param region: Either a bounding box (xmin, ymin, xmax, ymax) or a list of (x, y) points.
+        :return: A polygon representing the region.
+        :raise: ValueError if the region does not form a valid polygon.
+        :raise: ValueError if the region is not a bounding box or a list of points.
+        """
+        if isinstance(region, tuple) and len(region) == 4:
+            # Normalize the bounding box
+            xmin, ymin, xmax, ymax = util.normalize_rect(region)
+            if region[0] != xmin or region[1] != ymin:
+                logging.warning("Acquisition area %s rearranged into %s", region, (xmin, ymin, xmax, ymax))
+            points = [(xmin, ymin), (xmax, ymin), (xmax, ymax), (xmin, ymax)]
+        elif isinstance(region, list) and all(isinstance(point, tuple) and len(point) == 2 for point in region):
+            points = region
+        else:
+            raise ValueError(
+                "Region must either be a bounding box (xmin, ymin, xmax, ymax) or a list of (x, y) points."
+            )
+
+        polygon = Polygon(points)
+        if not polygon.is_valid:
+            raise ValueError("The provided region does not form a valid polygon.")
+        return polygon
+
     def _getFov(self, sd):
         """
         sd (Stream or DataArray): If it's a stream, it must be a live stream,
@@ -253,20 +301,21 @@ class TiledAcquisitionTask(object):
 
     def _getNumberOfTiles(self):
         """
-        Calculate needed number of tiles (horizontal and vertical) to cover the whole area,
-        and the adjusted position of the first tile.
+        Calculate the exact tiles required to cover the region.
         return:
-            nb (int, int): number of tile in X, Y
+            nb (int): total number of tiles to cover the region
             starting_position (float, float): center of the first tile (at the top-left)
+            tile_indices (List[Tuple[int, int]]: List of (col, row) indices for the tiles
         """
-        # The size of the smallest tile, non-including the overlap, which will be
-        # lost (and also indirectly represents the precision of the stage)
-        reliable_fov = ((1 - self._overlap) * self._sfov[0], (1 - self._overlap) * self._sfov[1])
+        if self._polygon is None:
+            raise ValueError("Polygon shape is not defined.")
 
-        logging.debug("Would need tiles: nx= %s, ny= %s",
-                      abs(self._area_size[0] / reliable_fov[0]),
-                      abs(self._area_size[1] / reliable_fov[1])
-                      )
+        # Define grid cell size based on field of view (FoV) and overlap
+        reliable_fov = (
+            self._sfov[0] * (1 - self._overlap),  # Width of the tile
+            self._sfov[1] * (1 - self._overlap)   # Height of the tile
+        )
+
         # Round up the number of tiles needed. With a twist: if we'd need less
         # than 1% of a tile extra, round down. This handles floating point
         # errors and other manual rounding when when the requested area size is
@@ -275,22 +324,85 @@ class TiledAcquisitionTask(object):
                      for s, f in zip(self._area_size, reliable_fov)]
         nx = math.ceil(area_size[0] / reliable_fov[0])
         ny = math.ceil(area_size[1] / reliable_fov[1])
-        logging.debug("Calculated number of tiles nx= %s, ny= %s" % (nx, ny))
 
         # We have a little bit more tiles than needed, we then have two choices
         # on how to spread them:
         # 1. Increase the total area acquired (and keep the overlap)
         # 2. Increase the overlap (and keep the total area)
         # We pick alternative 1 (no real reason)
-        center = (self._area[0] + self._area[2]) / 2, (self._area[1] + self._area[3]) / 2
+        xmin, ymin, xmax, ymax = self._polygon.bounds
+        center = ((xmin + xmax) / 2, (ymin + ymax) / 2)
         total_size = nx * reliable_fov[0], ny * reliable_fov[1]
+        xmin = center[0] - total_size[0] / 2
+        ymax = center[1] + total_size[1] / 2
 
-        # Compute the top-left of the "bigger" area, and from it, shift by half
-        # the size of the smallest tile.
-        starting_pos = {'x': center[0] - total_size[0] / 2 + reliable_fov[0] / 2,  # left
-                        'y': center[1] + total_size[1] / 2 - reliable_fov[1] / 2}  # top
+        # Create an empty grid for storing intersected tiles
+        tile_grid = numpy.zeros((ny, nx), dtype=bool)
 
-        return (nx, ny), starting_pos
+        def get_possible_intersected_tiles(row_pairs, col_pairs):
+            """Bresenham's line algorithm to determine the possible intersected tiles."""
+            tiles = set()
+            for (row1, row2), (col1, col2) in zip(row_pairs, col_pairs):
+                dx = abs(row2 - row1)
+                dy = abs(col2 - col1)
+                sx = 1 if row1 < row2 else -1
+                sy = 1 if col1 < col2 else -1
+                err = dx - dy
+
+                while True:
+                    tiles.add((row1, col1))
+                    # Add adjacent neighbors to ensure complete coverage
+                    tiles.add((row1 + sx, col1))
+                    tiles.add((row1 - sx, col1))
+                    tiles.add((row1, col1 + sy))
+                    tiles.add((row1, col1 - sy))
+                    if row1 == row2 and col1 == col2:
+                        break
+                    e2 = err * 2
+                    if e2 > -dy:
+                        err -= dy
+                        row1 += sx
+                    if e2 < dx:
+                        err += dx
+                        col1 += sy
+            return tiles
+
+        # Vectorized conversion of polygon points to grid coordinates
+        points = numpy.array(self._polygon.exterior.coords)
+        rows = numpy.floor((ymax - points[:, 1]) / reliable_fov[1]).astype(int)
+        cols = numpy.floor((points[:, 0] - xmin) / reliable_fov[0]).astype(int)
+
+        # Vectorized calculation of intersected grid cells
+        row_pairs = numpy.vstack((rows, numpy.roll(rows, -1))).T
+        col_pairs = numpy.vstack((cols, numpy.roll(cols, -1))).T
+
+        intersected_tiles = get_possible_intersected_tiles(row_pairs, col_pairs)
+
+        for row, col in intersected_tiles:
+            if 0 <= row < ny and 0 <= col < nx:
+                # Define the bounds of the current tile
+                tile_bounds = box(
+                    xmin + col * reliable_fov[0],
+                    ymax - (row + 1) * reliable_fov[1],
+                    xmin + (col + 1) * reliable_fov[0],
+                    ymax - row * reliable_fov[1]
+                )
+                # Check if the tile intersects with the polygon shape
+                if self._polygon.intersects(tile_bounds):
+                    tile_grid[row, col] = True
+
+        # Fill any holes in the grid to get contiguous tiles
+        filled_grid = binary_fill_holes(tile_grid)
+        rows, cols = numpy.nonzero(filled_grid)
+        tile_indices = list(zip(cols.tolist(), rows.tolist()))
+
+        # Calculate the starting position (top-left of the grid)
+        starting_position = {
+            "x": xmin + reliable_fov[0] / 2,
+            "y": ymax - reliable_fov[1] / 2
+        }
+
+        return len(tile_indices), starting_position, tile_indices
 
     def _cancelAcquisition(self, future):
         """
@@ -306,31 +418,25 @@ class TiledAcquisitionTask(object):
             logging.debug("Acquisition cancelled.")
         return True
 
-    def _generateScanningIndices(self, rep):
+    def _sort_tile_indices_zigzag(self, tile_indices: List[Tuple[int, int]]) -> List[Tuple[int, int]]:
         """
-        Generate the explicit X/Y position of each tile, in the scanning order
-        # Go left/down, with every second line backward:
-        # similar to writing/scanning convention, but move of just one unit
-        # every time.
-        # A-->-->-->--v
-        #             |
-        # v--<--<--<---
-        # |
-        # --->-->-->--Z
-        rep (int, int): X, Y number of tiles
-        return (generator of tuple(int, int)): x/y positions, starting from 0,0
+        Sort the given tile indices in a zigzag scanning order.
+        :param tile_indices: List of (int, int) tuples representing the tile indices
+        :return: List of (int, int) tuples sorted in a zigzag scanning order
         """
-        # For now we do forward/backward on X (fast), and Y (slowly)
-        direction = 1
-        for iy in range(rep[1]):
-            if direction == 1:
-                for ix in range(rep[0]):
-                    yield (ix, iy)
-            else:
-                for ix in range(rep[0] - 1, -1, -1):
-                    yield (ix, iy)
+        # Sort tile_indices by row first, then column
+        tile_indices.sort(key=lambda t: (t[1], t[0]))
 
-            direction *= -1
+        # Group indices by rows and apply zigzag pattern
+        sorted_indices = []
+        for row, group in groupby(tile_indices, key=lambda t: t[1]):
+            group = list(group)
+            # Reverse the order of the group if the row is odd
+            if row % 2 == 1:
+                group.reverse()
+            sorted_indices.extend(group)
+
+        return sorted_indices
 
     def _moveToTile(self, idx, prev_idx, tile_size):
         """
@@ -343,9 +449,9 @@ class TiledAcquisitionTask(object):
         # don't move on the axis that is not supposed to have changed
         m = {}
         idx_change = numpy.subtract(idx, prev_idx)
-        if idx_change[0]:
+        if idx[0] != prev_idx[0]:  # x-axis changed
             m["x"] = self._starting_pos["x"] + idx[0] * tile_size[0] * overlap
-        if idx_change[1]:
+        if idx[1] != prev_idx[1]:  # y-axis changed
             m["y"] = self._starting_pos["y"] - idx[1] * tile_size[1] * overlap
 
         logging.debug("Moving to tile %s at %s m", idx, m)
@@ -488,7 +594,7 @@ class TiledAcquisitionTask(object):
         """
         # Number of pixels for acquisition
         pxs = sum(self._estimateStreamPixels(s) for s in self._streams)
-        pxs *= self._nx * self._ny
+        pxs *= self._number_of_tiles
 
         # Memory calculation
         mem_est = pxs * self.MEMPP
@@ -507,7 +613,7 @@ class TiledAcquisitionTask(object):
         :returns: (float) estimated required time
         """
         if remaining is None:
-            remaining = self._nx * self._ny
+            remaining = self._number_of_tiles
 
         # After the acquisition of first tile, update the time taken for subsequent tiles based on time taken for
         # previous tiles
@@ -604,7 +710,7 @@ class TiledAcquisitionTask(object):
         :return DataArray: Acquired da for the current tile stream
         """
         # Update the progress bar
-        self._future.set_progress(end=self.estimateTime((self._nx * self._ny) - i) + time.time())
+        self._future.set_progress(end=self.estimateTime(self._number_of_tiles - i) + time.time())
         # Acquire data array for passed stream
         self._future.running_subf = acqmng.acquire([stream], self._settings_obs)
         das, e = self._future.running_subf.result()  # blocks until all the acquisitions are finished
@@ -646,12 +752,8 @@ class TiledAcquisitionTask(object):
         :return: (list of list of DataArrays): list of acquired data for each stream on each tile
         """
         da_list = []  # for each position, a list of DataArrays
-        prev_idx = [0, 0]
+        prev_idx = (-1, -1)  # start with a non-existing tile index so that the first tile is always moved to and acquired
         i = 0
-        # Make sure to begin from starting position
-        logging.debug("Moving to tile (0, 0) at %s m", self._starting_pos)
-        self._future.running_subf = self._stage.moveAbs(self._starting_pos)
-        self._future.running_subf.result()
 
         self._save_time = {"acq": [], "stitch": [], "move": [], "save": []}
         # The increase in the number of scanning indices increase with overlap between tiles. The time take
@@ -661,7 +763,12 @@ class TiledAcquisitionTask(object):
         self._save_time["stitch"] = [0]
         move_to_tile_start = None
         start_time = time.time()
-        for ix, iy in self._generateScanningIndices((self._nx, self._ny)):
+
+        # Sort the tile_indices in zigzag order to optimize the stage movement
+        zigzag_indices = self._sort_tile_indices_zigzag(self._tile_indices)
+
+        for ix, iy in zigzag_indices:
+            logging.debug("Acquiring tile %dx%d", ix, iy)
 
             if i > 0:
                 self.average_acquisition_time = (time.time() - start_time) / i

--- a/src/odemis/util/test/raster_test.py
+++ b/src/odemis/util/test/raster_test.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+@author: Nandish Patel
+
+Copyright © 2025 Nandish Patel, Delmic
+
+This file is part of Odemis.
+
+Odemis is free software: you can redistribute it and/or modify it under the terms
+of the GNU General Public License version 2 as published by the Free Software
+Foundation.
+
+Odemis is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+Odemis. If not, see http://www.gnu.org/licenses/.
+"""
+import unittest
+
+import numpy
+
+from odemis.util.raster import get_polygon_grid_cells
+
+
+class TestGetPossibleIntersections(unittest.TestCase):
+    def test_triangle(self):
+        polygon = numpy.array([[1, 2], [2, 4], [3, 2], [1, 2]])
+        expected = {(1, 2), (2, 4), (3, 2), (2, 3), (2, 2), (1, 3)}  # Adjusted for correct Bresenham tracing
+        result = get_polygon_grid_cells(polygon)
+        self.assertEqual(result, expected)
+
+    def test_pentagon(self):
+        polygon = numpy.array([[3, 3], [6, 2], [7, 4], [4, 6], [3, 4], [3, 3]])
+        expected = {(7, 4), (6, 2), (5, 5), (3, 4), (6, 5), (4, 3), (4, 6), (4, 5), (3, 3), (6, 3), (5, 2)}
+        result = get_polygon_grid_cells(polygon)
+        self.assertEqual(result, expected)
+
+    def test_auto_close_polygon(self):
+        polygon = numpy.array([[2, 1], [3, 1], [4, 1], [3, 3]])  # Not explicitly closed
+        expected = {(2, 1), (3, 1), (4, 1), (3, 3), (3, 2), (4, 2)}  # Auto-closing edge must be included
+        result = get_polygon_grid_cells(polygon)
+        self.assertEqual(result, expected)
+
+    def test_square(self):
+        """Tests a simple closed square."""
+        polygon_vertices = numpy.array([[2, 2], [2, 5], [5, 5], [5, 2], [2, 2]])  # Square
+        result = get_polygon_grid_cells(polygon_vertices, include_neighbours=False)
+        expected = {
+            (2, 2), (2, 3), (2, 4), (2, 5),
+            (3, 5), (4, 5), (5, 5),
+            (5, 4), (5, 3), (5, 2),
+            (4, 2), (3, 2)
+        }
+        self.assertEqual(result, expected)
+
+    def test_neighbours_enabled(self):
+        """Tests polygon intersection with neighbour inclusion."""
+        polygon_vertices = numpy.array([[2, 2], [4, 5], [6, 2], [2, 2]])  # Triangle with neighbours
+        result = get_polygon_grid_cells(polygon_vertices, include_neighbours=True)
+
+        for row, col in [(2, 2), (3, 3), (4, 4), (5, 3), (6, 2)]:
+            self.assertIn((row, col), result)
+            self.assertIn((row + 1, col), result)
+            self.assertIn((row - 1, col), result)
+            self.assertIn((row, col + 1), result)
+            self.assertIn((row, col - 1), result)
+
+    def test_invalid_polygon(self):
+        """Tests that an invalid polygon (less than 3 vertices) raises an error."""
+        polygon_vertices = numpy.array([[1, 1], [3, 3]])  # Only 2 points (invalid)
+        with self.assertRaises(ValueError):
+            get_polygon_grid_cells(polygon_vertices, include_neighbours=False)
+        polygon_vertices = numpy.array([[1, 1, 1], [3, 3, 3], [4, 4, 4], [5, 5, 5]])
+        with self.assertRaises(ValueError):
+            get_polygon_grid_cells(polygon_vertices, include_neighbours=False)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The code changes are similar to that of FASTEM ROA which is represented by points. One difference is that `TiledAcquisitionTask` supports both a bound box and points as an input region and is backwards compatible.

Attached an image for overview image acquisition of a rotated rectangle
![Screenshot from 2025-01-24 14-25-46](https://github.com/user-attachments/assets/a66a9fd6-9d00-4984-ad5e-5014e4949795)
