### PR TITLE
[fix] Remove incompatible wx align flag in metadata window

### DIFF
--- a/src/odemis/gui/comp/stream_panel.py
+++ b/src/odemis/gui/comp/stream_panel.py
@@ -737,7 +737,7 @@ class StreamPanel(wx.Panel):
 
         sizer = wx.BoxSizer(wx.VERTICAL)
         sizer.Add(textsizer, 1, flag=wx.ALL | wx.EXPAND, border=5)
-        sizer.Add(btnsizer, 0, flag=wx.ALIGN_CENTER_VERTICAL | wx.EXPAND | wx.BOTTOM, border=5)
+        sizer.Add(btnsizer, 0, flag=wx.EXPAND | wx.BOTTOM, border=5)
         frame.SetSizer(sizer)
         frame.CenterOnScreen()
         return frame


### PR DESCRIPTION
Fixes the following error with wxPython 4.1+ :
```
  File "/home/piel/development/odemis/src/odemis/gui/cont/stream.py", line 638, in _on_metadata_btn
    md_frame = self.stream_panel.create_text_frame(u"Metadata of %s" % self.stream.name.value, text)
  File "/home/piel/development/odemis/src/odemis/gui/comp/stream_panel.py", line 740, in create_text_frame
    sizer.Add(btnsizer, 0, flag=wx.ALIGN_CENTER_VERTICAL | wx.EXPAND | wx.BOTTOM, border=5)
wx._core.wxAssertionError: C++ assertion "CheckSizerFlags(!((flags) & (wxALIGN_RIGHT | wxALIGN_CENTRE_HORIZONTAL | wxALIGN_BOTTOM | wxALIGN_CENTRE_VERTICAL)))" failed at /tmp/pip-install-e
oie9qdr/wxpython_1b4ae2e90f734464912c8577e97b58ec/ext/wxWidgets/src/common/sizer.cpp(2288) in DoInsert(): wxALIGN_RIGHT | wxALIGN_CENTRE_HORIZONTAL | wxALIGN_BOTTOM | wxALIGN_CENTRE_VERTIC
AL will be ignored in this sizer: wxEXPAND overrides alignment flags in box sizers
```