### PR TITLE
[fix] util angleres: fix typo in error message

### DIFF
--- a/src/odemis/util/angleres.py
+++ b/src/odemis/util/angleres.py
@@ -786,7 +786,7 @@ def project_angular_spectrum_to_grid(
         line_bottom = data.metadata[model.MD_AR_MIRROR_BOTTOM]
         line_top = data.metadata[model.MD_AR_MIRROR_TOP]
     except KeyError:
-        raise ValueError("Metadata required: MD_MIRROR_*, MD_WL_LIST")
+        raise ValueError("Metadata required: MD_AR_MIRROR_*, MD_WL_LIST")
     if len(wl_list) != data.shape[1]:
         raise ValueError(f"MD_WL_LIST must be the same length as C dimension ({len(wl_list)} != {data.shape[1]})")
 


### PR DESCRIPTION
The name of the metadata was incorrect, which is a bit confusing when
looking for it.