### PR TITLE
[config] METEOR Tescan FIBSEM was missing some components

### DIFF
--- a/install/linux/usr/share/odemis/sim/meteor-tescan-fibsem-full-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/meteor-tescan-fibsem-full-sim.odm.yaml
@@ -35,8 +35,9 @@
 "EBeam Scanner": {
     role: e-beam,
     init: {},
-    affects: ["SE Detector"],
+    affects: ["EBeam Detector"],
 }
+
 "EBeam Detector": {
     role: se-detector,
     init: {},
@@ -52,7 +53,7 @@
 "Ion Scanner": {
     role: ion-beam,
     init: {},
-    affects: ["SE Detector"],
+    affects: ["Ion Detector"],
 }
 
 "Ion Detector": {
@@ -131,11 +132,11 @@
         # Note that the rz range in the TESCAN software is between -170° and 40°
         # Change the SEM tilt angle to a value that matches the customer's needs
         # Note that the accuracy of the FM/SEM switch might be reduced if starting at a different angle.
-        FAV_FM_POS_ACTIVE: {"rx": 0.261799, "rz": -1.326450}, # 15° tilt, -76° rotation
+        FAV_FM_POS_ACTIVE: {"rx": 0.261799, "rz": 4.9567353}, # 15° tilt, 284° rotation
         FAV_SEM_POS_ACTIVE: {"rx": 0.698132, "rz": 1.815142}, # 40° tilt, 104° rotation
         # MILL has the *milling angle* as rx.
         # To compute the tilt angle: tilt = MillingAngle + PreTilt (40°) + ColumnTilt (55°) - 90
-        FAV_MILL_POS_ACTIVE: {"rx": 0.174532925, "rz": -1.326450}, # Milling angle = 10°, -76° rotation
+        FAV_MILL_POS_ACTIVE: {"rx": 0.174532925, "rz": 4.9567353}, # Milling angle = 10°, 284° rotation
     },
 }
 
@@ -149,7 +150,17 @@
     affects: ["Camera"],
 }
 
-# Normally a IDS uEye or Zyla
+"Optical Objective": {
+    class: static.OpticalLens,
+    role: lens,
+    init: {
+        mag: 50.0, # ratio, (actually of the complete light path)
+        na: 0.8, # ratio, numerical aperture
+        ri: 1.0, # ratio, refractive index
+    },
+    affects: ["Camera"],
+}
+
 # Axes: X is horizontal on screen (going left->right), physical: far->close when looking at the door
 #       Y is vertical on screen (going bottom->top), physical: left->right when looking at the door
 "Camera": {
@@ -174,25 +185,26 @@
     class: tmcm.TMCLController,
     role: null,
     init: {
-        port: "/dev/fake6", # Simulator
-        address: null, # Simulator
-        axes: ["fw"],
-        ustepsize: [1.227184e-6], # [rad/µstep]
-        rng: [[-14, 7]], # rad, more than 0->2 Pi, in order to allow one extra rotation in both direction, when quickly switching
-        unit: ["rad"],
+        port: "/dev/fake6",
+        address: null,
+        axes: ["fw", "stig"],
+        ustepsize: [3.2724923e-4, 3.2724923e-4],  # [rad/µstep]
+        rng: [[-14.0, 7.0], [-7.0, 14.0]],  # rad, more than 0->2 Pi, in order to allow one extra rotation in both direction, when quickly switching
+        unit: ["rad", "rad"],
         refproc: "Standard",
-        refswitch: {"fw": 0}, #digital output used to switch on/off sensor
+        refswitch: {"fw": 0, "stig": 4}, # digital output used to switch on/off sensor
         inverted: ["fw"], # for the filter wheel, the direction doesn't matter, as long as the positions are correct
     },
 }
 
