### PR TITLE
[fix] Reported Detector.transpose was incorrect when using the default value

### DIFF
--- a/src/odemis/model/_components.py
+++ b/src/odemis/model/_components.py
@@ -607,7 +607,8 @@ class Detector(HwComponent, metaclass=ABCMeta):
     @roattribute
     def transpose(self):
         if self._transpose is None:
-            return tuple(range(len(self._shape) - 1))
+            # Should look like (1, 2, ...)
+            return tuple(range(1, len(self._shape)))
         else:
             return self._transpose
 


### PR DESCRIPTION
When no transp argument is passed, the default transpose is computed
based on the shape. The image would be (correctly) not transposed, but
the reported value was an impossible value such as "(0, 1)", instead of
"(1, 2)".