### PR TITLE
[fix] FIBSEM tab XRC caused errors with wxPython 4.1+

### DIFF
--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -9752,7 +9752,7 @@ B`\x82'''
                                       </object>
                                     </object>
                                   </object>
-                                  <flag>wxLEFT|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL</flag>
+                                  <flag>wxLEFT|wxALIGN_CENTER_VERTICAL</flag>
                                   <border>82</border>
                                   <option>0</option>
                                 </object>
@@ -9797,7 +9797,7 @@ B`\x82'''
                                       </object>
                                     </object>
                                   </object>
-                                  <flag>wxLEFT|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL</flag>
+                                  <flag>wxLEFT|wxALIGN_CENTER_VERTICAL</flag>
                                   <border>82</border>
                                   <option>0</option>
                                 </object>
@@ -10484,7 +10484,6 @@ B`\x82'''
                                             <style>wxGA_SMOOTH</style>
                                             <XRCED><assign_var>1</assign_var></XRCED>
                                           </object>
-                                          <flag>wxALIGN_CENTER_VERTICAL</flag>
                                         </object>
                                         <object class="spacer"><option>1</option></object>
                                       </object>

--- a/src/odemis/gui/xmlh/resources/panel_tab_fibsem.xrc
+++ b/src/odemis/gui/xmlh/resources/panel_tab_fibsem.xrc
@@ -280,7 +280,7 @@
                                       </object>
                                     </object>
                                   </object>
-                                  <flag>wxLEFT|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL</flag>
+                                  <flag>wxLEFT|wxALIGN_CENTER_VERTICAL</flag>
                                   <border>82</border>
                                   <option>0</option>
                                 </object>
@@ -325,7 +325,7 @@
                                       </object>
                                     </object>
                                   </object>
-                                  <flag>wxLEFT|wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL</flag>
+                                  <flag>wxLEFT|wxALIGN_CENTER_VERTICAL</flag>
                                   <border>82</border>
                                   <option>0</option>
                                 </object>
@@ -1012,7 +1012,6 @@
                                             <style>wxGA_SMOOTH</style>
                                             <XRCED><assign_var>1</assign_var></XRCED>
                                           </object>
-                                          <flag>wxALIGN_CENTER_VERTICAL</flag>
                                         </object>
                                         <object class="spacer"><option>1</option></object>
                                       </object>


### PR DESCRIPTION
The commit f8f78700d6d6 ([fix] update xrc files) changed some of the
sizer flags which turned out to not be useful. On wxPython 4.1 (eg,
Ubuntu 24.04) and later, these flags cause errors, like this:
```
15:43:12: XRC error: 281: horizontal alignment flag "wxALIGN_RIGHT" has no effect inside a horizontal box sizer, remove it and consider inserting a spacer instead
15:43:12: XRC error: 326: horizontal alignment flag "wxALIGN_RIGHT" has no effect inside a horizontal box sizer, remove it and consider inserting a spacer instead
15:43:12: XRC error: 1013: vertical alignment flag "wxALIGN_CENTER_VERTICAL" has no effect inside a vertical box sizer, remove it and consider inserting a spacer instead
```

=> Remove these unneeded flags.