### PR TITLE
[fix] simulated.Stage axis didn't specify unit = "m"

### DIFF
--- a/src/odemis/driver/simulated.py
+++ b/src/odemis/driver/simulated.py
@@ -456,7 +456,7 @@ class Stage(GenericComponent):
 
         axes_dict = {}
         for a in axes:
-            d = {}
+            d = {"unit": "m"}
             if a in ranges:
                 d["range"] = ranges[a]
             elif a in choices:


### PR DESCRIPTION
Commit d86124248 (driver simulated: Introduce GenericComponent)
refactored the class by making it use the GenericComponent. However,
this dropped the default unit of the axes as "m".

In practice, simulated stages would end up not having units, which in
general doesn't matter... however the cli does care, and will NOT use µm
with the move command. So "odemis move stage x 10" would typically fail
because it's out of bound, while normally it should move by 10µm.
Putting the unit back fixes it.