### PR TITLE
[fix] failing test_measure_z_pos_shifted in z_localization_test. Hand…

### DIFF
--- a/src/odemis/odemisd/mdupdater.py
+++ b/src/odemis/odemisd/mdupdater.py
@@ -341,9 +341,7 @@ class MetadataUpdater(model.Component):
 
         pos = filter.position.value
         bandwidth = filter.axes["band"].choices[pos["band"]]
-        if bandwidth == model.BAND_PASS_THROUGH:  # "pass-through" == no filter
-            return None
-        elif isinstance(bandwidth, str):  # Sometimes the filter is just a name like "red".
+        if isinstance(bandwidth, str):  # "pass-through" or sometimes the filter is just a name like "red".
             return bandwidth
         # Last, and most common, option: tuple/list of 2 floats (min, max)
         elif (isinstance(bandwidth, (tuple, list))
@@ -444,7 +442,6 @@ class MetadataUpdater(model.Component):
         def updateOutWLRange(pos, fl=filter, comp_affected=comp_affected):
             spec = self._det_to_spectrograph.get(comp_affected.name)  # can be None
             self.updateOutWavelength(comp_affected, fl, spec)
-
             # apply lateral chromatic correction to align with the reference channel
             apply_transform = fl.getMetadata().get(model.MD_CHROMATIC_COR, None)
             if apply_transform:


### PR DESCRIPTION
…le the pass-through filter as a string.

 At line 179, zshift, warning = f.result(30) failed due to TypeError: 'NoneType' object is not iterable at if not isinstance(next(iter(bands)), Iterable)
 
 **Handling:-**
When the filter used is pass-through, the code in tiff.py expects the filter as a string i.e. "pass-through" and not None. From tiff.py at line 1592
```

            if model.MD_OUT_WL in da.metadata:
                owl = da.metadata[model.MD_OUT_WL]
                if isinstance(owl, str):
                    filter = ET.SubElement(chan, "Filter", attrib={
                                    "ID": "Filter:%d:%d" % (idnum, subid)})
                    filter.attrib["Type"] = owl
                elif model.MD_IN_WL in da.metadata:
                    # Use excitation wavelength in case of multiple bands
                    iwl = da.metadata[model.MD_IN_WL]
                    ewl = fluo.get_one_center_em(owl, iwl) * 1e9  # in nm
                    chan.attrib["EmissionWavelength"] = "%d" % round(ewl)

         
```           
The pass through filter should go in the if block and not in elif block. When pass through filter is reset to None, it goes to elif block leading to the error. 
 
 
 **Full Error Message:**
src/odemis/acq/align/test/z_localization_test.py:183 (TestMeasureZ.test_measure_z_pos_shifted)
self = <z_localization_test.TestMeasureZ testMethod=test_measure_z_pos_shifted>

    def test_measure_z_pos_shifted(self):
        """
        Test measure_z with a pos within the FoV, but not in the center
        """
        # Note: the simulator image is not proper, so measure_z will return odd value
        # with a warning.
    
        # Ask to locate shift from the center (but within FoV)
        pos = self.stage.position.value
        fov = comp.compute_camera_fov(self.ccd)
        pos = pos["x"] + fov[0] / 3, pos["y"] - fov[1] / 4
    
        fms = stream.FluoStream("fluo", self.ccd, self.ccd.data,
                               self.light, self.filter, focuser=self.focus)
    
        angle = min(self.stigmator.getMetadata()[model.MD_CALIB].keys())
    
        f = measure_z(self.stigmator, angle, pos, fms, logpath="test-measurez.ome.tiff")
>       zshift, warning = f.result(30)

z_localization_test.py:202: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/lib/python3.10/concurrent/futures/_base.py:458: in result
    return self.__get_result()
/usr/lib/python3.10/concurrent/futures/_base.py:403: in __get_result
    raise self._exception
../../../util/__init__.py:772: in bindFuture
    result = fn(*args, **kwargs)
../z_localization.py:311: in _do_measure_z
    exporter.export(logpath, data + [sub_im])
../../../dataio/tiff.py:2071: in export
    _saveAsMultiTiffLT(filename, data, thumbnail, compressed, pyramid=pyramid)
../../../dataio/tiff.py:1799: in _saveAsMultiTiffLT
    ometxt = _convertToOMEMD(alldata, multiple_files, findex=file_index, fname=filename, uuids=uuid_list)
../../../dataio/tiff.py:534: in _convertToOMEMD
    _addImageElement(root, g, ifd, rois)
../../../dataio/tiff.py:1470: in _addImageElement
    ewl = fluo.get_one_center_em(owl, iwl) * 1e9  # in nm
../../../util/fluo.py:97: in get_one_center_em
    return get_center(get_one_band_em(bands, ex_band))
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

bands = None, ex_band = (0, 0)

    def get_one_band_em(bands, ex_band):
        """
        Return the band given or if it's a multi-band, return just the most likely
        one based on the current excitation band
        bands ((list of) tuple of 2 or 5 floats, or BAND_PASS_THROUGH): emission band(s)
        ex_band ((list of) tuple of 2 or 5 floats, or BAND_PASS_THROUGH): excitation band(s)
        return (tuple of 2 or 5 floats, or BAND_PASS_THROUGH): emission band
        """
        if bands == BAND_PASS_THROUGH:
            return bands
    
>       if not isinstance(next(iter(bands)), Iterable):
E       TypeError: 'NoneType' object is not iterable

../../../util/fluo.py:64: TypeError
