### PR TITLE
[test] Fix sleep in milling cancel test

### DIFF
--- a/src/odemis/acq/milling/test/millmng_test.py
+++ b/src/odemis/acq/milling/test/millmng_test.py
@@ -218,7 +218,10 @@ class TestAutomatedMillingManager(unittest.TestCase):
             task_list=self.task_list,
         )
 
-        time.sleep(5)
         f.cancel()
+        time.sleep(5)
 
         self.assertTrue(f.cancelled())
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The sleep was placed before the cancel call, which did not allow the system to properly cancel in time. Moved the sleep after the cancel call, and that resolves the problem. Furthermore, this file missed the `__main__` call, to run it from the command line. 