### PR TITLE
[MSD-219][fix] METEOR: rename MD_FAV_MILL_POS_ACTIVE["rx"] -> ["mill_angle"]

### DIFF
--- a/install/linux/usr/share/odemis/sim/meteor-fibsem-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/meteor-fibsem-sim.odm.yaml
@@ -93,7 +93,7 @@
         FAV_FM_POS_ACTIVE: {"rx": 0.2967059728390360  , "rz":  3.141592653589793}, # 17° - 180°
         FAV_SEM_POS_ACTIVE: {"rx": 0.6108652381980153, "rz": 0},  # pre-tilt 35°
         FAV_FIB_POS_ACTIVE: {"rx": 0.29670597283903605 , "rz": 3.141592653589793},
-        FAV_MILL_POS_ACTIVE: {"rx": 0.2443461, "rz": 0},  # rx (14°) defines the "milling angle" (ie, angle between ion beam column and sample plane)
+        FAV_MILL_POS_ACTIVE: {"mill_angle": 0.2443461, "rz": 0},  # milling angle (14°) is the angle between ion beam column and sample plane
     },
 }
 

--- a/install/linux/usr/share/odemis/sim/meteor-tescan-fibsem-full-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/meteor-tescan-fibsem-full-sim.odm.yaml
@@ -134,9 +134,8 @@
         # Note that the accuracy of the FM/SEM switch might be reduced if starting at a different angle.
         FAV_FM_POS_ACTIVE: {"rx": 0.261799, "rz": 4.9567353}, # 15° tilt, 284° rotation
         FAV_SEM_POS_ACTIVE: {"rx": 0.698132, "rz": 1.815142}, # 40° tilt, 104° rotation
-        # MILL has the *milling angle* as rx.
         # To compute the tilt angle: tilt = MillingAngle + PreTilt (40°) + ColumnTilt (55°) - 90
-        FAV_MILL_POS_ACTIVE: {"rx": 0.174532925, "rz": 4.9567353}, # Milling angle = 10°, 284° rotation
+        FAV_MILL_POS_ACTIVE: {"mill_angle": 0.174532925, "rz": 4.9567353}, # Milling angle = 10°, 284° rotation
     },
 }
 

--- a/install/linux/usr/share/odemis/sim/meteor-tescan-fibsem-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/meteor-tescan-fibsem-sim.odm.yaml
@@ -134,9 +134,8 @@
         # Note that the accuracy of the FM/SEM switch might be reduced if starting at a different angle.
         FAV_FM_POS_ACTIVE: {"rx": 0.261799, "rz": 4.9567353}, # 15° tilt, 284° rotation
         FAV_SEM_POS_ACTIVE: {"rx": 0.698132, "rz": 1.815142}, # 40° tilt, 104° rotation
-        # MILL has the *milling angle* as rx.
         # To compute the tilt angle: tilt = MillingAngle + PreTilt (40°) + ColumnTilt (55°) - 90
-        FAV_MILL_POS_ACTIVE: {"rx": 0.174532925, "rz": 4.9567353}, # Milling angle = 10°, 284° rotation
+        FAV_MILL_POS_ACTIVE: {"mill_angle": 0.174532925, "rz": 4.9567353}, # Milling angle = 10°, 284° rotation
     },
 }
 

--- a/install/linux/usr/share/odemis/sim/meteor-tfs3-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/meteor-tfs3-sim.odm.yaml
@@ -48,7 +48,7 @@
         # Active tilting (rx) & rotation(rz) angles positions when switching between SEM & FM.
         FAV_FM_POS_ACTIVE: {"rx": 0.29670597283903605  , "rz":  3.141592653589793}, # 17° - 180°
         FAV_SEM_POS_ACTIVE: {"rx": 0.6108652381980153, "rz": 0},  # pre-tilt 35°, 0° rotation
-        FAV_MILL_POS_ACTIVE: {"rx": 0.2443461, "rz": 0},  # rx (14°) defines the "milling angle" (ie, angle between ion beam column and sample plane)
+        FAV_MILL_POS_ACTIVE: {"mill_angle": 0.2443461, "rz": 0},  # milling angle (14°) is the angle between ion beam column and sample plane
     },
 }
 

