### PR TITLE
[TRCL-570][feat] introduce startScan Event to synchronize CCD with e-beam during SPARC acq

### DIFF
--- a/src/odemis/acq/stream/_sync.py
+++ b/src/odemis/acq/stream/_sync.py
@@ -1086,7 +1086,7 @@ class SEMCCDMDStream(MultipleDetectorStream):
         self._sccd = s1
         self._ccd = s1._detector
         self._ccd_df = s1._dataflow
-        self._trigger = self._ccd.softwareTrigger
+        self._trigger = self._emitter.startScan  # to acquire a CCD image every time the SEM starts a new scan
         self._ccd_idx = len(self._streams) - 1  # optical detector is always last in streams
 
     def _supports_hw_sync(self):
@@ -1685,11 +1685,6 @@ class SEMCCDMDStream(MultipleDetectorStream):
             # retrigger, or unsynchronise/resynchronise just before the end of
             # last scan).
 
-            # prepare detector
-            self._ccd_df.synchronizedOn(self._trigger)
-            # subscribe to last entry in _subscribers (optical detector)
-            self._ccd_df.subscribe(self._subscribers[self._ccd_idx])
-
             # Instead of subscribing/unsubscribing to the SEM for each pixel,
             # we've tried to keep subscribed, but request to be unsynchronised/
             # synchronised. However, synchronizing doesn't cancel the current
@@ -1730,6 +1725,12 @@ class SEMCCDMDStream(MultipleDetectorStream):
             logging.debug("Scanning resolution is %s and scale %s",
                           self._emitter.resolution.value,
                           self._emitter.scale.value)
+
+            # Prepare CCD: acquire one frame every time the SEM starts scanning.
+            # The SEM may scan multiple times for each CCD frame.
+            self._ccd_df.synchronizedOn(self._trigger)
+            # Get the CCD ready to acquire
+            self._ccd_df.subscribe(self._subscribers[self._ccd_idx])
 
             last_ccd_update = 0
             start_t = time.time()
@@ -1933,27 +1934,12 @@ class SEMCCDMDStream(MultipleDetectorStream):
             if self._acq_state == CANCELLED:
                 raise CancelledError()
 
-            # subscribe to _subscribers
+            # Start "all" the scanners (typically there is just one). The last one is the CCD, which
+            # is already subscribed, but waiting for the startScan event.
+            # As soon as the e-beam starts scanning (which can take a couple of ms), the
+            # startScan event is sent, which triggers the acquisition of one CCD frame.
             for s, sub in zip(self._streams[:-1], self._subscribers[:-1]):
                 s._dataflow.subscribe(sub)
-            # TODO: in theory (aka in a perfect world), the ebeam would immediately
-            # be at the requested position after the subscription starts. However,
-            # that's not exactly the case due to:
-            # * physics limits the speed of voltage change in the ebeam column,
-            #   so it takes the "settle time" before the beam is at the right
-            #   place (in the order of 10 µs).
-            # * the (odemis) driver is asynchronous, and between the moment it
-            #   receives the request to start and the actual moment it asks the
-            #   hardware to change voltages, several ms might have passed.
-            # One thing that would help is to not park the e-beam between each
-            # spot. This way, the ebeam would reach the position much quicker,
-            # and if it's not yet at the right place, it's still not that far.
-            # In the meantime, waiting a tiny bit ensures the CCD receives the
-            # right data.
-            time.sleep(5e-3)  # give more chances spot has been already processed
-
-            # send event to detector to acquire one image
-            self._trigger.notify()
 
             # wait for detector to acquire image
             timedout = self._waitForImage(img_time)
@@ -2018,6 +2004,11 @@ class SEMCCDMDStream(MultipleDetectorStream):
                 leech_nimg[li] -= 1
                 if leech_nimg[li] == 0:
                     try:
