### PR TITLE
[fix] change the port number for autoscript backend from 4242 to 4243

### DIFF
--- a/install/linux/usr/share/odemis/sim/meteor-fibsem-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/meteor-fibsem-sim.odm.yaml
@@ -1,6 +1,6 @@
 # Simulates a METEOR on TFS SEM, with control of the FIB (milling)
 # It requires the separate xtadapter-autoscript simulator. To start it, do:
-# python3 path/to/xtlib-adapter/xtadapter/server_autoscript.py sim
+# python3 path/to/xtlib-adapter/xtadapter/server_sim.py --type autoscript --port 4243
 
 "METEOR TFSv3 FIB Sim": {
     class: Microscope,
@@ -13,7 +13,7 @@
   init: {
     # address: "192.168.6.5",  # real
     address: "localhost",    # simulator
-    port: "4242"
+    port: "4243"
   },
   children: {
     stage: "Stage",

--- a/src/odemis/driver/autoscript_client.py
+++ b/src/odemis/driver/autoscript_client.py
@@ -106,7 +106,7 @@ class SEM(model.HwComponent):
     Microscope server is done via Pyro5. The component is a parent to the scanner, stage, focus, and detector components, and supports both SEM and FIB.
     """
 
-    def __init__(self, name, role, children, address, port: str = '4242', daemon=None,
+    def __init__(self, name, role, children, address, port: str = '4243', daemon=None,
                  **kwargs):
         """
         :param name: str, Name of the microscope.
@@ -121,7 +121,7 @@ class SEM(model.HwComponent):
             "stage": dict, Stage child configuration (optional).
             Note: At least one of the required scanners types must be included as a child.
         :param address: str, server ip address for the microscope server (sim address is localhost)
-        :param port: str, server port of the Microscope server, default is '4242'
+        :param port: str, server port of the Microscope server, default is '4243'
         :param daemon: Pyro4.Daemon (or None), as defined in HwComponent.
         :param kwargs: dict, Additional keyword arguments.
         """

--- a/src/odemis/driver/test/autoscript_client_test.py
+++ b/src/odemis/driver/test/autoscript_client_test.py
@@ -66,7 +66,7 @@ CONFIG_STAGE = {"name": "Stage", "role": "stage-bare"} # MD?
 
 CONFIG_FIBSEM = {"name": "FIBSEM", "role": "fibsem",
                  "address": "192.168.6.5",
-                 "port": 4242,
+                 "port": 4243,
                  "children": {
                     "sem-scanner": CONFIG_SEM_SCANNER,
                     "sem-detector": CONFIG_SEM_DETECTOR,


### PR DESCRIPTION
Run backend of xtadapter and autoscript on different ports 4242, 4243 respectively.

Tested on the simulator for autoscript on port 4243
- one test is failing (working on the PR) but it is not related to change in the port number
![image](https://github.com/user-attachments/assets/149b655a-a813-43ea-bdb8-19a11644dc5a)
