### PR TITLE
[fix] actuator test failure attempting to change readonly speed

### DIFF
--- a/src/odemis/driver/test/simulated_test.py
+++ b/src/odemis/driver/test/simulated_test.py
@@ -105,24 +105,6 @@ class ActuatorTest(object):
         f.result()  # wait
         testing.assert_pos_almost_equal(move, self.dev.position.value, atol=1e-7)
 
-        # Move to 0 (int), which used to cause a bug in the speed computation
-        speed = {}
-        for axis in self.dev.axes:
-            rng = self.dev.axes[axis].range
-            move[axis] = rng[0]
-            print(rng)
-            speed[axis] = (rng[1] - rng[0]) / 1  # 1 s to go to whole range
-        self.dev.moveAbsSync(move)
-        logging.info("Updating speed to %s", speed)
-        self.dev.speed.value = speed
-
-        # Should take ~1s (used to take 5s)
-        move = {a: 0 for a in self.dev.axes}
-        t_start = time.time()
-        self.dev.moveAbsSync(move)
-        t_end = time.time()
-        self.assertLess(t_end - t_start, 2)
-
     def test_moveRel(self):
         prev_pos = self.dev.position.value
         move = {}
@@ -219,6 +201,34 @@ class StageTest(unittest.TestCase, ActuatorTest):
 
     def tearDown(self):
         ActuatorTest.tearDown(self)
+
+    def test_moveAbs_0(self):
+        """
+        Move to 0 (int), which used to cause a bug in the speed computation, making the move very slow.
+        """
+        move = {}
+        # move to the centre
+        for axis in self.dev.axes:
+            rng = self.dev.axes[axis].range
+            move[axis] = (rng[0] + rng[1]) / 2
+        self.dev.moveAbsSync(move)
+
+        speed = {}
+        for axis in self.dev.axes:
+            rng = self.dev.axes[axis].range
+            move[axis] = rng[0]
+            print(rng)
+            speed[axis] = (rng[1] - rng[0]) / 1  # 1 s to go to whole range
+        self.dev.moveAbsSync(move)
+        logging.info("Updating speed to %s", speed)
+        self.dev.speed.value = speed
+
+        # Should take ~1s (used to take 5s)
+        move = {a: 0 for a in self.dev.axes}
+        t_start = time.time()
+        self.dev.moveAbsSync(move)
+        t_end = time.time()
+        self.assertLess(t_end - t_start, 2)
 
 
 class ChamberTest(unittest.TestCase):


### PR DESCRIPTION
Commit 81ee0f745f78 (simulated stage could take very long doing an
absolute move to 0) added a test to check that moving to 0 is not
especially slow, on the simulated stage. However it extend the generic
test case ActuatorTest. That class is used for testing other stages...
which didn't work with this very special test case.
=> Move the test case to only the StageTest, which is dedicated to the
simulated Stage.