### PR TITLE
[fix] gui HW_SETTING_CONFIG too specific for e-beam settings

### DIFF
--- a/src/odemis/gui/conf/data.py
+++ b/src/odemis/gui/conf/data.py
@@ -167,14 +167,11 @@ HW_SETTINGS_CONFIG = {
                 "event": wx.EVT_SCROLL_CHANGED  # only affects when it's a slider
             }),
             ("probeCurrent", {
-                "label": "Beam Current",
-                "control_type": odemis.gui.CONTROL_SLIDER,
-                "type": "float",
-                "scale": "linear",
-                "event": wx.EVT_SCROLL_CHANGED
+                "label": "Beam current",
+                "event": wx.EVT_SCROLL_CHANGED  # only affects when it's a slider
             }),
             ("spotSize", {
-                "tooltip": "Electron-beam Spot size",
+                "tooltip": "Electron-beam spot size",
             }),
             ("horizontalFoV", {
                 "label": "HFW",
@@ -242,16 +239,13 @@ HW_SETTINGS_CONFIG = {
         "ion-beam":
         OrderedDict((
             ("accelVoltage", {
-                "label": "Accel. Voltage",
+                "label": "Accel. voltage",
                 "tooltip": "Accelerating voltage",
                 "event": wx.EVT_SCROLL_CHANGED  # only affects when it's a slider
             }),
             ("probeCurrent", {
-                "label": "Beam Current",
-                "control_type": odemis.gui.CONTROL_SLIDER,
-                "type": "float",
-                "scale": "linear",
-                "event": wx.EVT_SCROLL_CHANGED
+                "label": "Beam current",
+                "event": wx.EVT_SCROLL_CHANGED  # only affects when it's a slider
             }),
             ("resolution", {
                 "label": "Resolution",


### PR DESCRIPTION
Commit e5fc2889 (minor gui/model changes for fibsem tab) changed the
e-beam settings to very specific. In particular, it forced the
probeCurrent VA to *always* be a slider. However, on some hardware this
VA can be a set of choices. This caused the GUI from failing to display
anything at all in such case.

When no control_type is specified, the type is automatically selected
using determine_default_control(). It should work for both cases of
Continuous and Enumerated VAs.