### PR TITLE
[METEOR-1737][feat] bug-reporter: also get microscope files from the last run

### DIFF
--- a/src/bugreporter/odemis_bugreporter.py
+++ b/src/bugreporter/odemis_bugreporter.py
@@ -324,6 +324,8 @@ class OdemisBugreporter(object):
 
             # Also pick every potential microscope model
             models.update(glob(os.path.join(odemis_config['CONFIGPATH'], '*.odm.yaml')))
+            # Hardware configuration files are also useful
+            models.update(glob(os.path.join(odemis_config['CONFIGPATH'], '*.tsv')))
 
             files.extend(models)
 

--- a/src/odemis/odemisd/main.py
+++ b/src/odemis/odemisd/main.py
@@ -85,7 +85,7 @@ class BackendContainer(model.Container):
         # TODO: have an argument to ask for disabling parallel start? same as create_sub_containers?
 
         # parse the instantiation file
-        logging.debug("model instantiation file is: %s", self._model.name)
+        logging.debug("model instantiation file is: %s", os.path.abspath(self._model.name))
         try:
             self._instantiator = modelgen.Instantiator(model_file, settings_file, self,
                                                        create_sub_containers, dry_run, strict_children)


### PR DESCRIPTION
If the user started odemis via the terminal, with the microscope file as parameter, we might not pick up the right microscope file. This is pretty common during installation. So let's try to pick it too.
Now save microsocpe files from 3 places:
    * MODEL -> in the root
    * CONFIGPATH -> in a sub-folder config-mic-files
    * last used -> in a sub-folder last-mic-files

Also include the *tsv files (which contain hardware config)
Also report the full path of the microscope file in the log, so that it's actually possible to know where the last file was.