### PR TITLE
[SWM-182][fix] axes-odometer util to read log lines as a string and not a byte

### DIFF
--- a/util/axes-odometer
+++ b/util/axes-odometer
@@ -37,7 +37,7 @@ import numbers
 # logging.getLogger().setLevel(logging.DEBUG)
 
 
-def open_file(fn, mode="rb"):
+def open_file(fn, mode="r"):
     """
     Open a file, which can be compressed
     fn (string): filename. If it ends with .gz, it will be decompressed on the fly


### PR DESCRIPTION
ERROR:root:Failed to parse b"Updated position to {'s': 0.0029690275, 'l': 0.0505179063}" Traceback (most recent call last):
  File "/home/dev/development/odemis/./util/axes-odometer", line 78, in add_distances
    pos = read_pos(l)
  File "/home/dev/development/odemis/./util/axes-odometer", line 64, in read_pos
    m = RE_UPD_POS.search(line)
TypeError: cannot use a string pattern on a bytes-like object Distance: {}