### PR TITLE
[SWM-171][fix] XmlResourceHandler now explicitly handle the hidden flag

### DIFF
--- a/src/odemis/gui/xmlh/xh_delmic.py
+++ b/src/odemis/gui/xmlh/xh_delmic.py
@@ -30,7 +30,8 @@ import logging
 
 import wx
 import wx.adv
-import wx.xrc as xrc
+from decorator import decorator
+from wx import xrc
 
 import odemis.gui.comp.buttons as btns
 import odemis.gui.comp.foldpanelbar as fpb
@@ -45,6 +46,25 @@ from odemis.gui.comp.stream_bar import StreamBar
 from odemis.gui.comp.stream_panel import StreamPanel
 
 HANDLER_CLASS_LIST = []
+
+# Since wxPython v4.1+, which uses wxWidgets 3.1+, the handling of the "hidden" tag has changed.
+# Previously, this was handled by the default .SetupWindow() method.
+# Now, every handler has to explicitly handle it, in DoCreateResource().
+# The standard wxWidget code does it via a macro XRC_MAKE_INSTANCE, but we cannot use a C macro.
+# => Do something similar with a decorator.
+@decorator
+def apply_hidden(f, self):
+    """
+    Decorator for DoCreateResource(), to hide the widget, if the "hidden" tag is True.
+    :param f: function to decorate
+    :param self: XmlResourceHandler
+    :return: the create widget (same as DoCreateResource())
+    """
+    widget = f(self)
+    if self.GetBool("hidden", False):
+        widget.Hide()
+
+    return widget
 
 
 ##################################
@@ -65,6 +85,7 @@ class StreamPanelXmlHandler(xrc.XmlResourceHandler):
     def CanHandle(self, node):
         return self.IsOfClass(node, "StreamPanel")
 
+    @apply_hidden
     def DoCreateResource(self):
         assert self.GetInstance() is None
 
@@ -104,6 +125,7 @@ class FoldPanelBarXmlHandler(xrc.XmlResourceHandler):
         return self.IsOfClass(node, 'FoldPanelBar')
 
     # Process XML parameters and create the object
