### PR TITLE
[fix] SEM Vector scanning fixes

### DIFF
--- a/src/odemis/acq/test/scan_test.py
+++ b/src/odemis/acq/test/scan_test.py
@@ -203,7 +203,7 @@ class TestVectorAcquisition(unittest.TestCase):
         ebeam_fov = ebeam_pxs[0] * ebeam_max_res[0], ebeam_pxs[1] * ebeam_max_res[1]
         exp_pxs = (ebeam_fov[0] / res[0], ebeam_fov[1] / res[1])
         testing.assert_tuple_almost_equal(img_md[model.MD_PIXEL_SIZE], exp_pxs)
-        testing.assert_tuple_almost_equal(img_md[model.MD_POS], ebeam_md[model.MD_POS])  # Full FoV, so no translation
+        testing.assert_tuple_almost_equal(img_md[model.MD_POS], ebeam_md.get(model.MD_POS, (0, 0)))  # Full FoV, so no translation
         self.assertEqual(img_md[model.MD_ROTATION], rotation)
 
     def test_2d_img_rotated(self):
@@ -238,7 +238,7 @@ class TestVectorAcquisition(unittest.TestCase):
         exp_pxs = (fov_ratio[0] * ebeam_fov[0] / res[0], fov_ratio[1] * ebeam_fov[1] / res[1])
         testing.assert_tuple_almost_equal(img_md[model.MD_PIXEL_SIZE], exp_pxs)
         # RoI centered on FoV, so no translation
-        testing.assert_tuple_almost_equal(img_md[model.MD_POS], ebeam_md[model.MD_POS])
+        testing.assert_tuple_almost_equal(img_md[model.MD_POS], ebeam_md.get(model.MD_POS, (0, 0)))
         self.assertEqual(img_md[model.MD_ROTATION], rotation)
 
 

--- a/src/odemis/driver/semnidaq.py
+++ b/src/odemis/driver/semnidaq.py
@@ -3113,7 +3113,7 @@ class Scanner(model.Emitter):
             # 1. for each output port which is controlled by the pixel signal,
             pixel_mask = dtype(sum(1 << c for c in self._pixel_ttl))
             # 2. all the samples where the signal is high is converted to the bitmask (using boolean AND bitmask)
-            pixel_bits = pixel_signal & pixel_mask
+            pixel_bits = pixel_signal * pixel_mask
             # 3. Invert all high samples => they are switched from inactive to active (using XOR)
             ttl_signal_dup[...] ^= pixel_bits
 
@@ -3127,7 +3127,7 @@ class Scanner(model.Emitter):
 
         if line_signal is not None and self._line_ttl:
             line_mask = dtype(sum(1 << c for c in self._line_ttl))
-            line_bits = line_signal & line_mask
+            line_bits = line_signal * line_mask
             ttl_signal_dup[...] ^= line_bits
 
         # Frame: copy as-is
@@ -3140,7 +3140,7 @@ class Scanner(model.Emitter):
 
         if frame_signal is not None and self._frame_ttl:
             frame_mask = dtype(sum(1 << c for c in self._frame_ttl))
-            frame_bits = frame_signal & frame_mask
+            frame_bits = frame_signal * frame_mask
             ttl_signal_dup[...] ^= frame_bits
 
         return ttl_signal

--- a/src/odemis/driver/test/semnidaq_test.py
+++ b/src/odemis/driver/test/semnidaq_test.py
@@ -1329,7 +1329,7 @@ class TestAnalogSEM(unittest.TestCase):
             [0, 0]     # Center
         ], dtype=float)
         # TTL signal: everything is a pixel, a line and a frame
-        all_high = numpy.ones(scan_path.shape[0] * 2, dtype=numpy.bool_)
+        all_high = numpy.ones(scan_path.shape[0] * 2, dtype=bool)
 
         self.scanner.scanPath.value = scan_path
         self.scanner.scanPixelTTL.value = all_high


### PR DESCRIPTION
2 small fixes related to vector scanning:
* Test failed because it expected a newer version of the SPARC simulator 
* TTL output by semnidaq during vector scanning didn't work