### PR TITLE
[fix] Independent EBIC detector might not have MD_POS

### DIFF
--- a/src/odemis/acq/stream/_helper.py
+++ b/src/odemis/acq/stream/_helper.py
@@ -1529,6 +1529,7 @@ class IndependentEBICStream(EBICSettingsStream):
 
         self._emitter_dataflow = emt_dataflow
         self._latest_emitter_md = {}  # the metadata of the emitter, to be copied onto the detector data
+        self._emitter_data_received = threading.Event()  # set when the emitter data (corresponding to one scan) is received
         self._acq_start_lock = threading.Lock()  # To be taken when starting/stopping acquisition
 
         # Change the standard dwell time setter to set both the detector and the emitter.
@@ -1550,6 +1551,11 @@ class IndependentEBICStream(EBICSettingsStream):
         """
         # Override standard method (on LiveStream), which checks whether the acquisition time has
         # changed "a lot", and in such case stop and restart the acquisition.
+        # Compared to the standard method, here, in adition to the detector, the scanner must also
+        # be restarted, which is more complex (see _restart_acquisition()). In addition, currently,
+        # this function is called just after active is set (although it's not stricly necessary), and
+        # this can trigger a restart while we are still starting the acquisition. All this is possible
+        # to handle, but for now, we keep it simple and just don't implement the functionality.
 
         prev_dur = self._prev_dur
         self._prev_dur = self.estimateAcquisitionTime()
@@ -1562,10 +1568,13 @@ class IndependentEBICStream(EBICSettingsStream):
             # very short anyway, not worthy
             return
 
-        logging.debug("Restarting acquisition because it lasts %f s", prev_dur)
-        # Use the dedicated restart method, in a thread as it shouldn't be blocking.
-        t = threading.Thread(target=self._restart_acquisition)
-        t.start()
+        # TODO: this code works... but it should not be called when the stream just becomes active
+        # as it conflicts with _startAcquisition() (or _startAcquisition() shouldn't be called)
+        # For now, it's disabled, as it's not a big deal if the acquisition time is not updated.
+        # logging.debug("Restarting acquisition because it lasts %f s", prev_dur)
+        # # Use the dedicated restart method, in a thread as it shouldn't be blocking.
+        # t = threading.Thread(target=self._restart_acquisition, args=(False,))
+        # t.start()
 
     def _onNewEmitterData(self, dataflow: model.DataFlow, data: model.DataArray) -> None:
         """
@@ -1578,6 +1587,7 @@ class IndependentEBICStream(EBICSettingsStream):
         useful_md = {k: v for k, v in data.metadata.items() if k in SCANNER_POS_MD}
         self._latest_emitter_md = useful_md
         self._updateMD(useful_md)
+        self._emitter_data_received.set()
 
     def _updateMD(self, md: Dict[str, Any]) -> None:
         """
@@ -1611,22 +1621,31 @@ class IndependentEBICStream(EBICSettingsStream):
         # continuous acquisition.
         # We cannot re-subscribe to the dataflow directly from here, as it's called from the dataflow,
         # which would cause a deadlock. So we do this in a separate thread.
-        t = threading.Thread(target=self._restart_acquisition)
+        t = threading.Thread(target=self._restart_acquisition, args=(True,))
         t.start()
 
-    def _restart_acquisition(self):
+    def _restart_acquisition(self, expect_emt_data: bool):
         """
-        Stops and immediately restarts the acquisition.
+        Stops and restarts the acquisition.
         This is to force the detectors to start a new acquisition, synchronized with the scanner.
+        :param expect_emt_data: if True, will wait a little bit to make sure the emitter
+        (aka e-beam/se-detector) data has also been received before stopping.
         """
         try:
             with self._acq_start_lock:
                 if self.is_active.value:
+                    # Make sure that the emitter data is received before restarting the acquisition,
+                    # otherwise, we might miss its metadata.
+                    if expect_emt_data:
+                        if not self._emitter_data_received.wait(0.5):  # 0.5s = a really long time (unlikely to happen)
+                            logging.warning("Emitter data not received, but will restart the acquisition")
+
                     logging.debug("Will stop and restart the acquisition")
                     self._emitter_dataflow.unsubscribe(self._onNewEmitterData)
                     self._dataflow.unsubscribe(self._onNewData)
 
                     self._dataflow.subscribe(self._onNewData)
+                    self._emitter_data_received.clear()
                     time.sleep(0.1)  # wait a bit, to ensure the detector is ready
                     self._emitter_dataflow.subscribe(self._onNewEmitterData)
         except Exception:
@@ -1637,9 +1656,9 @@ class IndependentEBICStream(EBICSettingsStream):
         Overrides the standard _onActive to start/stop the emitter as well.
         """
         if active:
-            # Set the emitter to the right settings
-            self._onDwellTime(self._scanner.dwellTime.value)
-            self._onResolution(self._scanner.resolution.value)
+            # Make sure the detector settings are up-to-date
+            # Note: the dwell time is set via _linkHwVAs()
+            self._set_det_resolution()
 
         with self._acq_start_lock:
             super()._onActive(active)
@@ -1655,6 +1674,7 @@ class IndependentEBICStream(EBICSettingsStream):
         super()._startAcquisition(future)
 
         # ...then start the emitter
+        self._emitter_data_received.clear()
         time.sleep(0.1)  # wait a bit, to ensure the detector is ready
         self._emitter_dataflow.subscribe(self._onNewEmitterData)
 
