### PR TITLE
[fix] Update pymodbus import for compatibility with latest version

### DIFF
--- a/src/odemis/driver/tfsbc.py
+++ b/src/odemis/driver/tfsbc.py
@@ -23,7 +23,11 @@ import logging
 
 import numpy
 import serial.tools.list_ports
-from pymodbus.client.sync import ModbusSerialClient
+try:
+    from pymodbus.client import ModbusSerialClient  # version 3.6
+except ImportError:
+    from pymodbus.client.sync import ModbusSerialClient  # version 2.1
+
 
 from odemis import model
 from odemis.model import HwError


### PR DESCRIPTION
In the latest version of pymodbus the location of ModbusSerialClient has changed. This commit fixes the import such that it works with old and new versions of pymodbus.