### PR TITLE
[fix] delete edit meteor configuration menu item

### DIFF
--- a/src/odemis/gui/cont/menu.py
+++ b/src/odemis/gui/cont/menu.py
@@ -131,8 +131,8 @@ class MenuController(object):
         main_frame.Bind(wx.EVT_MENU, self._on_debug_menu, id=main_frame.menu_item_debug.GetId())
         main_data.debug.subscribe(self._on_debug_va, init=True)
 
-        # /Help/Development/Edit METEOR Calibration : only show if it's a METEOR
-        if main_data.role != "meteor":
+        # /Help/Development/Edit METEOR Calibration : only show if it's a METEOR with Calibration metadata
+        if main_data.role != "meteor" or (main_data.stage.getMetadata().get(model.MD_CALIB, None) is None):
             menu_dev = main_frame.menu_item_edit_meteor_calibration.GetMenu()
             menu_dev.Delete(main_frame.menu_item_edit_meteor_calibration)
 

--- a/src/odemis/gui/cont/tabs/cryo_chamber_tab.py
+++ b/src/odemis/gui/cont/tabs/cryo_chamber_tab.py
@@ -125,8 +125,11 @@ class CryoChamberTab(Tab):
         self._move_cancelled = False
 
         # enable meteor calibration
-        main_frame.Bind(wx.EVT_MENU, self._edit_meteor_calibration, id=main_frame.menu_item_edit_meteor_calibration.GetId())
-        if self._role == 'meteor':
+        # For other roles and METEOR without calibration metadata, the menu item is deleted
+        # The deletion in handled in gui.cont.menu
+        if self._role == 'meteor' and self.tab_data_model.main.stage.getMetadata().get(model.MD_CALIB, None) is not None:
+            main_frame.Bind(wx.EVT_MENU, self._edit_meteor_calibration,
+                            id=main_frame.menu_item_edit_meteor_calibration.GetId())
             main_frame.menu_item_edit_meteor_calibration.Enable(True)
 
         self._current_posture = UNKNOWN  # position of the sample (regularly updated)


### PR DESCRIPTION
disabled/removed the menu entry for calibration for all the systems which are not METEOR and does not have CALIB in the stage metadata