### PR TITLE
[feat] FVEM-40 Disable offloading of calibration data to the technolution storage server

### DIFF
--- a/src/odemis/driver/technolution.py
+++ b/src/odemis/driver/technolution.py
@@ -1245,9 +1245,8 @@ class MPPC(model.Detector):
 
         md = self.getMetadata()
         custom_data = md.get(model.MD_EXTRA_SETTINGS, "")  # if no custom metadata, pass an empty string
-        # TODO support USER_NOTE in GUI
         info = md.get(model.MD_USER_NOTE, None)  # if no user note pass None, so it is not added to the metadata.yaml
-        z_position = md.get(model.MD_SLICE_IDX, 0)  # if slice number is not provided use 0. TODO support in GUI
+        z_position = md.get(model.MD_SLICE_IDX, 0)  # if slice number is not provided use 0.
         eff_field_size = md.get(model.MD_FIELD_SIZE, self._scanner.resolution.value)
 
         megafield_metadata = MegaFieldMetaData(

--- a/src/odemis/driver/technolution.py
+++ b/src/odemis/driver/technolution.py
@@ -1249,10 +1249,13 @@ class MPPC(model.Detector):
         z_position = md.get(model.MD_SLICE_IDX, 0)  # if slice number is not provided use 0.
         eff_field_size = md.get(model.MD_FIELD_SIZE, self._scanner.resolution.value)
 
+        offload_disable = True if ".calibrations" in self.filename.value else False
+
         megafield_metadata = MegaFieldMetaData(
             stack_id=os.path.basename(self.filename.value),
             info=info,
             storage_directory=os.path.dirname(self.filename.value),
+            offload_disable=offload_disable,
             custom_data=custom_data,
             stage_position_x=float(stage_position[0]),
             stage_position_y=float(stage_position[1]),


### PR DESCRIPTION
Previously we set the filename of calibration data to .calibrations to ensure that the calibration data did not get post processed. In v3.0 Technolution added support for disabling the offloading of data to the storage server

Also removed 2 TODOs in a separate commit in this PR, since the TODOs have been implemented by now.