### PR TITLE
[fix] picoquant related test cases

### DIFF
--- a/src/odemis/driver/test/picoquant_test.py
+++ b/src/odemis/driver/test/picoquant_test.py
@@ -124,7 +124,7 @@ class TestHH400Static(unittest.TestCase):
         self.assertRaises(Exception, picoquant.HH400, **wrong_config)
 
 
-class TestPicoBase(metaclass=ABCMeta):
+class PicoBaseTest(metaclass=ABCMeta):
     """
     Tests which can share a device initialization.
     To be inherited, for each type of device. The subclass should also inherit unittest.TestCase.
@@ -372,7 +372,7 @@ class TestPicoBase(metaclass=ABCMeta):
         self._lastdata = data
 
 
-class TestPH300(TestPicoBase, unittest.TestCase):
+class TestPH300(PicoBaseTest, unittest.TestCase):
     """
     Tests which can share one PH300 device
     """
@@ -387,7 +387,7 @@ class TestPH300(TestPicoBase, unittest.TestCase):
                 cls.det1 = child
 
 
-class TestPH330(TestPicoBase, unittest.TestCase):
+class TestPH330(PicoBaseTest, unittest.TestCase):
     """
     Tests which can share one PH330 device
     """
@@ -413,7 +413,7 @@ class TestPH330(TestPicoBase, unittest.TestCase):
         super().tearDownClass()
 
 
-class TestHH400(TestPicoBase, unittest.TestCase):
+class TestHH400(PicoBaseTest, unittest.TestCase):
     """
     Tests which can share one HH400 device
     """
@@ -458,7 +458,7 @@ class TestHH400(TestPicoBase, unittest.TestCase):
             self.assertEqual(self.dev.syncDiv.value, i)
 
 
-class TestPicoShuttersMixin(metaclass=ABCMeta):
+class PicoShuttersMixinTest(metaclass=ABCMeta):
     """
     Extra tests for devices with shutters.
     """
@@ -513,7 +513,7 @@ class TestPicoShuttersMixin(metaclass=ABCMeta):
         self.assertEqual(self.tc_act.position.value["shutter1"], 0)
 
 
-class TestPH300Shutters(TestPicoShuttersMixin, TestPH300):
+class TestPH300Shutters(PicoShuttersMixinTest, TestPH300):
     """
     Tests PH300 with shutters.
     """
@@ -535,7 +535,7 @@ class TestPH300Shutters(TestPicoShuttersMixin, TestPH300):
                 cls.det1 = child
 
 
-class TestPH330Shutters(TestPicoShuttersMixin, TestPH330):
+class TestPH330Shutters(PicoShuttersMixinTest, TestPH330):
     """
     Tests PH330 with shutters.
     """
@@ -556,7 +556,7 @@ class TestPH330Shutters(TestPicoShuttersMixin, TestPH330):
                 cls.det1 = child
 
 
-class TestHH400Shutters(TestPicoShuttersMixin, TestHH400):
+class TestHH400Shutters(PicoShuttersMixinTest, TestHH400):
     """
     Tests HH400 with shutters.
     """

--- a/src/odemis/driver/test/pmtctrl_test.py
+++ b/src/odemis/driver/test/pmtctrl_test.py
@@ -47,14 +47,23 @@ KWARGS_CTRL = KWARGS
 
 # Time-correlator Control (photon signal detector)
 class FakePH300(model.Component):
+    # For use by the RawDetector
+    trg_lvl_rng = (0, 100e-3)  # V
+    zc_lvl_rng = (0, 100e-3)  # V
+
     def __init__(self, name):
         self._shutters = {'shutter1': False}
         model.Component.__init__(self, name)
+
     def _toggle_shutters(self, shutters, open):
         for s in shutters:
             self._shutters[s] = open
+
     def GetCountRate(self, channel):
         return random.randint(0, 5000)
+
+    def SetInputCFD(self, channel, level, zero_cross):
+        pass
 
 
 CLASS_TR_CTRL = picoquant.RawDetector
@@ -358,7 +367,6 @@ class TestTCPMT(unittest.TestCase):
         # Protection should be reset after acquisition is done
         self.assertEqual(self.control.parent._shutters['shutter1'], False)
 
-
     def receive_image(self, dataflow, image):
         """
         callback for df
@@ -368,6 +376,7 @@ class TestTCPMT(unittest.TestCase):
 
         dataflow.unsubscribe(self.receive_image)
         self.is_received.set()
+
 
 class MatchLogHandler(BufferingHandler):
     def __init__(self, matcher):
@@ -395,6 +404,7 @@ class MatchLogHandler(BufferingHandler):
                 result = True
                 break
         return result
+
 
 class Matcher(object):
 


### PR DESCRIPTION
Commit 730491daad (picoquant: add support for PH330) changed the classes
to share a base class, both for the main driver classes and the test
classes.

This broke a couple of test cases (nothing actually running on a
microscope).
=> Change the name of the testing base class to not start with "Test"
because pytest thinks it a test (although unittest doesn't).

=> Adjust the mock FakePH300 class to be compatible with the new code
expectations.