### PR TITLE
[NSRPARMA-134][feat] IndependentEBICStream always shows a valid detector dwell time

### DIFF
--- a/src/odemis/acq/acqmng.py
+++ b/src/odemis/acq/acqmng.py
@@ -36,7 +36,7 @@ from odemis.acq import _futures
 from odemis.acq.stream import FluoStream, SEMCCDMDStream, SEMMDStream, SEMTemporalMDStream, \
     OverlayStream, OpticalStream, EMStream, ScannedFluoStream, ScannedFluoMDStream, \
     ScannedRemoteTCStream, ScannedTCSettingsStream
-from odemis.util import img, fluo, executeAsyncTask
+from odemis.util import img, fluo, executeAsyncTask, almost_equal
 import time
 import copy
 from odemis.model import prepare_to_listen_to_more_vas
@@ -311,7 +311,6 @@ def foldStreams(streams, reuse=None):
     return (set of Streams): The set of streams, with the ones that can be
       folded replaced by an MD streams, the other streams are pass as-is.
     """
-    # TODO: support SPARC streams
     if reuse is None:
         reuse = []
 
@@ -347,7 +346,7 @@ def foldStreams(streams, reuse=None):
             for smds in scan_semmds:
                 compatible = True
                 for smd in smds:
-                    if not (smd._dwellTime.value == s._dwellTime.value and
+                    if not (almost_equal(smd._dwellTime.value, s._dwellTime.value, rtol=0.01) and  # 1% tolerance
                             smd.repetition.value == s.repetition.value and
                             smd.roi.value == s.roi.value and
                             # as of now, each MDStream has only 2 streams, and the first one is always the SEM stream.

--- a/src/odemis/acq/stream/_helper.py
+++ b/src/odemis/acq/stream/_helper.py
@@ -1698,11 +1698,13 @@ class IndependentEBICStream(EBICSettingsStream):
             logging.warning("Failed to set the dwell time of %s to %s s: %s s accepted vs %s s by emitter",
                             self._detector.name, min_emt_dt, det_dt, emt_dt)
 
-        # We report the emitter dwell time, which is the actual exposure of the pixels
-        return emt_dt
+        # We report the detector dwell time, which is what will influence the data (and also what the
+        # user requested, so that's most intuitive)
+        return det_dt
 
     def _linkHwVAs(self):
         super()._linkHwVAs()
+        # Configure both detector and emitter dwell times, and update the dwell time VA with the accepted value
         emt_dt = self._set_hw_dwell_time(self.emtDwellTime.value)
         self.emtDwellTime.value = emt_dt
 

--- a/src/odemis/acq/stream/_sync.py
+++ b/src/odemis/acq/stream/_sync.py
@@ -279,11 +279,7 @@ class MultipleDetectorStream(Stream, metaclass=ABCMeta):
             shape = (len(pol_pos), rep[1], rep[0])
             # estimate acq time for leeches is based on two fastest axis
             if self._integrationTime:
-                # get the exposure time directly from the hardware (e.g. hardware rounds value) to calc counts
-                integration_count = int(math.ceil(self._integrationTime.value / self._ccd.exposureTime.value))
-                if integration_count != self._integrationCounts.value:
-                    logging.debug("Integration count of %d, does not match integration count of %d as expected",
-                                  integration_count, self._integrationCounts.value)
+                integration_count = self._integrationCounts.value
                 if integration_count > 1:
                     shape = (len(pol_pos), rep[1], rep[0], integration_count)  # overwrite shape
 

--- a/src/odemis/acq/stream/_sync.py
+++ b/src/odemis/acq/stream/_sync.py
@@ -338,7 +338,18 @@ class MultipleDetectorStream(Stream, metaclass=ABCMeta):
 
         # Order matters: if same local VAs for emitter (e-beam). The ones from
         # the last stream are used.
+        inde_detectors = []  # typically, 0 or 1 stream
         for s in self._streams:
+            # Do the independent detectors last, so that they control the exact scanner dwell time
+            det = s._detector
+            if model.hasVA(det, "dwellTime"):
+                inde_detectors.append(s)
+                continue
+            s._linkHwVAs()
+            s._linkHwAxes()
+
+        for s in inde_detectors:
+            logging.debug("Configuring stream %s settings as master", s)
             s._linkHwVAs()
             s._linkHwAxes()
 
@@ -2422,7 +2433,7 @@ class SEMMDStream(MultipleDetectorStream):
         # TODO: check that no fuzzing is requested (as it's not supported and
         # not useful).
 
-        dt = self._dwellTime.value
+        dt = self._emitter.dwellTime.value
 
         # Order matters (a bit)
         if model.hasVA(self._emitter, "blanker") and self._emitter.blanker.value is None:
@@ -2491,8 +2502,6 @@ class SEMMDStream(MultipleDetectorStream):
             # only be known once we start acquiring. One way would be to set a synchronization, and
             # then subscribe all the detectors, and finally check the dwell time.
             px_time = self._adjustHardwareSettings()
-            if not almost_equal(self._emitter.dwellTime.value, px_time):
-                raise IOError("Expected hw dt = %f but got %f" % (px_time, self._emitter.dwellTime.value))
             spot_pos = self._getSpotPositions()
             pos_flat = spot_pos.reshape((-1, 2))  # X/Y together (X iterates first)
             rep = self.repetition.value
@@ -2501,8 +2510,8 @@ class SEMMDStream(MultipleDetectorStream):
             self._current_scan_area = (0, 0, 0, 0)
             self._raw = []
             self._anchor_raw = []
-            logging.debug("Starting e-beam sync acquisition with components %s",
-                          ", ".join(s._detector.name for s in self._streams))
+            logging.debug("Starting e-beam sync acquisition @ %s s with components %s",
+                          px_time, ", ".join(s._detector.name for s in self._streams))
 
             tot_num = numpy.prod(rep)
 

--- a/src/odemis/acq/test/stream_test.py
+++ b/src/odemis/acq/test/stream_test.py
@@ -4166,8 +4166,6 @@ class SPARC2TestCaseIndependentDetector(unittest.TestCase):
     """
     This test case is specifically targeting the IndependentEBICStream
     """
-    backend_was_running = False
-
     @classmethod
     def setUpClass(cls):
         testing.start_backend(SPARC2_INDE_EBIC_CONFIG)
@@ -4177,6 +4175,42 @@ class SPARC2TestCaseIndependentDetector(unittest.TestCase):
         cls.ebeam = model.getComponent(role="e-beam")
         cls.sed = model.getComponent(role="se-detector")
         cls.ebic = model.getComponent(role="ebic-detector")
+        cls.filter = model.getComponent(role="filter")
+        cls.cl = model.getComponent(role="cl-detector")
+
+    def _roiToPhys(self, repst):
+        """
+        Compute the (expected) physical position of a stream ROI
+        repst (RepetitionStream): the repetition stream with ROI
+        return:
+            pos (tuple of 2 floats): physical position of the center
+            pxs (tuple of 2 floats): pixel size in m
+            res (tuple of ints): number of pixels
+        """
+        res = repst.repetition.value
+        pxs = (repst.pixelSize.value,) * 2
+
+        # To compute pos, we need to convert the ROI to physical coordinates
+        roi = repst.roi.value
+        roi_center = ((roi[0] + roi[2]) / 2, (roi[1] + roi[3]) / 2)
+
+        try:
+            sem_center = repst.detector.getMetadata()[model.MD_POS]
+        except KeyError:
+            # no stage => pos is always 0,0
+            sem_center = (0, 0)
+        # TODO: pixelSize will be updated when the SEM magnification changes,
+        # so we might want to recompute this ROA whenever pixelSize changes so
+        # that it's always correct (but maybe not here in the view)
+        emt = repst.emitter
+        sem_width = (emt.shape[0] * emt.pixelSize.value[0],
+                     emt.shape[1] * emt.pixelSize.value[1])
+        # In physical coordinates Y goes up, but in ROI, Y goes down => "1-"
+        pos = (sem_center[0] + sem_width[0] * (roi_center[0] - 0.5),
+               sem_center[1] - sem_width[1] * (roi_center[1] - 0.5))
+
+        logging.debug("Expecting pos %s, pxs %s, res %s", pos, pxs, res)
+        return pos, pxs, res
 
     def test_ebic_live_stream(self):
         """
