### PR TITLE
[fix] odemis-select-mic-start should start the GUI with the configured log level

### DIFF
--- a/install/linux/usr/bin/odemis-select-mic-start
+++ b/install/linux/usr/bin/odemis-select-mic-start
@@ -111,7 +111,9 @@ if [ $status == 0 ] || [ $status == 3 ] ; then
         sudo odemis-stop
     elif [ "$reply" == "GUI only" ]; then
         echo "Trying to start the GUI"
-        odemis-gui
+        # Read the LOGLEVEL from the configuration file
+        . /etc/odemis.conf
+        odemis-gui --log-level ${LOGLEVEL:-1}
         exit
     else
         exit


### PR DESCRIPTION
Need to read the log level from the configuration file and pass it to
the GUI. Otherwise, the log level for the GUI is fixed to (the default) WARNING.