### PR TITLE
[METEOR-1717][fix] pop up of edit meteor calibration works

### DIFF
--- a/src/odemis/gui/cont/menu.py
+++ b/src/odemis/gui/cont/menu.py
@@ -132,7 +132,7 @@ class MenuController(object):
         main_data.debug.subscribe(self._on_debug_va, init=True)
 
         # /Help/Development/Edit METEOR Calibration : only show if it's a METEOR with Calibration metadata
-        if main_data.role != "meteor" or (main_data.stage.getMetadata().get(model.MD_CALIB, None) is None):
+        if main_data.role != "meteor" or (main_data.stage_bare.getMetadata().get(model.MD_CALIB, None) is None):
             menu_dev = main_frame.menu_item_edit_meteor_calibration.GetMenu()
             menu_dev.Delete(main_frame.menu_item_edit_meteor_calibration)
 

--- a/src/odemis/gui/cont/tabs/cryo_chamber_tab.py
+++ b/src/odemis/gui/cont/tabs/cryo_chamber_tab.py
@@ -127,7 +127,7 @@ class CryoChamberTab(Tab):
         # enable meteor calibration
         # For other roles and METEOR without calibration metadata, the menu item is deleted
         # The deletion in handled in gui.cont.menu
-        if self._role == 'meteor' and self.tab_data_model.main.stage.getMetadata().get(model.MD_CALIB, None) is not None:
+        if self._role == 'meteor' and self.tab_data_model.main.stage_bare.getMetadata().get(model.MD_CALIB, None) is not None:
             main_frame.Bind(wx.EVT_MENU, self._edit_meteor_calibration,
                             id=main_frame.menu_item_edit_meteor_calibration.GetId())
             main_frame.menu_item_edit_meteor_calibration.Enable(True)


### PR DESCRIPTION
The definition of stage changed from stage-bare to sample stage which led to the conditions for enabling the pop up to fail. Now the conditions are checking metadata in stage-bare and not in stage.