### PR TITLE
[TRCL-634][fix] SPARC GUI: change the ebeam blanker wording from "blanking" to "pulsing"

### DIFF
--- a/src/odemis/gui/conf/data.py
+++ b/src/odemis/gui/conf/data.py
@@ -287,8 +287,8 @@ HW_SETTINGS_CONFIG = {
                 "event": wx.EVT_SCROLL_CHANGED,
             }),
             ("power", {
-                "label": "Blanking",
-                "tooltip": "Checked means the e-beam blanker is active (the e-beam is pulsed). \n"
+                "label": "Pulsing",
+                "tooltip": "Checked means the ultra-fast e-beam blanker is active (the e-beam is pulsed). \n"
                            "Unchecked means the e-beam is constantly active.",
             }),
             ("dutyCycle", {


### PR DESCRIPTION
The dedicated ebeam-blanker component is for so called "ultra fast beam
blanker". Typically, when active the blanker is not constantly blanking,
but instead it alternates, in order to provide a pulsed e-beam. So it's
clearer for the user to indicate this state as "pulsing".