### PR TITLE
[fix] test_overlay_stream failed due to change in API

### DIFF
--- a/src/odemis/acq/test/stream_overlay_test.py
+++ b/src/odemis/acq/test/stream_overlay_test.py
@@ -77,7 +77,9 @@ class TestOverlayStream(unittest.TestCase):
         ovrl.repetition.value = (4, 4)
 
         f = ovrl.acquire()
-        das = f.result()
+        das, ex = f.result()
+        self.assertIsNone(ex)
+
         cor_md = das[0].metadata
         for k in [model.MD_ROTATION_COR, model.MD_PIXEL_SIZE_COR, model.MD_POS_COR]:
             self.assertIn(k, cor_md)


### PR DESCRIPTION
Commit ea08ee662e (Support for partial SPARC acquisition) changed the
return type of .acquire(). The OverlayStream was updated to match this,
but not the test case.