### PR TITLE
[fix] skip semnidaq test case

### DIFF
--- a/src/odemis/driver/test/semnidaq_test.py
+++ b/src/odemis/driver/test/semnidaq_test.py
@@ -21,7 +21,8 @@ You should have received a copy of the GNU General Public License along with
 Odemis. If not, see http://www.gnu.org/licenses/.
 """
 import logging
-from unittest import skip
+import sys
+from unittest import SkipTest, skip
 
 logging.getLogger().setLevel(logging.DEBUG)
 logging.basicConfig(format="%(asctime)s  %(levelname)-7s %(module)s:%(lineno)d %(message)s")
@@ -153,6 +154,9 @@ class TestAnalogSEM(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
+        if sys.version_info < (3, 9):
+            raise SkipTest("semnidaq does not work for Ubuntu 20.04 or lower")
+
         cls.sem = semnidaq.AnalogSEM(**CONFIG_SEM)
 
         for child in cls.sem.children.value:


### PR DESCRIPTION
If python version is less than 3.9.0, skip the file