### PR TITLE
[feat] GUI SPARC: at init warn if the interlock is triggered at start

### DIFF
--- a/src/odemis/gui/cont/acquisition/sparc_acq.py
+++ b/src/odemis/gui/cont/acquisition/sparc_acq.py
@@ -68,16 +68,24 @@ class SparcAcquiController(object):
         self._tab_panel = tab_panel
         self._streambar_controller = streambar_controller
         self._interlockTriggered = False  # local/private bool to track interlock status
+        self._ebeam_blanker = None
+
+        if model.hasVA(self._main_data_model.light, "interlockTriggered"):
+            # subscribe to the VA and initialize the warning status
+            self._main_data_model.light.interlockTriggered.subscribe(self.on_interlock_change, init=True)
+
+        # Trick: _ebeam_blanker is set *after* on_interlock_change() is called at init.
+        # This way, at init, even if the interlock is already triggered, the blanker is untouched. Only the
+        # warning message is shown. This is to avoid the blanker to change the SEM state at init, as
+        # anyway the user might have been using the system as-is for a while, and it's confusing that
+        # suddenly the e-beam is blanked when the Odemis GUI starts. Especially, this helps the safety
+        # only if the interlock is triggered due to the SPARC cover being open... but they are many
+        # other reasons for the interlock to be triggered.
+
         if self._main_data_model.ebeam and model.hasVA(self._main_data_model.ebeam, "blanker"):
             # blanker state before interlock (to restore it when interlock is reset)
             self._ebeam_blanker = self._main_data_model.ebeam.blanker
             self._pre_interlock_blanker = self._ebeam_blanker.value
-        else:
-            self._ebeam_blanker = None
-
-        if model.hasVA(self._main_data_model.light, "interlockTriggered"):
-            # subscribe to the VA and initialize the warning status
-            self._main_data_model.light.interlockTriggered.subscribe(self.on_interlock_change)
 
         # For file selection
         self.conf = conf.get_acqui_conf()


### PR DESCRIPTION
During normal operation, if the laser interlock is triggered, a message
is shown, and the ebeam is blanked. Until now, nothing happened at init,
if the GUI starts while the interlock is already triggered.

With this change, in such corner case, the GUI will also show a
notification message, to remind the user something is "unusual".
However, the blanker is not activated, because it could be also cause
some confusion, or annoyance, if just the start of the Odemis GUI
blanks the beam while the user is using the SEM, and might have been
doing so safely for a while.

This new behaviour has been defined here: https://docs.google.com/document/d/1NXZB1rKTN90pdenfWxKe_vTNmEE1CSla4j65ngod8F4/edit?disco=AAABeskOnhI