### PR TITLE
[feat] limit the maximum dwell time of the time-correlator

### DIFF
--- a/src/odemis/gui/conf/data.py
+++ b/src/odemis/gui/conf/data.py
@@ -600,6 +600,7 @@ HW_SETTINGS_CONFIG = {
             ("dwellTime", {
                 "tooltip": "Time spent by the e-beam on each pixel",
                 "scale": "log",
+                "range": (1e-6, 1000.0),  # Make sure to not provide too long dwell times
             }),
             ("pixelDuration", {
                 "label": "Time resolution",


### PR DESCRIPTION
All detectors have their dwell time limited in the GUI (as some hardware can
support very long dwell/exposure times that make no sense for a user).
That is, except the time-correlator (for the SPARC labcube) which wasn't
limited. The picoquant hardware supports up to 4.5 days, which is really useless
in our use-case. => Limit to 1000 s, which is also the (arbitrary) limit of the
e-beam dwell time.