### PR TITLE
[fix] Improve log for fast-em autofocus

### DIFF
--- a/src/odemis/acq/align/autofocus.py
+++ b/src/odemis/acq/align/autofocus.py
@@ -190,7 +190,6 @@ def _DoBinaryFocus(
         else:
             logging.debug("No depth of field info found")
             dof = 1e-6  # m, not too bad value
-        logging.debug("Depth of field is %.7g", dof)
         min_step = dof / 2
 
         # adjust to rng_focus if provided
@@ -201,6 +200,8 @@ def _DoBinaryFocus(
         max_step = (rng[1] - rng[0]) / 2
         if max_step <= 0:
             raise ValueError("Unexpected focus range %s" % (rng,))
+        logging.debug("Depth of field is %.7g. Searching within z=%s at step size from %g to %g m",
+                      dof, rng, max_step, min_step)
 
         rough_search = True  # False once we've passed the maximum level (ie, start bouncing)
         # It's used to cache the focus level, to avoid reacquiring at the same

--- a/src/odemis/acq/align/test/fastem_test.py
+++ b/src/odemis/acq/align/test/fastem_test.py
@@ -104,7 +104,7 @@ class TestFastEMCalibration(unittest.TestCase):
         except ValueError:
             # Handle optical autofocus calibration raised ValueError when confidence is low.
             # For now, pass and continue with the test, even with low confidence the stage should be close to the good position.
-            pass
+            logging.warning("Optical autofocus calibration got low confidence")
 
         # check that z stage position is close to good position
         # Note: This accuracy is dependent on the value chosen for the magnification on the lens.


### PR DESCRIPTION
Sometimes, the fast-em autofocus test case fails, because the min/max is
the same as the current position. Hard to reproduce, so let's try to get
more information via the logs.