### PR TITLE
[fix] GUI analysis tab showed too many viewports on wxPython 4.1+

### DIFF
--- a/src/odemis/gui/cont/views.py
+++ b/src/odemis/gui/cont/views.py
@@ -109,6 +109,9 @@ class ViewPortController(object):
             vp.setView(view, self._data_model)
 
         self._data_model.views.value = views
+        if len(visible_views) > 4:
+            logging.warning("Visible viewports at init > 4, will limit them: %s", visible_views)
+            visible_views = visible_views[:4]
         self._data_model.visible_views.value = visible_views
 
         if self._data_model.visible_views.value:

--- a/src/odemis/gui/xmlh/xh_delmic.py
+++ b/src/odemis/gui/xmlh/xh_delmic.py
@@ -456,6 +456,7 @@ class MicroscopeViewportXmlHandler(xrc.XmlResourceHandler):
     def CanHandle(self, node):
         return self.IsOfClass(node, self.klass.__name__)
 
+    @apply_hidden
     def DoCreateResource(self):
         assert self.GetInstance() is None
 


### PR DESCRIPTION
On wxPython 4.1+, the hidden flag in XRC has to be explicitly treated by
XmlRessourceHandlers. Commit d82ad870df (XmlResourceHandler now
explicitly handle the hidden flag) took care of it... except it missed
the MicroscopeViewport class.

This caused the analysis tab, which has 12 viewports, to show all of
them at start up, and when opening a new file.

=> Also treat the hidden flag in this handler.

Also detect such error (which could be also due to modifying the XRC
file) of more than 4 viewports at init, and warn about it. This should
make it easier to find out next time.