### PR TITLE
[fix] adjust timing for independent EBIC detector acquisition

### DIFF
--- a/src/odemis/acq/stream/_sync.py
+++ b/src/odemis/acq/stream/_sync.py
@@ -2583,7 +2583,8 @@ class SEMMDStream(MultipleDetectorStream):
                 if has_inde_detectors:
                     # The independent detectors might need a bit of time to be ready.
                     # If not waiting, the first pixels might be missed.
-                    time.sleep(0.05)
+                    # Note: ephemeron EBIC hardware needs at least 0.1s
+                    time.sleep(0.1)
 
                 start = time.time()
                 self._acq_min_date = start


### PR DESCRIPTION
Now use the same timing as in the live mode. In practice, this makes the acquisition
a lot more reliable.

Ideally, we would have a mechanism to read this timing from the Odemis
HwComponent, or have a synchronization mechanism. However, for now, we
only support one type of "independent detector", which is the Ephemeron
MightyEBIC. So let's not over-engineer the fix. This can be improved
once we have to support other types of detectors.