### PR TITLE
[feat] GUI: open files using case insensitive wildcard

### DIFF
--- a/src/odemis/gui/cont/tabs/analysis_tab.py
+++ b/src/odemis/gui/cont/tabs/analysis_tab.py
@@ -273,7 +273,7 @@ class AnalysisTab(Tab):
             config = get_acqui_conf()
             path = config.last_path
 
-        wildcards, formats = guiutil.formats_to_wildcards(formats_to_ext, include_all=True)
+        wildcards, formats = guiutil.formats_to_wildcards(formats_to_ext, include_all=True, case_sensitive=False)
         dialog = wx.FileDialog(self.panel,
                                message="Choose a file to load",
                                defaultDir=path,

--- a/src/odemis/gui/cont/tabs/correlation_tab.py
+++ b/src/odemis/gui/cont/tabs/correlation_tab.py
@@ -188,7 +188,7 @@ class CorrelationTab(Tab):
 
         path = self.conf.last_path
 
-        wildcards, formats = guiutil.formats_to_wildcards(formats_to_ext, include_all=True)
+        wildcards, formats = guiutil.formats_to_wildcards(formats_to_ext, include_all=True, case_sensitive=False)
         msg = "Choose a file to load" if not tileset else "Choose a tileset to load"
         dialog = wx.FileDialog(self.panel,
                             message=msg,


### PR DESCRIPTION
On Linux, the filenames are case sensitive. That also means the
files extensions are case sensitive. Until now, Odemis would open *.tif
and *.hdf5. So a file name blabla.TIF would not even be listed to the
user when opening a file.

=> Add the upper case version of every extension to support it.

Only show it when opening a file. When saving a file, it's fine to use
always lower case (which is the standard on Linux).

Note that this is not exactly case-insensitive, as extension like "Tif"
would still not be detected, but that's very unlikely to exist.