+                        # Temporarily switch the CCD to a different event trigger, so that it
+                        # doesn't get triggered while the leech is running (because it could use the
+                        # e-beam, which would send a startScan event)
+                        self._ccd_df.synchronizedOn(self._ccd.softwareTrigger)
+
                         nimg = l.next([d[-1] for d in self._acq_data])
                         logging.debug("Ran leech %s successfully. Will run next leech after %s acquisitions.", l, nimg)
                     except Exception:
@@ -2026,6 +2017,9 @@ class SEMCCDMDStream(MultipleDetectorStream):
                     leech_nimg[li] = nimg
                     if self._acq_state == CANCELLED:
                         raise CancelledError()
+
+                    # re-use the real trigger
+                    self._ccd_df.synchronizedOn(self._trigger)
 
             # Since we reached this point means everything went fine, so
             # no need to retry
@@ -2055,12 +2049,12 @@ class SEMCCDMDStream(MultipleDetectorStream):
           CancelledError() if cancelled
           Exceptions if error
         """
-        # The idea of the acquiring with a scan stage:
+        # The main steps of an acquisition with a scan stage:
         #  (Note we expect the scan stage to be about at the center of its range)
         #  * Move the ebeam to 0, 0 (center), for the best image quality
-        #  * Start CCD acquisition with software synchronisation
+        #  * Start CCD acquisition with synchronisation on e-beam startScan
         #  * Move to next position with the stage and wait for it
-        #  * Start SED acquisition and trigger CCD
+        #  * Start SED acquisition -> startScan event triggers CCD
         #  * Wait for the CCD/SED data
         #  * Repeat until all the points have been scanned
         #  * Move back the stage to center in case of an 'independent' stage
@@ -2170,11 +2164,10 @@ class SEMCCDMDStream(MultipleDetectorStream):
                     if self._acq_state == CANCELLED:
                         raise CancelledError()
 
+                    # Start e-beam scan. As soon as it really starts, a startScan event is sent, which
+                    # triggers the CCD acquisition.
                     for s, sub in zip(self._streams[:-1], self._subscribers[:-1]):
                         s._dataflow.subscribe(sub)
-
-                    time.sleep(5e-3)  # give more chances spot has been already processed
-                    self._trigger.notify()
 
                     # wait for detector to acquire image
                     timedout = self._waitForImage(px_time)
@@ -2261,6 +2254,11 @@ class SEMCCDMDStream(MultipleDetectorStream):
                                 sstage.moveAbsSync(orig_spos)
                                 prev_spos.update(orig_spos)
                             try:
+                                # Temporarily switch the CCD to a different event trigger, so that it
+                                # doesn't get triggered while the leech is running (because it could use the
+                                # e-beam, which would send a startScan event)
+                                self._ccd_df.synchronizedOn(self._ccd.softwareTrigger)
+
                                 np = l.next([d[-1] for d in self._acq_data])
                             except Exception:
                                 logging.exception("Leech %s failed, will retry next pixel", l)
@@ -2268,6 +2266,9 @@ class SEMCCDMDStream(MultipleDetectorStream):
                             leech_np[li] = np
                             if self._acq_state == CANCELLED:
                                 raise CancelledError()
+
+                            # re-use the real trigger
+                            self._ccd_df.synchronizedOn(self._trigger)
 
                     for i, das in enumerate(self._acq_data):
                         self._assembleLiveData(i, das[-1], px_idx, cor_pos, rep, 0)

--- a/src/odemis/acq/stream/_sync.py
+++ b/src/odemis/acq/stream/_sync.py
@@ -175,7 +175,7 @@ class MultipleDetectorStream(Stream, metaclass=ABCMeta):
         self._current_scan_area = None  # l,t,r,b (int)
 
         # Start threading event for live update overlay
-        self._live_update_period = 2
+        self._live_update_period = 2  # s
         self._im_needs_recompute = threading.Event()
         self._init_thread(self._live_update_period)
 
@@ -2603,8 +2603,8 @@ class SEMMDStream(MultipleDetectorStream):
                 for i, s in enumerate(self._streams):
                     timeout = max(5.0, max_end_t - time.time())
                     if not self._acq_complete[i].wait(timeout):
-                        raise TimeoutError("Acquisition of repetition stream for frame %s timed out after %g s"
-                                           % (self._emitter.translation.value, time.time() - max_end_t))
+                        raise TimeoutError("Acquisition of repetition stream at pos %s timed out after %g s"
+                                           % (self._emitter.translation.value, time.time() - start))
                     if self._acq_state == CANCELLED:
                         raise CancelledError()
                     s._dataflow.unsubscribe(self._subscribers[i])

--- a/src/odemis/driver/semcomedi.py
+++ b/src/odemis/driver/semcomedi.py
@@ -1232,6 +1232,8 @@ class SEMComedi(model.HwComponent):
                     stop_arg=nrscans)
         start = time.time()
 
+        self._scanner.startScan.notify()  # Special event that will only actually notify on the first call
+
         # run the commands
         self._reader.run()
         self._writer.run()
@@ -1336,6 +1338,7 @@ class SEMComedi(model.HwComponent):
             comedi.internal_trigger(self._device, self._ao_subdevice, self._ao_trig)
 
         comedi.internal_trigger(self._device, self._ai_subdevice, 0)
+        self._scanner.startScan.notify()  # Special event that will only actually notify on the first call
 
         self._reader.run()
         if nwscans != 1:
@@ -1649,6 +1652,8 @@ class SEMComedi(model.HwComponent):
                     self.set_to_resting_position()
                     # wait until something new comes in
                     self._check_cmd_q(block=True)
+
+                    self._scanner.startScan.clear()  # Get ready for the next scan
         except CancelledError:
             logging.info("Acquisition threading terminated on request")
         except Exception:
@@ -1660,6 +1665,7 @@ class SEMComedi(model.HwComponent):
             except comedi.ComediError:
                 # can happen if the driver already terminated
                 pass
+            self._scanner.startScan.clear()  # Get ready for the next scan
             logging.info("Acquisition thread closed")
             self._acquisition_thread = None
 
@@ -2664,6 +2670,9 @@ class Scanner(model.Emitter):
         t.daemon = True
         t.start()
         self.indicate_scan_state(False)
+
+        # Event which is triggered at the beginning of the first frame of a scan
+        self.startScan = driver.EventOnce()
 
         # In theory the maximum resolution depends on the X/Y ranges, the actual
         # ranges that can be used and the maxdata. It also depends on the noise

--- a/src/odemis/driver/semnidaq.py
+++ b/src/odemis/driver/semnidaq.py
@@ -772,6 +772,7 @@ class Acquirer:
         try:
             self._scanner.active_ttl_mng.indicate_state(True)
             self._scanner.active_ttl_mng.wait_active()  # Blocks until the scan state is set
+            self._scanner.startScan.clear()  # Indicate the next notification should be sent (first frame)
 
             while True:
                 # Any more messages to process? Some could have arrived in the meantime
@@ -1405,6 +1406,7 @@ class Acquirer:
 
         # Now start!
         ai_task.start()
+        self._scanner.startScan.notify()  # Special event that will only actually notify on the first frame
         logging.debug("AI task started (with AO + DO too)")
 
         n_analog_det = len(acq_settings.analog_detectors)
@@ -2371,6 +2373,9 @@ class Scanner(model.Emitter):
         # Manage the "slow" TTL signals
         self.active_ttl_mng = ActiveTTLManager(parent, self, scanning_ttl or {}, scan_active_delay,
                                                self._on_active_state_change)
+
+        # Event which is triggered at the beginning of the first frame of a scan
+        self.startScan = driver.EventOnce()
 
         # Validate fast TTLs
         fast_do_channels = set()  # set of ints, to check all channels are unique

--- a/src/odemis/driver/simsem.py
+++ b/src/odemis/driver/simsem.py
@@ -132,6 +132,9 @@ class Scanner(model.Emitter):
         self._aperture = aperture
         self._working_distance = wd
 
+        # Event which is triggered at the beginning of the first frame of a scan
+        self.startScan = model.Event()
+
         fake_img = self.parent.fake_img
         if parent._drift_period:
             # half the size, to keep some margin for the drift
@@ -530,6 +533,7 @@ class Detector(model.Detector):
         the Dataflow.
         """
         try:
