### PR TITLE
[test] don't try to run scan_test TestVectorAcquisition on Ubuntu 20.04

### DIFF
--- a/src/odemis/acq/test/scan_test.py
+++ b/src/odemis/acq/test/scan_test.py
@@ -21,6 +21,7 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 
 import math
 import os
+import sys
 import unittest
 
 import numpy
@@ -165,6 +166,9 @@ class TestVectorAcquisition(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        if sys.version_info < (3, 9):
+            raise unittest.SkipTest("semnidaq does not work for Ubuntu 20.04 or lower")
+
         testing.start_backend(SPARC2_HWSYNC_CONFIG)
 
         # Find CCD & SEM components


### PR DESCRIPTION
This test requires semnidaq, which is only supported on Ubuntu 22.04 and later.

=> skip the test if the Ubuntu version is too old.