### PR TITLE
[fix] if there are no TOA tiles to acquire return 0 for estimate_acquisition_time

### DIFF
--- a/src/odemis/gui/comp/fastem_roa.py
+++ b/src/odemis/gui/comp/fastem_roa.py
@@ -448,6 +448,10 @@ class FastEMTOA(FastEMROABase):
 
         num_tiles = len(self.field_indices)  # Total number of tiles
 
+        # Return if there are no tiles to acquire
+        if num_tiles == 0:
+            return 0.0
+
         # Time for tile acquisition
         acq_time_tile = self.res.value[0] * self.res.value[1] * acq_dwell_time
 


### PR DESCRIPTION
count_stage_moves raises IndexError: too many indices for array when there are no tiles, return early if there are no tiles to acquire