### PR TITLE
[METEOR-1587][fix] show acquired sem overview stream panel

### DIFF
--- a/src/odemis/gui/cont/stream_bar.py
+++ b/src/odemis/gui/cont/stream_bar.py
@@ -2196,15 +2196,28 @@ class CryoFIBAcquiredStreamsController(CryoStreamsController):
     acquired view when the feature is selected.
     """
 
-    def __init__(self, tab_data, feature_view, *args, **kwargs):
+    def __init__(self, tab_data, feature_view, ov_view, *args, **kwargs):
         """
         feature_view (StreamView): the view to show the feature streams
+        ov_view (StreamView): the view to show the overview streams
         """
         super().__init__(tab_data, *args, **kwargs)
         self._feature_view = feature_view
+        self._ov_view = ov_view
         self.stream: Optional[StaticStream] = None  # The stream currently displayed, related the selected Feature
 
         tab_data.main.currentFeature.subscribe(self._on_current_feature_changes)
+
+    def showOverviewStream(self, stream) -> StreamController:
+        """
+        Shows an Overview stream (in the Overview view)
+        Must be run in the main GUI thread.
+        """
+        self._ov_view.addStream(stream)
+        sc = self._add_stream_cont(stream, show_panel=True, static=self.static_mode,
+                                   view=self._ov_view)
+        sc.stream_panel.show_remove_btn(True)
+        return sc
 
     def showFeatureStream(self, stream) -> StreamController:
         """
@@ -2248,6 +2261,9 @@ class CryoFIBAcquiredStreamsController(CryoStreamsController):
             if not isinstance(sc.stream, StaticSEMStream):
                 logging.warning("Unexpected non static stream: %s", sc.stream)
                 continue
+            # Leave the overview streams
+            if sc.stream in self._tab_data_model.overviewStreams.value:
+                continue
 
             self._stream_bar.remove_stream_panel(sc.stream_panel)
             if hasattr(v, "removeStream"):
@@ -2277,6 +2293,15 @@ class CryoFIBAcquiredStreamsController(CryoStreamsController):
                 for v in (self._feature_view, self._ov_view):
                     if hasattr(v, "removeStream"):
                         v.removeStream(stream)
+
+        if clear_model:
+            while self._tab_data_model.overviewStreams.value:
+                self._tab_data_model.overviewStreams.value.pop()
+
+            # Typically, all the features will also be deleted, but that's not our job
+            # (see CryoChamberTab._reset_project_data())
+            for f in self._tab_data_model.main.features.value:
+                f.streams.value.clear()
 
         # Clear the stream controller
         self.stream_controllers = []


### PR DESCRIPTION
When the sem overview streams are acquired in the fibsem tab, they are also added in the correlation tab and the localizaton tab. If the streams are updated in the correlation tab, they are also updated in the localization and the fibsem tabs. The update means addition of a new stream, deletion of the existing stream, modification in the correction metadata and lastly the reset of the correction metadata.



Other related fixes -
1) It (This PR)  also fixes [METROR-1438] by updating the SEM overview metadata correctly when the correction metadata is changed. 
2) It correctly loads the overviews from the cryo_chamber tab in the three tabs -> correlation, fibsem and localization. Earlier, the overviews were duplicating in the correlation tab as the overviews from fibsem and localization were instantiated two times.
3) In the correlation tab, the selected stream (also the move stream as displayed in the gui, see below) was not updated when changed. It updates the selected stream properly when changed by the user.
![image](https://github.com/user-attachments/assets/b5067b27-dd91-4031-8fae-52e99274b3ff)
