### PR TITLE
[refactor] GUI: remove unused function SelectFileDialog

### DIFF
--- a/src/odemis/gui/cont/tabs/cryo_chamber_tab.py
+++ b/src/odemis/gui/cont/tabs/cryo_chamber_tab.py
@@ -65,11 +65,7 @@ from odemis.gui.cont.tabs.tab import Tab
 from odemis.gui.util import call_in_wx_main
 from odemis.gui.util.widgets import AxisConnector, VigilantAttributeConnector
 from odemis.gui.util.wx_adapter import fix_static_text_clipping
-from odemis.gui.win.acquisition import (
-    LoadProjectFileDialog,
-    SelectFileDialog,
-    ShowChamberFileDialog,
-)
+from odemis.gui.win.acquisition import LoadProjectFileDialog, ShowChamberFileDialog
 from odemis.model import InstantaneousFuture
 from odemis.util import almost_equal
 from odemis.util.dataio import data_to_static_streams

--- a/src/odemis/gui/win/acquisition.py
+++ b/src/odemis/gui/win/acquisition.py
@@ -1547,28 +1547,3 @@ def LoadProjectFileDialog(
 
     # project path that has been selected...
     return dialog.GetPath()
-
-def SelectFileDialog(
-    parent: wx.Frame,
-    message: str,
-    default_path: str,
-) -> Optional[str]:
-    """
-    :param parent (wx.Frame): parent window
-    :param message (string): message to display in the dialog
-    :param default_path (string): default path to open the dialog
-    :return (string or None): the selected file name (or None if the user cancelled)
-    """
-    dialog = wx.FileDialog(
-        parent,
-        message=message,
-        defaultDir=default_path,
-        style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST,
-    )
-
-    # Show the dialog and check whether is was accepted or cancelled
-    if dialog.ShowModal() != wx.ID_OK:
-        return None
-
-    # project path have been selected...
-    return dialog.GetPath()


### PR DESCRIPTION
The function SelectFileDialog() had no user, just an import. => remove it.