### PR TITLE
[fix] andorcam2 should automatically disable shutter if full vertical binning

### DIFF
--- a/src/odemis/driver/andorcam2.py
+++ b/src/odemis/driver/andorcam2.py
@@ -2155,8 +2155,8 @@ class AndorCam2(model.DigitalCamera):
             elif readout < (self._exposure_time / 100):
                 logging.info("Leaving shutter opened because readout is %g times "
                              "smaller than exposure", self._exposure_time / readout)
-            elif b[1] == im_res[1]:
-                logging.info("Leaving shutter opened because binning is full vertical")
+            elif b[1] == self._shape[1]:
+                logging.info("Leaving shutter opened because binning is full vertical (%s px)", b[1])
             else:
                 logging.info("Shutter activated")
                 shutter_active = True


### PR DESCRIPTION
The code to check for full vertical binning was incorrect. It would work
only on cameras with vertical resolution == 1... which typically don't
have a shutter.
Now properly check by comparing the binning to the raw detector size.