### PR TITLE
[fix] METEOR GUI: closing "Create or load project" window causes error

### DIFF
--- a/src/odemis/gui/cont/tabs/cryo_chamber_tab.py
+++ b/src/odemis/gui/cont/tabs/cryo_chamber_tab.py
@@ -1027,6 +1027,10 @@ class CryoChamberTab(Tab):
                 elif ans == wx.ID_YES:
                     logging.debug("loading project")
                     ret = self._load_project_data(None)
+                else:  # Closed the window
+                    # The user cannot be bothered => create a new project automatically
+                    self._create_new_dir()
+                    ret = True
 
                 # break if the user successfully created or loaded a project
                 if ret:


### PR DESCRIPTION
The initial window only allows to create or load... but if you press
Alt+F4 on Ubuntu 24.04, you can still close the window. We could re-open
it, but let's make it a hidden shortcut that the suggested new project name
is fine, and automatically create a directory.

This avoids such error:
```
2025-12-15 18:37:27,928 ERROR   main:422:       Traceback (most recent call last):
  File "/home/piel/.local/lib/python3.12/site-packages/wx/core.py", line 3425, in <lambda>
    lambda event: event.callable(*event.args, **event.kw) )
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/piel/development/odemis/src/odemis/gui/cont/tabs/tab_bar_controller.py", line 102, in _on_tab_change
    tab.Show()
  File "/home/piel/development/odemis/src/odemis/gui/cont/tabs/cryo_chamber_tab.py", line 1032, in Show
    if ret:
       ^^^
UnboundLocalError: cannot access local variable 'ret' where it is not associated with a value
```