### PR TITLE
[fix] sparc2 autofocus test cases

### DIFF
--- a/src/odemis/acq/align/test/autofocus_test.py
+++ b/src/odemis/acq/align/test/autofocus_test.py
@@ -164,6 +164,11 @@ class TestSparc2AutoFocus(unittest.TestCase):
         # The good focus position is the start up position
         cls._good_focus = cls.focus.position.value["z"]
 
+    @classmethod
+    def tearDownClass(cls):
+        # Move the focus back to the good position, because the backend is used in multiple tests
+        cls.focus.moveAbs({"z": cls._good_focus}).result()
+
     def setUp(self):
         self.opm = acq.path.OpticalPathManager(model.getMicroscope())
 
@@ -300,6 +305,11 @@ class TestSparc2AutoFocus_2(unittest.TestCase):
 
         # The good focus position is the start up position
         cls._good_focus = cls.focus.position.value["z"]
+
+    @classmethod
+    def tearDownClass(cls):
+        # Move the focus back to the good position, because the backend is used in multiple tests
+        cls.focus.moveAbs({"z": cls._good_focus}).result()
 
     def setUp(self):
         self.opm = acq.path.OpticalPathManager(model.getMicroscope())


### PR DESCRIPTION
TestSparc2AutoFocus_2.test_cancel and TestSparc2AutoFocus_2::test_one_det failed because the stage tried to move out of range. This happened because at initialization of the test class the good focus is set based on the current stage position. In the test the focus moves 200um away from the good focus. Because the backend does not restart when running multiple test classes with the same backend, the second class that was run had the wrong good focus position.