### PR TITLE
[CSDM-1118][fix] SPARC streak cam alignment should start with the slit almost closed

### DIFF
--- a/src/odemis/acq/path.py
+++ b/src/odemis/acq/path.py
@@ -138,7 +138,7 @@ SPARC2_MODES = {
             'streak-align': ("streak-ccd",  # alignment tab
                 {'lens-switch': {'x': ("MD:" + model.MD_FAV_POS_DEACTIVE, 'off')},
                  'lens-mover': {'x': "MD:" + model.MD_FAV_POS_ACTIVE},
-                 'slit-in-big': {'x': 'on'},  # fully opened (independent of spg.slit-in)
+                 'slit-in-big': {'x': 'off'},  # slit small at init, but user can change later
                  'chamber-light': {'power': 'off'},
                  'pol-analyzer': {'pol': MD_POL_NONE},
                  'light-aligner': {'x': "MD:" + model.MD_FAV_POS_ACTIVE,


### PR DESCRIPTION
It's safer for the camera to let the spectrograph slit "almost" closed (ie, not fully
opened via the slit-in-big). The user can still change it from the GUI,
so this is not a big change.

Note that this affects only the SPARCs where there streakcam is after the
standard spectrograph, not the ones which uses the light tunnel.