@@ -1706,16 +1726,20 @@ class IndependentEBICStream(EBICSettingsStream):
         emt_dt = self._set_hw_dwell_time(self.emtDwellTime.value)
         self.emtDwellTime.value = emt_dt
 
+    def _set_det_resolution(self):
+        res = self._scanner.resolution.value
+        self._detector.resolution.value = res
+
+        if self._detector.resolution.value != res:
+            logging.warning("Failed to set the resolution of %s to %s: %s accepted",
+                            self._detector.name, res, self._detector.resolution.value)
+
     def _onResolution(self, value: Tuple[int, int]):
         """
         Overrides the standard _onResolution to set the dwell time on the emitter as well.
         """
         if self.is_active.value:
-            self._detector.resolution.value = value
-
-            if self._detector.resolution.value != value:
-                logging.warning("Failed to set the resolution of %s to %s: %s accepted",
-                                self._detector.name, value, self._detector.resolution.value)
+            self._set_det_resolution()
 
         super()._onResolution(value)
 

--- a/src/odemis/acq/stream/_sync.py
+++ b/src/odemis/acq/stream/_sync.py
@@ -2579,14 +2579,15 @@ class SEMMDStream(MultipleDetectorStream):
                 for s, sub in zip(self._streams, self._subscribers):
                     s._dataflow.subscribe(sub)
 
+                start = time.time()
+                self._acq_min_date = start
+
                 if has_inde_detectors:
                     # The independent detectors might need a bit of time to be ready.
                     # If not waiting, the first pixels might be missed.
                     time.sleep(0.05)
 
-                start = time.time()
-                self._acq_min_date = start
-                self._trigger.notify()
+                self._trigger.notify()  # starts the e-beam scan
                 # Time to scan a frame
                 frame_time = px_time * npixels2scan
 

--- a/src/odemis/acq/test/stream_test.py
+++ b/src/odemis/acq/test/stream_test.py
@@ -4185,7 +4185,7 @@ class SPARC2TestCaseIndependentDetector(unittest.TestCase):
         """
         ebics = stream.IndependentEBICStream("test ebic", self.ebic, self.ebic.data,
                                              self.ebeam, self.sed.data,
-                                             detvas={"dwellTime"})
+                                             emtvas={"dwellTime"})
 
         self._images = []
         ebics.image.subscribe(self._on_image)
@@ -4196,14 +4196,14 @@ class SPARC2TestCaseIndependentDetector(unittest.TestCase):
         ebics.repetition.value = (15, 26)
 
         # set GUI VAs
-        ebics.detDwellTime.value = 1e-3  # s
+        ebics.emtDwellTime.value = 0.5e-3  # s
 
         # update stream (live)
         ebics.should_update.value = True
         # activate/play stream, optical path should be corrected immediately (no need to wait)
         ebics.is_active.value = True
 
-        # Wait long enough that *several* images are acquired
+        # Wait long enough that *several* (~5) images are acquired
         time.sleep(4)
         ebics.is_active.value = False
 
@@ -4211,7 +4211,7 @@ class SPARC2TestCaseIndependentDetector(unittest.TestCase):
         time.sleep(0.2)
 
         nb_images = len(self._images)
-        self.assertGreater(nb_images, 1, "Not several EBIC images received after 4s")
+        self.assertGreater(nb_images, 2, "Not several EBIC images received after 4s")
         self.assertIsInstance(self._images[0], model.DataArray)
         # check if metadata is correctly stored
         md = self._images[0].metadata
@@ -4238,20 +4238,20 @@ class SPARC2TestCaseIndependentDetector(unittest.TestCase):
                                 emtvas={"dwellTime", "scale", "magnification", "pixelSize"})
         ebics = stream.IndependentEBICStream("test ebic", self.ebic, self.ebic.data,
                                              self.ebeam, self.sed.data,
-                                             detvas={"dwellTime"})
+                                             emtvas={"dwellTime"})
         sms = stream.SEMMDStream("test sem-md", [sems, ebics])
 
         # Now, proper acquisition
         ebics.roi.value = (0, 0.2, 0.3, 0.6)
 
         # dwell time of sems shouldn't matter
-        ebics.detDwellTime.value = 2e-6  # s
+        ebics.emtDwellTime.value = 2e-6  # s
 
         ebics.repetition.value = (500, 700)
         exp_pos, exp_pxs, exp_res = roi_to_phys(ebics)
 
         # Start acquisition
-        timeout = 1 + 1.5 * sms.estimateAcquisitionTime()
+        timeout = 5 + 1.5 * sms.estimateAcquisitionTime()
         start = time.time()
         f = sms.acquire()
 

--- a/src/odemis/driver/simsem.py
+++ b/src/odemis/driver/simsem.py
@@ -674,11 +674,15 @@ class IndependentDetector(model.Detector):
         the Dataflow.
         """
         try:
+            first_frame = True
             while not self._acquisition_must_stop.is_set():
                 dwelltime = self.dwellTime.value
                 resolution = self.resolution.value
                 duration = numpy.prod(resolution) * dwelltime
                 self.data._waitSync()
+                if first_frame:
+                    time.sleep(0.005)  # simulate a little bit of delay to start
+                    first_frame = False
                 img = self._simulate_image()
                 if self._acquisition_must_stop.wait(duration):
                     break


### PR DESCRIPTION
The MD_POS needs to be copied from the scanner metadata. However, the
acquisition restart function could easily stop the scanner *just* before
receiving the data (and metadata).
=> Wait explicitly for the scanner data before restarting the
acquisition.

Also fix a few issues in the test cases and simulator.