### PR TITLE
[fix] TestSimStreakCamGenericCamSynchronized test_basic

### DIFF
--- a/src/odemis/driver/test/cam_test_abs.py
+++ b/src/odemis/driver/test/cam_test_abs.py
@@ -705,7 +705,14 @@ class VirtualTestSynchronized(metaclass=ABCMeta):
         self.ccd.data.synchronizedOn(None)
 
         logging.info("Took %g s", self.end_time - start)
-        time.sleep(exp + readout)
+
+        # Wait for any pending acquisitions to complete
+        max_wait_time = (exp + readout) * 2  # 2x expected time
+        timeout_start = time.time()
+
+        while self.ccd_left > 0 and (time.time() - timeout_start) < max_wait_time:
+            time.sleep(0.1)  # Poll every 100ms
+
         self.assertEqual(self.ccd_left, 0)
 
         # check we can still get data normally


### PR DESCRIPTION
Add timeout buffer for pending CCD acquisitions in sync test.

**Problem**: The test_basic method in `VirtualTestSynchronized` was experiencing random test failures with `AssertionError: 1 != 0` due to a race condition where the test checked `self.ccd_left == 0` before all CCD image acquisition callbacks finished executing.

**Solution**: Added a polling timeout mechanism that waits up to 2x (exposure + readout) time for any pending CCD acquisitions to complete before performing the final assertion.

**Result**: This eliminates the random test failures while preserving the core functionality of validating SEM-CCD trigger synchronization.