-"AntiBacklash for Filter Wheel": {
+"AntiBacklash Actuators": {
     class: actuator.AntiBacklashActuator,
     role: null,
     init: {
         backlash: {
             # Force every move to always finish in the same direction
             "fw": 50.e-3,  # rad
+            "stig": 20.e-3,  # rad
         },
     },
     dependencies: {"slave": "Optical Actuators"},
@@ -201,20 +213,49 @@
 "Filter Wheel": {
     class: actuator.FixedPositionsActuator,
     role: filter,
-    dependencies: {"band": "AntiBacklash for Filter Wheel"},
+    dependencies: {"band": "AntiBacklash Actuators"},
     init: {
         axis_name: "fw",
         positions: {
              # pos (rad) -> m,m
-             0.08: [414.e-9, 450.e-9], # FF01-432/36
-             0.865398: [500.e-9, 530.e-9], # FF01-515/30
-             1.650796: [579.5e-9, 610.5e-9], # FF01-595/31
-             2.4361944: [663.e-9, 733.e-9], # FF02-698/70
-             3.2215924: "pass-through", # empty slot
+             0.85: "pass-through", # Slot 1: always empty
+             1.897197551: [414.e-9, 450.e-9], # Slot 2: FF01-432/36
+             2.944395102: [500.e-9, 530.e-9], # Slot 3: FF01-515/30
+             # 3.991592653: [0.e-9, 0.e-9], # Slot 4: Spare position for custom filter: specify the band(s) if a filter is present
+             5.038790204: [579.5e-9, 610.5e-9], # Slot 5: FF01-595/31
+             6.085987755: [663.e-9, 733.e-9], # Slot 6: FF02-698/70
         },
         cycle: 6.283185, # position of ref switch (0) after a full turn
     },
     affects: ["Camera"],
+}
+
+"Stigmator": {
+    class: actuator.RotationActuator,
+    role: stigmator,
+    affects: ["Camera"],
+    dependencies: {"rz": "AntiBacklash Actuators"},
+    init: {
+        axis_name: "stig",
+        cycle: 6.283185, # rad
+#        ref_start: null, # rad, value to where start the referencing, default is to start at 5% of cycle
+        ref_frequency: null, # Disable auto referencing. Use a number (eg 5) to automatically reference after N moves
+    },
+    metadata: {
+        POS_COR: -2.62486607383, # rad, adjustment needed for 0 = no astigmatism
+        # SuperZ calibration
+        CALIB: {
+            200.e-9: {
+                angle: 0.1309,
+                x: {a: -0.011214230270591402, b: 0.03581851396840028, c: 1215.384506512626,  d: 370.0567109324832,  w0: 11.765876020198268},
+                y: {a: 0.26798558796593386, b: 0.055348037953943205, c: 532.5800366796377,  d: 419.5479939702831, w0: 11.913803945482204},
+                feature_angle: 1.3028,  # rad
+                upsample_factor: 5,
+                z_least_confusion: 8.746549309861972e-07,  # m
+                z_calibration_range: [-8.746549309861972e-07, 7.625345069013803e-06]   # m
+            }
+        },
+    },
 }
 
 # CLS3252dsc-1

--- a/install/linux/usr/share/odemis/sim/meteor-tescan-fibsem-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/meteor-tescan-fibsem-sim.odm.yaml
@@ -17,78 +17,73 @@
     },
     children: {
         stage: "Stage",
-        scanner: "EBeam Scanner",
-        detector0: "EBeam Detector",
-        focus: "EBeam Focus",
-        fib-scanner: "Ion Scanner",
-        fib-detector: "Ion Detector",
-        light: "Chamber Light"
+        scanner: "Electron-Beam",
+        detector0: "Electron-Detector",
+        focus: "Electron-Focus",
+        fib-scanner: "Ion-Beam",
+        fib-detector: "Ion-Detector",
+        #light: "Chamber Light"
     }
 }
 
