### PR TITLE
[TRCL-611][feat] SEMTemporalMDStream now use synchronizing event on the time-correlator

### DIFF
--- a/src/odemis/acq/stream/_sync.py
+++ b/src/odemis/acq/stream/_sync.py
@@ -2829,10 +2829,11 @@ class SEMTemporalMDStream(MultipleDetectorStream):
             raise ValueError("Second stream detector needs to have 'time-correlator' " +
                              "as its role, not %s." % streams[1]._detector.role)
 
-        super(SEMTemporalMDStream, self).__init__(name, streams)
+        super().__init__(name, streams)
 
         self._se_stream = streams[0]
         self._tc_stream = streams[1]
+        self._trigger = self._emitter.startScan  # to acquire a CCD image every time the SEM starts a new scan
 
     def _estimateRawAcquisitionTime(self):
         res = numpy.prod(self._tc_stream.repetition.value)
@@ -2866,6 +2867,22 @@ class SEMTemporalMDStream(MultipleDetectorStream):
         self._tc_stream._detector.dwellTime.value = dwell_time
         self._emitter.dwellTime.value = dwell_time
 
+        # Order matters (a bit). At least, on the Tescan, only the "external" waits extra time to ensure
+        # a stable e-beam condition, so it should be done last.
+        if model.hasVA(self._emitter, "blanker") and self._emitter.blanker.value is None:
+            # When the e-beam is set to automatic blanker mode, it would switch on/off for every
+            # block of acquisition. This is not efficient, and can disrupt the e-beam. So we force
+            # "blanker" off while the acquisition is running.
+            self._orig_hw_values[self._emitter.blanker] = self._emitter.blanker.value
+            self._emitter.blanker.value = False
+
+        if model.hasVA(self._emitter, "external") and self._emitter.external.value is None:
+            # When the e-beam is set to automatic external mode, it would switch on/off for every
+            # block of acquisition. This is not efficient, and can disrupt the e-beam. So we force
+            # "external" while the acquisition is running.
+            self._orig_hw_values[self._emitter.external] = self._emitter.external.value
+            self._emitter.external.value = True
+
         return px_time, ninteg
 
     def _runAcquisition(self, future) -> Tuple[List[model.DataArray], Optional[Exception]]:
@@ -2887,13 +2904,18 @@ class SEMTemporalMDStream(MultipleDetectorStream):
         se_data = []
         tc_data = []
         spot_pos = self._getSpotPositions()
+        tcdf = self._tc_stream._dataflow
 
-        # Dwell times can be modified to account for drift correction, save original values to
-        # restore at the end of the acquisition
-        emitter_dt = self._emitter.dwellTime.value
-        tc_dt = self._tc_stream._detector.dwellTime.value
         try:
             img_time, ninteg = self._adjustHardwareSettings()
+
+            # Prepare the time-correlator: acquire one frame every time the SEM starts scanning.
+            # The SEM may scan multiple times for each CCD frame.
+            tcdf.synchronizedOn(self._trigger)
+            # Get the time-correlator ready to acquire
+            tcdf.subscribe(self._subscribers[-1])
+
+            start_t = time.time()
 
             for px_idx in numpy.ndindex(*self.repetition.value[::-1]):
                 x, y = tuple(spot_pos[px_idx])
@@ -2918,15 +2940,23 @@ class SEMTemporalMDStream(MultipleDetectorStream):
                     logging.debug("Memory used = %d bytes", udriver.readMemoryUsage())
                     # Perform drift correction
                     if self._dc_estimator:
-                        drift_est.acquire()
-                        dc_vect = drift_est.estimate()
-                        tot_dc_vect[0] += dc_vect[0]
-                        tot_dc_vect[1] += dc_vect[1]
+                        try:
+                            # Temporarily switch the detector to a different event trigger, so that it
+                            # doesn't get triggered while the drift estimator is running (because it uses the
+                            # e-beam, which sends a startScan event)
+                            tcdf.synchronizedOn(self._tc_stream._detector.softwareTrigger)
+                            drift_est.acquire()
+                            dc_vect = drift_est.estimate()
+                            tot_dc_vect[0] += dc_vect[0]
+                            tot_dc_vect[1] += dc_vect[1]
+                        except Exception:
+                            logging.exception("Drift correction failed, will retry next pixel")
+                        tcdf.synchronizedOn(self._trigger)
+
                 n += 1
                 logging.info("Acquired %d out of %d pixels", n, numpy.prod(self.repetition.value))
 
-                # TODO: use _integrateImages(), once the function is per image
-
+                # TODO: use ImageIntegrator for the image integration
                 # Sum up the partial data to get the full output for the pixel
                 dtype = tc_px_data[0].dtype
                 idt = numpy.iinfo(dtype)
@@ -2940,6 +2970,8 @@ class SEMTemporalMDStream(MultipleDetectorStream):
                 pxsum = model.DataArray(pxsum.astype(dtype), tc_md)
                 tc_data.append(pxsum)
 
+                # TODO: this is actually not really correct as the SEM data is "normalized", so the
+                # final data should be divided by ninteg. This is done correctly in ImageIntegrator.
                 pxsum = numpy.sum(se_px_data, 0)
                 pxsum = numpy.minimum(pxsum, idt.max * numpy.ones(pxsum.shape))
                 se_md = se_px_data[0].metadata.copy()
@@ -2952,6 +2984,11 @@ class SEMTemporalMDStream(MultipleDetectorStream):
 
                 # Live update the setting stream with the new data
                 self._tc_stream._onNewData(self._tc_stream._dataflow, tc_data[-1])
+
+            dur = time.time() - start_t
+            logging.info("Acquisition completed in %g s -> %g s/frame", dur, dur / n)
+            tcdf.unsubscribe(self._subscribers[-1])
+            tcdf.synchronizedOn(None)
 
             self._onCompletedData(0, se_data)
             self._onCompletedData(1, tc_data)
