### PR TITLE
[fix] METEOR overview acquisition failed to open if e-beam has no pixelSize

### DIFF
--- a/src/odemis/gui/win/acquisition.py
+++ b/src/odemis/gui/win/acquisition.py
@@ -848,7 +848,7 @@ class OverviewAcquisitionDialog(xrcfr_overview_acq):
 
         self.zsteps.subscribe(self.on_setting_change)
         self.focus_points_dist.subscribe(self.on_setting_change)
-        if self._main_data_model.ebeam:
+        if self._main_data_model.ebeam and model.hasVA(self._main_data_model.ebeam, "pixelSize"):
             self._main_data_model.ebeam.pixelSize.subscribe(self.on_pixel_size)
         self.tiles_nx.subscribe(self.on_tiles_number)
         self.tiles_ny.subscribe(self.on_tiles_number)


### PR DESCRIPTION
Fix issue introduced in commit 8751e3f08a ([fix] Update area value after
updating HFW).

Most e-beam components have a .pixelSizeview. However, that's not the case
of the xt_client if it is instantiated without a detector (because no
detector means no pixel, so no pixel size).

The code assumed that an e-beam has always a pixelSize VA.
=> protect against such case