### PR TITLE
[fix] stop_backend: if the backend fail to stop, always try odemis-stop

### DIFF
--- a/src/odemis/util/testing.py
+++ b/src/odemis/util/testing.py
@@ -152,7 +152,7 @@ def stop_backend():
         else:
             break
     else:
-        raise IOError("Backend still stopping after 15 s")
+        logging.warning("Backend still stopping after 15 s")
 
     model._core._microscope = None  # force reset of the microscope for next connection
 


### PR DESCRIPTION
When the backend doesn't end within 15s, don't immediately give up, but
also call odemis-stop, as done already in other cases of failure.

This should help in some cases during unit testing, when a previously
running backend fails to stop, preventing the new testing from running.