### PR TITLE
[fix] TFS adapter drivers failed to transfer new version

### DIFF
--- a/src/odemis/driver/autoscript_client.py
+++ b/src/odemis/driver/autoscript_client.py
@@ -197,6 +197,18 @@ class SEM(model.HwComponent):
             self._fib_detector = Detector(parent=self, daemon=daemon, channel="ion", **ckwargs)
             self.children.value.add(self._fib_detector)
 
+    def transfer_latest_package(self, data: bytes) -> None:
+        """
+        Transfer a (new) xtadapter package.
+        Note:
+            Pyro has a 1 gigabyte message size limitation.
+            https://pyro5.readthedocs.io/en/latest/tipstricks.html#binary-data-transfer-file-transfer
+        :param data: The package's zip file data in bytes.
+        """
+        with self._proxy_access:
+            self.server._pyroClaimOwnership()
+            return self.server.transfer_latest_package(data)
+
     def get_software_version(self) -> str:
         """Returns: (str) the software version of the microscope."""
         with self._proxy_access:

--- a/src/odemis/driver/xt_client.py
+++ b/src/odemis/driver/xt_client.py
@@ -203,18 +203,6 @@ def check_latest_package(
                 return latest_package
     return None
 
-def transfer_latest_package(client: 'SEM', data: bytes) -> None:
-    """
-    Transfer the latest xtadapter package.
-    Note:
-        Pyro has a 1 gigabyte message size limitation.
-        https://pyro5.readthedocs.io/en/latest/tipstricks.html#binary-data-transfer-file-transfer
-    :param data: The package's zip file data in bytes.
-    """
-    with client._proxy_access:
-        client.server._pyroClaimOwnership()
-        return client.server.transfer_latest_package(data)
-
 def check_and_transfer_latest_package(client: 'SEM') -> None:
     """Check if a latest xtadapter package is available and then transfer it."""
     try:
@@ -366,6 +354,18 @@ class SEM(model.HwComponent):
             else:
                 self._detector = Detector(parent=self, daemon=daemon, **ckwargs)
             self.children.value.add(self._detector)
+
+    def transfer_latest_package(self, data: bytes) -> None:
+        """
+        Transfer a (new) xtadapter package.
+        Note:
+            Pyro has a 1 gigabyte message size limitation.
+            https://pyro5.readthedocs.io/en/latest/tipstricks.html#binary-data-transfer-file-transfer
+        :param data: The package's zip file data in bytes.
+        """
+        with self._proxy_access:
+            self.server._pyroClaimOwnership()
+            return self.server.transfer_latest_package(data)
 
     def move_stage(self, position: Dict[str, float], rel: bool = False) -> None:
         """


### PR DESCRIPTION
Commit 76ded477 (add autoscript client for openfibsem) adjusted the code
to detect a new version of the xtadapter and transfer it, so that it
could be shared between the xt_client and autoscript_client drivers.

However, while the transfer_latest_package() was generalised, the caller
wasn't updated. This broke the transfer mechanism.

Just provide the same function on both clients, and use the same old
caller.