### PR TITLE
[refactor] Change use of depecated ENZEL sim to METEOR sim

### DIFF
--- a/install/linux/usr/share/odemis/sim/meteor-fibsem-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/meteor-fibsem-sim.odm.yaml
@@ -190,6 +190,69 @@
     affects: ["Camera"],
 }
 
+# Controller for the stigmator
+"Stigmator Actuator": {
+    class: tmcm.TMCLController,
+    role: null,
+    init: {
+        # address: 8,
+        port: "/dev/fake", # Simulator
+        address: null, # Simulator
+        axes: ["stig"],
+        ustepsize: [27.2e-6], # [rad/µstep]
+        rng: [[-14, 7]], # rad, more than 0->2 Pi, in order to allow one extra rotation in both direction, when quickly switching
+        unit: ["rad"],
+        refproc: "Standard",
+        refswitch: {"stig": 0}, #digital output used to switch on/off sensor
+    },
+}
+
+# Backlash corrected actuators for Stigmator
+"AntiBacklash for Stigmator": {
+    class: actuator.AntiBacklashActuator,
+    role: null,
+    init: {
+        backlash: {
+            "stig": 20.e-3,  # rad of move
+        },
+    },
+    children: {"slave": "Stigmator Actuator"},
+}
+
+"Stigmator": {
+    class: actuator.RotationActuator,
+    role: stigmator,
+    affects: ["Camera"],
+    children: {"rz": "AntiBacklash for Stigmator"},
+    init: {
+        axis_name: "stig",
+        #cycle: 2 * pi, # rad
+        # ref_start: null, # rad, value to where start the referencing, default is to start at 5% of cycle
+    },
+    metadata: {
+        POS_COR: -0.5,  # rad, adjustment needed for 0 = no astigmatism
+        # Z localization calibration: stigmator angle -> calibration
+        CALIB: {
+            0.08726: { # 5°
+                    'x': {'a': -0.24759672307261632, 'b': 1.0063089478825507, 'c': 653.0753677001792,  'd': 638.8463397122532,  'w0': 11.560179003062268},
+                    'y': {'a': 0.5893174060828265, 'b': 0.23950839318911246, 'c': 1202.1980639514566,  'd': 425.6030263781317, 'w0': 11.332043010740446},
+                    'feature_angle': -3.1416,
+                    'upsample_factor': 5,
+                    'z_least_confusion': 9.418563712742548e-07,
+                    'z_calibration_range': [-9.418563712742548e-07, 8.781436287257452e-07]
+            },
+            0.17453: { # 10°
+                    'x': {'a': -0.24759672307261632, 'b': 1.0063089478825507, 'c': 653.0753677001792,  'd': 638.8463397122532,  'w0': 11.560179003062268},
+                    'y': {'a': 0.5893174060828265, 'b': 0.23950839318911246, 'c': 1202.1980639514566,  'd': 425.6030263781317, 'w0': 11.332043010740446},
+                    'feature_angle': -3.1416,
+                    'upsample_factor': 5,
+                    'z_least_confusion': 9.418563712742548e-07,
+                    'z_calibration_range': [-9.418563712742548e-07, 8.781436287257452e-07]
+            },
+        },
+    },
+}
+
 # CLS3252dsc-1
 "Optical Focus": {
     class: smaract.MCS2,

--- a/install/linux/usr/share/odemis/sim/meteor-tfs3-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/meteor-tfs3-sim.odm.yaml
@@ -66,7 +66,6 @@
         # Active tilting (rx) & rotation(rz) angles positions when switching between SEM & FM.
         FAV_FM_POS_ACTIVE: {"rx": 0.29670597283903605  , "rz":  3.141592653589793}, # 17° - 180°
         FAV_SEM_POS_ACTIVE: {"rx": 0.6108652381980153, "rz": 0},  # pre-tilt 35°, 0° rotation
-        FAV_MILL_POS_ACTIVE: {"rx": 0.314159, "rz": 0},  # Note that milling angle (rx) can be changed per session
     },
 }
 
@@ -161,6 +160,69 @@
     },
     # TODO: a way to indicate the best filter to use during alignement and brightfield? via some metadata?
     affects: ["Camera"],
