### PR TITLE
[fix] test cases in move_test.py for zeiss

### DIFF
--- a/src/odemis/acq/move.py
+++ b/src/odemis/acq/move.py
@@ -1303,9 +1303,14 @@ class MeteorZeiss1PostureManager(MeteorPostureManager):
         sem_pos_active = stage_md[model.MD_FAV_SEM_POS_ACTIVE]
 
         # Define values that are used more than once
-        rx_sem = pos["rx"]  # Current tilt angle (can differ per point of interest)
+        try:
+            rx_sem = pos["rx"]  # Current tilt angle (can differ per point of interest)
+            z = pos["z"]
+        except KeyError:
+            raise KeyError(f"The stage position does not have rx or z axis. pos={pos}")
+
         rx_fm = fm_pos_active["rx"]  # Calibrated tilt angle, for imaging perpendicular to objective
-        b_0 = pos["z"] - calibrated_values["z_ct"]
+        b_0 = z - calibrated_values["z_ct"]
         x_0 = calibrated_values["x"]
         y_0 = calibrated_values["y"]
         m_0 = calibrated_values["m"]

--- a/src/odemis/acq/test/move_test.py
+++ b/src/odemis/acq/test/move_test.py
@@ -345,7 +345,9 @@ class TestMeteorZeiss1Move(TestMeteorTFS1Move):
     ROTATION_AXES = {'rx', 'rm'}
 
     def test_moving_in_grid1_fm_imaging_area_after_loading(self):
-        """Check if the stage moves in the right direction when moving in the fm imaging grid 1 area."""
+        """
+        Check if the stage moves in the right direction when moving in the fm imaging grid 1 area.
+        """
         super().test_moving_in_grid1_fm_imaging_area_after_loading()
 
         # move in the same imaging mode using linked YM stage
@@ -358,6 +360,41 @@ class TestMeteorZeiss1Move(TestMeteorTFS1Move):
         estimated_beta = math.atan2(new_stage_pos["m"] - old_stage_pos["m"], new_stage_pos["y"] - old_stage_pos["y"])
         self.assertAlmostEqual(beta, estimated_beta, places=5, msg="The stage moved in the wrong direction in "
                                                                    "the FM imaging grid 1 area.")
+
+    def test_transformFromSEMToMeteor(self):
+        """
+        Test the keys in stage position for _transformFromSEMToMeteor.
+        """
+        stage_md = self.stage.getMetadata()
+        grid1_pos = stage_md[model.MD_SAMPLE_CENTERS][POSITION_NAMES[GRID_1]]
+        grid2_pos = stage_md[model.MD_SAMPLE_CENTERS][POSITION_NAMES[GRID_2]]
+        # Above position are updated in linear axes and do not have rotation axes,
+        # so should raise KeyError when rotation axes are accessed
+        with self.assertRaises(KeyError):
+            self.posture_manager._transformFromSEMToMeteor(grid1_pos)
+        with self.assertRaises(KeyError):
+            self.posture_manager._transformFromSEMToMeteor(grid2_pos)
+
+        # update the stage with rotation axes
+        grid1_pos.update(stage_md[model.MD_FAV_SEM_POS_ACTIVE])
+        grid2_pos.update(stage_md[model.MD_FAV_SEM_POS_ACTIVE])
+
+        # check if no error is raised (test fails if error is raised)
+        self.posture_manager._transformFromSEMToMeteor(grid1_pos)
+        current_grid = self.posture_manager.getCurrentGridLabel()
+        self.assertEqual(GRID_1, current_grid)
+        self.posture_manager._transformFromSEMToMeteor(grid2_pos)
+        current_grid = self.posture_manager.getCurrentGridLabel()
+        self.assertEqual(GRID_2, current_grid)
+
+    def test_unknown_label_at_initialization(self):
+        # Find a position that is not in any defined posture i.e. it is outside the imaging range
+        arbitrary_position = {"x": 0.0, "y": 0.0, "z": 0.0e-3}
+        self.stage.moveAbs(arbitrary_position).result()
+        current_imaging_mode = self.posture_manager.getCurrentPostureLabel()
+        self.assertEqual(UNKNOWN, current_imaging_mode)
+        current_grid = self.posture_manager.getCurrentGridLabel()
+        self.assertEqual(current_grid, None)
 
 
 class TestMeteorTFS3Move(unittest.TestCase):


### PR DESCRIPTION
Two tests were not modified for the ZeissPosture manager

src/odemis/acq/test/move_test.py:563 (TestMeteorZeiss1Move.test_unknown_label_at_initialization)
self = <move_test.TestMeteorZeiss1Move testMethod=test_unknown_label_at_initialization>

    def test_unknown_label_at_initialization(self):
        arbitrary_position = {"x": 0.0, "y": 0.0, "z": -3.0e-3}
>       self.stage.moveAbs(arbitrary_position).result()

src/odemis/acq/test/move_test.py:566: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/lib/python3/dist-packages/Pyro4/futures.py:315: in result
    return self.__get_result()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <ClientFuture at 0x7f3f1d713910 for Proxy of Component 'AntiBacklash Stage'>

    def __get_result(self):
        if self._exception:
>           raise self._exception
E           ValueError: Position -0.003 for axis z outside of range 0.000000->0.050000

/usr/lib/python3/dist-packages/Pyro4/futures.py:299: ValueError

----------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_transformFromSEMToMeteor(self):
 def _transformFromSEMToMeteor(self, pos: Dict[str, float]) -> Dict[str, float]:
        """
        Transforms the current stage position from the SEM imaging area to the
        meteor/FM imaging area.
        :param pos: (dict str->float) the current stage position.
        :return: (dict str->float) the transformed position.
        """
        stage_md = self.stage.getMetadata()
        transformed_pos = pos.copy()
    
        # Call out calibrated values and stage tilt and rotation angles
        calibrated_values = stage_md[model.MD_CALIB]
        fm_pos_active = stage_md[model.MD_FAV_FM_POS_ACTIVE]
        sem_pos_active = stage_md[model.MD_FAV_SEM_POS_ACTIVE]
    
        # Define values that are used more than once
>       rx_sem = pos["rx"]  # Current tilt angle (can differ per point of interest)
E       KeyError: 'rx'

src/odemis/acq/move.py:1308: KeyError