### PR TITLE
[fix] METEOR GUI: revert automatically activating "interpolate content" in the localization tab

### DIFF
--- a/src/odemis/gui/cont/tabs/localization_tab.py
+++ b/src/odemis/gui/cont/tabs/localization_tab.py
@@ -77,18 +77,6 @@ class LocalizationTab(Tab):
         # Order matters!
         self.view_controller = viewcont.ViewPortController(tab_data, panel, vpv)
 
-        # If the camera native resolution is larger than the viewport, the image displayed will be
-        # scaled down. On the screen, at digital zoom levels just below 1x, or around x0.5, x0.25...
-        # this can result in aliasing artifacts. In particular, it's been noticed with the Andor Sona,
-        # on the METEOR v2, with res ~2000x2000. To avoid this, we interpolate the content. The only
-        # drawback of interpolation is that it lowers the frame rate, which can be annoying when
-        # manually focusing, so we don't activate it by default.
-        if main_data.ccd.resolution.range[1][0] > wx.DisplaySize()[1] * 0.95:  # px
-            logging.debug("Activating interpolation in localization tab, as camera has resolution %s",
-                          main_data.ccd.resolution.range[1][0])
-            for v in tab_data.views.value:
-                v.interpolate_content.value = True
-
         # Connect the view selection buttons
         buttons = collections.OrderedDict([
             (panel.btn_secom_view_all,


### PR DESCRIPTION
Commit e50553ad74a ("avoid aliasing in image of camera with large
resolution") automatically activated interpolate content when the camera
resolution is large. However, with the option activated, the frame rate
is slow... and especially if the user loads a large image (eg
10000x10000), then it can get extremely slow and block  the whole GUI
for seconds every time the display is updated.

=> Let's leave this option off by default.