### PR TITLE
[feat] metadata OUT_WL should also come from the tc-filter

### DIFF
--- a/src/odemis/odemisd/mdupdater.py
+++ b/src/odemis/odemisd/mdupdater.py
@@ -111,7 +111,7 @@ class MetadataUpdater(model.Component):
                     self._det_to_spectrograph[dn] = a
                     # update the output wavelength range
                     observed = self.observeSpectrograph(a, d)
-                elif a.role in ("cl-filter", "filter"):
+                elif a.role in ("cl-filter", "filter", "tc-filter"):
                     self._det_to_filter[dn] = a
                     # update the output wavelength range
                     observed = self.observeFilter(a, d)


### PR DESCRIPTION
The tc-filter affects the time-correlator detector(s) typically. It
works exactly like other filters. So it should also be observed, in
order to properly store the MD_OUT_WL metadata information during a
SPARC acquisition.