### PR TITLE
[fix] dataio.tiff: loading file with mix of z-stack and non z-stack fail

### DIFF
--- a/src/odemis/dataio/tiff.py
+++ b/src/odemis/dataio/tiff.py
@@ -989,9 +989,19 @@ def _updateMDFromOME(root, das):
         # the ome stores the Z position in the metadata of each plane
         # but odemis MD_POS is the centre of the image
         if z_positions:
-            for da in das:
+            z_center = statistics.median(z_positions)
+            for ifd in hd_2_ifd.flat:
+                if ifd == -1:
+                    continue
+                try:
+                    da = das[ifd]
+                except IndexError:
+                    logging.warning("IFD %d not present, cannot update its metadata", ifd)
+                    continue
+                if da is None:
+                    continue
                 pos = da.metadata[model.MD_POS]
-                da.metadata[model.MD_POS] = pos[0], pos[1], statistics.median(z_positions)
+                da.metadata[model.MD_POS] = pos[0], pos[1], z_center
 
         # Update metadata of each da, so that they will be merged
         if deltats:


### PR DESCRIPTION
When loading a z-stack, the center position in Z must be computed and
updated to all image *of the z-stack*. It used to update to all images
in the TIFF file, which caused various issues. One of the main one being
that if another image was a preview image, it would not have metadata,
and the whole process would fail.
It could also potential put incorrect metadata.

Fixes issues like this:
```
2025-05-19 16:42:49,661 ERROR   log:41: Failed to decode OME XML
Traceback (most recent call last):
  File "/home/piel/development/odemis/src/odemis/dataio/tiff.py", line 2596, in _getAllOMEDataArrayShadows
    _updateMDFromOME(omeroot, data)
  File "/home/piel/development/odemis/src/odemis/dataio/tiff.py", line 993, in _updateMDFromOME
    pos = da.metadata[model.MD_POS]
AttributeError: 'NoneType' object has no attribute 'metadata'
```