### PR TITLE
[fix] GUI: on wxPython 4.1+, don't show warning box every time a dialog box is opened

### DIFF
--- a/src/odemis/gui/comp/text.py
+++ b/src/odemis/gui/comp/text.py
@@ -597,6 +597,23 @@ class _NumberValidator(wx.Validator):
 
         raise NotImplementedError
 
+    def TransferToWindow(self) -> bool:
+        """
+        Transfer data from window to validator.
+
+        The default implementation returns False, indicating that an error
+        occurred. We simply return True, as we don't do any data transfer.
+        """
+        return True  # Prevent wxDialog from complaining.
+
+    def TransferFromWindow(self) -> bool:
+        """
+        Transfer data from window to validator.
+
+        The default implementation returns False, indicating that an error
+        occurred. We simply return True, as we don't do any data transfer.
+        """
+        return True  # Prevent wxDialog from complaining.
 
 def _step_from_range(min_val, max_val):
     """ Dynamically create step size based on range """
@@ -665,6 +682,24 @@ class PatternValidator(wx.Validator):
     def Clone(self):
         """ Required method """
         return PatternValidator(self._pattern)
+
+    def TransferToWindow(self) -> bool:
+        """
+        Transfer data from window to validator.
+
+        The default implementation returns False, indicating that an error
+        occurred. We simply return True, as we don't do any data transfer.
+        """
+        return True  # Prevent wxDialog from complaining.
+
+    def TransferFromWindow(self) -> bool:
+        """
+        Transfer data from window to validator.
+
+        The default implementation returns False, indicating that an error
+        occurred. We simply return True, as we don't do any data transfer.
+        """
+        return True  # Prevent wxDialog from complaining.
 
 
 class _NumberTextCtrl(wx.TextCtrl):


### PR DESCRIPTION
With the latest version of wxPython, every time the user would open a
dialog box containing some number control, there would be first show a
warning box stating: "Could not transfer data to window".

It turns out it's coming from a new feature of the Validators which
allow to copy the data. The base class is very pessimistic and assumes
it failed. So every inheriting class must override it and return True to
indicate there was no data to copy anyway.