### PR TITLE
[METEOR-1653] [fix] Update area value after updating HFW

### DIFF
--- a/src/odemis/gui/win/acquisition.py
+++ b/src/odemis/gui/win/acquisition.py
@@ -848,6 +848,8 @@ class OverviewAcquisitionDialog(xrcfr_overview_acq):
 
         self.zsteps.subscribe(self.on_setting_change)
         self.focus_points_dist.subscribe(self.on_setting_change)
+        if self._main_data_model.ebeam:
+            self._main_data_model.ebeam.pixelSize.subscribe(self.on_pixel_size)
         self.tiles_nx.subscribe(self.on_tiles_number)
         self.tiles_ny.subscribe(self.on_tiles_number)
         self.autofocus_roi_ckbox.subscribe(self.on_setting_change)
@@ -1047,6 +1049,12 @@ class OverviewAcquisitionDialog(xrcfr_overview_acq):
     def on_tiles_number(self, _=None):
         """
         Called when the user enters values for the tiles number in the GUI.
+        """
+        self.update_setting_display()
+
+    def on_pixel_size(self, _=None):
+        """
+        Called when the user changes the pixel size in the GUI.
         """
         self.update_setting_display()
 


### PR DESCRIPTION
Add subscribe to pixel size VA, so the settings are updated when changing HFW or magnification (and thus the area is recalculated).

See how to "Tiled area size" value updates after changing the HFW.
![Screencast from 25-07-25 13_59_01](https://github.com/user-attachments/assets/8ccaa411-eb76-45a7-9509-d0c2240a296e)

