### PR TITLE
[fix] GUI METEOR: protect function call outside of main GUI thread

### DIFF
--- a/src/odemis/gui/cont/tabs/cryo_chamber_tab.py
+++ b/src/odemis/gui/cont/tabs/cryo_chamber_tab.py
@@ -634,6 +634,7 @@ class CryoChamberTab(Tab):
     def _update_movement_controls(self):
         """
         Enable/disable chamber move controls (position and stage) based on current move
+        Must be called within the main GUI thread
         """
         # Get current movement (including unknown and on the path)
         self._current_posture = self.posture_manager.current_posture.value
@@ -895,6 +896,7 @@ class CryoChamberTab(Tab):
         self._end_pos = end_pos
         return self.posture_manager.cryoSwitchSamplePosition(self._target_posture)
 
+    @call_in_wx_main
     def _on_posture(self, posture: int) -> None:
         logging.info(f"Stage posture changed to {POSITION_NAMES[posture]}")
         self._update_movement_controls()


### PR DESCRIPTION
Now the .posture VA of the PostureManager is subscribed by the chamber
tab. However, althgouh the posture can change from outside the main GUI
thread (eg, when the stage moves), the callback wasn't protected.
This caused from time to time crash or freeze of the GUI.

=> Protect the _on_posture() callback function.