+            first_frame = True
             while not self._acquisition_must_stop.is_set():
                 dwelltime = self.parent._scanner.dwellTime.value
                 resolution = self.parent._scanner.resolution.value
@@ -540,6 +544,9 @@ class Detector(model.Detector):
                 # as in Odemis the convention for SEM is that the ebeam waits
                 # for _all_ the detectors to be ready before scanning.
                 self.data._waitSync()
+                if first_frame:  # startScan event is sent at the beginning of the *first* frame only
+                    self.parent._scanner.startScan.notify()
+                    first_frame = False
                 callback(self._simulate_image())
         except Exception:
             logging.exception("Unexpected failure during image acquisition")

--- a/src/odemis/driver/test/semcomedi_test.py
+++ b/src/odemis/driver/test/semcomedi_test.py
@@ -531,49 +531,6 @@ class TestSEM(unittest.TestCase):
 
         self.assertEqual(self.left, 0)
 
-#     @unittest.skip("simple")
-    def test_new_position_event(self):
-        """
-        check the new position works at least when the frequency is not too high
-        """
-        self.scanner.dwellTime.value = 1e-3
-        self.size = (10, 10)
-        self.scanner.resolution.value = self.size
-        numbert = numpy.prod(self.size)
-        # pixel write/read setup is pretty expensive ~10ms
-        expected_duration = self.compute_expected_duration() + numbert * 0.01
-
-        self.left = 1 # unsubscribe just after one
-        self.events = 0 # reset
-
-        # simulate the synchronizedOn() method of a DataFlow
-        self.scanner.newPixel.subscribe(self)
-
-        self.sed.data.subscribe(self.receive_image)
-        for i in range(10):
-            # * 2 because it can be quite long to setup each pixel.
-            time.sleep(expected_duration * 2 / 10)
-            if self.left == 0:
-                break # just to make it quicker if it's quicker
-
-        self.assertEqual(self.left, 0)
-
-        # Note: there could be slightly more events if the next acquisition starts,
-        # and that's kind of ok (although it's better to be able to stop the
-        # acquisition immediately after receiving the right number of images)
-        self.assertEqual(self.events, numbert)
-
-        self.scanner.newPixel.unsubscribe(self)
-        self.sed.data.get()
-        time.sleep(0.1)
-        self.assertEqual(self.events, numbert)
-
-    def onEvent(self):
-        """
-        Called by the SEM when a new position happens
-        """
-        self.events += 1
-
     def receive_image(self, dataflow, image):
         """
         callback for df of test_acquire_flow()

--- a/src/odemis/driver/test/simsem_test.py
+++ b/src/odemis/driver/test/simsem_test.py
@@ -95,6 +95,19 @@ class TestSEMStatic(unittest.TestCase):
         sem.terminate()
         daemon.shutdown()
 
+
+class EventReceiver:
+    """
+    Helper class to receive model.Events
+    """
+    def __init__(self):
+        self.count = 0
+
+    def onEvent(self):
+        logging.debug("Received an event")
+        self.count += 1
+
+
 class TestSEM(unittest.TestCase):
     """
     Tests which can share one SEM device
