### PR TITLE
[fix] SPARC acquisition streakcam test cases could fail

### DIFF
--- a/src/odemis/acq/stream/_sync.py
+++ b/src/odemis/acq/stream/_sync.py
@@ -596,8 +596,8 @@ class MultipleDetectorStream(Stream, metaclass=ABCMeta):
         if self._acq_min_date > data.metadata.get(model.MD_ACQ_DATE, 0):
             # This is a sign that the e-beam might have been at the wrong (old)
             # position while Rep data is acquiring
-            logging.warning("Dropping data because it started %g s too early",
-                            self._acq_min_date - data.metadata.get(model.MD_ACQ_DATE, 0))
+            logging.warning("Dropping data (of stream %d) because it started %g s too early",
+                            n, self._acq_min_date - data.metadata.get(model.MD_ACQ_DATE, 0))
             # TODO: As the detector is synchronised, we need to restart it.
             # Or maybe not, as the typical reason it arrived early is that the
             # detector was already running, in which case they haven't

--- a/src/odemis/acq/stream/_sync.py
+++ b/src/odemis/acq/stream/_sync.py
@@ -279,11 +279,7 @@ class MultipleDetectorStream(Stream, metaclass=ABCMeta):
             shape = (len(pol_pos), rep[1], rep[0])
             # estimate acq time for leeches is based on two fastest axis
             if self._integrationTime:
-                # get the exposure time directly from the hardware (e.g. hardware rounds value) to calc counts
-                integration_count = int(math.ceil(self._integrationTime.value / self._ccd.exposureTime.value))
-                if integration_count != self._integrationCounts.value:
-                    logging.debug("Integration count of %d, does not match integration count of %d as expected",
-                                  integration_count, self._integrationCounts.value)
+                integration_count = self._integrationCounts.value
                 if integration_count > 1:
                     shape = (len(pol_pos), rep[1], rep[0], integration_count)  # overwrite shape
 

--- a/src/odemis/acq/test/stream_test.py
+++ b/src/odemis/acq/test/stream_test.py
@@ -2434,6 +2434,12 @@ class SPARC2StreakCameraTestCase(unittest.TestCase):
 
         cls.filter = model.getComponent(role="filter")
 
+    def setUp(self):
+        # Wait a bit for the simulator to be "ready" again (as it's not a very good simulator)
+        # Otherwise, if immediately stopping & starting, the simulator may generate an old image,
+        # very early.
+        time.sleep(2)
+
     def _roiToPhys(self, repst):
         """
         Compute the (expected) physical position of a stream ROI
@@ -3128,6 +3134,7 @@ class SPARC2StreakCameraTestCase(unittest.TestCase):
         # check the dtype is correct
         self.assertEqual(ts_da.dtype, numpy.uint32)
 
+        time.sleep(2)
         # do a second acquisition with longer exp time and check values are bigger due to integration
         streaks.integrationTime.value = 2.5  # s
 
@@ -3183,10 +3190,11 @@ class SPARC2StreakCameraTestCase(unittest.TestCase):
 
         # set stream VAs
         streaks.integrationTime.value = 2  # s
-        # TODO use fixed repetition value -> set ROI?
-        streaks.repetition.value = (3, 5)  # results in (1, 2)
+        # The maximum exposure time of the streak-ccd is 1s => 2 images are integrated
+        assert streaks.integrationCounts.value == 2
+        streaks.roi.value = (0, 0.2, 0.4, 0.8)
+        streaks.repetition.value = (3, 5)  # results in (2, 4)
 
-        streaks.roi.value = (0, 0.2, 0.3, 0.6)
         dc = leech.AnchorDriftCorrector(self.ebeam, self.sed)
         dc.period.value = 1  # s  so should run leech for sub acquisitions (between integrating 2 images)
         dc.roi.value = (0.525, 0.525, 0.6, 0.6)


### PR DESCRIPTION
The changes to the SPARC acquisition to use the new "startScan" event caused some issues with the streakcam simulator. That broke some test cases.