### PR TITLE
[fix] bugreporter GUI had mix of incompatible flag

### DIFF
--- a/src/bugreporter/odemis_bugreporter.py
+++ b/src/bugreporter/odemis_bugreporter.py
@@ -544,7 +544,7 @@ class BugreporterFrame(wx.Frame):
         gdpr_lbl.SetMinSize((-1, 100))  # High enough to fit all the text
         font = wx.Font(10, wx.NORMAL, wx.ITALIC, wx.NORMAL)
         gdpr_lbl.SetFont(font)
-        gdpr_sizer.Add(gdpr_lbl, 10, wx.EXPAND | wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL | wx.ALL, 10)
+        gdpr_sizer.Add(gdpr_lbl, 10, wx.EXPAND | wx.ALIGN_LEFT | wx.ALL, 10)
         sizer.Add(gdpr_sizer, 0, wx.EXPAND)
 
         # Status update label


### PR DESCRIPTION
Fix the bugreporter not working on wxPython v4.1+ (ie, Ubuntu 24.04),
showing this "non" error:
```
Traceback (most recent call last):
  File "/usr/bin/odemis-bug-report", line 898, in <module>
    bugreporter.run()
  File "/usr/bin/odemis-bug-report", line 202, in run
    self.gui = BugreporterFrame(self)
               ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/bin/odemis-bug-report", line 547, in __init__
    gdpr_sizer.Add(gdpr_lbl, 10, wx.EXPAND | wx.ALIGN_LEFT | wx.ALIGN_CENTER_VERTICAL | wx.ALL, 10)
wx._core.wxAssertionError: C++ assertion "CheckSizerFlags(!((flags) & (wxALIGN_RIGHT | wxALIGN_CENTRE_HORIZONTAL | wxALIGN_BOTTOM | wxALIGN_CENTRE_VERTICAL)))" failed at ./src/common/sizer.cpp(2299) in DoInsert(): wxALIGN_RIGHT | wxALIGN_CENTRE_HORIZONTAL | wxALIGN_BOTTOM | wxALIGN_CENTRE_VERTICAL will be ignored in this sizer: wxEXPAND overrides alignment flags in box sizers

DO NOT PANIC !!

If you're an end user running a program not developed by you, please ignore this message, it is harmless, and please try reporting the problem to the program developers.

You may also set WXSUPPRESS_SIZER_FLAGS_CHECK environment variable to suppress all such checks when running this program.
```