### PR TITLE
[fix] Adjust stepsize of exhaustive autofocus range when stepsize > s…

### DIFF
--- a/src/odemis/acq/align/autofocus.py
+++ b/src/odemis/acq/align/autofocus.py
@@ -453,6 +453,10 @@ def _DoExhaustiveFocus(future, detector, emt, focus, dfbkg, good_focus, rng_focu
         # difference compared to the focus levels measured so far.
         step = 8 * dof
         lower_bound, upper_bound = rng
+        # Ensure we take at least 10 steps
+        if (upper_bound - lower_bound) < 10 * step:
+            logging.debug("Focus range < 10 steps, adjusting step size to %g m", (upper_bound - lower_bound) / 10)
+            step = (upper_bound - lower_bound) / 10
         # start moving upwards until we reach the upper bound or we find some
         # significant deviation in focus level
         # The number of steps is the distance to the upper bound divided by the step size.


### PR DESCRIPTION
…earch range

In the exhaustive autofocus method the stepsize could be larger than the range. This caused the code to completely skip the exhaustive search and go to a binary search immediately. This fix ensures that we take at least 10 steps in an exhaustive search.