### PR TITLE
[feat] SettingsObserver should also store axes "user-friendly" info if available

### DIFF
--- a/src/odemis/acq/acqmng.py
+++ b/src/odemis/acq/acqmng.py
@@ -29,7 +29,7 @@ from concurrent.futures import CancelledError
 import logging
 import os
 import threading
-from typing import Set
+from typing import Set, Dict
 
 from odemis import model
 from odemis.acq import _futures
@@ -726,11 +726,31 @@ class SettingsObserver(object):
                     continue
                 # Store current value of VA (calling .value might take some time)
                 self._all_settings[comp.name][va_name] = [va.value, va.unit]
+
+                if va_name == "position" and hasattr(comp, "axes") and isinstance(comp.axes, dict):
+                    # For the .position, the axes definition may contain also the "user-friendly" name
+                    # of the axis, so we can add it to the metadata.
+                    def update_settings(value: Dict[str, float], comp_name=comp.name, va_name=va_name, comp=comp):
+                        try:
+                            axes_def: Dict[str, model.Axis] = comp.axes
+                            value = value.copy()
+                            for axis_name, p in value.items():
+                                if (axis_name in axes_def and hasattr(axes_def[axis_name], "choices")
+                                    and isinstance(axes_def[axis_name].choices, dict)
+                                    and p in axes_def[axis_name].choices
+                                   ):
+                                    value[axis_name] = f"{p} ({axes_def[axis_name].choices[p]})"
+                        except Exception:
+                            logging.exception("Failed to interpret user-friendly axis info for %s.position", comp_name)
+
+                        self._all_settings[comp_name][va_name][0] = value
+                else:  # Standard version: just store the VA value as-is
+                    def update_settings(value, comp_name=comp.name, va_name=va_name):
+                        self._all_settings[comp_name][va_name][0] = value
+
                 # Subscribe to VA, update dictionary on callback
-                def update_settings(value, comp_name=comp.name, va_name=va_name):
-                    self._all_settings[comp_name][va_name][0] = value
                 self._va_updaters.append(update_settings)
-                va.subscribe(update_settings)
+                va.subscribe(update_settings, init=True)
 
     def get_all_settings(self):
         return copy.deepcopy(self._all_settings)


### PR DESCRIPTION
For some axes, the "position" is an abritrary number. For instance, on
the spectrograph, the band is 1->4. This is not helpful for the user.
However, the .axes contains the information to map that value (eg, 1) to
a user-friendly description (eg, "1200 l/mm (blaze: 500.0)").

Several SPARC users requested for this info to be stored too.

=> When available, also store the axis definition.