### PR TITLE
[build] Use new sphinx docs build method

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Build-Depends: debhelper (>= 11),
                inkscape,
                cython3,
                python3-setuptools,
-               python3-sphinx (>= 1.1.3),
+               python3-sphinx (>= 1.8.5),
                python3-numpy,
                python3-all-dev (>= 3.6.1)
 X-Python3-Version: >= 3.6

--- a/debian/rules
+++ b/debian/rules
@@ -20,13 +20,11 @@ override_dh_installdocs:
 	make -C doc/develop/ images # To build dependencies (eg: SVG -> PDF)
 
 	# build & install multiple doc in multiple formats
-	python3 setup.py build_sphinx --source-dir doc/develop/ --build-dir build/doc/develop/ --builder html --version $(VER) --release $(VER)
-	# HTML is build/doc/develop/html/ , but rename so that it looks like ../develop-html
-	mv build/doc/develop/html/ build/doc/develop/develop-html
+	sphinx-build -b html -D version=$(VER) -D release=$(VER) doc/develop/ build/doc/develop/develop-html
 	dh_installdocs build/doc/develop/develop-html
 	
 	# rst -> latex -> pdf
-	python3 setup.py build_sphinx --source-dir doc/develop/ --build-dir build/doc/develop/ --builder latex --version $(VER) --release $(VER)
+	sphinx-build -b latex -D version=$(VER) -D release=$(VER) doc/develop/ build/doc/develop/latex
 	make -C build/doc/develop/latex all-pdf # PDF is build/doc/develop/latex/odemis-develop.pdf
 	dh_installdocs build/doc/develop/latex/odemis-develop.pdf
 
@@ -35,7 +33,7 @@ override_dh_installdocs:
 
 override_dh_python3:
 	# Leave the scripts marked as /usr/bin/python as-is. We'll switch to Python 3
-	# explicitily.
+	# explicitly.
 	dh_python3 --no-shebang-rewrite
 
 override_dh_compress:

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ try:
     gver = _get_version_git()
     if "-" in gver:
         sys.stderr.write("Warning: packaging a non-tagged version: %s\n" % gver)
-    if VERSION != gver:
+    if VERSION != gver.strip("v"):
         sys.stderr.write("Warning: package version and git version don't match:"
                          " %s <> %s\n" % (VERSION, gver))
 except LookupError:


### PR DESCRIPTION
Migrate Sphinx doc build from setup.py build_sphinx to sphinx-build for compatibility with modern Python packaging and Ubuntu 24.04. Adjusted debian/rules accordingly.

Manual calls to the new methods work on all Ubuntu versions (given that an up-to-date version of sphinx is used).
Not tested: building the debian package