### PR TITLE
[refactor] FAST-EM Update voltage adjustment pop-up

### DIFF
--- a/src/odemis/gui/comp/fastem_user_settings_panel.py
+++ b/src/odemis/gui/comp/fastem_user_settings_panel.py
@@ -244,7 +244,8 @@ class FastEMUserSettingsPanel(object):
             dlg = wx.MessageDialog(
                 ctrl,
                 "Do you want to change the Voltage value? "
-                "If Yes, the system needs to be re-calibrated.",
+                "If Yes, the system needs to be re-calibrated, this can only be done"
+                " by a user trained on running the voltage adjustment script.",
                 "Confirm",
                 wx.YES_NO | wx.NO_DEFAULT | wx.ICON_QUESTION,
             )


### PR DESCRIPTION
The current message is a bit too friendly, this does not convey the warning that voltage adjustment should only be done by a trained user.