### PR TITLE
[test] PostureManager: add test case for the TescanPostureManager on Tescan FIBSEM

### DIFF
--- a/install/linux/usr/share/odemis/sim/meteor-tescan-fibsem-full-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/meteor-tescan-fibsem-full-sim.odm.yaml
@@ -36,6 +36,11 @@
     role: e-beam,
     init: {},
     affects: ["EBeam Detector"],
+    properties: {
+      # Set scan rotation to 180°, which is the standard, to ensure the camera
+      # rotation is matching.
+      rotation: 3.141592653589,  # rad, 180°
+    },
 }
 
 "EBeam Detector": {
@@ -54,6 +59,11 @@
     role: ion-beam,
     init: {},
     affects: ["Ion Detector"],
+    properties: {
+      # Set scan rotation to 180°, which is the standard, to ensure the camera
+      # rotation is matching.
+      rotation: 3.141592653589,  # rad, 180°
+    },
 }
 
 "Ion Detector": {

--- a/src/odemis/acq/test/move_tescan_test.py
+++ b/src/odemis/acq/test/move_tescan_test.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Copyright © 2020 Delmic
+Copyright © 2023-2025 Delmic
 
 This file is part of Odemis.
 
@@ -18,20 +18,22 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 import logging
 import math
 import os
+import time
 import unittest
-
-from odemis.util import testing
 
 import odemis
 from odemis import model
-from odemis.acq.move import (FM_IMAGING, SEM_IMAGING, UNKNOWN)
+from odemis.acq.move import (FM_IMAGING, SEM_IMAGING, UNKNOWN, MicroscopePostureManager, LOADING)
 from odemis.acq.test.move_tfs1_test import TestMeteorTFS1Move
+from odemis.acq.test.move_tfs3_test import TestMeteorTFS3Move
+from odemis.util import testing
 
 logging.getLogger().setLevel(logging.DEBUG)
 logging.basicConfig(format="%(asctime)s  %(levelname)-7s %(module)s:%(lineno)d %(message)s")
 
 CONFIG_PATH = os.path.dirname(odemis.__file__) + "/../../install/linux/usr/share/odemis/"
 METEOR_TESCAN1_CONFIG = CONFIG_PATH + "sim/meteor-tescan-sim.odm.yaml"
+METEOR_TESCAN1_FIBSEM_CONFIG = CONFIG_PATH + "sim/meteor-tescan-fibsem-full-sim.odm.yaml"
 
 
 class TestMeteorTescan1Move(TestMeteorTFS1Move):
@@ -164,6 +166,75 @@ class TestMeteorTescan1Move(TestMeteorTFS1Move):
         self.assertAlmostEqual(zshift["x"], shift["x"], places=5)
         self.assertAlmostEqual(zshift["z"], shift["z"], places=5)
 
+
+class TestMeteorTescan1FibsemMove(TestMeteorTFS3Move):
+    MIC_CONFIG = METEOR_TESCAN1_FIBSEM_CONFIG
+    ROTATION_AXES = {'rx', 'rz'}
+
+    @classmethod
+    def setUpClass(cls):
+        testing.start_backend(cls.MIC_CONFIG)
+        cls.microscope = model.getMicroscope()
+        cls.pm = MicroscopePostureManager(microscope=cls.microscope)
+
+        # get the stage components
+        cls.stage_bare = model.getComponent(role="stage-bare")
+        cls.stage = cls.pm.sample_stage
+
+        # get the metadata
+        cls.stage_md = cls.stage_bare.getMetadata()
+        cls.stage_grid_centers = cls.stage_md[model.MD_SAMPLE_CENTERS]
+        cls.stage_loading = cls.stage_md[model.MD_FAV_POS_DEACTIVE]
+
+        # Reset to loading position (in case the backend was already running and in a different posture)
+        f = cls.pm.cryoSwitchSamplePosition(LOADING)
+        f.result()
+
+    def test_fixed_fm_z(self):
+        self.skipTest("Test not meaningful for Tescan")
+
+    def test_revert_from_fixed_fm_z(self):
+        self.skipTest("Test not meaningful for Tescan")
+
+    def test_stage_to_chamber(self):
+        # Override, as Tescan has different behaviour: the Z axis is directly connected the chamber Z
+        # go to sem imaging
+        f = self.pm.cryoSwitchSamplePosition(SEM_IMAGING)
+        f.result()
+        time.sleep(0.1)
+
+        # calculate the vertical shift in chamber coordinates
+        shift = {"x": 100e-6, "z": 50e-6}
+        zshift = self.pm._transformFromChamberToStage(shift)
+        # Should return the same movement
+        testing.assert_pos_almost_equal(zshift, shift)
+
+    def test_rel_move_fm_posture(self):
+        f = self.pm.cryoSwitchSamplePosition(FM_IMAGING)
+        f.result()
+        current_imaging_mode = self.pm.getCurrentPostureLabel()
+        self.assertEqual(FM_IMAGING, current_imaging_mode)
+
+        # relative moves in sample stage coordinates
+        sample_stage_moves = [
+            {"x": 10e-6, "y": 0},
+            {"x": 0, "y": 10e-6},
+        ]
+        # Corresponding stage-bare relative moves (based on "ground truth" tested on hardware)
+        # The system is configured with a scan rotation of 180°, so all the moves are inverted.
+        stage_bare_moves = [
+            {"x": -10e-6, "y": 0, "z": 0},
+            {"x": 0, "y": -5.9e-6, "z": -6.7e-6},  # 40° pre-tilt
+        ]
+        for m_sample, m_bare in zip(sample_stage_moves, stage_bare_moves):
+            old_bare_pos = self.stage_bare.position.value
+            self.stage.moveRel(m_sample).result()
+            new_bare_pos = self.stage_bare.position.value
+
+            exp_bare_pos = old_bare_pos.copy()
+            for axis in m_bare.keys():
+                exp_bare_pos[axis] += m_bare[axis]
+            testing.assert_pos_almost_equal(new_bare_pos, exp_bare_pos, atol=1e-6)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Use the same test cases as for the TFS3 FIBSEM to test the
TescanPostureManager with the Meteor FIBSEM on Tescan.