### PR TITLE
[TRCL-533][feat] Add support for e-beam gun exciter metadata

### DIFF
--- a/install/linux/usr/share/odemis/sim/sparc2-streakcam-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/sparc2-streakcam-sim.odm.yaml
@@ -130,7 +130,6 @@
     },
 }
 
-
 # In reality, this is a Zyla, but you need libandor3-dev to simulate an AndorCam3
 # Depending exactly on the configuration, it might also be used for spectrometer
 "Camera": {
@@ -162,7 +161,57 @@
         tracking: {2: "INV"},
         off_voltage: [0.0, null],  # V, null = "output disabled"
     },
-    affects: ["SEM E-beam", "Streak Readout CCD"],
+    affects: ["SEM E-beam", "Streak Readout CCD", "SEM Detector", "CL Detector", "EBIC"],
+}
+
+# Fake laser component, made of a laser and a interlock reader
+"Exciter Laser": {
+    class: simulated.GenericComponent,
+    role: null,
+    init: {
+        vas: {
+            "power": {"value": 0.0, "unit": "W", "range": [0.0, 100.e-3]},
+            "spectra": {"value": [358.e-9, 359.e-9, 360.e-9, 361.e-9, 362.e-9], "unit": "m", "readonly": True},
+            "period": {"value": 1.e-6, "unit": "s", "readonly": True},
+            "hwName": {"value": "Pulsed Laser Sim", "readonly": True},
+        },
+    },
+}
+
+# Laser interlock reading via a DAQ MCC device
+# Provides a "interlockTriggered" VA.
+"Laser Interlock": {
+    class: pwrmccdaq.MCCDevice,
+    role: null,
+    init: {
+        mcc_device: "fake",
+        # di_channels port B 8-15 -> pin 32-39
+        # specified as [name, TTL_HIGH]
+        di_channels: {14: ["interlockTriggered", False]},
+    },
+}
+
+# Simpler simulator, which provides the interlockTriggered VA, read & write,
+# to easily test software reaction to a change.
+#"Laser Interlock": {
+#    class: simulated.GenericComponent,
+#    role: null,
+#    init: {
+#        vas: {
+#            "interlockTriggered": {"value": False},
+#        },
+#    },
+#}
+
+# Merge the two components
+"Ebeam Gun Exciter": {
+    class: compositer.CompositedComponent,
+    role: ebeam-gun-exciter,
+    dependencies: {  # sorted following the "internal roles" alphabetical order
+        "dep0": "Exciter Laser",
+        "dep1": "Laser Interlock",
+    },
+    affects: ["SEM E-beam", "Streak Readout CCD", "SEM Detector", "CL Detector", "EBIC"],
 }
 
 # simple simulated streak camera

--- a/src/odemis/driver/compositer.py
+++ b/src/odemis/driver/compositer.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+"""
+Created on 9 May 2025
+
+@author: Éric Piel
+
+Copyright © 2025 Éric Piel, Delmic
+
+This file is part of Odemis.
+
+Odemis is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License version 2 as published by the Free Software Foundation.
+
+Odemis is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with Odemis. If not, see http://www.gnu.org/licenses/.
+"""
+
+import logging
+from typing import Dict, Any
+
+from odemis import model
+
+
+HIDDEN_VAS = {"children", "dependencies", "affects"}
+
+class CompositedComponent(model.HwComponent):
+    """
+    Wrapper component to merge multiple components together, seen as one, providing all the
+    VigilantAttributes from all the components.
+    The metadata is taken from the first component.
+    For more specific use cases, see MultiplexLight, MultiplexActuator, and CompositedScanner.
+    """
+    def __init__(self, name, role, dependencies: Dict[str, model.HwComponent], **kwargs):
+        """
+        :param dependencies: internal role -> sub-component. The components to wrap together.
+        The internal role is used to sort the components (alphabetically). If several
+        components have the same VA, the one from the first component is used.
+        """
+        model.HwComponent.__init__(self, name, role, dependencies=dependencies, **kwargs)
+        if not dependencies:
+            raise ValueError("CompositedComponent needs dependencies")
+
+        sorted_deps = sorted(dependencies.items(), key=lambda x: x[0])
+        self._base_comp = sorted_deps[0][1]  # The first component is the base component (for metadata)
+
+        # Add all the VAs, without overriding the ones already present on the previous components
+        for role, comp in sorted_deps:
+            if not isinstance(comp, model.ComponentBase):
+                raise ValueError(f"Dependency {role} is not a HwComponent.")
+
+            for vaname, va in model.getVAs(comp).items():
+                if vaname in HIDDEN_VAS:
+                    continue
+                if hasattr(self, vaname):
+                    logging.info("Skipping %s.%s for composition, as already present on previous dependency",
+                                 comp.name, vaname)
+                    continue
+
+                logging.debug("Using %s.%s for composition",comp.name, vaname)
+                setattr(self, vaname, va)
+
+    def getMetadata(self) -> Dict[str, Any]:
+        """
+        Get the metadata of the component.
+        """
+        return self._base_comp.getMetadata()
+
+    def updateMetadata(self, md: Dict[str, Any]):
+        """
+        Update the metadata of the component.
+        """
+        self._base_comp.updateMetadata(md)

