### PR TITLE
[fix] MeteorTescan1PostureManager could go directly from UNKNOWN to FM_IMAGING

### DIFF
--- a/src/odemis/acq/move.py
+++ b/src/odemis/acq/move.py
@@ -1791,10 +1791,10 @@ class MeteorTescan1PostureManager(MeteorPostureManager):
                     target_pos_sem = self.getTargetPosition(SEM_IMAGING)
                     if not isNearPosition(focus.position.value, focus_deactive, focus.axes):
                         sub_moves.append((focus, focus_deactive))
-                    sub_moves.append((stage, filter_dict({'x'}, target_pos)))
-                    sub_moves.append((stage, filter_dict({'y', 'rz'}, target_pos)))
-                    sub_moves.append((stage, filter_dict({'rx'}, target_pos)))
-                    sub_moves.append((stage, filter_dict({'z'}, target_pos)))
+                    sub_moves.append((stage, filter_dict({'x'}, target_pos_sem)))
+                    sub_moves.append((stage, filter_dict({'y', 'rz'}, target_pos_sem)))
+                    sub_moves.append((stage, filter_dict({'rx'}, target_pos_sem)))
+                    sub_moves.append((stage, filter_dict({'z'}, target_pos_sem)))
 
             if target in (GRID_1, GRID_2):
                 # The current mode doesn't change.


### PR DESCRIPTION
When requesting a move from UNKNOWN to FM_IMAGING, the code *tried* to first go
to SEM posture, but a typo made it actually go directly to FM_IMAGING.
=> fix the variable name to do the right thing.

Note that currently the GUI actually doesn't allow going from UNKNOW to FM_IMAGING,
so that not a big deal. Still, if the code is there, it should do the
right thing.