### PR TITLE
[MSD-39][feature] Adjust the Odemis FIBSEM milling tab to Tescan settings

### DIFF
--- a/src/odemis/acq/feature.py
+++ b/src/odemis/acq/feature.py
@@ -149,7 +149,9 @@ class CryoFeature(object):
                  stage_position: Dict[str, float],
                  fm_focus_position: Dict[str, float],
                  streams: Optional[List[Stream]] = None,
-                 milling_tasks: Optional[Dict[str, MillingTaskSettings]] = None, correlation_data=None):
+                 milling_tasks: Optional[Dict[str, MillingTaskSettings]] = None,
+                 correlation_data = None,
+                 general_params = {}):
         """
         :param name: (string) the feature name
         :param stage_position: (dict) the stage position of the feature (stage-bare)
@@ -166,7 +168,7 @@ class CryoFeature(object):
         self.posture_positions: Dict[str, Dict[str, float]] = {} # positions for each posture
 
         if milling_tasks is None:
-            milling_tasks = load_milling_tasks(DEFAULT_MILLING_TASKS_PATH)
+            milling_tasks = load_milling_tasks(DEFAULT_MILLING_TASKS_PATH, general_params)
         self.milling_tasks: Dict[str, MillingTaskSettings] = milling_tasks
 
         self.status = model.StringVA(FEATURE_ACTIVE)

--- a/src/odemis/acq/feature.py
+++ b/src/odemis/acq/feature.py
@@ -353,7 +353,7 @@ def read_features(project_dir: str) -> List[CryoFeature]:
     """
     Deserialize and return the features list from the json file
     :param project_dir: directory to read the file from (typically project directory)
