### PR TITLE
[feat] SPARC GUI: force the SEM survey stream to always start with the same settings

### DIFF
--- a/src/odemis/gui/cont/tabs/sparc_acquisition_tab.py
+++ b/src/odemis/gui/cont/tabs/sparc_acquisition_tab.py
@@ -92,13 +92,11 @@ class SparcAcquisitionTab(Tab):
 
         # Check the settings are proper for a survey stream (as they could be
         # left over from spot mode)
-        # => full FoV + not too low scale + not too long dwell time
+        # => full FoV + not too high scale + short dwell time
         if hasattr(sem_stream, "emtDwellTime"):
-            if sem_stream.emtDwellTime.value > 100e-6:
-                sem_stream.emtDwellTime.value = sem_stream.emtDwellTime.clip(10e-6)
+            sem_stream.emtDwellTime.value = sem_stream.emtDwellTime.clip(1e-6)
         if hasattr(sem_stream, "emtScale"):
-            if any(s > 16  for s in sem_stream.emtScale.value):
-                sem_stream.emtScale.value = sem_stream.emtScale.clip((16, 16))
+            sem_stream.emtScale.value = sem_stream.emtScale.clip((8, 8))
             sem_scale = sem_stream.emtScale.value
         else:
             sem_scale = 1, 1


### PR DESCRIPTION
The original idea was to pick the settings from the current hardware
settings. So this would allow to adjust the default settings in the
microscope file, and if the GUI is closed and restarted the previous
settings values would be used.

Nice idea, but it doesn't work well in practice because after an
acquisition the settings are changed to "weird" values. So the user ends
up sometimes with weirds values, and in general with a little bit
"random" values.

Instead, always use scale 8 and dwell time 1 µs. That should be good
enough for most of the usage, and be a lot let surprising.