### PR TITLE
[test] Avoid GUI TestWindowsUpdater from segfaulting

### DIFF
--- a/src/odemis/gui/util/test/updater_test.py
+++ b/src/odemis/gui/util/test/updater_test.py
@@ -40,6 +40,15 @@ class FakeApp(wx.App):
         super().__init__(*args, **kwargs)
 
 class TestWindowsUpdater(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.app = FakeApp(standalone=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.app.ExitMainLoop()
+
     def test_version(self):
         # That should work on any OS
         u = updater.WindowsUpdater()
@@ -52,8 +61,7 @@ class TestWindowsUpdater(unittest.TestCase):
         # u.check_for_update()
 
     def test_downloader(self):
-        app = FakeApp(standalone=True)
-        app.main_frame = wx.Frame()
+        self.app.main_frame = wx.Frame()
         u = updater.WindowsUpdater()
         rv = u.get_remote_version()
         self.assertIsInstance(rv, str)


### PR DESCRIPTION
If the wx app is created in the function, it gets automatically
destroyed at the end of the function, which causes various issues if the
program keeps running... including segfault.

=> create the app at the beginning of the test cases.

This avoids errors such as displayed in syslog:
python[1582684]: segfault at 0 ip 000076b899fb77cf sp 00007ffe5aac0028 error 4 in libwx_gtk3u_core-3.2.so.0[76b899ec6000+408000] likely on CPU 6 (core 2, socket 0)