@@ -4311,6 +4345,72 @@ class SPARC2TestCaseIndependentDetector(unittest.TestCase):
         numpy.testing.assert_allclose(ebic_md[model.MD_POS], exp_pos)
         numpy.testing.assert_allclose(ebic_md[model.MD_PIXEL_SIZE], exp_pxs)
         self.assertEqual(ebic_md[model.MD_USER_TINT], (255, 0, 0))  # from .tint
+
+    def test_acq_cl_se_ebic(self):
+        """
+        Test acquisition for SE+CL+EBIC acquisition simultaneously (aka "folded stream")
+        """
+        # create axes
+        axes = {"filter": ("band", self.filter)}
+
+        # Create the stream
+        sems = stream.SEMStream("test sem", self.sed, self.sed.data, self.ebeam,
+                                emtvas={"dwellTime", "scale", "magnification", "pixelSize"})
+        mcs = stream.CLSettingsStream("testCL",
+                                      self.cl, self.cl.data, self.ebeam,
+                                      axis_map=axes,
+                                      emtvas={"dwellTime", })
+        ebics = stream.IndependentEBICStream("test ebic", self.ebic, self.ebic.data,
+                                             self.ebeam, self.sed.data,
+                                             emtvas={"dwellTime"})
+
+        sms = stream.SEMMDStream("test sem-md", [sems, mcs, ebics])
+
+        # Now, proper acquisition
+        mcs.roi.value = (0, 0.2, 0.3, 0.6)
+        mcs.tint.value = (255, 0, 0)  # Red colour
+        ebics.roi.value = (0, 0.2, 0.3, 0.6)
+        ebics.tint.value = (0, 255, 0)  # Green colour
+
+        # EBIC stream can adjust quite a lot the dwell time => use that value to configure the CL stream
+        ebics.emtDwellTime.value = 10e-6  # s
+        mcs.emtDwellTime.value = ebics.emtDwellTime.value
+
+        mcs.repetition.value = (500, 700)
+        ebics.repetition.value = (500, 700)
+        exp_pos, exp_pxs, exp_res = self._roiToPhys(mcs)
+
+        # Start acquisition
+        logging.debug("Estimating %g s", sms.estimateAcquisitionTime())
+        timeout = 1 + 1.5 * sms.estimateAcquisitionTime()
+        start = time.time()
+        f = sms.acquire()
+
+        # wait until it's over
+        data, exp = f.result(timeout)
+        dur = time.time() - start
+        logging.debug("Acquisition took %g s", dur)
+        self.assertTrue(f.done())
+        self.assertIsNone(exp)
+        self.assertEqual(len(data), len(sms.raw))
+
+        # Both SEM and the two CLs should have the same shape
+        self.assertEqual(len(sms.raw), 3)
+        self.assertEqual(sms.raw[0].shape, exp_res[::-1])
+        self.assertEqual(sms.raw[1].shape, exp_res[::-1])
+        self.assertEqual(sms.raw[2].shape, exp_res[::-1])
+        sem_md = sms.raw[0].metadata
+        cl_md = sms.raw[1].metadata
+        cl_two_md = sms.raw[2].metadata
+        numpy.testing.assert_allclose(sem_md[model.MD_POS], cl_md[model.MD_POS])
+        numpy.testing.assert_allclose(sem_md[model.MD_PIXEL_SIZE], cl_md[model.MD_PIXEL_SIZE])
+        numpy.testing.assert_allclose(cl_md[model.MD_POS], exp_pos)
+        numpy.testing.assert_allclose(cl_md[model.MD_PIXEL_SIZE], exp_pxs)
+        numpy.testing.assert_allclose(cl_two_md[model.MD_POS], exp_pos)
+        numpy.testing.assert_allclose(cl_two_md[model.MD_PIXEL_SIZE], exp_pxs)
+        self.assertEqual(cl_md[model.MD_USER_TINT], (255, 0, 0))  # from .tint
+        self.assertEqual(cl_two_md[model.MD_USER_TINT], (0, 255, 0))  # from .tint
+        self.assertEqual(mcs.axisFilter.value, self.filter.position.value["band"])
 
 
 class TimeCorrelatorTestCase(unittest.TestCase):

