### PR TITLE
[fix] GUI conf: don't fail to start if licence file is not available

### DIFF
--- a/src/odemis/gui/conf/licences.py
+++ b/src/odemis/gui/conf/licences.py
@@ -1,3 +1,25 @@
+# -*- coding: utf-8 -*-
+"""
+Created on 20 Jan 2025
+
+@author: Patrick Cleeve
+
+Copyright © 2025 Delmic
+
+This file is part of Odemis.
+
+Odemis is free software: you can redistribute it and/or modify it under the terms
+of the GNU General Public License version 2 as published by the Free Software
+Foundation.
+
+Odemis is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+Odemis. If not, see http://www.gnu.org/licenses/.
+"""
+
 import configparser
 import logging
 import os
@@ -8,7 +30,7 @@ from odemis.gui.conf.file import CONF_PATH
 
 # tmp flag for odemis advanced mode
 # TODO: remove and replace once the licenced version is released
-def get_license_enabled() -> bool:
+def get_license_enabled() -> dict:
     """
     Temporary function to get the license status.
     Allows to enable/disable without changing the code.
@@ -17,29 +39,33 @@ def get_license_enabled() -> bool:
     fibsem_enabled = False
     milling_enabled = False
     correlation_enabled = False
+    expires_at = datetime(1970, 1, 1)  # default to 1970-01-01
+
     odemis_advanced_config = os.path.abspath(os.path.join(CONF_PATH, "odemis_advanced.config"))
     if os.path.exists(odemis_advanced_config):
         config = configparser.ConfigParser(interpolation=None)
         config.read(odemis_advanced_config)
+        if "licence" not in config:
+            config["licence"] = {}
+
         enabled = config["licence"].get("enabled", "False") == "True"
         fibsem_enabled = config["licence"].get("fibsem", "True") == "True"
         milling_enabled = config["licence"].get("milling", "True") == "True"
         correlation_enabled = config["licence"].get("correlation", "True") == "True"
 
-        # expiry date
-        expires_at = config["licence"].get("expires_at", "1970-01-01") # YYYY-MM-DD
-        if expires_at:
+        # Decode expiry date as YYYY-MM-DD
+        if "expires_at" in config["licence"]:
             try:
-                expires_at = datetime.strptime(expires_at, "%Y-%m-%d")
+                expires_at = datetime.strptime(config["licence"]["expires_at"], "%Y-%m-%d")
             except ValueError:
                 logging.error("Invalid date format in odemis_advanced.config: 'expires_at' must be in the format 'YYYY-MM-DD'")
-                expires_at = datetime(1970, 1, 1) # default to 1970-01-01
-            if expires_at < datetime.now():
-                enabled = False
-                fibsem_enabled = False
-                milling_enabled = False
-                correlation_enabled = False
-                logging.warning("odemis-advanced licence has expired on %s", expires_at.strftime("%Y-%m-%d"))
+
+        if expires_at < datetime.now():
+            enabled = False
+            fibsem_enabled = False
+            milling_enabled = False
+            correlation_enabled = False
+            logging.warning("odemis-advanced licence has expired on %s", expires_at.strftime("%Y-%m-%d"))
 
     logging.debug(f"odemis-advanced mode is {'enabled' if enabled else 'disabled'}")
     return {"enabled": enabled,


### PR DESCRIPTION
Commit 249adb9a0 (migrate licence file, add expiry date) introduced
a bug which prevented the GUI from starting when the licence file
is not present.

=> always define "expires_at" variable.

Also add a header to the file.