@@ -364,6 +377,10 @@ class TestSEM(unittest.TestCase):
     def test_acquire_flow(self):
         expected_duration = self.compute_expected_duration()
 
+        # Also check that the startScan event is properly sent just once after the first acquisition
+        evt_counter = EventReceiver()
+        self.scanner.startScan.subscribe(evt_counter)
+
         number = 5
         self.left = number
         self.sed.data.subscribe(self.receive_image)
@@ -371,6 +388,9 @@ class TestSEM(unittest.TestCase):
         self.acq_done.wait(number * (2 + expected_duration * 1.1))  # 2s per image should be more than enough in any case
 
         self.assertEqual(self.left, 0)
+
+        self.assertEqual(evt_counter.count, 1)
+        self.scanner.startScan.unsubscribe(evt_counter)
 
     def test_acquire_with_va(self):
         """
@@ -429,6 +449,10 @@ class TestSEM(unittest.TestCase):
         number = 5
         expected_duration = self.compute_expected_duration()
 
+        # Also check that the startScan event is properly sent just once after the first acquisition
+        evt_counter = EventReceiver()
+        self.scanner.startScan.subscribe(evt_counter)
+
         self.left = 10000 + number # don't unsubscribe automatically
 
         for i in range(number):
@@ -438,6 +462,9 @@ class TestSEM(unittest.TestCase):
 
         # if it has acquired a least 5 pictures we are already happy
         self.assertLessEqual(self.left, 10000)
+
+        self.assertEqual(evt_counter.count, number)
+        self.scanner.startScan.unsubscribe(evt_counter)
 
     def receive_image(self, dataflow, image):
         """

