### PR TITLE
[fix] Update scripts and documentation for newer version of Conda on Windows

### DIFF
--- a/doc/develop/extending.rst
+++ b/doc/develop/extending.rst
@@ -225,8 +225,8 @@ Open *PowerShell* and execute the following commands in succession::
    be installed, which requires a lot more dependencies. On miniconda, it's not
    installed by default.
 
-Download, install `Build Tools for Visual Studio 2019 <https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2019>`_,
-and pick the "Visual C++ build tools". Install also the pre-selected options.
+Download, install `Microsoft C++ Build Tools <https://visualstudio.microsoft.com/visual-cpp-build-tools/>`_,
+and pick the "Desktop development with C++". Install all the pre-selected options.
 
 
 Final steps
@@ -262,7 +262,7 @@ Building Odemis Viewer and the installer
 
 Install `NSIS <https://nsis.sourceforge.io/Download>`_.
 
-Download the latest version of the `KillProc NSIS plugin <http://nsis.sourceforge.net/KillProc_plug-in>`_.
+Download the latest version of the `KillProc NSIS plugin <https://nsis.sourceforge.io/KillProc_plug-in>`_.
 Unzip it, and place the ``KillProc.dll`` in ``C:\\Program Files (x86)\\NSIS\\Plugins\\x86-unicode\``.
 
 (If not done at least once) Open *PowerShell* and execute the following commands in succession::
@@ -279,7 +279,8 @@ Once initialized, open *PowerShell* and execute the following commands in succes
 
 To build just the viewer executable::
 
-   pyinstaller -y install\windows\viewer.spec
+   cd install\windows\
+   pyinstaller -y viewer.spec
 
 To build the installer::
 

--- a/install/windows/setup.nsi
+++ b/install/windows/setup.nsi
@@ -65,7 +65,14 @@ ShowInstDetails show
 ShowUnInstDetails show
 
 Section "MainSection" SEC01
-  SetOutPath "$APPDATA\${PRODUCT_NAME}"
+  RMDir /r "$INSTDIR"  ; Remove old files to avoid loading old versions of the libraries
+  ; If it fails, it can be due to the exe file being in use
+  IfErrors 0 no_error_delete
+  MessageBox MB_OK "Please close Odemis Viewer first, and then press OK."
+  RMDir /r "$INSTDIR"
+
+  no_error_delete:
+  SetOutPath "$APPDATA\${PRODUCT_NAME}"  ; ensure this directory is created
   SetOutPath "$INSTDIR"
   File /r .\dist\${PRODUCT_NAME}\*.*
   CreateDirectory "$SMPROGRAMS\${PRODUCT_HNAME}"

--- a/install/windows/setup.py
+++ b/install/windows/setup.py
@@ -11,7 +11,6 @@ This file is also automatically called from the Odemis Viewer Build script
 """
 
 from Cython.Build import cythonize
-from distutils import msvc9compiler
 from distutils.core import setup
 import glob
 import numpy

--- a/src/odemis/__init__.py
+++ b/src/odemis/__init__.py
@@ -70,13 +70,17 @@ def _get_version():
         try:
             return _get_version_setuptools()
         except LookupError:
-            # Last attempt: see if there is a version file
+            # Last attempt: see if there is a version file (for the Windows Viewer)
             import sys
             if getattr(sys, 'frozen', False):
-                path = os.path.join(os.path.dirname(sys.executable), 'version.txt')
-                if os.path.exists(path):
-                    with open(path, 'r') as f:
-                        return f.readline().strip()
+                exe_path = os.path.dirname(sys.executable)
+                # Old versions of pyinstaller put everything in the same directory, and newer versions
+                # (v6.0+) place it in "_internal" subdirectory.
+                for subdir in ("", "_internal"):
+                    path = os.path.join(exe_path, subdir, 'version.txt')
+                    if os.path.exists(path):
+                        with open(path, 'r') as f:
+                            return f.readline().strip()
 
             logging.warning("Unable to find the actual version")
             return "Unknown"


### PR DESCRIPTION
Now that Python 3.6 is not supported anymore, we really needed to bump
the Windows build to a newer version of Python, and conda.

Update the instructions use the latest version of Conda, with Python
3.10.

Also update the installation scripts for PyInstaller v6.0, and newer
version of setuptools (v80).
In particular, the installation files are stored in a subfolder
"_internal", so so code needs to be aware of this path. Also, to make
the transition smooth, we need to delete the files of the old Odemis
install, to be certain they are not loaded first.