### PR TITLE
[fix] driver ueye: use str to handle daemon status message

### DIFF
--- a/src/odemis/driver/ueye.py
+++ b/src/odemis/driver/ueye.py
@@ -1397,9 +1397,9 @@ class Camera(model.DigitalCamera):
             logging.debug("Daemon check not working outside of Linux")
             return False
 
-        ds_str = subprocess.check_output(["/etc/init.d/ueyeusbdrc", "status"])
+        ds_str = subprocess.check_output(["/etc/init.d/ueyeusbdrc", "status"]).decode("utf-8", errors="ignore")
         logging.debug("Daemon status is '%s'", ds_str.strip())
-        if b"not" in ds_str:
+        if "not" in ds_str:
             logging.info("Attempting to restart the daemon")
             ret = subprocess.call(["sudo", "/usr/sbin/service", "ueyeusbdrc", "stop"])
             if ret != 0:


### PR DESCRIPTION
As it's the output from another program, it's received as bytes, but
it's supposed to be english text, so it's more natural to convert to a
string. It's also prettier in the log.