+}
+
+# Controller for the stigmator
+"Stigmator Actuator": {
+    class: tmcm.TMCLController,
+    role: null,
+    init: {
+        # address: 8,
+        port: "/dev/fake", # Simulator
+        address: null, # Simulator
+        axes: ["stig"],
+        ustepsize: [27.2e-6], # [rad/µstep]
+        rng: [[-14, 7]], # rad, more than 0->2 Pi, in order to allow one extra rotation in both direction, when quickly switching
+        unit: ["rad"],
+        refproc: "Standard",
+        refswitch: {"stig": 0}, #digital output used to switch on/off sensor
+    },
+}
+
+# Backlash corrected actuators for Stigmator
+"AntiBacklash for Stigmator": {
+    class: actuator.AntiBacklashActuator,
+    role: null,
+    init: {
+        backlash: {
+            "stig": 20.e-3,  # rad of move
+        },
+    },
+    children: {"slave": "Stigmator Actuator"},
+}
+
+"Stigmator": {
+    class: actuator.RotationActuator,
+    role: stigmator,
+    affects: ["Camera"],
+    children: {"rz": "AntiBacklash for Stigmator"},
+    init: {
+        axis_name: "stig",
+        #cycle: 2 * pi, # rad
+        # ref_start: null, # rad, value to where start the referencing, default is to start at 5% of cycle
+    },
+    metadata: {
+        POS_COR: -0.5,  # rad, adjustment needed for 0 = no astigmatism
+        # Z localization calibration: stigmator angle -> calibration
+        CALIB: {
+            0.08726: { # 5°
+                    'x': {'a': -0.24759672307261632, 'b': 1.0063089478825507, 'c': 653.0753677001792,  'd': 638.8463397122532,  'w0': 11.560179003062268},
+                    'y': {'a': 0.5893174060828265, 'b': 0.23950839318911246, 'c': 1202.1980639514566,  'd': 425.6030263781317, 'w0': 11.332043010740446},
+                    'feature_angle': -3.1416,
+                    'upsample_factor': 5,
+                    'z_least_confusion': 9.418563712742548e-07,
+                    'z_calibration_range': [-9.418563712742548e-07, 8.781436287257452e-07]
+            },
+            0.17453: { # 10°
+                    'x': {'a': -0.24759672307261632, 'b': 1.0063089478825507, 'c': 653.0753677001792,  'd': 638.8463397122532,  'w0': 11.560179003062268},
+                    'y': {'a': 0.5893174060828265, 'b': 0.23950839318911246, 'c': 1202.1980639514566,  'd': 425.6030263781317, 'w0': 11.332043010740446},
+                    'feature_angle': -3.1416,
+                    'upsample_factor': 5,
+                    'z_least_confusion': 9.418563712742548e-07,
+                    'z_calibration_range': [-9.418563712742548e-07, 8.781436287257452e-07]
+            },
+        },
+    },
 }
 
 # CLS3252dsc-1

--- a/src/odemis/util/test/testing_test.py
+++ b/src/odemis/util/test/testing_test.py
@@ -30,7 +30,7 @@ from odemis.util import driver, testing
 logging.getLogger().setLevel(logging.DEBUG)
 
 CONFIG_PATH = os.path.dirname(odemis.__file__) + "/../../install/linux/usr/share/odemis/"
-ENZEL_CONFIG = CONFIG_PATH + "sim/enzel-sim.odm.yaml"
+METEOR_CONFIG = CONFIG_PATH + "sim/meteor-sim.odm.yaml"
 SPARC_CONFIG = CONFIG_PATH + "sim/sparc-sim.odm.yaml"
 
 
@@ -52,23 +52,23 @@ class TestBackendStarter(unittest.TestCase):
         # check if there is no running backend
         backend_status = driver.get_backend_status()
         self.assertIn(backend_status, [driver.BACKEND_STOPPED, driver.BACKEND_DEAD])
-        # run enzel
-        testing.start_backend(ENZEL_CONFIG)
-        # now check if the role is enzel
+        # run meteor
+        testing.start_backend(METEOR_CONFIG)
+        # now check if the role is meteor
         role = model.getMicroscope().role
-        self.assertEqual(role, "enzel")
+        self.assertEqual(role, "meteor")
 
     def test_running_backend_same_as_requested(self):
-        # run enzel backend
-        testing.start_backend(ENZEL_CONFIG)
-        # check if the role is enzel
+        # run meteor backend
+        testing.start_backend(METEOR_CONFIG)
+        # check if the role is meteor
         role = model.getMicroscope().role
-        self.assertEqual(role, "enzel")
-        # run enzel backend again
-        testing.start_backend(ENZEL_CONFIG)
-        # it should still be enzel.
+        self.assertEqual(role, "meteor")
+        # run meteor backend again
+        testing.start_backend(METEOR_CONFIG)
+        # it should still be meteor.
         role = model.getMicroscope().role
-        self.assertEqual(role, "enzel")
+        self.assertEqual(role, "meteor")
 
     def test_running_backend_different_from_requested(self):
         # run sparc backend
@@ -76,11 +76,11 @@ class TestBackendStarter(unittest.TestCase):
         # check if the role is sparc
         role = model.getMicroscope().role
         self.assertEqual(role, "sparc")
-        # now run another backend (enzel)
-        testing.start_backend(ENZEL_CONFIG)
-        # check if the role now is enzel instead of sparc
+        # now run another backend (meteor)
+        testing.start_backend(METEOR_CONFIG)
+        # check if the role now is meteor instead of sparc
         role = model.getMicroscope().role
-        self.assertEqual(role, "enzel")
+        self.assertEqual(role, "meteor")
 
 
 class TestFakeBackendDir(unittest.TestCase):


### PR DESCRIPTION
Several test cases used the ENZEL simulator. However the ENZEL is not
supported anymore. So adjust these test cases to use a METEOR simulator
instead.