### PR TITLE
[test] fix start_test failing to import SECOM_CONFIG from stream_test

### DIFF
--- a/src/odemis/odemisd/test/start_test.py
+++ b/src/odemis/odemisd/test/start_test.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import threading
 import time
@@ -6,9 +7,12 @@ from unittest import mock
 
 import notify2
 
-from odemis.acq.test.stream_test import SECOM_CONFIG
+import odemis
 from odemis.odemisd.start import find_window, main
 from odemis.util import testing
+
+CONFIG_PATH = os.path.dirname(odemis.__file__) + "/../../install/linux/usr/share/odemis/"
+SECOM_CONFIG = CONFIG_PATH + "sim/secom-sim.odm.yaml"
 
 
 class StartTestCase(unittest.TestCase):


### PR DESCRIPTION
Commit da7ef8e67a9 (Extend SPARC acquisition to support rotation)
updated the stream_test and broke it into different files. However, this
broken start_test which relied on it to define SECOM_CONFIG.

=> Just hard-code separately SECOM_CONFIG in start_test.