### PR TITLE
[fix] Technolution driver remove scanning first field twice

### DIFF
--- a/src/odemis/driver/technolution.py
+++ b/src/odemis/driver/technolution.py
@@ -1342,15 +1342,6 @@ class MPPC(model.Detector):
                         continue
 
                     try:
-                        # FIXME: Hack: The current ASM HW does not scan the very first field image correctly. This issue
-                        #  needs to be fixed in HW. However, until this is done, we need to "throw away" the first field
-                        #  image and scan it a second time to receive a good first field image. To do so, just always
-                        #  scan the first image twice. Note: scan_field is a blocking call - it waits until the scan is
-                        #  finished.
-                        if field_data.position_x == 0 and field_data.position_y == 0:
-                            logging.debug("Rescanning first field to workaround hardware limitations.")
-                            self.parent.asmApiPostCall("/scan/scan_field", 204, field_data.to_dict())
-
                         self.parent.asmApiPostCall("/scan/scan_field", 204, field_data.to_dict())
 
                         if DATA_CONTENT_TO_ASM[dataContent] is None:


### PR DESCRIPTION
There was a fault in the hardware, this caused the very first field of a megafield to not be recorded at all. This is now fixed in the hardware, therefore the fix can be removed.