### PR TITLE
[fix] SPARC acquisition: make it possible to go from spot tool -> RoA

### DIFF
--- a/src/odemis/gui/cont/stream_bar.py
+++ b/src/odemis/gui/cont/stream_bar.py
@@ -716,7 +716,8 @@ class StreamBarController(object):
         else:
             # The stream is now paused. If it used the spot stream, pause that one too.
             if isinstance(stream, self._spot_required) and spots:
-                self._tab_data_model.tool.value = TOOL_NONE
+                if self._tab_data_model.tool.value == TOOL_SPOT:
+                    self._tab_data_model.tool.value = TOOL_NONE
                 spots.is_active.value = False
 
     def on_tool_change(self, tool):


### PR DESCRIPTION
Until now, if a stream using the spot mode is playing (eg, spectrum),
and the user presses the "RoA" tool, then the stream pauses, the spot
tool is disabled... and the RoA tool is disabled too. Then the user has
to press a second time on the RoA tool.

That's because when stopping the spot stream, the scheduler would
incondionally reset the tool mode. Instead, it should just make sure
the tool mode is not "spot" any more.