--- a/src/odemis/util/driver.py
+++ b/src/odemis/util/driver.py
@@ -374,6 +374,24 @@ def checkLightBand(band):
     # no error found
 
 
+class EventOnce(model.Event):
+    """
+    Special Event class which passes the event only once to the listener (using .notify()),
+    until it's reset (using .clear()).
+    """
+    def __init__(self):
+        super().__init__()
+        self._notified = False
+
+    def notify(self):
+        if not self._notified:
+            self._notified = True
+            super().notify()
+
+    def clear(self):
+        self._notified = False
+
+
 # Special trick functions for speeding up Pyro start-up
 def _speedUpPyroVAConnect(comp):
     """

--- a/src/odemis/util/test/driver_test.py
+++ b/src/odemis/util/test/driver_test.py
@@ -41,7 +41,7 @@ from odemis.util.driver import (
     getSerialDriver,
     guessActuatorMoveDuration,
     readMemoryUsage,
-    speedUpPyroConnect,
+    speedUpPyroConnect, EventOnce,
 )
 
 logging.getLogger().setLevel(logging.DEBUG)
@@ -94,6 +94,31 @@ class TestDriver(unittest.TestCase):
         else:
             with self.assertRaises(LookupError):
                 v = get_linux_version()
+
+    def onEvent(self):
+        """
+        callback for the Event
+        """
+        self._event_notifications += 1
+
+    def test_event_once(self):
+        self._event_notifications = 0
+
+        event = EventOnce()
+        event.subscribe(self)
+
+        # Should send the first notification
+        event.notify()
+        self.assertEqual(self._event_notifications, 1)
+        # and all further notifications should be ignored
+        event.notify()
+        event.notify()
+        self.assertEqual(self._event_notifications, 1)
+
+        # ... until we reset the event
+        event.clear()
+        event.notify()
+        self.assertEqual(self._event_notifications, 2)
 
     def test_estimateMoveDuration(self):
         """Test estimateMoveDuration takes the correct input and returns a correct estimation."""


### PR DESCRIPTION
From the moment that the acquisition ask the e-beam scanner to start and the e-beam is actually at the right position, it takes *some* time.  It's in the order of a few ms. So far, the only e-beam scanner was  semcomedi, and it was (surprisingly) constant in terms of time. It would  take between 2 and 5 ms. So it was good enough to just always wait 5ms.

We now also have semnidaq, and the NI-DAQ library introduces a lot longer latency. While it can be as "fast" as 10ms, it sometimes takes 40ms to start a scan. There are probably ways to make it a little faster, but it's  unlikely it will be possible to always keep all scanners < 5ms.
    
=> Use a new Event, startScan, for the e-beam scanner to report the e-beam is ready. Then, we can use it to directly start a CCD acquisition.