### PR TITLE
[fix] ion channel current in autoscript driver consists of choices in…

### DIFF
--- a/src/odemis/driver/test/autoscript_client_test.py
+++ b/src/odemis/driver/test/autoscript_client_test.py
@@ -335,6 +335,15 @@ class TestMicroscope(unittest.TestCase):
 
             info = self.microscope.beam_current_info(channel=ch)
             self.assertTrue(isinstance(info, dict))
+            if ch == "ion":
+                # ion beam consists of discrete currents as choice instead of a range
+                if "choices" in info:
+                    self.assertTrue(isinstance(info["choices"], list))
+                    self.assertTrue(len(info["choices"]) > 0)
+                    for choice in info["choices"]:
+                        self.assertTrue(isinstance(choice, (int, float)))
+                continue
+
             _range = info["range"]
             self.assertTrue(isinstance(_range[0], (int, float)))
             self.assertTrue(isinstance(_range[1], (int, float)))


### PR DESCRIPTION
…stead of range

adapt the test case to test choices for ion channel and range for electron channel

Tested by running autoscript test case on simulator 
![image](https://github.com/user-attachments/assets/58dbdda9-dfcd-48d8-ad20-1c8b72fcb2d7)
