### PR TITLE
[fix] add sample grid overlay for SEM and FM imaging modes in main_gui_data

### DIFF
--- a/src/odemis/gui/cont/tabs/fibsem_tab.py
+++ b/src/odemis/gui/cont/tabs/fibsem_tab.py
@@ -96,6 +96,11 @@ class FibsemTab(Tab):
         panel.vp_secom_bl.canvas.remove_view_overlay(panel.vp_secom_bl.canvas.play_overlay)
         panel.vp_secom_br.canvas.remove_view_overlay(panel.vp_secom_br.canvas.play_overlay)
 
+        # Add a sample overlay to each view (if we have information)
+        if main_data.get_sample_centers(SEM_IMAGING):
+            for vp in (panel.vp_secom_tl, panel.vp_secom_bl):
+                vp.show_sample_overlay(main_data.get_sample_centers(SEM_IMAGING), main_data.sample_radius)
+
         tab_data.focussedView.subscribe(self._on_view, init=True)
 
         self._view_selector = viewcont.ViewButtonController(

--- a/src/odemis/gui/cont/tabs/localization_tab.py
+++ b/src/odemis/gui/cont/tabs/localization_tab.py
@@ -107,9 +107,9 @@ class LocalizationTab(Tab):
         panel.vp_secom_tr.canvas.remove_view_overlay(panel.vp_secom_tr.canvas.play_overlay)
 
         # Add a sample overlay to each view (if we have information)
-        if main_data.sample_centers:
+        if main_data.get_sample_centers(FM_IMAGING):
             for vp in (panel.vp_secom_tl, panel.vp_secom_tr, panel.vp_secom_bl, panel.vp_secom_br):
-                vp.show_sample_overlay(main_data.sample_centers, main_data.sample_radius)
+                vp.show_sample_overlay(main_data.get_sample_centers(FM_IMAGING), main_data.sample_radius)
 
         # Default view is the Live 1
         tab_data.focussedView.value = panel.vp_secom_bl.view

--- a/src/odemis/gui/win/acquisition.py
+++ b/src/odemis/gui/win/acquisition.py
@@ -711,24 +711,24 @@ class OverviewAcquisitionDialog(xrcfr_overview_acq):
         # * Total area
         # * autofocus
 
-        if self._main_data_model.sample_centers:
+        if self._main_data_model.get_sample_centers():
             self.autofocus_chkbox.Show()
-            self.autofocus_roi_ckbox.value = True
+            self.autofocus_roi_ckbox.value = False
 
-            self.whole_grid_chkbox.Value = True
+            self.whole_grid_chkbox.Value = False
 
             # GridSelectionPanel doesn't have xmlh helper, and in addition a refactoring
             # would be needed to allow changing the grid layout after init. So
             # for now we use a placeholder panel, and insert the GridSelectionPanel
             # here at runtime.
-            layout = sample_positions_to_layout(self._main_data_model.sample_centers)
+            layout = sample_positions_to_layout(self._main_data_model.get_sample_centers())
             subsizer = wx.BoxSizer(wx.VERTICAL)
             self.selected_grid_pnl_holder.SetSizer(subsizer)
             self._grids = buttons.GridSelectionPanel(self.selected_grid_pnl_holder, layout)
             subsizer.Add(self._grids, flag=wx.EXPAND)
 
             # Default to selecting all grids
-            self._selected_grids = set(self._main_data_model.sample_centers.keys())
+            self._selected_grids = set(self._main_data_model.get_sample_centers().keys())
 
             # Connect the buttons (and update their status)
             for name, btn in self._grids.buttons.items():
@@ -738,8 +738,7 @@ class OverviewAcquisitionDialog(xrcfr_overview_acq):
             # Connect, and make sure the status is correct
             self.whole_grid_chkbox.Bind(wx.EVT_CHECKBOX, self._on_whole_grid_chkbox)
             self._on_whole_grid_chkbox()
-
-            self.pnl_view_acq.show_sample_overlay(self._main_data_model.sample_centers,
+            self.pnl_view_acq.show_sample_overlay(self._main_data_model.get_sample_centers(),
                                                   self._main_data_model.sample_radius)
         else:
             self.whole_grid_chkbox.Hide()
@@ -931,7 +930,7 @@ class OverviewAcquisitionDialog(xrcfr_overview_acq):
             # Cast to list, to have a consistent format with the alternative path
             areas = [area] if area is not None else []
         else:
-            if not self._main_data_model.sample_centers:
+            if not self._main_data_model.get_sample_centers():
                 raise NotImplementedError(
                     "If using the whole grid method, sample centers should be defined."
                 )
@@ -943,7 +942,7 @@ class OverviewAcquisitionDialog(xrcfr_overview_acq):
                     "a specific MainGUIData model."
                 )
 
-            sample_centers = [pos for name, pos in self._main_data_model.sample_centers.items()
+            sample_centers = [pos for name, pos in self._main_data_model.get_sample_centers().items()
                 if name in self._selected_grids]
 
             areas = get_tiled_bboxes(


### PR DESCRIPTION
Tested on the simulator by adding feature and changing between different postures
Image 1 --> FIBSEM tab 
Image 2 --> Localisation tab 
Currently the sample centres are active only for FM and SEM imaging and for Meteor Posture Manager. 
![image](https://github.com/user-attachments/assets/d9eee3c6-95cf-41e1-93b2-8198cb0d27ab)
![image](https://github.com/user-attachments/assets/ab414c25-7841-4ff0-b858-b6f7c1265654)

