### PR TITLE
[fix] [METEOR-1347] Tescan e-beam current API use

### DIFF
--- a/src/odemis/gui/conf/data.py
+++ b/src/odemis/gui/conf/data.py
@@ -168,7 +168,10 @@ HW_SETTINGS_CONFIG = {
             }),
             ("probeCurrent", {
                 "label": "Beam current",
-                "event": wx.EVT_SCROLL_CHANGED  # only affects when it's a slider
+                # The following only affects when it's a slider
+                "event": wx.EVT_SCROLL_CHANGED,
+                "scale": "log",
+                "accuracy": 3,
             }),
             ("spotSize", {
                 "tooltip": "Electron-beam spot size",


### PR DESCRIPTION
Use SetBeamCurrent/GetBeamCurrent over the deprecated SetPCIndex API method. As a consequence, we don't have to do list index handling and we can have a continuous VA. Since the current range is device specific, a default value is introduced that is over-writable via the yaml.

And separately, I also introduced a log scale, since there was otherwise no differentiation on the slider for smaller values.

Tescan Sim
![image](https://github.com/user-attachments/assets/df66cdbd-b851-41ac-8779-e1f561be065b)
Odemis
![image](https://github.com/user-attachments/assets/1e38ed45-c768-4343-a879-4a3244933767)

