### PR TITLE
[feat] METEOR GUI: automatically delete empty project folder

### DIFF
--- a/src/odemis/gui/cont/tabs/cryo_chamber_tab.py
+++ b/src/odemis/gui/cont/tabs/cryo_chamber_tab.py
@@ -1080,6 +1080,18 @@ class CryoChamberTab(Tab):
         ans = box.ShowModal()  # Waits for the window to be closed
         return ans == wx.ID_YES
 
+    def terminate(self):
+        super().terminate()
+        # Delete the current project folder if empty
+        proj_path = self.tab_data_model.main.project_path.value
+        try:
+            if os.path.isdir(proj_path) and not os.listdir(proj_path):
+                logging.debug("Deleting empty project folder %s", proj_path)
+                os.rmdir(proj_path)  # only removes empty folders
+        except Exception as ex:
+            # It might be just due to some access rights, let's not worry too much
+            logging.warning("Failed to delete project folder %s: %s", proj_path, ex)
+
     @classmethod
     def get_display_priority(cls, main_data):
         if main_data.role in ("enzel", "meteor", "mimas"):


### PR DESCRIPTION
When closing the GUI, if the project folder, it means the user didn't
use it. No need to keep it. This avoids filling up the main folder with
empty project folders, and allows to have automatically the same name as
the previous project when restarting the GUI, if it wasn't used.