### PR TITLE
[PPSI-3780][fix] SPARC acquisition: after acquisition, hardware setting must be restored

### DIFF
--- a/src/odemis/acq/stream/_sync.py
+++ b/src/odemis/acq/stream/_sync.py
@@ -1871,6 +1871,7 @@ class SEMCCDMDStream(MultipleDetectorStream):
             self._current_scan_area = None  # Indicate we are done for the live (also in case of error)
             for s in self._streams:
                 s._unlinkHwVAs()
+            self._restoreHardwareSettings()
             self._dc_estimator = None
             self._current_future = None
             self._acq_data = [[] for _ in self._streams]  # regain a bit of memory
@@ -2348,6 +2349,7 @@ class SEMCCDMDStream(MultipleDetectorStream):
 
             for s in self._streams:
                 s._unlinkHwVAs()
+            self._restoreHardwareSettings()
             self._acq_data = [[] for _ in self._streams]  # regain a bit of memory
             self._dc_estimator = None
             self._current_future = None


### PR DESCRIPTION
With the support for the "external" and "blanker" signals, the
acqusition code must restore the values after it's completed. There are
5 different versions of the "runAcquisition()" function, but only 3 did
restore the settings.

=> Call the _restoreHardwareSettings() from all the runAcquisition()
functions.