### PR TITLE
[fix] read SEM tiles with scan rotation applied

### DIFF
--- a/src/odemis/acq/stitching/_weaver.py
+++ b/src/odemis/acq/stitching/_weaver.py
@@ -77,7 +77,9 @@ class Weaver(metaclass=ABCMeta):
         # how the user regularly sees the images.
         # However, when stitching SEM images, typically that is applied without changing the sample coordinates,
         # so usually the stitched image needs to take that rotation into account to be correct.
-        rotation = self.tiles[0].metadata.get(model.MD_ROTATION, 0) + self.tiles[0].metadata.get(model.MD_BEAM_SCAN_ROTATION, 0)
+        # TODO To properly handle this, stitching of tiles should work with and without the scan rotation applied.
+        #  Now, the stitching SEM tiles will only work with the scan rotation applied and not without it.
+        rotation = self.tiles[0].metadata.get(model.MD_ROTATION, 0)
         center_of_rot = self.tiles[0].metadata[model.MD_POS]
 
         tiles = []


### PR DESCRIPTION
This is a temporary fix to read tiles with scan rotation applied and perform movement in SEM/FIB live imaging. But it does not work properly with turning off the scan rotation and moving the stage in SEM/FIB live imaging.

Without scan rotation
- the stage in FIB/SEM moves in the opposite direction when double clicking/dragging in live imaging.