### PR TITLE
[METEOR-1349][feat] andorcam3: better support for Sona and report blemish filter use

### DIFF
--- a/src/odemis/driver/andorcam3.py
+++ b/src/odemis/driver/andorcam3.py
@@ -416,9 +416,18 @@ class AndorCam3(model.DigitalCamera):
         # Another advantage of global shutter allows to simplify if we need to
         # connect exposure to light.
 
+        filters = []
         if self.isImplemented("SpuriousNoiseFilter"):
             self.SetBool("SpuriousNoiseFilter", True)
-            self._metadata['Filter'] = "Spurious noise filter" # FIXME tag?
+            filters.append("Spurious noise")
+
+        if self.isImplemented("StaticBlemishCorrection"):
+            # It is activated by default on the Sona and Zyla, but just in case, explicitly set it.
+            self.SetBool("StaticBlemishCorrection", True)
+            filters.append("Blemish correction")
+
+        if filters:
+            self._metadata[model.MD_DATA_FILTER] = ", ".join(filters)
 
         if self.isImplemented("Overlap"):
             # No overlap, as it can introduce additional noise, and we don't need

--- a/src/odemis/driver/test/andorcam3_test.py
+++ b/src/odemis/driver/test/andorcam3_test.py
@@ -30,7 +30,9 @@ from cam_test_abs import VirtualTestCam, VirtualStaticTestCam, \
     VirtualTestSynchronized
 
 
-logging.getLogger().setLevel(logging.DEBUG)
+logging.basicConfig(format="%(asctime)s  %(levelname)-7s %(module)s:%(lineno)d %(message)s",
+                    level=logging.DEBUG,
+                    force=True)
 
 CLASS = andorcam3.AndorCam3
 KWARGS = dict(name="camera", role="ccd", device=0, transpose=[2, -1],
@@ -63,6 +65,17 @@ class TestAndorCam3(VirtualTestCam, unittest.TestCase):
     """
     camera_type = CLASS
     camera_kwargs = KWARGS
+
+    def test_gain(self):
+        """
+        Check that changing the gain works. On some cameras, the readout rate is updated by the gain,
+        and it used to fail.
+        """
+        for g in self.camera.gain.choices:
+            self.camera.gain.value = g
+            logging.debug("gain = %s, readout rate = %s", g, self.camera.readoutRate.value)
+            self.camera.data.get()
+
 
 #@skip("simple")
 class TestSynchronized(VirtualTestSynchronized, unittest.TestCase):

--- a/src/odemis/gui/conf/data.py
+++ b/src/odemis/gui/conf/data.py
@@ -121,6 +121,9 @@ HW_SETTINGS_CONFIG = {
             ("frameDuration", {
                 "control_type": odemis.gui.CONTROL_NONE,
             }),
+            ("frameRate", {
+                "control_type": odemis.gui.CONTROL_NONE,
+            }),
             # Advanced settings for andorcam2
             ("verticalReadoutRate", {
                 "control_type": odemis.gui.CONTROL_NONE,


### PR DESCRIPTION
Add . frameRate VA to limit the frameRate, if necessary. One of such case is for sustaining a live stream at full res on the Sona, which can do 100Hz for a brief period, but only supports 40Hz for longer than 1 s.

Also improve a little bit recovery of the live stream when such timeout happen. It now takes only 1.5s to recover, instead of ~4s.

Also make the readout rate read-only on the Sona, as it is fixed, dependent on the current gain.

Finally, indicate in the metadata when the blemish filter is in use (which is activated by default on cameras supporting it).
