### PR TITLE
[fix] AntiBacklashActuator: the move after a failing move could be at the wrong position

### DIFF
--- a/src/odemis/driver/actuator.py
+++ b/src/odemis/driver/actuator.py
@@ -1041,6 +1041,12 @@ class AntiBacklashActuator(model.Actuator):
                     f.result(timeout=0.01)
                 except futures.TimeoutError:
                     pass  # Keep waiting for end of move
+                except Exception:
+                    with self._shifted_lock:
+                        # revert the shifted status as the move failed
+                        for a in axes:
+                            self._shifted[a] = False
+                    raise
                 else:
                     done = True
 
@@ -1081,6 +1087,12 @@ class AntiBacklashActuator(model.Actuator):
                     f.result(timeout=0.01)
                 except futures.TimeoutError:
                     pass  # Keep waiting for end of move
+                except Exception:
+                    with self._shifted_lock:
+                        # revert the shifted status as the move failed
+                        for a in axes:
+                            self._shifted[a] = False
+                    raise
                 else:
                     done = True
 


### PR DESCRIPTION
If a move that required a anti-backlash move failed, then the
anti-backlash move wouldn't be executed (which is good).
If the next move was a move not requiring anti-backlash, then an
anti-backlash move would still be applied, making the final position
incorrect.

=> When a move fails, explicitly handle it, and remove the flag requiring anti-backlash move.