### PR TITLE
[TRCL-582][feat] SPARC align: allow to control the slit opening in TUNNEL alignment

### DIFF
--- a/src/odemis/gui/cont/tabs/sparc2_align_tab.py
+++ b/src/odemis/gui/cont/tabs/sparc2_align_tab.py
@@ -314,6 +314,12 @@ class Sparc2AlignTab(Tab):
                                         add_to_view=self.panel.vp_align_lens_ext.view)
                     self._ccd_spe_ext.stream_panel.flatten()
 
+                    # When going to tunnel-lens-align, the slit-in is automatically opened at the maximum.
+                    # Still, add a slit-in axis control to the stream panel, so that it's possible to go to
+                    # the minimum opening, in order to do a fine alignment in X.
+                    hw_conf = get_hw_config(spec, main_data.hw_settings_config)
+                    self._ccd_spe_ext.add_axis_entry("slit-in", spec, hw_conf.get("slit-in"))
+
                     # To activate the SEM spot when the external CCD plays
                     ccd_stream_ext.should_update.subscribe(self._on_ccd_stream_play)
 


### PR DESCRIPTION
Typically, the tunnel alignment is done with the spectrograph slit-in opened
to the maximum. However, once the alignment is reached, it helps to
confirm it by setting the slit to the minimum opening. Then, optimizing the light intensity
while moving in X can help the alignment.