--- a/src/odemis/driver/ephemeron.py
+++ b/src/odemis/driver/ephemeron.py
@@ -38,7 +38,7 @@ from functools import wraps
 from typing import Optional, Tuple, Dict, Any, List
 
 from odemis import model
-from odemis.model import Detector, oneway, MD_ACQ_DATE, HwError
+from odemis.model import Detector, oneway, MD_ACQ_DATE, HwError, FloatContinuous
 
 import numpy
 try:
@@ -133,8 +133,7 @@ class MightyEBIC(Detector):
                                                        channels=self._channel + 1,
                                                        spp=MAX_SAMPLES_PER_PIXEL,
                                                        delay=0)
-        self.dwellTime = model.FloatContinuous(dt_min, (dt_min, dt_max), unit="s",
-                                               setter=self.on_dwell_time_change)
+        self.dwellTime = DwellTimeVA(dt_min, (dt_min, dt_max), detector=self)
 
         self.data = EBICDataFlow(self)
         self._acquisition_thread: Optional[threading.Thread] = None
@@ -194,7 +193,7 @@ class MightyEBIC(Detector):
             delay = 0
             md = self.getMetadata()
 
-            act_dt, spp, os = self._opc_client.guess_samples_per_pixel_and_oversampling(self.dwellTime.value, self._channel + 1, 0)
+            act_dt, spp, os = self.find_dwell_time_settings(self.dwellTime.value)
             md[model.MD_DWELL_TIME] = act_dt
             md[model.MD_INTEGRATION_COUNT] = os * spp
             scan_time = self._opc_client.calculate_scan_time(act_dt, res[0], res[1])