-    :return: list of deserialized featuers
+    :return: list of deserialized features
     """
     filename = os.path.join(project_dir, "features.json")
     if not os.path.exists(filename):

--- a/src/odemis/acq/milling/fibsemos.py
+++ b/src/odemis/acq/milling/fibsemos.py
@@ -45,6 +45,7 @@ try:
         Point,
         FibsemImage,
         FibsemImageMetadata,
+        FibsemRectangle,
         BeamType,
         ImageSettings,
         MicroscopeState,
@@ -56,6 +57,47 @@ except ImportError as e:
     FIBSEMOS_INSTALLED = False
 
 _persistent_millmng: Optional["FibsemOSMillingTaskManager"] = None
+
+
+def _get_reference_image(feature: CryoFeature) -> model.DataArray:
+    """Get the in-memory reference image for a feature or raise."""
+
+    if feature.reference_image is None:
+        logging.error(
+            "Missing reference image for feature '%s' (path=%s). "
+            "This feature was likely loaded from disk without hydrating reference_image.",
+            feature.name.value,
+            getattr(feature, "path", None),
+        )
+        raise ValueError("Missing feature.reference_image.")
+    return feature.reference_image
+
+
+def _crop_to_reduced_area(ref_img: 'FibsemImage', rect: 'FibsemRectangle') -> 'FibsemImage':
+    """Crop a fibsemOS image to the provided reduced-area rectangle.
+
+    :param ref_img: The image to crop.
+    :param rect: Rectangle with fractional coordinates (left, top, width, height).
+    :return: The same image instance with cropped data.
+    """
+
+    h, w = ref_img.data.shape[-2], ref_img.data.shape[-1]
+
+    # fractional to pixel indices
+    x0 = int(rect.left * w)
+    y0 = int(rect.top * h)
+    x1 = int((rect.left + rect.width) * w)
+    y1 = int((rect.top + rect.height) * h)
+
+    # clamp to valid range just in case of rounding
+    x0 = max(0, min(w, x0))
+    x1 = max(0, min(w, x1))
+    y0 = max(0, min(h, y0))
+    y1 = max(0, min(h, y1))
+
+    # crop along the last two axes, DataArray slicing behaves like numpy
+    ref_img.data = ref_img.data[..., y0:y1, x0:x1]
+    return ref_img
 
 
 def create_fibsemos_tfs_microscope() -> 'OdemisThermoMicroscope':
@@ -112,8 +154,7 @@ def create_fibsemos_tescan_microscope() -> 'OdemisTescanMicroscope':
     return microscope
 
 def create_fibsemos_microscope() -> Union['OdemisThermoMicroscope', 'OdemisTescanMicroscope']:
-    """Create and return a fibsemOS microscope instance matching the detected stage version.
-    """
+    """Create and return a fibsemOS microscope instance matching the detected stage version."""
     stage_bare = model.getComponent(role="stage-bare")
     stage_md = stage_bare.getMetadata()
     md_calib = stage_md.get(model.MD_CALIB, {})
@@ -260,28 +301,11 @@ class FibsemOSMillingTaskManager:
                         raise CancelledError()
 
                 logging.info(f"Running milling stage: {stage.name}")
-                ref_img = from_odemis_image(self.feature.reference_image)
+                ref_img = from_odemis_image(_get_reference_image(self.feature))
                 ref_img.metadata.image_settings.path = self.path
                 ref_img.metadata.image_settings.reduced_area = stage.alignment.rect
 
-                # crop ref_img.data (DataArray) to the reduced area
-                rect = stage.alignment.rect
-                h, w = ref_img.data.shape[-2], ref_img.data.shape[-1]
-
-                # fractional -> pixel indices
-                x0 = int(rect.left * w)
-                y0 = int(rect.top * h)
-                x1 = int((rect.left + rect.width) * w)
-                y1 = int((rect.top + rect.height) * h)
-
-                # clamp to valid range just in case of rounding
-                x0 = max(0, min(w, x0))
-                x1 = max(0, min(w, x1))
-                y0 = max(0, min(h, y0))
-                y1 = max(0, min(h, y1))
-
-                # crop along the last two axes; DataArray slicing behaves like numpy
-                ref_img.data = ref_img.data[..., y0:y1, x0:x1]
+                ref_img = _crop_to_reduced_area(ref_img, stage.alignment.rect)
 
                 mill_stages(self.microscope, [stage], ref_img)
 

--- a/src/odemis/acq/milling/fibsemos.py
+++ b/src/odemis/acq/milling/fibsemos.py
@@ -267,6 +267,27 @@ class FibsemOSMillingTaskManager:
                 logging.info(f"Running milling stage: {stage.name}")
                 ref_img = from_odemis_image(self.feature.reference_image)
                 ref_img.metadata.image_settings.path = self.path
+                ref_img.metadata.image_settings.reduced_area = stage.alignment.rect
+
+                # crop ref_img.data (DataArray) to the reduced area
+                rect = stage.alignment.rect
+                h, w = ref_img.data.shape[-2], ref_img.data.shape[-1]
+
+                # fractional -> pixel indices
+                x0 = int(rect.left * w)
+                y0 = int(rect.top * h)
+                x1 = int((rect.left + rect.width) * w)
+                y1 = int((rect.top + rect.height) * h)
+
+                # clamp to valid range just in case of rounding
+                x0 = max(0, min(w, x0))
+                x1 = max(0, min(w, x1))
+                y0 = max(0, min(h, y0))
+                y1 = max(0, min(h, y1))
+
+                # crop along the last two axes; DataArray slicing behaves like numpy
+                ref_img.data = ref_img.data[..., y0:y1, x0:x1]
+
                 mill_stages(self.microscope, [stage], ref_img)
 
         finally:

--- a/src/odemis/acq/milling/fibsemos.py
+++ b/src/odemis/acq/milling/fibsemos.py
@@ -214,6 +214,37 @@ def _convert_microexpansion_pattern(p: MicroexpansionPatternParameters) -> 'Micr
         point=Point(x=p.center.value[0], y=p.center.value[1])
     )
 
+def _format_preset(voltage: float, current: float) -> str:
+    """
+    Format voltage (V) and current (A) into a string like:
+    '30 keV; 150 pA', scaling units automatically.
+    """
+
+    # Voltage: always shown in keV
+    voltage_keV = voltage / 1000
+    voltage_str = f"{voltage_keV:g} keV"
+
+    # Current: choose pA, nA, or uA
+    abs_I = abs(current)
+
+    if abs_I < 1e-9:
+        # pA
+        current_val = current * 1e12
+        unit = "pA"
+    elif abs_I < 1e-6:
+        # nA
+        current_val = current * 1e9
+        unit = "nA"
+    else:
+        # uA
+        current_val = current * 1e6
+        unit = "uA"
+
+    current_str = f"{current_val:g} {unit}"
+
+    return f"{voltage_str}; {current_str}"
+
+
 def convert_milling_settings(s: MillingSettings) -> 'FibsemMillingSettings':
     """Convert Odemis milling settings to fibsemOS milling settings."""
     return FibsemMillingSettings(
@@ -221,8 +252,9 @@ def convert_milling_settings(s: MillingSettings) -> 'FibsemMillingSettings':
         milling_voltage=s.voltage.value,
         patterning_mode=s.mode.value,
         hfw=s.field_of_view.value,
-        rate=s.rate.value,                # um^3/nA/s
-        dwell_time=s.dwell_time.value     # us
+        rate=s.rate.value,                # m^3/A/s
+        dwell_time=s.dwell_time.value,    # s
+        preset=_format_preset(s.voltage.value, s.current.value)
     )
 
 # task converter

--- a/src/odemis/acq/milling/millmng.py
+++ b/src/odemis/acq/milling/millmng.py
@@ -434,10 +434,10 @@ class AutomatedMillingManager(object):
         self._future.msg = f"{feature.name.value}: Milling: {self.current_workflow}"
         self._future.set_progress()
 
-        filename = self.get_filename(feature, "Milling-Tasks")
         if fibsemos.FIBSEMOS_INSTALLED:
             self._future.running_subf = run_milling_tasks_fibsemos(tasks=milling_tasks)
         else:
+            filename = self.get_filename(feature, "Milling-Tasks")
             self._future.running_subf = run_milling_tasks(tasks=milling_tasks,
                                                       fib_stream=self.fib_stream,
                                                       filename=filename)

--- a/src/odemis/acq/milling/millmng.py
+++ b/src/odemis/acq/milling/millmng.py
@@ -27,6 +27,7 @@ import logging
 import os
 import threading
 import time
+from pathlib import Path
 from concurrent.futures import Future
 from concurrent.futures._base import CANCELLED, FINISHED, RUNNING, CancelledError
 from datetime import datetime
@@ -245,7 +246,7 @@ class TFSMillingTaskManager:
             self._future._task_state = FINISHED
 
 
-# TODO: replace with run_milling_tasks_fibsemos
+# NOTE: replaced with run_milling_tasks_fibsemos
 def run_milling_tasks(tasks: List[MillingTaskSettings], fib_stream: FIBStream, filename: str = None) -> Future:
     """
     Run multiple milling tasks in order.
