### PR TITLE
[fix] GUI: only show the Edit METEOR calibration on METEOR

### DIFF
--- a/src/odemis/gui/cont/menu.py
+++ b/src/odemis/gui/cont/menu.py
@@ -131,6 +131,11 @@ class MenuController(object):
         main_frame.Bind(wx.EVT_MENU, self._on_debug_menu, id=main_frame.menu_item_debug.GetId())
         main_data.debug.subscribe(self._on_debug_va, init=True)
 
+        # /Help/Development/Edit METEOR Calibration : only show if it's a METEOR
+        if main_data.role != "meteor":
+            menu_dev = main_frame.menu_item_edit_meteor_calibration.GetMenu()
+            menu_dev.Delete(main_frame.menu_item_edit_meteor_calibration)
+
         # TODO: make it work on Windows too
         # /Help/Report a problem...
         if sys.platform.startswith('win32'):


### PR DESCRIPTION
It's not possible to hide a menu item by default. Instead, if it's not
going to be used, delete it.