-"EBeam Scanner": {
-    # Internal child of Tescan, so no class
+"Electron-Beam": {
     role: e-beam,
     init: {
-        fov_range: [196.e-9, 25586.e-6]
+        fov_range: [200.e-9, 6600.e-6]
     },
 }
 
-"EBeam Detector": {
+"Electron-Detector": {
     role: se-detector,
-    init: {
-        channel: 0,
-        detector: "e-t",
-    },
-}
-
-"EBeam Focus": {
-    role: ebeam-focus,
-    init: {axes: [z]},
-    affects: ["EBeam Scanner"]
-}
-
-# FIB specific components
-"Ion Scanner": {
-    role: ion-beam,
-
-    init: {
-        fov_range: [196.e-9, 25586.e-6]
-    },
-}
-
-"Ion Detector": {
-    role: se-detector-ion,
-
     init: {
         channel: 0,
         detector: "se",
     },
+#    properties: {
+#        type: "SE",
+#    },
+}
+
+"Electron-Focus": {
+    role: ebeam-focus,
+    init: {axes: [z]},
+    affects: ["Electron-Beam"]
+}
+
+# FIB specific components
+"Ion-Beam": {
+    role: ion-beam,
+    init: {
+        fov_range: [196.e-9, 25586.e-6]
+    },
+}
+
+"Ion-Detector": {
+    role: se-detector-ion,
+    init: {
+        channel: 0,
+        detector: "se",
+    },
+#    properties: {
+#        type: "SE",
+#    },
 }
 
 # With calibration values for sample stage
 "Stage": {
-    class: tmcm.TMCLController,
     role: stage-bare,
     init: {
-        port: "/dev/fake6",
-        address: null,
-        axes: ["x", "y", "z", "rx", "rz"],
-        ustepsize: [1.e-7, 1.e-7, 1.e-7, 1.2e-5, 1.2e-5], # unit/µstep
-        rng: [[ -50.e-3, 50.e-3 ],
-              [ -50.e-3, 50.e-3 ],
-              [ 0, 94.e-3 ],
-              [ -0.4363323129985824, 1.0122909661567112 ],
-              [ -6.283185307179586, 6.283185307179586 ]
-        ],
-        unit: ["m", "m", "m", "rad", "rad"],
-        refproc: "Standard",
+        # By default, the Odemis tescan driver inverts the XYZ axes. So, to get
+        # exactly the same reading as in the Tescan software, we invert it back.
+        # The Odemis Posture Manager takes care of inverting the axes again for
+        # the Sample Stage, depending on the scan rotation.
+        inverted: {"x", "y", "z"},
     },
     metadata: {
         # Loading position:
         FAV_POS_DEACTIVE: {
             'rx': 0.0,
-            'rz': -1.0471975511965976,
+            'rz': 4.9567353,
             'x': -30.e-3,
             'y': -40.e-03,
             'z': 45.e-3
@@ -122,16 +117,13 @@
         # Calibrated values used for the SEM/FM switching behaviour
         CALIB: {
             "version": "tescan_1",
-            # These three values were only present in the original meteor-tescan file.
             "x_0": 3.577e-3,
             "y_0": -0.164e-3,
             "z_ct": 4.561291055e-3,
-            # The following parameters were both present at the original meteor-tescan and tfs3 file, with the exception
-            # of pre-tilt.
             "dx": 40.419e-3,
             "dy": 0.268e-3,
             "b_y": -0.400216e-3,
-            "pre-tilt": 0.698132,
+            "pre-tilt": 0.698132,  # Radians (40°).
             "use_linked_sem_focus_compensation": false,
         },
         # Active tilting (T/rx) & rotation (R/rz) angles positions when switching between SEM & FM.
@@ -140,17 +132,12 @@
         # Note that the rz range in the TESCAN software is between -170° and 40°
         # Change the SEM tilt angle to a value that matches the customer's needs
         # Note that the accuracy of the FM/SEM switch might be reduced if starting at a different angle.
-        FAV_FM_POS_ACTIVE: {"rx": 0.261799, "rz": -1.326450}, # 15° tilt, -76° rotation
+        FAV_FM_POS_ACTIVE: {"rx": 0.261799, "rz": 4.9567353}, # 15° tilt, 284° rotation
         FAV_SEM_POS_ACTIVE: {"rx": 0.698132, "rz": 1.815142}, # 40° tilt, 104° rotation
-        FAV_MILL_POS_ACTIVE: {"rx": 0.261799, "rz": -1.326450}, # 15° tilt, -76° rotation (same as FM)
+        # MILL has the *milling angle* as rx.
+        # To compute the tilt angle: tilt = MillingAngle + PreTilt (40°) + ColumnTilt (55°) - 90
+        FAV_MILL_POS_ACTIVE: {"rx": 0.174532925, "rz": 4.9567353}, # Milling angle = 10°, 284° rotation
     },
-}
-
-# (IR) light for the SEM chamber
-"Chamber Light": {
-    role: chamber-light,
-    init: {},
-    affects: ["Chamber Cam"],
 }
 
 "Light Source": {
@@ -163,36 +150,17 @@
     affects: ["Camera"],
 }
 
-"Linked YZ": {
-    class: actuator.ConvertStage,
-    role: null,
-    dependencies: {
-        "under": "Stage"
-    },
+"Optical Objective": {
+    class: static.OpticalLens,
+    role: lens,
     init: {
-        axes: [ "y", "z" ], # name of the axes in the dependency, mapped to x,y (if identity transformation)0.4663076582 1.103377919
-        rotation: 0.523598775, # rad , 30° (should be equal to the pre-tilt angle of the shuttle being used) NOTE:
-        shear: [-0.4663076582, 0], # [-tan(rx_fm), 0], where rx_fm is equal to rx in FAV_FM_POS_ACTIVE 0.2679491924311227
-        scale: [1, 1.103377919] # [1, 1/cos(rx_fm)], where rx_fm is equal to rx in FAV_FM_POS_ACTIVE 1.035276180410083
-        #inverted: ["z"],
+        mag: 50.0, # ratio, (actually of the complete light path)
+        na: 0.8, # ratio, numerical aperture
+        ri: 1.0, # ratio, refractive index
     },
+    affects: ["Camera"],
 }
 
-"Meteor Stage": {
-    class: actuator.MultiplexActuator,
-    role: stage,
-    dependencies: { "x": "Stage", "y": "Linked YZ", "z": "Linked YZ"},
-    init: {
-        axes_map: { "x": "x", "y": "x", "z": "y"},
-    },
-    affects: ["Camera", "EBeam Scanner"],
-    metadata: {
-        # Should match exactly the FM imaging range metadata for the "Stage" component!
-        POS_ACTIVE_RANGE: {"x": [-44.e-3, -24.e-3], "y": [-0.04, 0.04]}
-    },
-}
-
-# Normally a IDS uEye or Zyla
 # Axes: X is horizontal on screen (going left->right), physical: far->close when looking at the door
 #       Y is vertical on screen (going bottom->top), physical: left->right when looking at the door
 "Camera": {
@@ -220,7 +188,7 @@
         port: "/dev/fake6", # Simulator
         address: null, # Simulator
         axes: ["fw"],
-        ustepsize: [1.227184e-6], # [rad/µstep]
+        ustepsize: [3.2724923e-4], # [rad/µstep]
         rng: [[-14, 7]], # rad, more than 0->2 Pi, in order to allow one extra rotation in both direction, when quickly switching
         unit: ["rad"],
         refproc: "Standard",


### PR DESCRIPTION
Optical lens component was missing... which was causing surprisingly
little issues in Odemis. Still, that meant the CCD image had no
MD_PIXEL_SIZE, which is required for some parts.

Add the SuperZ support, to test on a MIMAS too.

Adjust the filter positions to make them more realistic, and make the
switch faster.

The component names have changed, so the names in the "affects" should also be updated.