### PR TITLE
[fix] move org.freedesktop.Notifications.service dependency to odemis.install

### DIFF
--- a/debian/odemis.install
+++ b/debian/odemis.install
@@ -2,3 +2,4 @@ install/linux/etc/logrotate.d/odemisd etc/logrotate.d/
 install/linux/etc/sudoers.d/odemis etc/sudoers.d/
 install/linux/usr/share/bash-completion/completions/odemis-cli usr/share/bash-completion/completions/
 install/linux/usr/share/bash-completion/completions/odemis-convert usr/share/bash-completion/completions/
+install/linux/usr/share/dbus-1/services/org.freedesktop.Notifications.service usr/share/dbus-1/services/

--- a/install/linux/usr/share/dbus-1/services/org.freedesktop.Notifications.service
+++ b/install/linux/usr/share/dbus-1/services/org.freedesktop.Notifications.service
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=org.freedesktop.Notifications
+Exec=/usr/lib/notification-daemon/notification-daemon


### PR DESCRIPTION
By doing so the service will be installed during odemis install/update