+    @apply_hidden
     def DoCreateResource(self):
         w = fpb.FoldPanelBar(
             self.GetParentAsWindow(),
@@ -134,6 +156,7 @@ class CaptionBarXmlHandler(xrc.XmlResourceHandler):
         return self.IsOfClass(node, 'CaptionBar')
 
     # Process XML parameters and create the object
+    @apply_hidden
     def DoCreateResource(self):
         parent = self.GetParentAsWindow()
         w = fpb.CaptionBar(
@@ -155,6 +178,7 @@ class FoldPanelItemXmlHandler(xrc.XmlResourceHandler):
         return self.IsOfClass(node, 'FoldPanelItem')
 
     # Process XML parameters and create the object
+    @apply_hidden
     def DoCreateResource(self):
         parent = self.GetParentAsWindow()
         w = fpb.FoldPanelItem(parent,
@@ -184,6 +208,7 @@ class StreamBarXmlHandler(xrc.XmlResourceHandler):
         return self.IsOfClass(node, 'StreamBar')
 
     # Process XML parameters and create the object
+    @apply_hidden
     def DoCreateResource(self):
         parent = self.GetParentAsWindow()
         w = StreamBar(parent,
@@ -210,6 +235,7 @@ class FastEMProjectListXmlHandler(xrc.XmlResourceHandler):
         return self.IsOfClass(node, 'FastEMProjectList')
 
     # Process XML parameters and create the object
+    @apply_hidden
     def DoCreateResource(self):
         parent = self.GetParentAsWindow()
         w = FastEMProjectList(parent,
@@ -239,6 +265,7 @@ class _ImageButtonHandler(xrc.XmlResourceHandler):
         return self.IsOfClass(node, self.klass.__name__)
 
     # Process XML parameters and create the object
+    @apply_hidden
     def DoCreateResource(self):
         assert self.GetInstance() is None
 
@@ -333,6 +360,7 @@ class SuggestTextCtrlHandler(xrc.XmlResourceHandler):
         return self.IsOfClass(node, 'SuggestTextCtrl')
 
     # Process XML parameters and create the object
+    @apply_hidden
     def DoCreateResource(self):
         assert self.GetInstance() is None
 
@@ -358,6 +386,7 @@ class UnitIntegerCtrlHandler(xrc.XmlResourceHandler):
         return self.IsOfClass(node, 'UnitIntegerCtrl')
 
     # Process XML parameters and create the object
+    @apply_hidden
     def DoCreateResource(self):
         assert self.GetInstance() is None
 
@@ -387,6 +416,7 @@ class UnitFloatCtrlHandler(xrc.XmlResourceHandler):
         return self.IsOfClass(node, 'UnitFloatCtrl')
 
     # Process XML parameters and create the object
+    @apply_hidden
     def DoCreateResource(self):
         assert self.GetInstance() is None
 
@@ -537,6 +567,7 @@ class UnitIntegerSliderHandler(xrc.XmlResourceHandler):
     def CanHandle(self, node):
         return self.IsOfClass(node, "UnitIntegerSlider")
 
+    @apply_hidden
     def DoCreateResource(self):
         assert self.GetInstance() is None
 
@@ -573,6 +604,7 @@ class UnitFloatSliderHandler(xrc.XmlResourceHandler):
     def CanHandle(self, node):
         return self.IsOfClass(node, "UnitFloatSlider")
 
+    @apply_hidden
     def DoCreateResource(self):
         assert self.GetInstance() is None
 
@@ -618,6 +650,7 @@ class VisualRangeSliderHandler(xrc.XmlResourceHandler):
     def CanHandle(self, node):
         return self.IsOfClass(node, "VisualRangeSlider")
 
+    @apply_hidden
     def DoCreateResource(self):
         assert self.GetInstance() is None
         # Now create the object
@@ -642,6 +675,7 @@ class BandwidthSliderHandler(xrc.XmlResourceHandler):
     def CanHandle(self, node):
         return self.IsOfClass(node, "BandwidthSlider")
 
+    @apply_hidden
     def DoCreateResource(self):
         assert self.GetInstance() is None
         # Now create the object
@@ -682,6 +716,7 @@ class OwnerDrawnComboBoxHandler(xrc.XmlResourceHandler):
     def CanHandle(self, node):
         return self.IsOfClass(node, "OwnerDrawnComboBox")
 
+    @apply_hidden
     def DoCreateResource(self):
         assert self.GetInstance() is None
 
@@ -718,6 +753,7 @@ class ToolBarHandler(xrc.XmlResourceHandler):
     def CanHandle(self, node):
         return self.IsOfClass(node, 'ToolBar')
 
+    @apply_hidden
     def DoCreateResource(self):
         assert self.GetInstance() is None
 
@@ -755,6 +791,7 @@ class ViewportGridHandler(xrc.XmlResourceHandler):
     def CanHandle(self, node):
         return self.IsOfClass(node, 'ViewportGrid')
 
+    @apply_hidden
     def DoCreateResource(self):
         assert self.GetInstance() is None
 

--- a/src/odemis/gui/xmlh/xh_delmic.py
+++ b/src/odemis/gui/xmlh/xh_delmic.py
@@ -3,7 +3,7 @@
 """
 @author: Rinze de Laat
 
-Copyright © 2012 Rinze de Laat, Delmic
+Copyright © 2012-2025 Rinze de Laat, Éric Piel, Delmic
 
 This file is part of Odemis.
 
@@ -46,10 +46,10 @@ from odemis.gui.comp.stream_panel import StreamPanel
 
 HANDLER_CLASS_LIST = []
 
+
 ##################################
 # Fold Panel Bar related Handlers
 ##################################
-
 
 class StreamPanelXmlHandler(xrc.XmlResourceHandler):
     def __init__(self):
@@ -63,9 +63,7 @@ class StreamPanelXmlHandler(xrc.XmlResourceHandler):
 
     # This method and the next one are required for XmlResourceHandlers
     def CanHandle(self, node):
-        capable = self.IsOfClass(node, "StreamPanel")
-
-        return capable
+        return self.IsOfClass(node, "StreamPanel")
 
     def DoCreateResource(self):
         assert self.GetInstance() is None
@@ -100,153 +98,127 @@ HANDLER_CLASS_LIST.append(StreamPanelXmlHandler)
 class FoldPanelBarXmlHandler(xrc.XmlResourceHandler):
     def __init__(self):
         xrc.XmlResourceHandler.__init__(self)
-        # Standard styles
         self.AddWindowStyles()
-        #self._isInside = False
 
     def CanHandle(self, node):
-        # return not self._isInside and self.IsOfClass(node, 'wx.lib.foldpanelbar.FoldPanelBar') or \
-        #        self._isInside and self.IsOfClass(node, 'foldpanel')
         return self.IsOfClass(node, 'FoldPanelBar')
 
     # Process XML parameters and create the object
     def DoCreateResource(self):
+        w = fpb.FoldPanelBar(
+            self.GetParentAsWindow(),
+            self.GetID(),
+            self.GetPosition(),
+            self.GetSize(),
+            self.GetStyle()
+        )
+        self.SetupWindow(w)
 
-        if self.GetClass() == 'FoldPanelBar':
-            #print "Creating FoldpanelBar"
-            w = fpb.FoldPanelBar(
-                self.GetParentAsWindow(),
-                self.GetID(),
-                self.GetPosition(),
-                self.GetSize(),
-                self.GetStyle()
-            )
-            self.SetupWindow(w)
+        parent = w.GetParent()
+        if parent.__class__ == wx.ScrolledWindow:
+            parent.EnableScrolling(False, True)
+            parent.SetScrollbars(-1, 10, 1, 1)
 
-            parent = w.GetParent()
-            if parent.__class__ == wx.ScrolledWindow:
-                parent.EnableScrolling(False, True)
-                parent.SetScrollbars(-1, 10, 1, 1)
+        self.CreateChildren(w, False)
 
-            self.CreateChildren(w, False)
-
-            return w
+        return w
 HANDLER_CLASS_LIST.append(FoldPanelBarXmlHandler)
 
 
 class CaptionBarXmlHandler(xrc.XmlResourceHandler):
     def __init__(self):
         xrc.XmlResourceHandler.__init__(self)
-        # Standard styles
         self.AddWindowStyles()
-        # Custom styles
 
     def CanHandle(self, node):
         return self.IsOfClass(node, 'CaptionBar')
 
-
     # Process XML parameters and create the object
     def DoCreateResource(self):
-
-        if self.GetClass() == 'CaptionBar':
-            #print "Creating CaptionBar"
-            parent = self.GetParentAsWindow()
-            w = fpb.CaptionBar(
-                            parent,
-                            self.GetText('label'),
-                            self.GetBool('collapsed')
-            )
-            self.SetupWindow(w)
-            return w
+        parent = self.GetParentAsWindow()
+        w = fpb.CaptionBar(
+                        parent,
+                        self.GetText('label'),
+                        self.GetBool('collapsed')
+        )
+        self.SetupWindow(w)
+        return w
 HANDLER_CLASS_LIST.append(CaptionBarXmlHandler)
 
 
 class FoldPanelItemXmlHandler(xrc.XmlResourceHandler):
     def __init__(self):
         xrc.XmlResourceHandler.__init__(self)
-        # Standard styles
         self.AddWindowStyles()
-        # Custom styles
 
     def CanHandle(self, node):
         return self.IsOfClass(node, 'FoldPanelItem')
 
     # Process XML parameters and create the object
     def DoCreateResource(self):
+        parent = self.GetParentAsWindow()
+        w = fpb.FoldPanelItem(parent,
+                              self.GetID(),
+                              self.GetPosition(),
+                              self.GetSize(),
+                              self.GetStyle(),
+                              self.GetText('label'),
+                              self.GetBool('collapsed'),
+                              nocaption=self.GetBool('nocaption'))
+        self.SetupWindow(w)
+        self.CreateChildren(w, False)
 
-        if self.GetClass() == 'FoldPanelItem':
-            parent = self.GetParentAsWindow()
-            w = fpb.FoldPanelItem(parent,
-                                  self.GetID(),
-                                  self.GetPosition(),
-                                  self.GetSize(),
-                                  self.GetStyle(),
-                                  self.GetText('label'),
-                                  self.GetBool('collapsed'),
-                                  nocaption=self.GetBool('nocaption'))
-            self.SetupWindow(w)
-            self.CreateChildren(w, False)
-
-            # Move all the FoldPanelItem children to the main sizer
-            w.children_to_sizer()
-            parent.add_item(w)
-            return w
+        # Move all the FoldPanelItem children to the main sizer
+        w.children_to_sizer()
+        parent.add_item(w)
+        return w
 HANDLER_CLASS_LIST.append(FoldPanelItemXmlHandler)
 
 
 class StreamBarXmlHandler(xrc.XmlResourceHandler):
     def __init__(self):
         xrc.XmlResourceHandler.__init__(self)
-        # Standard styles
         self.AddWindowStyles()
-        # Custom styles
 
     def CanHandle(self, node):
         return self.IsOfClass(node, 'StreamBar')
 
     # Process XML parameters and create the object
     def DoCreateResource(self):
-
-        if self.GetClass() == 'StreamBar':
-            parent = self.GetParentAsWindow()
-            w = StreamBar(parent,
-                                 self.GetID(),
-                                 self.GetPosition(),
-                                 self.GetSize(),
-                                 self.GetStyle(),
-                                 add_button=self.GetBool('add_button'))
-            self.SetupWindow(w)
-            # 'Dirty' fix for the hard coded 'add stream' child button
-            if self.GetBool('add_button'):
-                w.btn_add_stream.SetBackgroundColour(w.GetBackgroundColour())
-            parent.add_item(w)
-            return w
+        parent = self.GetParentAsWindow()
+        w = StreamBar(parent,
+                             self.GetID(),
+                             self.GetPosition(),
+                             self.GetSize(),
+                             self.GetStyle(),
+                             add_button=self.GetBool('add_button'))
+        self.SetupWindow(w)
+        # 'Dirty' fix for the hard coded 'add stream' child button
+        if self.GetBool('add_button'):
+            w.btn_add_stream.SetBackgroundColour(w.GetBackgroundColour())
+        parent.add_item(w)
+        return w
 HANDLER_CLASS_LIST.append(StreamBarXmlHandler)
 
 
 class FastEMProjectListXmlHandler(xrc.XmlResourceHandler):
     def __init__(self):
         xrc.XmlResourceHandler.__init__(self)
-        # Standard styles
         self.AddWindowStyles()
-        # Custom styles
 
     def CanHandle(self, node):
         return self.IsOfClass(node, 'FastEMProjectList')
 
     # Process XML parameters and create the object
     def DoCreateResource(self):
-
-        if self.GetClass() == 'FastEMProjectList':
-            parent = self.GetParentAsWindow()
-            w = FastEMProjectList(parent,
-                                  self.GetID(),
-                                  self.GetPosition(),
-                                  self.GetSize(),
-                                  self.GetStyle())
-            self.SetupWindow(w)
-            #parent.add_item(w)
-            return w
+        parent = self.GetParentAsWindow()
+        w = FastEMProjectList(parent,
+                              self.GetID(),
+                              self.GetPosition(),
+                              self.GetSize(),
+                              self.GetStyle())
+        self.SetupWindow(w)
+        return w
 HANDLER_CLASS_LIST.append(FastEMProjectListXmlHandler)
 
 
@@ -256,12 +228,12 @@ class _ImageButtonHandler(xrc.XmlResourceHandler):
 
     def __init__(self):
         xrc.XmlResourceHandler.__init__(self)
-        # Standard styles
-        self.AddWindowStyles()
         # Custom styles
         self.AddStyle('wxALIGN_LEFT', wx.ALIGN_LEFT)
         self.AddStyle('wxALIGN_RIGHT', wx.ALIGN_RIGHT)
         self.AddStyle('wxALIGN_CENTRE', wx.ALIGN_CENTRE)
+        # Standard styles
+        self.AddWindowStyles()
 
     def CanHandle(self, node):
         return self.IsOfClass(node, self.klass.__name__)
@@ -304,7 +276,7 @@ class _ImageButtonHandler(xrc.XmlResourceHandler):
                 **kwargs)
 
         except ValueError:
-            print("Failed to create ImageButton %s" % (self.GetName(),))
+            logging.error("Failed to create ImageButton %s" % (self.GetName(),))
             raise
 
         self.SetupWindow(w)
@@ -355,9 +327,7 @@ class SuggestTextCtrlHandler(xrc.XmlResourceHandler):
 
     def __init__(self):
         xrc.XmlResourceHandler.__init__(self)
-        # Standard styles
         self.AddWindowStyles()
-        # Custom styles
 
     def CanHandle(self, node):
         return self.IsOfClass(node, 'SuggestTextCtrl')
@@ -382,9 +352,7 @@ class UnitIntegerCtrlHandler(xrc.XmlResourceHandler):
 
     def __init__(self):
         xrc.XmlResourceHandler.__init__(self)
-        # Standard styles
         self.AddWindowStyles()
-        # Custom styles
 
     def CanHandle(self, node):
         return self.IsOfClass(node, 'UnitIntegerCtrl')
@@ -413,9 +381,7 @@ class UnitFloatCtrlHandler(xrc.XmlResourceHandler):
 
     def __init__(self):
         xrc.XmlResourceHandler.__init__(self)
-        # Standard styles
         self.AddWindowStyles()
-        # Custom styles
 
     def CanHandle(self, node):
         return self.IsOfClass(node, 'UnitFloatCtrl')
@@ -447,64 +413,7 @@ HANDLER_CLASS_LIST.append(UnitFloatCtrlHandler)
 # Canvas Handlers
 ##################################
 
-class CameraViewportXmlHandler(xrc.XmlResourceHandler):
-
-    klass = vport.CameraViewport
-
-    def __init__(self):
-        xrc.XmlResourceHandler.__init__(self)
-        # Specify the styles recognized by objects of this type
-        self.AddStyle("wxTAB_TRAVERSAL", wx.TAB_TRAVERSAL)
-        self.AddWindowStyles()
-
-    # This method and the next one are required for XmlResourceHandlers
-    def CanHandle(self, node):
-        return self.IsOfClass(node, "CameraViewport")
-
-    def DoCreateResource(self):
-        assert self.GetInstance() is None
-
-        # Now create the object
-        panel = self.klass(self.GetParentAsWindow(),
-                           id=self.GetID(),
-                           pos=self.GetPosition(),
-                           size=self.GetSize(),
-                           style=self.GetStyle())
-        self.SetupWindow(panel)
-        return panel
-HANDLER_CLASS_LIST.append(CameraViewportXmlHandler)
-
-
-class FixedOverviewViewportXmlHandler(xrc.XmlResourceHandler):
-
-    klass = vport.FixedOverviewViewport
-
-    def __init__(self):
-        xrc.XmlResourceHandler.__init__(self)
-        # Specify the styles recognized by objects of this type
-        self.AddStyle("wxTAB_TRAVERSAL", wx.TAB_TRAVERSAL)
-        self.AddWindowStyles()
-
-    # This method and the next one are required for XmlResourceHandlers
-    def CanHandle(self, node):
-        return self.IsOfClass(node, "FixedOverviewViewport")
-
-    def DoCreateResource(self):
-        assert self.GetInstance() is None
-
-        # Now create the object
-        panel = self.klass(self.GetParentAsWindow(),
-                           id=self.GetID(),
-                           pos=self.GetPosition(),
-                           size=self.GetSize(),
-                           style=self.GetStyle())
-        self.SetupWindow(panel)
-        return panel
-HANDLER_CLASS_LIST.append(FixedOverviewViewportXmlHandler)
-
-
 class MicroscopeViewportXmlHandler(xrc.XmlResourceHandler):
-
     klass = vport.MicroscopeViewport
 
     def __init__(self):
@@ -515,7 +424,7 @@ class MicroscopeViewportXmlHandler(xrc.XmlResourceHandler):
 
     # This method and the next one are required for XmlResourceHandlers
     def CanHandle(self, node):
-        return self.IsOfClass(node, "MicroscopeViewport")
+        return self.IsOfClass(node, self.klass.__name__)
 
     def DoCreateResource(self):
         assert self.GetInstance() is None
@@ -535,132 +444,85 @@ class MicroscopeViewportXmlHandler(xrc.XmlResourceHandler):
 HANDLER_CLASS_LIST.append(MicroscopeViewportXmlHandler)
 
 
+class CameraViewportXmlHandler(MicroscopeViewportXmlHandler):
+    klass = vport.CameraViewport
+HANDLER_CLASS_LIST.append(CameraViewportXmlHandler)
+
+
+class FixedOverviewViewportXmlHandler(MicroscopeViewportXmlHandler):
+    klass = vport.FixedOverviewViewport
+HANDLER_CLASS_LIST.append(FixedOverviewViewportXmlHandler)
+
+
 class LiveViewportXmlHandler(MicroscopeViewportXmlHandler):
-
     klass = vport.LiveViewport
-
-    def CanHandle(self, node):
-        return self.IsOfClass(node, "LiveViewport")
 HANDLER_CLASS_LIST.append(LiveViewportXmlHandler)
 
 
 class RawLiveViewportXmlHandler(MicroscopeViewportXmlHandler):
-
     klass = vport.RawLiveViewport
-
-    def CanHandle(self, node):
-        return self.IsOfClass(node, "RawLiveViewport")
 HANDLER_CLASS_LIST.append(RawLiveViewportXmlHandler)
 
 
 class FeatureOverviewViewportXmlHandler(MicroscopeViewportXmlHandler):
-
     klass = vport.FeatureOverviewViewport
-
-    def CanHandle(self, node):
-        return self.IsOfClass(node, "FeatureOverviewViewport")
 HANDLER_CLASS_LIST.append(FeatureOverviewViewportXmlHandler)
 
 
 class ARAcquiViewportXmlHandler(MicroscopeViewportXmlHandler):
-
     klass = vport.ARAcquiViewport
-
-    def CanHandle(self, node):
-        return self.IsOfClass(node, "ARAcquiViewport")
 HANDLER_CLASS_LIST.append(ARAcquiViewportXmlHandler)
 
 
 class PointSpectrumViewportXmlHandler(MicroscopeViewportXmlHandler):
-
     klass = vport.PointSpectrumViewport
-
-    def CanHandle(self, node):
-        return self.IsOfClass(node, "PointSpectrumViewport")
 HANDLER_CLASS_LIST.append(PointSpectrumViewportXmlHandler)
 
 
 class ChronographViewportXmlHandler(MicroscopeViewportXmlHandler):
-
     klass = vport.ChronographViewport
-
-    def CanHandle(self, node):
-        return self.IsOfClass(node, "ChronographViewport")
 HANDLER_CLASS_LIST.append(ChronographViewportXmlHandler)
 
 
 class ThetaViewportXmlHandler(MicroscopeViewportXmlHandler):
-
     klass = vport.ThetaViewport
-
-    def CanHandle(self, node):
-        return self.IsOfClass(node, "ThetaViewport")
 HANDLER_CLASS_LIST.append(ThetaViewportXmlHandler)
 
 
 class ARLiveViewportXmlHandler(MicroscopeViewportXmlHandler):
-
     klass = vport.ARLiveViewport
-
-    def CanHandle(self, node):
-        return self.IsOfClass(node, "ARLiveViewport")
 HANDLER_CLASS_LIST.append(ARLiveViewportXmlHandler)
 
 
 class EKLiveViewportXmlHandler(MicroscopeViewportXmlHandler):
-
     klass = vport.EKLiveViewport
-
-    def CanHandle(self, node):
-        return self.IsOfClass(node, "EKLiveViewport")
 HANDLER_CLASS_LIST.append(EKLiveViewportXmlHandler)
 
 
 class AngularResolvedViewportXmlHandler(MicroscopeViewportXmlHandler):
-
     klass = vport.AngularResolvedViewport
-
-    def CanHandle(self, node):
-        return self.IsOfClass(node, "AngularResolvedViewport")
 HANDLER_CLASS_LIST.append(AngularResolvedViewportXmlHandler)
 
 
 class LineSpectrumViewportXmlHandler(MicroscopeViewportXmlHandler):
-
     klass = vport.LineSpectrumViewport
-
-    def CanHandle(self, node):
-        return self.IsOfClass(node, "LineSpectrumViewport")
 HANDLER_CLASS_LIST.append(LineSpectrumViewportXmlHandler)
 
 
 class TemporalSpectrumViewportXmlHandler(MicroscopeViewportXmlHandler):
-
     klass = vport.TemporalSpectrumViewport
-
-    def CanHandle(self, node):
-        return self.IsOfClass(node, "TemporalSpectrumViewport")
-
-
 HANDLER_CLASS_LIST.append(TemporalSpectrumViewportXmlHandler)
 
+
 class FastEMMainViewportXmlHandler(MicroscopeViewportXmlHandler):
-
     klass = vport.FastEMMainViewport
-
-    def CanHandle(self, node):
-        return self.IsOfClass(node, "FastEMMainViewport")
 HANDLER_CLASS_LIST.append(FastEMMainViewportXmlHandler)
 
+
 class AngularSpectrumViewportXmlHandler(MicroscopeViewportXmlHandler):
-
     klass = vport.AngularSpectrumViewport
-
-    def CanHandle(self, node):
-        return self.IsOfClass(node, "AngularSpectrumViewport")
-
-
 HANDLER_CLASS_LIST.append(AngularSpectrumViewportXmlHandler)
+
 
 ##################################
 # Sliders
@@ -669,13 +531,11 @@ HANDLER_CLASS_LIST.append(AngularSpectrumViewportXmlHandler)
 class UnitIntegerSliderHandler(xrc.XmlResourceHandler):
     def __init__(self):
         xrc.XmlResourceHandler.__init__(self)
-        # Specify the styles recognized by objects of this type
         self.AddWindowStyles()
 
     # This method and the next one are required for XmlResourceHandlers
     def CanHandle(self, node):
-        capable = self.IsOfClass(node, "UnitIntegerSlider")
-        return capable
+        return self.IsOfClass(node, "UnitIntegerSlider")
 
     def DoCreateResource(self):
         assert self.GetInstance() is None
@@ -707,7 +567,6 @@ HANDLER_CLASS_LIST.append(UnitIntegerSliderHandler)
 class UnitFloatSliderHandler(xrc.XmlResourceHandler):
     def __init__(self):
         xrc.XmlResourceHandler.__init__(self)
-        # Specify the styles recognized by objects of this type
         self.AddWindowStyles()
 
     # This method and the next one are required for XmlResourceHandlers
@@ -753,13 +612,11 @@ HANDLER_CLASS_LIST.append(UnitFloatSliderHandler)
 class VisualRangeSliderHandler(xrc.XmlResourceHandler):
     def __init__(self):
         xrc.XmlResourceHandler.__init__(self)
-        # Specify the styles recognized by objects of this type
         self.AddWindowStyles()
 
     # This method and the next one are required for XmlResourceHandlers
     def CanHandle(self, node):
-        capable = self.IsOfClass(node, "VisualRangeSlider")
-        return capable
+        return self.IsOfClass(node, "VisualRangeSlider")
 
     def DoCreateResource(self):
         assert self.GetInstance() is None
@@ -836,6 +693,7 @@ class OwnerDrawnComboBoxHandler(xrc.XmlResourceHandler):
                                             style=self.GetStyle())
         new_ctrl.SetButtonBitmaps(img.getBitmap("button/btn_down.png"), pushButtonBg=False)
         self.SetupWindow(new_ctrl)
+
         return new_ctrl
 HANDLER_CLASS_LIST.append(OwnerDrawnComboBoxHandler)
 
@@ -856,11 +714,8 @@ class ToolBarHandler(xrc.XmlResourceHandler):
 
         # Standard styles
         self.AddWindowStyles()
-        #self._isInside = False
 
     def CanHandle(self, node):
-        # return not self._isInside and self.IsOfClass(node, 'wx.lib.foldpanelbar.FoldPanelBar') or \
-        #        self._isInside and self.IsOfClass(node, 'foldpanel')
         return self.IsOfClass(node, 'ToolBar')
 
     def DoCreateResource(self):
@@ -894,7 +749,6 @@ class ViewportGridHandler(xrc.XmlResourceHandler):
 
     def __init__(self):
         xrc.XmlResourceHandler.__init__(self)
-
         # Standard styles
         self.AddWindowStyles()
 


### PR DESCRIPTION
In the XRC files, each component may have a "hidden" flag. Up to  wxPython 4.0.x, which had wxWidgets 3.0, this flag was handled  automatically by .SetupWindow().

However, commit 7baf1ce2f (Don't show windows with "hidden" XRC attribute at all) https://github.com/wxWidgets/wxWidgets/commit/7baf1ce2fd9bcf21e2bc336de46dd95fecf7a56b changed this behaviour, and now every class has to do it (or not) in `DoCreateResource()`.
    
This makes sure it also happens on our own classes. This fixes issues where GUI widgets would be incorrectly shown at init when using wxPython 4.1+ (for instance, on Ubunut 24.04).
    
Note that it always run, even on wxPython 4.0, but that's not an issue, as it just makes the hidden flag a tiny bit more efficient.

Also refactor the code. => look as 2 separate commits for easier review!