### PR TITLE
[feat] hdf5: also store MD_LIGHT_POWER metadata

### DIFF
--- a/src/odemis/dataio/hdf5.py
+++ b/src/odemis/dataio/hdf5.py
@@ -726,6 +726,7 @@ def _parse_physical_data(pdgroup, da):
         read_metadata(pdgroup, i, md, "ExcitationWavelength", model.MD_IN_WL, converter=float)
         read_metadata(pdgroup, i, md, "EmissionWavelength", model.MD_OUT_WL, converter=float)
         read_metadata(pdgroup, i, md, "Magnification", model.MD_LENS_MAG, converter=float)
+        read_metadata(pdgroup, i, md, "LightPower", model.MD_LIGHT_POWER, converter=float)
 
         # Our extended metadata
         read_metadata(pdgroup, i, md, "Baseline", model.MD_BASELINE, converter=float)
@@ -955,6 +956,11 @@ def _add_image_metadata(group, image, mds):
     gp["Magnification"] = [1.0 if m is None else m for m in mags]
     state = [ST_INVALID if v is None else ST_REPORTED for v in mags]
     _h5svi_set_state(gp["Magnification"], state)
+
+    powers = [md.get(model.MD_LIGHT_POWER) for md in mds]
+    gp["LightPower"] = [0.0 if p is None else p for p in powers]
+    state = [ST_INVALID if v is None else ST_REPORTED for v in powers]
+    _h5svi_set_state(gp["LightPower"], state)
 
     ofts = [md.get(model.MD_BASELINE) for md in mds]
     gp["Baseline"] = [0.0 if m is None else m for m in ofts]

--- a/src/odemis/dataio/test/hdf5_test.py
+++ b/src/odemis/dataio/test/hdf5_test.py
@@ -514,6 +514,7 @@ class TestHDF5IO(unittest.TestCase):
                      model.MD_POS: (1e-3, -30e-3),  # m
                      model.MD_EXP_TIME: 1.2,  # s
                      model.MD_LENS_MAG: 1200,  # ratio
+                     model.MD_LIGHT_POWER: 0.5,  # W
                     },
                     {model.MD_SW_VERSION: "1.0-test",
                      model.MD_HW_NAME: "fake spec",
@@ -561,6 +562,8 @@ class TestHDF5IO(unittest.TestCase):
             self.assertEqual(im.metadata[model.MD_ACQ_DATE], md[model.MD_ACQ_DATE])
             if model.MD_LENS_MAG in md:
                 self.assertEqual(im.metadata[model.MD_LENS_MAG], md[model.MD_LENS_MAG])
+            if model.MD_LIGHT_POWER in md:
+                self.assertEqual(im.metadata[model.MD_LIGHT_POWER], md[model.MD_LIGHT_POWER])
 
             # None of the images are using light => no MD_IN_WL
             self.assertFalse(model.MD_IN_WL in im.metadata,
@@ -656,6 +659,8 @@ class TestHDF5IO(unittest.TestCase):
             self.assertEqual(im.metadata[model.MD_ACQ_DATE], md[model.MD_ACQ_DATE])
             if model.MD_LENS_MAG in md:
                 self.assertEqual(im.metadata[model.MD_LENS_MAG], md[model.MD_LENS_MAG])
+            if model.MD_LIGHT_POWER in md:
+                self.assertEqual(im.metadata[model.MD_LIGHT_POWER], md[model.MD_LIGHT_POWER])
 
             # None of the images are using light => no MD_IN_WL
             self.assertFalse(model.MD_IN_WL in im.metadata,
@@ -767,6 +772,8 @@ class TestHDF5IO(unittest.TestCase):
             # Check the metadata stays the same, when the metadata was present
             if model.MD_LENS_MAG in md:
                 self.assertEqual(im.metadata[model.MD_LENS_MAG], md[model.MD_LENS_MAG])
+            if model.MD_LIGHT_POWER in md:
+                self.assertEqual(im.metadata[model.MD_LIGHT_POWER], md[model.MD_LIGHT_POWER])
             if model.MD_AR_POLE in md:
                 self.assertEqual(im.metadata[model.MD_AR_POLE], md[model.MD_AR_POLE])
             if model.MD_AR_MIRROR_TOP in md:
@@ -896,6 +903,8 @@ class TestHDF5IO(unittest.TestCase):
                 self.assertEqual(im.metadata[model.MD_AR_PARABOLA_F], md[model.MD_AR_PARABOLA_F])
             if model.MD_LENS_MAG in md:
                 self.assertEqual(im.metadata[model.MD_LENS_MAG], md[model.MD_LENS_MAG])
+            if model.MD_LIGHT_POWER in md:
+                self.assertEqual(im.metadata[model.MD_LIGHT_POWER], md[model.MD_LIGHT_POWER])
             if model.MD_EBEAM_CURRENT in md:
                 self.assertEqual(im.metadata[model.MD_EBEAM_CURRENT], md[model.MD_EBEAM_CURRENT])
             if model.MD_EBEAM_VOLTAGE in md:
@@ -1415,6 +1424,8 @@ class TestHDF5IO(unittest.TestCase):
             self.assertEqual(im.metadata[model.MD_ACQ_DATE], md[model.MD_ACQ_DATE])
             if model.MD_LENS_MAG in md:
                 self.assertEqual(im.metadata[model.MD_LENS_MAG], md[model.MD_LENS_MAG])
+            if model.MD_LIGHT_POWER in md:
+                self.assertEqual(im.metadata[model.MD_LIGHT_POWER], md[model.MD_LIGHT_POWER])
 
             # None of the images are using light => no MD_IN_WL
             self.assertFalse(model.MD_IN_WL in im.metadata,


### PR DESCRIPTION
HDF5 is not commonly used on systems with light, so we never supported
this metadata... but now some SPARCs have input light (for PL), so let's
add support for this metadata too.