### PR TITLE
[ci] Ensure all tests are runnable

### DIFF
--- a/src/odemis/acq/align/test/roi_autofocus_test.py
+++ b/src/odemis/acq/align/test/roi_autofocus_test.py
@@ -145,3 +145,7 @@ class RoiAutofocusTestCase(unittest.TestCase):
         min_time = n_focus_points * estimateAutoFocusTime(self.ccd, None, self.focus, rng_focus=self.focus_range)
         estimated_time = estimate_autofocus_in_roi_time(n_focus_points, self.ccd, self.focus, self.focus_range)
         self.assertGreaterEqual(estimated_time, min_time)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/odemis/acq/milling/test/patterns_test.py
+++ b/src/odemis/acq/milling/test/patterns_test.py
@@ -224,3 +224,7 @@ class MicroexpansionPatternParametersTestCase(unittest.TestCase):
         self.assertAlmostEqual(patterns[1].rotation.value, 0)
         numpy.testing.assert_array_almost_equal(patterns[1].center.value, (self.spacing, 0))
         self.assertEqual(patterns[1].scan_direction.value, "TopToBottom")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/odemis/dataio/test/ij_tiff_test.py
+++ b/src/odemis/dataio/test/ij_tiff_test.py
@@ -241,3 +241,7 @@ class TestImageJTiffIO(unittest.TestCase):
                  (40, 1, 10, 300, 400)
                  ]
         self.checkImageJMetadata(sizes, num_channels=2, num_frames=1, num_slices=10)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/odemis/driver/test/autoscript_client_test.py
+++ b/src/odemis/driver/test/autoscript_client_test.py
@@ -925,4 +925,8 @@ class TestMicroscope(unittest.TestCase):
         self.assertTrue(isinstance(info["z"].range, tuple)) # (min, max)
         self.assertTrue(len(info["z"].range) == 2)
         self.assertTrue(isinstance(info["z"].range[0], (int,float)))
-        self.assertTrue(isinstance(info["z"].range[1], (int,float)))
+        self.assertTrue(isinstance(info["z"].range[1], (int, float)))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/odemis/util/test/interpolation_test.py
+++ b/src/odemis/util/test/interpolation_test.py
@@ -96,3 +96,7 @@ class TestInterpolationUtil(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             interpolate_z_stack(model.DataArray(bad_dims, metadata=bad_md))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
by calling unittest.main() at the bottom of the files