@@ -2970,16 +3007,20 @@ class SEMTemporalMDStream(MultipleDetectorStream):
             # TODO: once live data is supported, return the partial data
             raise
         finally:
+            for s, sub in zip(self._streams, self._subscribers):
+                s._dataflow.unsubscribe(sub)
+            tcdf.synchronizedOn(None)  # In case of exception
+
+            for s in self._streams:
+                s._unlinkHwVAs()
+            self._restoreHardwareSettings()
+
             logging.debug("TC acquisition finished")
             self._acq_done.set()
-            # Reset hardware settings (dwell times might have been reduced due
-            # to subpixel drift correction)
-            self._tc_stream._detector.dwellTime.value = tc_dt
-            self._emitter.dwellTime.value = emitter_dt
 
         return self.raw, None
 
-    def _acquireImage(self, x, y, img_time):
+    def _acquireImage(self, x: float, y: float, img_time: float) -> Tuple[model.DataArray, model.DataArray]:
         try:
             for ce in self._acq_complete:
                 ce.clear()
@@ -2992,21 +3033,21 @@ class SEMTemporalMDStream(MultipleDetectorStream):
 
             self._acq_min_date = time.time()
 
-            # Get data
-            for s, sub in zip(self._streams, self._subscribers):
+            # Start "all" the detectors but the time-correlator => start the e-beam
+            for s, sub in zip(self._streams[:-1], self._subscribers[:-1]):
                 s._dataflow.subscribe(sub)
 
             # Wait for detector to acquire image
             for i, s in enumerate(self._streams):
                 timeout = 2.5 * img_time + 3
                 if not self._acq_complete[i].wait(timeout):
-                    raise TimeoutError()
+                    raise TimeoutError(f"Timeout waiting for stream {i}")
             if self._acq_state == CANCELLED:
                 raise CancelledError()
             tc_data, se_data = self._acq_data[-1][-1], self._acq_data[0][-1]
             return tc_data, se_data
         finally:
-            for s, sub in zip(self._streams, self._subscribers):
+            for s, sub in zip(self._streams[:-1], self._subscribers[:-1]):
                 s._dataflow.unsubscribe(sub)
 
     def _onCompletedData(self, n, raw_das):

--- a/src/odemis/acq/test/stream_test.py
+++ b/src/odemis/acq/test/stream_test.py
@@ -4317,19 +4317,10 @@ class TimeCorrelatorTestCase(unittest.TestCase):
     """
     Tests the SEMTemporalMDStream.
     """
-    backend_was_running = False
 
     @classmethod
     def setUpClass(cls):
-        try:
-            testing.start_backend(TIME_CORRELATOR_CONFIG)
-        except LookupError:
-            logging.info("A running backend is already found, skipping tests")
-            cls.backend_was_running = True
-            return
-        except IOError as exp:
-            logging.error(str(exp))
-            raise
+        testing.start_backend(TIME_CORRELATOR_CONFIG)
 
         # Find CCD & SEM components
         cls.time_correlator = model.getComponent(role="time-correlator")
@@ -4343,16 +4334,6 @@ class TimeCorrelatorTestCase(unittest.TestCase):
         # (during referencing the shutters are force closed, so the acquisition
         # goes faster because the shutters can't open anyway, which is not realistic)
         time.sleep(10)
-
-    @classmethod
-    def tearDownClass(cls):
-        if cls.backend_was_running:
-            return
-        testing.stop_backend()
-
-    def setUp(self):
-        if self.backend_was_running:
-            self.skipTest("Running backend found")
 
     def test_acquisition(self):
         """
@@ -4420,9 +4401,6 @@ class TimeCorrelatorTestCase(unittest.TestCase):
         self.assertIn(self.ebeam.dwellTime.value, (1, 1e-6))
         data, exp = f.result()
         self.assertIsNone(exp)
-        # Dwell time on detector and emitter should be back to normal
-        self.assertEqual(self.time_correlator.dwellTime.value, 2)
-        self.assertEqual(self.ebeam.dwellTime.value, 0.042)
 
         self.assertEqual(len(data), 3)  # additional anchor region data array
         self.assertEqual(data[0].shape[-1], 1)
@@ -4440,7 +4418,7 @@ class TimeCorrelatorTestCase(unittest.TestCase):
             self.time_correlator,
             self.time_correlator.data,
             self.ebeam,
-            # No local VA, to check it also works the "old" way
+            detvas={"dwellTime"},
         )
         sem_stream = stream.SpotSEMStream("Ebeam", self.sed, self.sed.data, self.ebeam)
         sem_tc_stream = stream.SEMTemporalMDStream("SEM Time Correlator",
@@ -4448,7 +4426,7 @@ class TimeCorrelatorTestCase(unittest.TestCase):
 
         sem_tc_stream.roi.value = (0, 0, 0.1, 0.2)
         tc_stream.repetition.value = (5, 3)
-        self.time_correlator.dwellTime.value = 5e-3
+        self.time_correlator.dwellTime.value = 1  # s
         f = sem_tc_stream.acquire()
 
         # Check if there is a live update in the setting stream.


### PR DESCRIPTION
The picoquant driver used to not support synchronization, so the
acquisition code had to start/stop explicitly the time-correlator
acquisition for each pixel. Now that the driver supports
synchronization, we can use the same pattern as the standard SPARC
acquisition.

This brings 2 advantages:
* avoids opening/closing "things" like the shutter and blanker for each
  pixel. This used to cause ~1s overhead per pixel.
* makes the code closer to the standard code, so we are one (little)
  step closer to merging this code into the standard code.

Also adjust the test cases to still work, now that the acquisition is
much faster.