@@ -308,12 +307,12 @@ class MightyEBIC(Detector):
         das = [model.DataArray(channel_data, md) for channel_data in raw_arr]
         return das
 
-    def on_dwell_time_change(self, value: float) -> float:
+    def find_dwell_time_settings(self, value: float) -> Tuple[float, int, int]:
         """
         Called when the dwell time is changed, the value is checked and a value compatible with the
         hardware and *smaller* or equal to the requested value is returned.
         :param value: request dwell time (s)
-        :return: accepted dwell time (s)
+        :return: accepted dwell time (s), samples per pixel, oversampling
         """
         # Find the closest SPP & oversampling that matches the requested dwell time. It always returns a smaller or equal value,
         # unless a value smaller than the minimum is requested (in which case it returns the minimum)
@@ -321,6 +320,39 @@ class MightyEBIC(Detector):
         if not value * 0.9 <= dt <= value: # 10% tolerance as a rule-of-thumb (it does happen sometimes)
             logging.warning(f"Requested dwell time {value} differs from calculated dwell time {dt}, "
                             f"with {self._channel + 1} channels, using SPP {spp} and oversampling {os}.")
+        return dt, spp, os
+
+
+class DwellTimeVA(FloatContinuous):
+    """
+    Dedicated VA for setting (and clipping) the dwell time
+    """
+    def __init__(self, value: float, rng: Tuple[float, float], detector: MightyEBIC):
+        super().__init__(value, rng, unit="s", setter=self._set_dwell_time)
+        self._detector = detector
+
+    def clip(self, value: float) -> float:
+        """
+        Return the dwell time accepted by the MightyEBIC that is closest to the requested value, and within the allowed range.
+        :param value: requested dwell time
+        :return: acceptable dwell time
+        """
+        if value <= self._range[0]:
+            return self._range[0]
+        if value >= self._range[1]:
+            return self._range[1]
+
+        dt, spp, os = self._detector.find_dwell_time_settings(value)
+        return dt
+
+    def _set_dwell_time(self, value: float) -> float:
+        """
+        Called when the dwell time is changed, the value is checked and a value compatible with the
+        hardware and *smaller* or equal to the requested value is returned.
+        :param value: request dwell time (s)
+        :return: accepted dwell time (s)
+        """
+        dt, spp, os = self._detector.find_dwell_time_settings(value)
         return dt
 
 

--- a/src/odemis/driver/test/ephemeron_test.py
+++ b/src/odemis/driver/test/ephemeron_test.py
@@ -181,7 +181,10 @@ class TestMightyEBICDetector(unittest.TestCase):
         is always less or equal to the requested value.
         """
         for dt in self.dwell_time_values:
+            exp_dt = self.ebic_det.dwellTime.clip(dt)
             self.ebic_det.dwellTime.value = dt
+            # Clip should return the accepted value (without actually setting it)
+            self.assertEqual(self.ebic_det.dwellTime.value, exp_dt)
             self.assertLessEqual(self.ebic_det.dwellTime.value, dt)
 
     def test_acquisition(self):


### PR DESCRIPTION
On the SPARC, users with an EBIC and PMT detectors can acquire both at the same time. This happens automatically if the dwell time and repetition settings of the streams are identical. However, the EBIC "independent detector" has limited dwell time options. This would make it very hard to select the same dwell time for the two streams.

=> Make sure the dwell time of the independent detector is always a valid dwell time for the hardware, and consider that the dwell times are the same if they are within 1%. Finally, make sure that in case the dwell times are not identical, they are "reconciled" at the start of the acquisition (instead of failing).