### PR TITLE
[ci] specify python version for linting

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -21,6 +21,8 @@ jobs:
 
       - name: Setup Python environment
         uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'  # As on Ubuntu 24.04
 
       - name: Install flake8
         run: pip install flake8


### PR DESCRIPTION
Setting up Python, it would warn like this:
Warning: Neither 'python-version' nor 'python-version-file' inputs were supplied. Attempting to find '.python-version' file.
Warning: .python-version doesn't exist.
Warning: The `python-version` input is not set.  The version of Python currently in `PATH` will be used.

Probably, that means it runs flake8 with whatever version of Python is
availble on the latest Ubuntu, but it's nicer to use an explicit
version, indeed.