@@ -302,6 +303,7 @@ class AutomatedMillingManager(object):
                  sem_stream: SEMStream,
                  fib_stream: FIBStream,
                  task_list: List[MillingWorkflowTask],
+                 config_path: Path=None
                  ):
 
         self.stage = stage
@@ -313,6 +315,7 @@ class AutomatedMillingManager(object):
         self._exporter = find_fittest_converter("filename.ome.tiff")
         self.pm = MicroscopePostureManager(model.getMicroscope())
         self._prefix: str = ""
+        self.config_path = config_path
 
         self._future = future
         if future is not None:
@@ -432,7 +435,7 @@ class AutomatedMillingManager(object):
         self._future.set_progress()
 
         if fibsemos.FIBSEMOS_INSTALLED:
-            self._future.running_subf = run_milling_tasks_fibsemos(tasks=milling_tasks, feature=feature, path=feature.path)
+            self._future.running_subf = run_milling_tasks_fibsemos(tasks=milling_tasks, feature=feature, path=feature.path, config_path=self.config_path)
         else:
             filename = self.get_filename(feature, "Milling-Tasks")
             self._future.running_subf = run_milling_tasks(tasks=milling_tasks,
@@ -513,6 +516,7 @@ def run_automated_milling(features: List[CryoFeature],
                           sem_stream: SEMStream,
                           fib_stream: FIBStream,
                           task_list: List[MillingWorkflowTask],
+                          config_path: Path=None
                           ) -> Future:
     """
     Automatically mill and image a list of features.
@@ -529,6 +533,7 @@ def run_automated_milling(features: List[CryoFeature],
         fib_stream=fib_stream,
         task_list=task_list,
         features=features,
+        config_path=config_path
     )
     # add the ability of cancelling the future during execution
     future.task_canceller = amm.cancel

--- a/src/odemis/acq/milling/millmng.py
+++ b/src/odemis/acq/milling/millmng.py
@@ -389,9 +389,6 @@ class AutomatedMillingManager(object):
                 ############# STAGE MOVEMENT #############
                 self._move_to_milling_position(feature)
 
-                ############# ALIGNMENT #############
-                self._align_reference_image(feature)
-
                 ############# MILLING #############
                 self._run_milling_tasks(feature, milling_tasks)
 

--- a/src/odemis/acq/milling/millmng.py
+++ b/src/odemis/acq/milling/millmng.py
@@ -432,7 +432,7 @@ class AutomatedMillingManager(object):
         self._future.set_progress()
 
         if fibsemos.FIBSEMOS_INSTALLED:
-            self._future.running_subf = run_milling_tasks_fibsemos(tasks=milling_tasks)
+            self._future.running_subf = run_milling_tasks_fibsemos(tasks=milling_tasks, feature=feature, path=feature.path)
         else:
             filename = self.get_filename(feature, "Milling-Tasks")
             self._future.running_subf = run_milling_tasks(tasks=milling_tasks,

--- a/src/odemis/acq/milling/tasks.py
+++ b/src/odemis/acq/milling/tasks.py
@@ -62,8 +62,8 @@ class MillingSettings:
         return MillingSettings(current=data["current"],
                                voltage=data["voltage"],
                                field_of_view=data["field_of_view"],
-                               rate=data["rate"],
-                               dwell_time=data["dwell_time"],
+                               rate=data.get("rate", 0),
+                               dwell_time=data.get("dwell_time", 0),
                                mode=data.get("mode", "Serial"),
                                channel=data.get("channel", "ion"),
                                align=data.get("align", True)

--- a/src/odemis/acq/milling/test/fibsemos_millmng_test.py
+++ b/src/odemis/acq/milling/test/fibsemos_millmng_test.py
@@ -23,9 +23,11 @@ import time
 import unittest
 
 import odemis
+import numpy
 from odemis import model
 from odemis.acq.milling import fibsemos, DEFAULT_MILLING_TASKS_PATH
 from odemis.acq.milling.tasks import load_milling_tasks
+from odemis.acq.feature import CryoFeature
 from odemis.util import testing
 
 logging.getLogger().setLevel(logging.DEBUG)
@@ -56,10 +58,21 @@ class TestFibsemOSMillingManager(unittest.TestCase):
         cls.microscope = model.getMicroscope()
         cls.milling_tasks = load_milling_tasks(DEFAULT_MILLING_TASKS_PATH)
 
+        # Minimal feature object expected by FibsemOSMillingTaskManager (reference image is required).
+        cls.feature = CryoFeature(
+            name="TestFeature-1",
+            stage_position={"x": 0.0, "y": 0.0, "z": 0.0, "rx": 0.0, "rz": 0.0},
+            fm_focus_position={"z": 0.0},
+        )
+        cls.feature.reference_image = model.DataArray(numpy.zeros(shape=(1024, 1536)), metadata={})
+
     def test_estimate_total_milling_time(self):
         """Test the estimate_total_milling_time function"""
-        fibsemos_milling_manager = fibsemos.FibsemOSMillingTaskManager(None,
-                                                                       list(self.milling_tasks.values()))
+        fibsemos_milling_manager = fibsemos.FibsemOSMillingTaskManager()
+        # Keep this test purely about time estimation; don't start a milling run.
+        fibsemos_milling_manager.milling_stages = fibsemos.convert_milling_tasks_to_milling_stages(
+            list(self.milling_tasks.values())
+        )
 
         # check that the estimated time is greater than 0
         estimated_time = fibsemos_milling_manager.estimate_milling_time()
@@ -69,7 +82,7 @@ class TestFibsemOSMillingManager(unittest.TestCase):
         """Test the FibsemOSMillingManager"""
         tasks = list(self.milling_tasks.values())
 
-        f = fibsemos.run_milling_tasks_fibsemos(tasks)
+        f = fibsemos.run_milling_tasks_fibsemos(tasks, feature=self.feature, path=os.getcwd())
         f.result()
 
         # check workflow finished
@@ -80,7 +93,7 @@ class TestFibsemOSMillingManager(unittest.TestCase):
         """Test cancel milling tasks"""
         tasks = list(self.milling_tasks.values())
 
-        f = fibsemos.run_milling_tasks_fibsemos(tasks)
+        f = fibsemos.run_milling_tasks_fibsemos(tasks, feature=self.feature, path=os.getcwd())
 
         time.sleep(5)
         f.cancel()

--- a/src/odemis/acq/milling/test/fibsemos_reference_image_test.py
+++ b/src/odemis/acq/milling/test/fibsemos_reference_image_test.py
@@ -1,0 +1,28 @@
+import unittest
+
+import numpy
+
+from odemis import model
+from odemis.acq.feature import CryoFeature
+from odemis.acq.milling.fibsemos import _get_reference_image
+
+
+class TestResolveFeatureReferenceImage(unittest.TestCase):
+    def test_returns_in_memory_reference_image(self):
+        feature = CryoFeature(name="f1", stage_position={}, fm_focus_position={})
+        da = model.DataArray(numpy.zeros((10, 12), dtype=numpy.uint16), metadata={model.MD_DIMS: "YX"})
+        feature.reference_image = da
+
+        out = _get_reference_image(feature)
+        self.assertIs(out, da)
+
+    def test_raises_if_missing_in_memory(self):
+        feature = CryoFeature(name="f1", stage_position={}, fm_focus_position={})
+        setattr(feature, "reference_image", None)
+
+        with self.assertRaises(ValueError):
+            _get_reference_image(feature)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/odemis/acq/milling/test/tasks_test.py
+++ b/src/odemis/acq/milling/test/tasks_test.py
@@ -48,7 +48,16 @@ class MillingTaskTestCase(unittest.TestCase):
         field_of_view = 400e-6
         mode = "Serial"
         channel = "ion"
-        milling_settings = MillingSettings(current, voltage, field_of_view, mode, channel)
+
+        milling_settings = MillingSettings(
+            current=current,
+            voltage=voltage,
+            field_of_view=field_of_view,
+            rate=0.0,
+            dwell_time=0.0,
+            mode=mode,
+            channel=channel,
+        )
 
         self.assertEqual(milling_settings.current.value, current)
         self.assertEqual(milling_settings.voltage.value, voltage)
@@ -71,7 +80,15 @@ class MillingTaskTestCase(unittest.TestCase):
         self.assertEqual(milling_settings_from_dict.channel.value, channel)
 
     def test_milling_task_settings(self):
-        milling_settings = MillingSettings(100e-9, 30e3, 400e-6, "Serial", "ion")
+        milling_settings = MillingSettings(
+            current=100e-9,
+            voltage=30e3,
+            field_of_view=400e-6,
+            rate=0.0,
+            dwell_time=0.0,
+            mode="Serial",
+            channel="ion",
+        )
         trench_pattern = TrenchPatternParameters(1e-6, 1e-6, 100e-9, 1e-6, (0, 0))
 
         milling_task_settings = MillingTaskSettings(milling_settings, [trench_pattern], "Milling Task")
@@ -105,11 +122,27 @@ class MillingTaskTestCase(unittest.TestCase):
         self.assertEqual(milling_task_settings_from_dict.patterns[0].center.value, trench_pattern.center.value)
 
     def test_save_load_task_settings(self):
-        milling_settings = MillingSettings(100e-9, 30e3, 400e-6, "Serial", "ion")
+        milling_settings = MillingSettings(
+            current=100e-9,
+            voltage=30e3,
+            field_of_view=400e-6,
+            rate=0.0,
+            dwell_time=0.0,
+            mode="Serial",
+            channel="ion",
+        )
         trench_pattern = TrenchPatternParameters(10e-6, 3e-6, 100e-9, 2e-6, (0, 0))
         trench_task_settings = MillingTaskSettings(milling_settings, [trench_pattern], "Trench")
 
-        milling_settings = MillingSettings(100e-9, 30e3, 400e-6, "Serial", "ion")
+        milling_settings = MillingSettings(
+            current=100e-9,
+            voltage=30e3,
+            field_of_view=400e-6,
+            rate=0.0,
+            dwell_time=0.0,
+            mode="Serial",
+            channel="ion",
+        )
         microexpansion_pattern = MicroexpansionPatternParameters(1e-6, 10e-6, 100e-9, 10e-6, (0, 0))
         microexpansion_task_settings = MillingTaskSettings(milling_settings, [microexpansion_pattern], "Microexpansion")
 

--- a/src/odemis/gui/conf/__init__.py
+++ b/src/odemis/gui/conf/__init__.py
@@ -30,6 +30,7 @@ CONF_GENERAL = None
 CONF_ACQUI = None
 CONF_CHAMB = None
 CONF_CALIB = None
+CONF_MILLING = None
 
 
 def get_general_conf():
@@ -38,6 +39,7 @@ def get_general_conf():
         from .file import GeneralConfig
         CONF_GENERAL = GeneralConfig()
     return CONF_GENERAL
+
 
 def get_chamber_conf():
     """ Return the Chamber config object and create/read it first if it does not yet exist """
@@ -58,9 +60,18 @@ def get_acqui_conf():
 
 
 def get_calib_conf():
-    """ Return the calibration config object and create/read it first if it does not yet exist """
+    """ Return the Calibration config object and create/read it first if it does not yet exist """
     global CONF_CALIB
     if not CONF_CALIB:
         from .file import CalibrationConfig
         CONF_CALIB = CalibrationConfig()
     return CONF_CALIB
+
+
+def get_milling_conf():
+    """ Return the Milling config object and create/read it first if it does not yet exist """
+    global CONF_MILLING
+    if not CONF_MILLING:
+        from .file import MillingConfig
+        CONF_MILLING = MillingConfig()
+    return CONF_MILLING

--- a/src/odemis/gui/conf/file.py
+++ b/src/odemis/gui/conf/file.py
@@ -573,3 +573,45 @@ class CalibrationConfig(Config):
                 logging.exception("Failed to read calibration data")
 
         return None
+
+
+class MillingConfig(Config):
+    """ FIB milling configuration values """
+
+    file_name = "milling.config"
+
+    def __init__(self):
+        super(MillingConfig, self).__init__()
+
+        # Define the default settings for milling
+        self.default.add_section("milling")
+        self.default.set("milling", "rate", "1e-8")
+        self.default.set("milling", "dwell_time", "1e-6")
+
+        # Define the default settings for fibsemOS
+        self.default.add_section("fibsemos")
+        self.default.set("fibsemos", "config_path", "microscope-configuration.yaml")
+
+    @property
+    def rate(self):
+        return float(self.get("milling", "rate"))
+
+    @rate.setter
+    def rate(self, value):
+        self.set("milling", "rate", value)
+
+    @property
+    def dwell_time(self):
+        return float(self.get("milling", "dwell_time"))
+
+    @dwell_time.setter
+    def dwell_time(self, value):
+        self.set("milling", "dwell_time", value)
+
+    @property
+    def config_path(self):
+        return self.get("fibsemos", "config_path")
+
+    @config_path.setter
+    def config_path(self, config_path):
+        self.set("fibsemos", "config_path", config_path)

--- a/src/odemis/gui/conf/test/conf_test.py
+++ b/src/odemis/gui/conf/test/conf_test.py
@@ -209,5 +209,43 @@ class CalibrationConfigTest(ConfigTest, unittest.TestCase):
             else:
                 self.assertAlmostEqual(o, b)
 
+
+class MillingConfigTest(ConfigTest, unittest.TestCase):
+
+    conf_class = gui.conf.file.MillingConfig
+
+    def test_simple(self):
+        conf = gui.conf.get_milling_conf()
+        self.assertIsInstance(conf.rate, float)
+        self.assertIsInstance(conf.dwell_time, float)
+        self.assertIsInstance(conf.config_path, str)
+
+    def test_save(self):
+        conf = gui.conf.get_milling_conf()
+        conf.rate = 2e-8
+        conf.dwell_time = 2e-6
+        conf.config_path = "test-config.yaml"
+
+        # reset
+        del conf
+        gui.conf.CONF_MILLING = None
+
+        conf = gui.conf.get_milling_conf()
+        self.assertAlmostEqual(conf.rate, 2e-8)
+        self.assertAlmostEqual(conf.dwell_time, 2e-6)
+        self.assertEqual(conf.config_path, "test-config.yaml")
+
+    def test_default(self):
+        try:
+            os.remove(self.filename)
+        except OSError:
+            pass
+
+        conf = gui.conf.get_milling_conf()
+        self.assertAlmostEqual(conf.rate, 1e-8)
+        self.assertAlmostEqual(conf.dwell_time, 1e-6)
+        self.assertEqual(conf.config_path, "microscope-configuration.yaml")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/odemis/gui/cont/milling.py
+++ b/src/odemis/gui/cont/milling.py
@@ -44,6 +44,8 @@ from odemis.acq.feature import (
 )
 from odemis.acq.milling import millmng, DEFAULT_MILLING_TASKS_PATH
 from odemis.acq.milling.millmng import MillingWorkflowTask, run_automated_milling
+from odemis.acq.milling import fibsemos
+from odemis.acq.milling.fibsemos import run_milling_tasks_fibsemos
 from odemis.acq.milling.patterns import RectanglePatternParameters
 from odemis.acq.milling.tasks import MillingTaskSettings, load_milling_tasks
 from odemis.acq.move import (
@@ -53,7 +55,7 @@ from odemis.gui.comp.milling import MillingTaskPanel
 from odemis.gui.comp.overlay.base import Vec
 from odemis.gui.comp.overlay.rectangle import RectangleOverlay
 from odemis.gui.comp.overlay.shapes import EditableShape, ShapesOverlay
-from odemis.gui.conf import get_acqui_conf
+from odemis.gui.conf import get_acqui_conf, get_milling_conf
 from odemis.gui.util import call_in_wx_main, wxlimit_invocation
 from odemis.gui.util.widgets import (
     ProgressiveFutureConnector,
@@ -154,10 +156,16 @@ class MillingTaskController:
         self.canvas = self.viewport.canvas  # fib canvas
 
         self.pm = self._tab_data.main.posture_manager
-        self.conf = get_acqui_conf()
+        self.acqui_conf = get_acqui_conf()
+        self.milling_conf = get_milling_conf()
 
+        # general milling parameters applicable to all the milling tasks
+        general_params = {
+            "rate": self.milling_conf.rate,
+            "dwell_time": self.milling_conf.dwell_time
+        }
         # load the milling tasks
-        self.milling_tasks = load_milling_tasks(DEFAULT_MILLING_TASKS_PATH) # TODO: move to main_data
+        self.milling_tasks = load_milling_tasks(DEFAULT_MILLING_TASKS_PATH, general_params) # TODO: move to main_data
         self._default_milling_tasks = copy.deepcopy(self.milling_tasks)
         self.allow_milling_pattern_move = True
 
@@ -470,8 +478,11 @@ class MillingTaskController:
 
         # run the milling tasks
         tasks = [task for task_name, task in self.milling_tasks.items() if task_name in self.selected_tasks.value]
-        self._mill_future = millmng.run_milling_tasks(tasks=tasks,
-                                                      fib_stream=self._tab.fib_stream)
+
+        if fibsemos.FIBSEMOS_INSTALLED:
+            self._mill_future = run_milling_tasks_fibsemos(tasks=tasks, config_path=self.milling_conf.config_path)
+        else:
+            self._mill_future = millmng.run_milling_tasks(tasks=tasks, fib_stream=self._tab.fib_stream)
 
         # link the milling gauge to the milling future
         self._gauge_future_conn = ProgressiveFutureConnector(
@@ -559,7 +570,7 @@ class MillingTaskController:
         self._panel.btn_run_automated_milling.Enable(milling_enabled)
 
         if not has_tasks:
-            txt = "No Tasks Selected..."
+            txt = "No tasks selected..."
             self._panel.txt_milling_est_time.SetLabel(txt)
             self._panel.txt_automated_milling_est_time.SetLabel(txt)
 
@@ -583,8 +594,8 @@ class AutomatedMillingController:
         self._panel = tab_panel
         self._tab = tab
 
-        from odemis.gui.conf import get_acqui_conf
-        self.conf = get_acqui_conf()
+        self.acqui_conf = get_acqui_conf()
+        self.milling_conf = get_milling_conf()
 
         # automated milling tasks
         self.task_list = [MillingWorkflowTask.RoughMilling, MillingWorkflowTask.Polishing]
@@ -623,7 +634,6 @@ class AutomatedMillingController:
             wx.MessageBox(disabled_txt, "Info", wx.OK | wx.ICON_INFORMATION)
 
     def _update_feature_status(self, feature: CryoFeature):
-
         self._update_features(self._tab_data.main.features.value)
 
     @call_in_wx_main
@@ -657,7 +667,7 @@ class AutomatedMillingController:
 
         # tmp: add the path to the features, as it's not saved in the feature
         for feature in features:
-            feature.path = os.path.join(self.conf.pj_last_path, feature.name.value)
+            feature.path = os.path.join(self.acqui_conf.pj_last_path, feature.name.value)
 
         task_list = [t for i, t in enumerate(self.task_list) if self._panel.workflow_task_chk_list.IsChecked(i)]
         logging.info(f"Running automated milling for tasks: {task_list}")
@@ -691,6 +701,7 @@ class AutomatedMillingController:
                                     sem_stream=sem_stream,
                                     fib_stream=fib_stream,
                                     task_list=task_list,
+                                    config_path=self.milling_conf.config_path
                                     )
 
         # link the milling gauge to the milling future

--- a/src/odemis/gui/cont/stream_bar.py
+++ b/src/odemis/gui/cont/stream_bar.py
@@ -36,7 +36,7 @@ import odemis.acq.stream as acqstream
 import odemis.gui.conf.file
 import odemis.gui.model as guimodel
 from odemis import model
-from odemis.acq.stream import StaticSEMStream, StaticStream
+from odemis.acq.stream import StaticSEMStream, StaticFIBStream, StaticStream
 from odemis.acq.stream_settings import StreamSettingsConfig
 from odemis.gui.conf.data import get_local_vas
 from odemis.gui.cont.stream import StreamController
@@ -2283,7 +2283,7 @@ class CryoFIBAcquiredStreamsController(CryoStreamsController):
         # Remove the panels, and indirectly it will clear the view
         v = self._feature_view
         for sc in self.stream_controllers.copy():
-            if not isinstance(sc.stream, StaticSEMStream):
+            if not isinstance(sc.stream, StaticFIBStream):
                 logging.warning("Unexpected non static stream: %s", sc.stream)
                 continue
             # Leave the overview streams

--- a/src/odemis/gui/model/tab_gui_data.py
+++ b/src/odemis/gui/model/tab_gui_data.py
@@ -34,7 +34,7 @@ from odemis.acq.feature import CryoFeature, get_feature_position_at_posture, Tar
 from odemis.acq.move import FM_IMAGING, SEM_IMAGING
 from odemis.acq.stream import StaticFluoStream
 from odemis.gui import conf
-from odemis.gui.conf import get_general_conf
+from odemis.gui.conf import get_general_conf, get_milling_conf
 from odemis.gui.cont.fastem_project_tree import FastEMTreeNode, NodeType
 from odemis.gui.model._constants import (
     FLM_ALIGN,
@@ -260,6 +260,7 @@ class CryoGUIData(MicroscopyGUIData):
             raise ValueError(
                 "Expected a microscope role of 'enzel', 'meteor', or 'mimas' but found it to be %s." % main.role)
         super().__init__(main)
+        self.milling_conf = get_milling_conf()
 
         # the streams to correlate among all streams in .streams
         self.selected_stream = model.VigilantAttribute(None)
@@ -342,7 +343,13 @@ class CryoGUIData(MicroscopyGUIData):
             else:
                 md = self.main.focus.getMetadata()
                 fm_focus_position = md[model.MD_FAV_POS_ACTIVE]
-        feature = CryoFeature(f_name, stage_position, fm_focus_position)
+
+        # general milling parameters applicable to all the milling tasks
+        general_params = {
+            "rate": self.milling_conf.rate,
+            "dwell_time": self.milling_conf.dwell_time
+        }
+        feature = CryoFeature(f_name, stage_position, fm_focus_position, general_params=general_params)
         for p in pm.postures: # calculate the position at all postures
             get_feature_position_at_posture(pm, feature, p)
 

--- a/src/odemis/util/dataio.py
+++ b/src/odemis/util/dataio.py
@@ -126,6 +126,9 @@ def data_to_static_streams(data):
             # Only decide it's RGB as last resort, because most microscopy data is not RGB
             name = d.metadata.get(model.MD_DESCRIPTION, "RGB data")
             klass = stream.RGBStream
+        elif acqtype == model.MD_AT_FIB:
+            name = d.metadata.get(model.MD_DESCRIPTION, "FIB")
+            klass = stream.StaticFIBStream
         else:
             # Now, either it's a flat greyscale image and we decide it's a SEM image,
             # or it's gone too weird and we try again on flat images


### PR DESCRIPTION
- Add a `milling.config` file to define the milling rate, dwell time, and the path to the fibsemOS configuration file.
- Pass the milling rate, dwell time, and the config file path from Odemis to fibsemOS.
- Define default values for the milling rate and dwell time.
- Construct and pass the milling preset string to fibsemOS (controversial).
- Use a static FIB stream for the cryo feature view to remove the warning.