### PR TITLE
[fix] Technolution convert phase shift to int

### DIFF
--- a/src/odemis/driver/technolution.py
+++ b/src/odemis/driver/technolution.py
@@ -1007,7 +1007,8 @@ class MirrorDescanner(model.Emitter):
         setpoints = numpy.minimum(setpoints, I16_SYM_RANGE[1] - 1)
 
         # Shift the setpoints to the right by a percentage of the total number of setpoints.
-        setpoints = numpy.roll(setpoints, round(len(setpoints) * self.shift.value))
+        # On python/numpy <= 3.8 round(...) returns a float, explicitly convert to int.
+        setpoints = numpy.roll(setpoints, int(round(len(setpoints) * self.shift.value)))
         return setpoints.tolist()
 
     def getYAcqSetpoints(self):


### PR DESCRIPTION
To shift the setpoints by a shift-factor the numpy array is rolled by that factor multiplied by the number of setpoints. `round` was used to convert to an integer value to roll by, however in old versions of python/numpy round can return a float instead of an int, this could lead to numpy.roll failing with the error

TypeError: slice indices must be integers or None or have an __index__ method

FVEM-184