--- a/src/odemis/driver/test/compositer_test.py
+++ b/src/odemis/driver/test/compositer_test.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on 9 May 2025
+
+@author: Éric Piel
+Copyright © 2025 Éric Piel, Delmic
+
+This file is part of Odemis.
+
+Odemis is free software: you can redistribute it and/or modify it under the terms
+of the GNU General Public License version 2 as published by the Free Software
+Foundation.
+
+Odemis is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+Odemis. If not, see http://www.gnu.org/licenses/.
+"""
+
+import logging
+import unittest
+
+from odemis.driver import simulated, compositer
+from odemis import model
+
+logging.getLogger().setLevel(logging.DEBUG)
+logging.basicConfig(format="%(asctime)s  %(levelname)-7s %(module)s:%(lineno)d %(message)s")
+
+
+class TestCompositedDetector(unittest.TestCase):
+    def setUp(self):
+        # Create a simulated external detector
+        self.sub_comp_1 = simulated.GenericComponent(
+            name="Sub Comp 1",
+            role="test",
+            vas={
+                "power": {"value": 0.1, "unit": "W", "range": [0, 1]},
+                "spectra": {"value": [100e-9, 140e-9, 150e-9, 160e-9, 200e-9], "unit": "m", "readonly": True},
+            },
+        )
+
+        self.sub_comp_2 = simulated.GenericComponent(
+            name="Sub Comp 2",
+            role="test",
+            vas={
+                "period": {"value": 1e-6, "unit": "s", "range": [1e-9, 1000], "readonly": True},
+                "power": {"value": 10, "unit": "W", "range": [0, 10]},  # Should be ignored, as it'd override the one from sub_comp_1
+            },
+        )
+
+        # Create a CompositedDetector instance
+        self.composited_comp = compositer.CompositedComponent(
+            name="composited Detector",
+            role="test",
+            dependencies={
+                "dep1": self.sub_comp_1,
+                "dep2": self.sub_comp_2,
+            }
+        )
+
+    def test_merged_vas(self):
+        """
+        Test that the merged virtual attributes (VAs) of the CompositedDetector are correct.
+        """
+        # Check that the merged VAs contain the expected values
+        assert model.hasVA(self.composited_comp, "power")
+        assert model.hasVA(self.composited_comp, "spectra")
+        assert model.hasVA(self.composited_comp, "period")
+
+        # Check that the power VA is from the first dependency by checking its value
+        self.assertEqual(self.composited_comp.power.value, 0.1)
+        self.composited_comp.power.value = 0.2
+        self.assertEqual(self.sub_comp_1.power.value, 0.2)
+
+    def test_metadata_sharing(self):
+        """
+        Test that metadata is shared correctly between the CompositedDetector and its first dependency.
+        """
+        metadata = {model.MD_POS: (1, 2)}
+        self.composited_comp.updateMetadata(metadata)
+        retrieved_metadata = self.composited_comp.getMetadata()
+        self.assertEqual(retrieved_metadata[model.MD_POS], (1, 2))
+        self.assertEqual(self.sub_comp_1.getMetadata(), self.composited_comp.getMetadata())
+
+        # Test that the second component's metadata is not shared
+        self.assertEqual(self.sub_comp_2.getMetadata(), {})
+
+    def test_invalid_dependency(self):
+        # Test invalid dependency raises ValueError
+        with self.assertRaises(ValueError):
+            compositer.CompositedComponent(
+                name="invalid component",
+                role="test",
+                parent=None,
+                dependencies={"external": object()}  # Invalid dependency
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/odemis/gui/conf/data.py
+++ b/src/odemis/gui/conf/data.py
@@ -299,6 +299,12 @@ HW_SETTINGS_CONFIG = {
                 "control_type": odemis.gui.CONTROL_NONE,
             }),
         )),
+    "ebeam-gun-exciter":
+        OrderedDict((
+            ("power", {
+                 "scale": "cubic",  # If a slider is used (float), then use a non-linear scale
+            }),
+        )),
     "laser-mirror":
         OrderedDict((
             ("dwellTime", {

--- a/src/odemis/gui/cont/settings.py
+++ b/src/odemis/gui/cont/settings.py
@@ -428,6 +428,10 @@ class SettingsBarController(object):
                     logging.debug("No config found for %s: %s", hw_comp.role, name)
                     va_conf = None
                 va = vas_comp[name]
+                # Don't show read-only settings, unless they are explicitly indicated in the config
+                if va.readonly and name not in vas_config:
+                    continue
+
                 setting_controller.add_setting_entry(name, va, hw_comp, va_conf)
             except TypeError:
                 msg = "Error adding %s setting for: %s"
@@ -797,6 +801,22 @@ class AnalysisSettingsController(SettingsBarController):
 
         self._pnl_calibration.Refresh()
         self.tab_panel.Layout()
+
+
+class GunExciterSettingsController(SettingsBarController):
+    """
+    A whole "bar" just for the ebeam gun exciter settings.
+    Used by the SPARC acquisition tab.
+    If the ebeam gun exciter is not present, the bar is hidden.
+    """
+
+    def __init__(self, tab_panel: wx.Panel, tab_data: MicroscopyGUIData):
+        super().__init__(tab_data)
+        main_data = tab_data.main
+        if main_data.ebeam_gun_exciter:
+            tab_panel.fp_settings_gun_exciter.Show()  # Hidden by default, as this is a rare configuration
+            self._settings_ctrl = SettingsController(tab_panel.fp_settings_gun_exciter, "")
+            self.add_hw_component(main_data.ebeam_gun_exciter, self._settings_ctrl)
 
 
 class EBeamBlankerSettingsController(SettingsBarController):

--- a/src/odemis/gui/cont/tabs/sparc_acquisition_tab.py
+++ b/src/odemis/gui/cont/tabs/sparc_acquisition_tab.py
@@ -31,7 +31,7 @@ import wx
 from odemis import model
 import odemis.acq.stream as acqstream
 import odemis.gui.cont.acquisition as acqcont
-from odemis.gui.cont.settings import EBeamBlankerSettingsController
+from odemis.gui.cont.settings import EBeamBlankerSettingsController, GunExciterSettingsController
 from odemis.gui.cont.stream_bar import SparcStreamsController
 import odemis.gui.cont.views as viewcont
 import odemis.gui.model as guimod
@@ -244,7 +244,10 @@ class SparcAcquisitionTab(Tab):
 
         tab_data.tool.subscribe(self.on_tool_change)
 
+        # Will show the e-beam "gun exciter" settings (for pulsed e-beam), if available, otherwise will do nothing
+        self._gun_exciter_ctrl = GunExciterSettingsController(panel, tab_data)
         # Will show the (pulsed) ebeam blanker settings, if available, otherwise will do nothing
+        # Note: both hardware may be present, but typically only one of them is used at a time
         self._ebeam_blanker_ctrl = EBeamBlankerSettingsController(panel, tab_data)
 
         if main_data.ebeam_blanker and main_data.streak_unit:

--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -1378,6 +1378,7 @@ class xrcpnl_tab_sparc_acqui(wx.Panel):
         self.vp_sparc_as = xrc.XRCCTRL(self, "vp_sparc_as")
         self.scr_win_right = xrc.XRCCTRL(self, "scr_win_right")
         self.fpb_settings = xrc.XRCCTRL(self, "fpb_settings")
+        self.fp_settings_gun_exciter = xrc.XRCCTRL(self, "fp_settings_gun_exciter")
         self.fp_settings_ebeam_blanker = xrc.XRCCTRL(self, "fp_settings_ebeam_blanker")
         self.pnl_sparc_streams = xrc.XRCCTRL(self, "pnl_sparc_streams")
         self.txt_filename = xrc.XRCCTRL(self, "txt_filename")
@@ -17755,6 +17756,15 @@ D\x02\x12\x0c/\x81\x10.\xc4\xcc\xb0\x8f\xa1\x9e\xa1\x81a/\x90\x05\x06\x8d\
                   <orient>wxVERTICAL</orient>
                   <object class="sizeritem">
                     <object class="FoldPanelBar" name="fpb_settings">
+                      <object class="FoldPanelItem" name="fp_settings_gun_exciter">
+                        <label>GUN EXCITER</label>
+                        <hidden>1</hidden>
+                        <fg>#1A1A1A</fg>
+                        <bg>#555555</bg>
+                        <XRCED>
+                          <assign_var>1</assign_var>
+                        </XRCED>
+                      </object>
                       <object class="FoldPanelItem" name="fp_settings_ebeam_blanker">
                         <label>EBEAM BLANKER</label>
                         <hidden>1</hidden>

--- a/src/odemis/gui/model/main_gui_data.py
+++ b/src/odemis/gui/model/main_gui_data.py
@@ -114,6 +114,7 @@ class MainGUIData(object):
         "stigmator": "stigmator",
         "ebeam-focus": "ebeam_focus",
         "ebeam-blanker": "ebeam_blanker",
+        "ebeam-gun-exciter": "ebeam_gun_exciter",
         "overview-focus": "overview_focus",
         "mirror": "mirror",
         "mirror-xy": "mirror_xy",
@@ -199,6 +200,7 @@ class MainGUIData(object):
         self.ebeam = None
         self.ebeam_focus = None  # change the e-beam focus
         self.ebeam_blanker = None  # for advanced blanker control (eg, pulsed)
+        self.ebeam_gun_exciter = None  # for advanced e-beam control (eg, pulsed)
         self.sed = None  # secondary electron detector
         self.bsd = None  # backscattered electron detector
         self.ebic = None  # electron beam-induced current detector

--- a/src/odemis/gui/xmlh/resources/panel_tab_sparc_acqui.xrc
+++ b/src/odemis/gui/xmlh/resources/panel_tab_sparc_acqui.xrc
@@ -240,6 +240,15 @@
                   <orient>wxVERTICAL</orient>
                   <object class="sizeritem">
                     <object class="FoldPanelBar" name="fpb_settings">
+                      <object class="FoldPanelItem" name="fp_settings_gun_exciter">
+                        <label>GUN EXCITER</label>
+                        <hidden>1</hidden>
+                        <fg>#1A1A1A</fg>
+                        <bg>#555555</bg>
+                        <XRCED>
+                          <assign_var>1</assign_var>
+                        </XRCED>
+                      </object>
                       <object class="FoldPanelItem" name="fp_settings_ebeam_blanker">
                         <label>EBEAM BLANKER</label>
                         <hidden>1</hidden>


### PR DESCRIPTION
Adds support for storing the metadata about the laser used as e-beam gun exciter.
As the hardware is not directly accessible, it is done by composing a "manual" component (where the user can type the actual value manually) and another component which reads the interlock state. Does so by introducing a new wrapper component.
Then, extend the GUI to show the gun-exciter settings.

See specification here:
https://docs.google.com/document/d/1XbXPDlujfZbwrEAxPMY7FqeBsLTMu79p/edit?pli=1

The result looks like:
![image](https://github.com/user-attachments/assets/d9544475-baa2-4066-812b-5e42ff583ed2)
