### PR TITLE
[fix] driver autoscript: also handle raw coordinate offset on rotation axes

### DIFF
--- a/src/odemis/driver/autoscript_client.py
+++ b/src/odemis/driver/autoscript_client.py
@@ -1258,7 +1258,6 @@ class Scanner(model.Emitter):
         """
         Read all the current settings from the SEM and reflects them on the VAs
         """
-        logging.debug("Updating SEM settings")
         try:
             if self._has_detector:
                 dwell_time = self.parent.get_dwell_time(self.channel)
@@ -1870,7 +1869,6 @@ class Stage(model.Actuator):
         """
         # We don't use the VA setters, to avoid sending back to the hardware a
         # set request
-        logging.debug("Updating SEM stage position")
         try:
             self._updatePosition()
         except Exception:
@@ -2060,7 +2058,6 @@ class Focus(model.Actuator):
         """
         # We don't use the VA setters, to avoid sending back to the hardware a
         # set request
-        logging.debug("Updating SEM focus position")
         try:
             self._updatePosition()
         except Exception:


### PR DESCRIPTION
Normally, the stages have no offset between raw and speciment
coordinate systems on the rotation axes (rx & rz)... except we found
one system where the rz offset is 180.2°. In such case, the rz value
didn't match the one reported on the TFS GUI, which is quite confusing.