### PR TITLE
[fix] acq_test test_metadata failed

### DIFF
--- a/src/odemis/acq/test/acq_test.py
+++ b/src/odemis/acq/test/acq_test.py
@@ -343,8 +343,8 @@ class SPARCTestCase(unittest.TestCase):
         data, exp = f.result()
         self.assertIsNone(exp)
 
-        spec1_data = data[0][1]
-        spec2_data = data[0][3]
+        spec1_data = data[1]
+        spec2_data = data[3]
         self.assertEqual(spec1_data.metadata[model.MD_EXTRA_SETTINGS]["Microscope"]['Model'],
                          ("sparc", None))
         self.assertEqual(spec1_data.metadata[model.MD_EXTRA_SETTINGS][self.spec.name]['binning'],


### PR DESCRIPTION
commit e0424ae90a51 (acq_test: adjust acqmng.acquire() API usage) made
the code more explicit for receiving the errors, but didn't adjust the
follow up code. So that broke the test.

=> now that the two return values data & exp are separate, "data" can be
accessed directly.