### PR TITLE
[feat] util release-odemis: upload via SSH instead of FTP

### DIFF
--- a/util/release-odemis
+++ b/util/release-odemis
@@ -78,10 +78,10 @@ fi
 # Typically, the first version of a branch (VM.N.0) is released on the "beta"
 # channel (-proposed PPA)
 if [[ "$RELVER" =~ [2-9]\.[0-9]+\.0$ ]] ; then
-    PPA_NAME=ppa:delmic-soft/odemis-proposed
+    PPA_NAME=ssh-ppa:delmic-soft/odemis-proposed
     IS_PATCH_RELEASE="false"
 else
-    PPA_NAME=ppa:delmic-soft/odemis
+    PPA_NAME=ssh-ppa:delmic-soft/odemis
     IS_PATCH_RELEASE="true"
 fi
 


### PR DESCRIPTION
FTP upload doesn't always work (IPv6 issue?). SSH seems a lot more reliable.
=> Let's move to the 21st century.