--- a/src/odemis/acq/move.py
+++ b/src/odemis/acq/move.py
@@ -339,6 +339,23 @@ class MeteorPostureManager(MicroscopePostureManager):
         # In this case, MD_CALIB["SEM-Eucentric-Focus"] specifies the fixed focus position to use.
         self.use_linked_sem_focus_compensation: bool = md_calib.get("use_linked_sem_focus_compensation", False)
 
+        # Upgrade path MD_FAV_MILL_POS_ACTIVE["rx"] -> ["mill_angle"]
+        # Can be deleted once all installations microscope files have been updated.
+        # In Odemis v3.7, MD_FAV_MILL_POS_ACTIVE used the "rx" key to refer to the milling angle.
+        # From Odemis v3.8 onwards, the "mill_angle" key is used instead.
+        # As now, the "rx" angle is not used, we know the precense of a "rx" key indicates it's a
+        # legacy config. So we automatically convert it here, and it will stay as-is for as long as the
+        # back-end runs.
+        if model.MD_FAV_MILL_POS_ACTIVE in stage_md:
+            mill_md = stage_md[model.MD_FAV_MILL_POS_ACTIVE]
+            if "rx" in mill_md:
+                if "mill_angle" in mill_md:
+                    raise ValueError("stage-bare metadata FAV_MILL_POS_ACTIVE contains both 'rx' and "
+                                     "'mill_angle' keys. Only 'mill_angle' should be provided.")
+                logging.info("Upgrading stage metadata %s: converting 'rx' to 'mill_angle'", model.MD_FAV_MILL_POS_ACTIVE)
+                mill_md["mill_angle"] = mill_md.pop("rx")
+                self.stage.updateMetadata({model.MD_FAV_MILL_POS_ACTIVE: mill_md})
+
         # current posture va
         self.current_posture = model.VigilantAttribute(UNKNOWN)
         self.stage.position.subscribe(self._update_posture, init=True)
@@ -489,7 +506,7 @@ class MeteorPostureManager(MicroscopePostureManager):
             return stage_md[model.MD_FAV_FIB_POS_ACTIVE]
         elif posture == MILLING:
             md = stage_md[model.MD_FAV_MILL_POS_ACTIVE]
