### PR TITLE
[METEOR-1571][fix] Make RGBProjection .getRawValue() and .projectAsRaw() compatible with fluorescence z-stacks

### DIFF
--- a/src/odemis/acq/stream/_base.py
+++ b/src/odemis/acq/stream/_base.py
@@ -1267,9 +1267,11 @@ class Stream(object):
         raw = self.raw[0]
         md = self._find_metadata(raw.metadata)
         pxs = md.get(model.MD_PIXEL_SIZE, (1e-6, 1e-6))
+        pxs = pxs[:2]  # Take only X & Y, even if Z is available
         rotation = md.get(model.MD_ROTATION, 0)
         shear = md.get(model.MD_SHEAR, 0)
         translation = md.get(model.MD_POS, (0, 0))
+        translation = translation[:2]  # Take only X & Y, even if Z is available
         size = raw.shape[-1], raw.shape[-2]
         # The `pxs`, `rotation` and `shear` arguments are not directly passed
         # in the `AffineTransform` because the formula of the `AffineTransform`


### PR DESCRIPTION
`.getRawValue()` is used to show the value under the cursor in the GUI.
`.projectAsRaw()` is used to export images in the "post-processing TIFF"
format.

Both of these functions exist for a long time. Z-stack support also
exist for a long time. However, they had never been compatible, and
recently some users (finally) started to complain.
=> support explicitly 3D data.