### PR TITLE
[fix] increase the size of the select update channel dialog

### DIFF
--- a/install/linux/usr/bin/odemis-select-channel
+++ b/install/linux/usr/bin/odemis-select-channel
@@ -186,7 +186,7 @@ choice=$(zenity --list --radiolist \
   $stable_selected "stable" "Stable channel" \
   $proposed_selected "proposed" "Release candidate channel" \
   $dev_selected "dev" "Development channel" \
-  --width=400 --height=250
+  --width=400 --height=350
 )
 
 echo "Selected Odemis channel: $choice"


### PR DESCRIPTION
On Ubuntu 24.04, the zenity window is shown quite different, and less
compact. The current height of 250 px was completely fine on 22.04, but
on 24.04, it only allowed to the first of the 3 choices, which is quite
confusing.