-            rx = calculate_stage_tilt_from_milling_angle(milling_angle=md["rx"],
+            rx = calculate_stage_tilt_from_milling_angle(milling_angle=md["mill_angle"],
                                                         pre_tilt=self.pre_tilt,
                                                         column_tilt=self.fib_column_tilt)
             return {"rx": rx, "rz": md["rz"]}
@@ -740,7 +757,7 @@ class MeteorPostureManager(MicroscopePostureManager):
 
     def _transformFromSEMToMilling(self, pos: Dict[str, float]) -> Dict[str, float]:
         """
-        Transforms the stage position from sem imaging to milling position"
+        Transforms the stage position from sem imaging to milling position
         :param pos: (dict str->float) the current stage position
         :return: (dict str->float) the transformed stage position.
         """
@@ -1682,7 +1699,7 @@ class MeteorTescan1PostureManager(MeteorPostureManager):
         # TODO: update MILLING transformations when changing milling angle
         if model.MD_FAV_MILL_POS_ACTIVE in stage_md:
             mill_pos_active = stage_md[model.MD_FAV_MILL_POS_ACTIVE]
-            rx_mill = calculate_stage_tilt_from_milling_angle(milling_angle=mill_pos_active["rx"],
+            rx_mill = calculate_stage_tilt_from_milling_angle(milling_angle=mill_pos_active["mill_angle"],
                                                               pre_tilt=self.pre_tilt,
                                                               column_tilt=self.fib_column_tilt)
             # Scan rotation and pre-tilt are the same as in SEM imaging, so can reuse tf_sr
@@ -1901,12 +1918,9 @@ class MeteorTescan1PostureManager(MeteorPostureManager):
 
         # Define values that are used more than once
         rx_sem = pos["rx"]  # Current tilt angle (can differ per point of interest)
-        # NOTE: mill_pos_active uses the "rx" key to refer to the milling angle (the angle between the ion beam and the sample plane)
-        # not the actual Rx (the tilt with regard to the SEM column axis)!
-        # TODO MD_FAV_MILL_POS_ACTIVE["rx"] should be renamed for better clarity to something like "milling_angle"
-        mill_angle = mill_pos_active.pop("rx")
+        mill_angle = mill_pos_active.pop("mill_angle")
         rx_mill = calculate_stage_tilt_from_milling_angle(mill_angle, pre_tilt=self.pre_tilt, column_tilt=self.fib_column_tilt)
-        mill_pos_active["rx"] = rx_mill # update the computed rx based on the milling angle, see the note above
+        mill_pos_active["rx"] = rx_mill  # update the computed rx based on the milling angle
 
         z_ct = calibrated_values["z_ct"]
         b_y = calibrated_values["b_y"]
@@ -1950,7 +1964,8 @@ class MeteorTescan1PostureManager(MeteorPostureManager):
 
         # Define values that are used more than once
         rx_sem = sem_pos_active["rx"]
-        rx_mill = calculate_stage_tilt_from_milling_angle(milling_angle=mill_pos_active["rx"], pre_tilt=self.pre_tilt, column_tilt=self.fib_column_tilt)
+        rx_mill = calculate_stage_tilt_from_milling_angle(milling_angle=mill_pos_active["mill_angle"],
+                                                          pre_tilt=self.pre_tilt, column_tilt=self.fib_column_tilt)
 
         z_ct = calibrated_values["z_ct"]
         b_y = calibrated_values["b_y"]
@@ -2045,11 +2060,11 @@ class MeteorTescan1PostureManager(MeteorPostureManager):
 
                 if current_posture == MILLING:
                     # Store current milling angle, to go back to that same position next time
-                    rx_milling = calculate_milling_angle_from_stage_tilt(current_pos["rx"],
+                    mill_angle = calculate_milling_angle_from_stage_tilt(current_pos["rx"],
                                             pre_tilt=self.pre_tilt,
                                             column_tilt=self.fib_column_tilt)
                     mill_pos_active = self.stage.getMetadata()[model.MD_FAV_MILL_POS_ACTIVE]
-                    mill_pos_active["rx"] = rx_milling
+                    mill_pos_active["mill_angle"] = mill_angle
                     self.stage.updateMetadata({model.MD_FAV_MILL_POS_ACTIVE: mill_pos_active})
                     # TODO: update transformation matrices for milling (at the moment the milling angle is changed)
 

--- a/src/odemis/gui/cont/tabs/fibsem_tab.py
+++ b/src/odemis/gui/cont/tabs/fibsem_tab.py
@@ -187,7 +187,7 @@ class FibsemTab(Tab):
         self.pm.stage.position.subscribe(self._on_stage_pos, init=True)
         self.panel = panel
 
-        rx = self.pm.stage.getMetadata()[model.MD_FAV_MILL_POS_ACTIVE]["rx"]
+        rx = self.pm.stage.getMetadata()[model.MD_FAV_MILL_POS_ACTIVE]["mill_angle"]
         self.panel.ctrl_milling_angle.SetValue(math.degrees(rx))
         self.panel.ctrl_milling_angle.SetValueRange(*MILLING_RANGE)
         self.panel.ctrl_milling_angle.Bind(wx.EVT_COMMAND_ENTER, self._update_milling_angle)
@@ -413,7 +413,7 @@ class FibsemTab(Tab):
         milling_angle = math.radians(self.panel.ctrl_milling_angle.GetValue())
         current_md = self.pm.stage.getMetadata()
         self.pm.stage.updateMetadata({
-            model.MD_FAV_MILL_POS_ACTIVE: {"rx": milling_angle,
+            model.MD_FAV_MILL_POS_ACTIVE: {"mill_angle": milling_angle,
                                            "rz": current_md[model.MD_FAV_MILL_POS_ACTIVE]["rz"]}
         })
 


### PR DESCRIPTION
"rx" is too easy to confuse with the stage-bare tilt. So rename the key
to "mill_angle", and add a "upgrade" code that automatically updates the
metadata of the stage-bare if a backend was started with an old
configuration.