### PR TITLE
[feat] Add "(development)" in the GUI window title when running the development version

### DIFF
--- a/src/odemis/gui/main.py
+++ b/src/odemis/gui/main.py
@@ -132,6 +132,11 @@ class OdemisGUIApp(wx.App):
                     gui.logo = img.getBitmap("logo_delphi.png")
                     gui.legend_logo = "legend_logo_delphi.png"
 
+        # Warn the user the version is a development version.
+        # Stable versions are of the form "vX.Y.Z", while development versions are "vX.Y.0-QQQ..."
+        if "-" in odemis.__version__:
+            gui.name += " (development)"
+
         # TODO: if microscope.ghost is not empty => wait and/or display a special
         # "hardware status" tab.
 


### PR DESCRIPTION
Users should normally always run the stable (or release candidate) versions, unless there is a really good reason.
There have been some cases when for debugging purpose Odemis was switch "temporarily" to the development version, and left as-is afterwards.

To highlight that the development version is running (and so some things might be broken), explicitly indicate it in the window title.