### PR TITLE
[fix] simcam with polarization display could fail if the font was missing

### DIFF
--- a/src/odemis/driver/simcam.py
+++ b/src/odemis/driver/simcam.py
@@ -307,8 +307,13 @@ class Camera(model.DigitalCamera):
 
         shape = image.shape
         binning = self.binning.value
-        fnt_size = int(80/binning[0])
-        fnt = ImageFont.truetype('FreeSans.ttf', fnt_size)
+        fnt_size = max(2, 80 // binning[0])
+        try:
+            fnt = ImageFont.truetype("DejaVuSans.ttf", fnt_size)
+        except OSError as ex:
+            # Fall back to default font
+            logging.warning("Could not load 'DejaVuSans.ttf' font (%s), falling back to tiny default font", ex)
+            fnt = ImageFont.load_default()
         # create txt image for overlay
         im_txt = Image.new('F', shape[::-1], 0)
         d = ImageDraw.Draw(im_txt)


### PR DESCRIPTION
It used FreeSans.ttf, which is not installed by default on Ubuntu
anymore (from 24.04). It's still in the pacakge fonts-freefont-ttf.

The simplest is to use DejaVuSans.ttf, which is available by default on
Ubuntu (it's the default font). It's also a little prettier.
In addition, now, if the font cannot be found, it falls back to using
the internal (small and ugly) font of PIL.

This fixes such error:
```
ERROR    root:__init__.py:727 Failure while calling repeating timer 'SimCam image generator'
Traceback (most recent call last):
  File "/home/testing/development/odemis/src/odemis/util/__init__.py", line 721, in run
    self.callback()
  File "/home/testing/development/odemis/src/odemis/util/weak.py", line 36, in __call__
    return self.f(ins, *arg, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/testing/development/odemis/src/odemis/driver/simcam.py", line 268, in _generate
    gen_img = self._write_txt_image(gen_img, txt)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/testing/development/odemis/src/odemis/driver/simcam.py", line 311, in _write_txt_image
    fnt = ImageFont.truetype('FreeSans.ttf', fnt_size)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/PIL/ImageFont.py", line 819, in truetype
    return freetype(font)
           ^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/PIL/ImageFont.py", line 816, in freetype
    return FreeTypeFont(font, size, index, encoding, layout_engine)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/PIL/ImageFont.py", line 245, in __init__
    self.font = core.getfont(
```