### PR TITLE
[ci] add basic acq.move test cases to the cloud testing

### DIFF
--- a/.github/workflows/unit_tests_cloud.yml
+++ b/.github/workflows/unit_tests_cloud.yml
@@ -175,6 +175,14 @@ jobs:
           python3 -m unittest src/odemis/acq/milling/test/patterns_test.py --verbose
           python3 -m unittest src/odemis/acq/milling/test/tasks_test.py --verbose
 
+    # Note: some tests rely on simple backends like TestMeteorTFS1Move or TestMeteorZeiss1Move,
+    # however, they are very long (>10 min) and sometimes block at the end.
+    - name: Run tests from odemis.acq.move (which do not require backend)
+      if: ${{ !cancelled() }}
+      run: |
+          export PYTHONPATH="$PWD/src:$PYTHONPATH"
+          python3 -m unittest --verbose src.odemis.acq.test.move_test.TestMoveUtil
+
     - name: Run tests from odemis.acq.leech
       if: ${{ !cancelled() }}
       run: |


### PR DESCRIPTION
Tried to also add the "real" test cases using the backend, but they are
way too long (>10 min for each system) and sometimes block at the end.