### PR TITLE
[TRCL-543] [fix] odemisd: handle metadata for monochromator with both spectrograph and filter

### DIFF
--- a/src/odemis/odemisd/mdupdater.py
+++ b/src/odemis/odemisd/mdupdater.py
@@ -21,7 +21,8 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 '''
 import collections
 import logging
-import numpy
+from typing import Optional, Tuple, Dict, Union, Iterable
+
 from odemis import model
 
 
@@ -54,6 +55,10 @@ class MetadataUpdater(model.Component):
         # All the components already observed
         # str -> set of str: name of affecting component -> names of affected
         self._observed = collections.defaultdict(set)
+
+        # To handle monochromator (aka detectors), which are affected both by the spectrograph and the filter
+        self._det_to_spectrograph : Dict[str, model.HwComponent] = {}  # Detector name -> Spectrograph that affects that detector
+        self._det_to_filter : Dict[str, model.HwComponent] = {}  # Detector name -> Filter that affects that detector
 
         microscope.alive.subscribe(self._onAlive, init=True)
 
@@ -102,9 +107,11 @@ class MetadataUpdater(model.Component):
                     # update the emitted light wavelength
                     observed = self.observeLight(a, d)
                 elif a.role and a.role.startswith("spectrograph"):  # spectrograph-XXX too
+                    self._det_to_spectrograph[dn] = a
                     # update the output wavelength range
                     observed = self.observeSpectrograph(a, d)
                 elif a.role in ("cl-filter", "filter"):
+                    self._det_to_filter[dn] = a
                     # update the output wavelength range
                     observed = self.observeFilter(a, d)
                 elif a.role == "quarter-wave-plate":
@@ -298,25 +305,108 @@ class MetadataUpdater(model.Component):
 
         return True
 
+    def getMonochromatorBandwidth(self, spectrograph: Optional[model.HwComponent]) -> Optional[Tuple[float, float]]:
+        """
+        Get the bandwidth of the monochromator based on the spectrograph settings.
+        :param spectrograph: a spectrograph component
+        :return: the bandwidth of the monochromator (min, max) in m, or None if not available
+        """
+        if spectrograph is None:
+            return None
+
+        # For monochomators, we need to know the minimum and maximum wavelength
+        # detected based on the spectrograph settings. => Update MD_OUT_WL
+        pos = spectrograph.position.value
+        if 'slit-monochromator' not in pos:
+            logging.info("No 'slit-monochromator' axis was found, will not be able to compute monochromator bandwidth.")
+            wl = pos["wavelength"]
+            if wl < 10e-9:  # 0 (or very small value) indicates it's in 0th order mode => all light is passed
+                return None
+            return (wl, wl)
+        else:
+            width = pos['slit-monochromator']
+            bandwidth = spectrograph.getOpeningToWavelength(width)  # always a tuple
+            return bandwidth
+
+    def getFilterBandwidth(self, filter: Optional[model.HwComponent]) -> Union[Iterable[float], str, None]:
+        """
+        Get the bandwidth of the filter based on the filter settings.
+        :param filter: a (light) "filter" (wheel) component (should have a "band" axis)
+        :return: the bandwidth of the filter (min, max) in m,
+                 or a string if it's defined just as a name,
+                 or None if there is no filter.
+        """
+        if filter is None:
+            return None
+
+        pos = filter.position.value
+        bandwidth = filter.axes["band"].choices[pos["band"]]
+        if bandwidth == model.BAND_PASS_THROUGH:  # "pass-through" == no filter
+            return None
+        elif isinstance(bandwidth, str):  # Sometimes the filter is just a name like "red".
+            return bandwidth
+        # Last, and most common, option: tuple/list of 2 floats (min, max)
+        elif (isinstance(bandwidth, (tuple, list))
+              and len(bandwidth) == 2
+              and all(isinstance(v, float) for v in bandwidth)):
+            return bandwidth
+        else:
+            logging.warning("Invalid filter (%s) bandwidth: %s", filter.name, bandwidth)
+            return None
+
+    def updateOutWavelength(self, comp_affected: model.HwComponent,
+                            filter: Optional[model.HwComponent],
+                            spectrograph: Optional[model.HwComponent]) -> None:
+        """
+        Computes MD_OUT_WL as intersection of the filter and the spectrograph configuration,
+        and updates the metadata of the affected component.
+        :param comp_affected: Detector component affected by the filter and the spectrograph.
+        Its metadata will be updated.
+        :param filter: a (light) filter-(wheel) component (should have a "band" axis)
+        :param spectrograph: a spectrograph component (should have a "wavelength" axis)
+        Only used if the detector has the role "monochromator".
+        """
+        filter_bandwidth = self.getFilterBandwidth(filter)
+
+        # We only need to care about the spectrograph in the case of the monochromator, because for
+        # the other types of components (eg, spectrometer), MD_OUT_WL is used exclusively for the
+        # filter info, and the MD_WL_LIST is used to store the wavelength info (handled separately).
+        if comp_affected.role == "monochromator":
+            spec_bandwidth = self.getMonochromatorBandwidth(spectrograph)  # None if wavelength == 0
+        else:
+            spec_bandwidth = None
+
+        if spec_bandwidth is None:  # Standard case, for everything except monochromators
+            bandwidth = filter_bandwidth  # None, str or tuple
+        elif filter_bandwidth is None:
+            bandwidth = spec_bandwidth
+        elif isinstance(filter_bandwidth, str):
+            # We don't support computing the intersection of a string & a tuple -> just trust the spectrograph
+            logging.info("Filter %s is not a range, will use spectrograph bandwidth for MD_OUT_WL", filter_bandwidth)
+            bandwidth = spec_bandwidth
+        else:  # Both are a wavelength range => take the intersection
+            bandwidth = (max(spec_bandwidth[0], filter_bandwidth[0]),
+                         min(spec_bandwidth[1], filter_bandwidth[1]))
+            if bandwidth[0] > bandwidth[1]:  # Empty intersection
+                # In theory, that means the detector receives no light. Maybe that's true,
+                # but it's not helpful to store as metadata. It might also be that the filter
+                # info is not correct. So let's just use the spectrograph bandwidth.
+                logging.warning("No intersection between filter %s and spectrograph %s, will use spectrograph bandwidth",
+                                filter_bandwidth, spec_bandwidth)
+                bandwidth = spec_bandwidth
+
+        logging.debug("Updating %s with intersection of filter %s and spectrograph %s -> %s",
+                      comp_affected.name, filter_bandwidth, spec_bandwidth, bandwidth)
+
+        comp_affected.updateMetadata({model.MD_OUT_WL: bandwidth})
+
     def observeSpectrograph(self, spectrograph, comp_affected):
 
         if comp_affected.role == "monochromator":
-            # For monochomators, we need to know the minimum and maximum wavelength
-            # detected based on the spectrograph settings. => Update MD_OUT_WL
-            if 'slit-monochromator' not in spectrograph.axes:
-                logging.info("No 'slit-monochromator' axis was found, will not be able to compute monochromator bandwidth.")
-
-                def updateOutWLRange(pos, comp_affected=comp_affected):
-                    wl = pos["wavelength"]
-                    md = {model.MD_OUT_WL: (wl, wl)}
-                    comp_affected.updateMetadata(md)
-
-            else:
-                def updateOutWLRange(pos, sp=spectrograph, comp_affected=comp_affected):
-                    width = pos['slit-monochromator']
-                    bandwidth = sp.getOpeningToWavelength(width)
-                    md = {model.MD_OUT_WL: bandwidth}
-                    comp_affected.updateMetadata(md)
+            def updateOutWLRange(pos, sp=spectrograph, comp_affected=comp_affected):
+                self.updateOutWavelength(comp_affected,
+                                         self._det_to_filter.get(comp_affected.name),
+                                         sp)
 
             spectrograph.position.subscribe(updateOutWLRange, init=True)
             self._onTerminate.append((spectrograph.position.unsubscribe, (updateOutWLRange,)))
@@ -345,16 +435,16 @@ class MetadataUpdater(model.Component):
             spectrograph.position.subscribe(updateWavelengthList, init=True)
             self._onTerminate.append((spectrograph.position.unsubscribe, (updateWavelengthList,)))
         else:
-            False
+            return False
 
         return True
 
     def observeFilter(self, filter, comp_affected):
-        # FIXME: If a monochromator + spectrograph, which MD_OUT_WL to pick?
         # update any affected component
         def updateOutWLRange(pos, fl=filter, comp_affected=comp_affected):
-            wl_out = fl.axes["band"].choices[pos["band"]]
-            comp_affected.updateMetadata({model.MD_OUT_WL: wl_out})
+            spec = self._det_to_spectrograph.get(comp_affected.name)  # can be None
+            self.updateOutWavelength(comp_affected, fl, spec)
+
             # apply lateral chromatic correction to align with the reference channel
             apply_transform = fl.getMetadata().get(model.MD_CHROMATIC_COR, None)
             if apply_transform:


### PR DESCRIPTION
With a monochromator, both the filter (in front of the spectrograph),
and the spectrograph center wavelength + output slit opening have effect
on which wavelength is observed. Until now, move on any of the axes
would update MD_OUT_WL... but only the latest move would define the
value.
That's especially annoying if the lastest move is to move the filter to
"pass-through" (very common). In this case, the MD_OUT_WL would be empty
(incorrectly).

The right way to compute MD_OUT_WL is to take into account all the axes
together. Essentially, taking the intersection between the filter
wavelength range and the output slit opening range.