### PR TITLE
[TRCL-658][feat] SPARC: support for LabCube after spectrograph

### DIFF
--- a/plugins/blanker_spectrum.py
+++ b/plugins/blanker_spectrum.py
@@ -228,7 +228,7 @@ class BlExtraPlugin(Plugin):
         main_data = self.main_app.main_data
         stctrl = self._tab.streambar_controller
 
-        spg = stctrl._getAffectingSpectrograph(detector)
+        spg = stctrl._getAffectingSpectrograph(detector, default=main_data.spectrograph)
 
         axes = {"wavelength": ("wavelength", spg),
                 "grating": ("grating", spg),

--- a/plugins/la_spec.py
+++ b/plugins/la_spec.py
@@ -276,7 +276,7 @@ class SpecExtraPlugin(Plugin):
         main_data = self.main_app.main_data
         stctrl = self._tab.streambar_controller
 
-        spg = stctrl._getAffectingSpectrograph(detector)
+        spg = stctrl._getAffectingSpectrograph(detector, default=main_data.spectrograph)
 
         axes = {"wavelength": ("wavelength", spg),
                 "grating": ("grating", spg),

--- a/plugins/photo_det_live.py
+++ b/plugins/photo_det_live.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+"""
+Created on 5 Dec 2025
+
+@author: Éric Piel
+
+Provides live display of photo-detector signals (of a time-correlator) over time for SPARCs.
+Can be use to adjust the alignment of the optical path, by looking at the signal.
+
+Copyright © 2025 Éric Piel, Delmic
+
+This file is part of Odemis.
+
+Odemis is free software: you can redistribute it and/or modify it under the terms of the GNU
+General Public License version 2 as published by the Free Software Foundation.
+
+Odemis is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even
+the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+Public License for more details.
+
+You should have received a copy of the GNU General Public License along with Odemis. If not,
+see http://www.gnu.org/licenses/.
+"""
+import functools
+import logging
+
+from odemis import model
+from odemis.acq.stream import MonochromatorSettingsStream
+from odemis.gui.conf.data import get_local_vas
+from odemis.gui.main import OdemisGUIApp
+from odemis.gui.plugin import Plugin
+
+
+class PhotoDetectorLivePlugin(Plugin):
+    name = "Photo-detector live display"
+    __version__ = "1.0"
+    __author__ = "Éric Piel"
+    __license__ = "GPLv2"
+
+    def __init__(self, microscope: model.Microscope, main_app: OdemisGUIApp):
+        super().__init__(microscope, main_app)
+        main_data = self.main_app.main_data
+        if not (microscope and main_data.photo_ds and main_data.role.startswith("sparc")):
+            logging.info("%s plugin cannot load as the microscope is not a SPARC with a photo detector.",
+                         self.name)
+            return
+
+        self._tab = self.main_app.main_data.getTabByName("sparc_acqui")
+        stctrl = self._tab.streambar_controller
+        for det in main_data.photo_ds:
+            name = f"{det.name} alignment"
+            act = functools.partial(self.add_photo_det_stream, name=name, detector=det)
+            stctrl.add_action(name, act)
+
+        # Note: no need to explicitly add the "Temporal Intensity" viewport, because it's normally
+        # always created when a time-correlator is available, which is the assumption here.
+
+    def add_photo_det_stream(self, name: str, detector: model.Detector) -> "StreamController":
+        """ Create a Monochromator stream, using a photo-detector and add to all compatible viewports"""
+        main_data = self.main_app.main_data
+        stctrl = self._tab.streambar_controller
+
+        # Axes on the "LabCube", which are always affecting the time-correlator photo-detectors
+        axes = {"density": ("density", main_data.tc_od_filter),
+                "filter": ("band", main_data.tc_filter)}
+
+        spg = stctrl._getAffectingSpectrograph(detector, default=main_data.spectrograph)
+        axes.update({
+            "wavelength": ("wavelength", spg),
+            "grating": ("grating", spg),
+            "iris-in": ("iris-in", spg),
+            "slit-in": ("slit-in", spg),
+            "slit-monochromator": ("slit-monochromator", spg),
+       })
+
+        # Also add light filter if it affects the detector
+        filter_in = main_data.light_filter
+        if filter_in and detector.name in filter_in.affects.value:
+            axes["filter-in"] = ("band", filter_in)
+
+        axes = stctrl._filter_axes(axes)
+
+        photodet_stream = MonochromatorSettingsStream(
+            name,
+            detector,
+            detector.data,
+            main_data.ebeam,
+            sstage=main_data.scan_stage,
+            opm=main_data.opm,
+            axis_map=axes,
+            emtvas={"dwellTime"},
+            detvas=get_local_vas(detector, main_data.hw_settings_config),
+        )
+        stctrl._set_default_spectrum_axes(photodet_stream)
+
+        # Don't call _addRepStream(), because we only add a live stream, no acquisition stream
+
+        stream_cont = stctrl._add_stream(photodet_stream, add_to_view=True)
+        stream_cont.stream_panel.show_visible_btn(False)
+        return stream_cont

--- a/plugins/spectrum_arbscor.py
+++ b/plugins/spectrum_arbscor.py
@@ -245,7 +245,7 @@ class SpectrumArbitraryScanOrderPlugin(Plugin):
 
         logging.debug("Adding spectrum arbitrary order stream for %s", detector.name)
 
-        spectrograph = stctrl._getAffectingSpectrograph(detector)
+        spectrograph = stctrl._getAffectingSpectrograph(detector, default=main_data.spectrograph)
 
         axes = {"wavelength": ("wavelength", spectrograph),
                 "grating": ("grating", spectrograph),

--- a/plugins/spectrum_raw.py
+++ b/plugins/spectrum_raw.py
@@ -384,7 +384,7 @@ class SpectrumRawPlugin(Plugin):
             # Removes exposureTime from local (GUI) VAs to use a new one, which allows to integrate images
             detvas.remove("exposureTime")
 
-        spectrograph = stctrl._getAffectingSpectrograph(main_data.ccd)
+        spectrograph = stctrl._getAffectingSpectrograph(main_data.ccd, default=main_data.spectrograph)
         spectrometer = stctrl._find_spectrometer(main_data.ccd)
 
         axes = {"wavelength": ("wavelength", spectrograph),

--- a/src/odemis/acq/path.py
+++ b/src/odemis/acq/path.py
@@ -192,6 +192,8 @@ SPARC2_MODES = {
                  'pol-analyzer': {'pol': MD_POL_NONE},
                  'light-aligner': {'x': "MD:" + model.MD_FAV_POS_ACTIVE,
                                    'z': "MD:" + model.MD_FAV_POS_ACTIVE},
+                 # Can affect in case the time-correlator is placed as output of the spectrograph
+                 'slit-in-big': {'x': 'off'},  # closed
                 }),
             'mirror-align': (r"ccd.*",  # Also used for lens alignment
                 {'lens-switch': {'x': ("MD:" + model.MD_FAV_POS_DEACTIVE, 'off')},

--- a/src/odemis/driver/test/tmcm_test.py
+++ b/src/odemis/driver/test/tmcm_test.py
@@ -522,6 +522,29 @@ class TestActuator(unittest.TestCase):
         # Close shutters
         self.dev.moveAbsSync({"shutter0": 0, "shutter1": 10})
 
+    def test_protection(self):
+        """Check the LED protection"""
+        # Not much to test, but at least we can set .protection VA on and off and check the related
+        # axes (shutter*) have moved.
+        self.dev.protection.value = True
+        self.assertTrue(self.dev.protection.value)
+
+        pos = self.dev.position.value
+        self.assertEqual(pos["shutter0"], 0)
+        self.assertEqual(pos["shutter1"], 10)
+
+        # Referencing should also activate the protection internally, and afterward set it back to the latest value
+        f = self.dev.reference({"x"})
+        f.result()
+        self.assertTrue(self.dev.protection.value)
+
+        time.sleep(0.1)
+        self.dev.protection.value = False
+        self.assertFalse(self.dev.protection.value)
+        pos = self.dev.position.value
+        self.assertEqual(pos["shutter0"], 1)
+        self.assertEqual(pos["shutter1"], 5)
+
 
 class TestActuatorAbsEnc(TestActuator):
 

--- a/src/odemis/driver/tmcm.py
+++ b/src/odemis/driver/tmcm.py
@@ -38,6 +38,7 @@ import struct
 import threading
 from collections import OrderedDict
 from concurrent.futures import CancelledError
+from typing import Dict, Optional, Set
 
 try:
     import canopen
@@ -443,6 +444,7 @@ class TMCLController(model.Actuator):
         # Add digital output axes
         self._do_axes = do_axes or {}
         self._led_prot_do = led_prot_do or {}
+        self._expected_do_pos: Dict[str, float] = {}  # DO positions, as requested by the user
         for channel, (an, hpos, lpos, dur) in self._do_axes.items():
             if an in self._name_to_axis or an in self._name_to_do_axis:
                 raise ValueError("Axis %s specified multiple times" % an)
@@ -450,12 +452,19 @@ class TMCLController(model.Actuator):
                 raise ValueError("Axis %s duration %s should be in seconds" % (an, dur))
             axes_def[an] = model.Axis(choices={lpos, hpos})
             self._name_to_do_axis[an] = channel
+            self._expected_do_pos[an] = lpos  # Always set to low at init via call to _releaseRefSwitch() just after
 
         for channel, pos in self._led_prot_do.items():
             if channel not in self._do_axes:
                 raise ValueError("led_prot_do channel %s is not specified as a do-axis" % channel)
             if pos not in self._do_axes[channel][1:3]:
                 raise ValueError("led_prot_do of channel %d has position %s, not in do_axes" % (channel, pos))
+
+        if self._led_prot_do:
+            # Add a VA to allow forcing the LED protection on
+            # If it's False: normal operation, the protection is activated during referencing
+            # If it's True: the protection is always active
+            self.protection = model.BooleanVA(False, setter=self._set_protection)
 
         model.Actuator.__init__(self, name, role, axes=axes_def, **kwargs)
 
@@ -479,7 +488,7 @@ class TMCLController(model.Actuator):
                 logging.warning("Acceleration of axis %s is null, most probably due to a bad hardware configuration", n)
 
         # Check state of refswitch on startup
-        self._expected_do_pos = {}  # do positions before referencing, will be reset after refswitch is released
+        # Use _refswitch_lock to access this attribute
         self._leds_on = any(self.GetIO(2, rs) for rs in self._refswitch.values())
         if self._leds_on:
             logging.debug("Refswitch is on during initialization, releasing refswitch for all axes.")
@@ -1450,30 +1459,65 @@ class TMCLController(model.Actuator):
             gparam = 128 + axis
             self.SetGlobalParam(2, gparam, 3)  # 3 => indicate cancelled
 
+    def _switch_led_prot(self, protected: bool) -> None:
+        """
+        Blocks until the move duration is passed, and will update .position based on the actual
+        state of the DO axes.
+        Must be called with _refswitch_lock held.
+        :param protected: If True, force the shutters closed. If False, set them
+          to the expected position (if _leds_on is False).
+        """
+        tsleep = 0  # max transition period for all shutters
+        if protected:
+            logging.debug("Forcing the protection active")
+            for channel, val in self._led_prot_do.items():
+                do_an, hpos, lpos, dur = self._do_axes[channel]
+                # If the shutter is already in the right position, no need to wait for it to move
+                if self.position.value[do_an] == val:
+                    logging.debug("Shutter on axis %s already in protected position", do_an)
+                else:
+                    tsleep = max(tsleep, dur)
+                # Set the DO to the "protected" position even if the position reports it's already
+                # there to be really sure. It's very fast anyway.
+                self.SetIO(2, channel, val == hpos)
+        else:
+            # Set the shutter in the "right" position:
+            # if _leds_on is False, set to the expected position
+            # if _leds_on is True, leave them closed (ie, do nothing)
+            if not self._leds_on:
+                # Set digital axis outputs to latest requested value
+                for an, val in self._expected_do_pos.items():
+                    channel = self._name_to_do_axis[an]
+                    if channel not in self._led_prot_do:
+                        continue
+                    _, hpos, lpos, dur = self._do_axes[channel]
+                    if self.position.value[an] == val:
+                        logging.debug("Shutter on axis %s already in protected position", an)
+                    else:
+                        tsleep = max(tsleep, dur)
+                    self.SetIO(2, channel, val == hpos)
+
+        time.sleep(tsleep)
+        self._updatePosition(axes=set(), do_axes=None)  # update all DO axes, but not the others as they didn't move
+
+    def _set_protection(self, protected: bool) -> bool:
+        if self.protection.value == protected:
+            return protected  # no change
+
+        with self._refswitch_lock:
+            self._switch_led_prot(protected)
+
+        return protected
+
     def _requestRefSwitch(self, axis):
         refswitch = self._refswitch.get(axis)
         if refswitch is None:
             return
 
         with self._refswitch_lock:
-            # Set _leds_on attribute before closing shutters to make sure they are not
-            # opened again in a concurrent thread
-            leds_were_on = self._leds_on
-            self._leds_on = True  # do this before closing shutters
-            # Close shutters
-            tsleep = 0  # max transition period for all shutters
-            for channel, val in self._led_prot_do.items():
-                do_an, hpos, lpos, dur = self._do_axes[channel]
-                if not leds_were_on:
-                    self._expected_do_pos[do_an] = self.position.value[do_an]
-                # TODO: ideally, for each DO, we should know when was the last time it
-                # was set, and if it's been set to the requested value for long
-                # enough, we don't need to do the extra sleep
-                self.SetIO(2, channel, val == hpos)
-                tsleep = max(tsleep, dur)
-
-            time.sleep(tsleep)
-            self._updatePosition()
+            self._leds_on = True
+            # Activate protection (ie, force the shutters closed)
+            self._switch_led_prot(protected=True)
 
             self._active_refswitchs.add(axis)
             logging.debug("Activating ref switch power line %d (for axis %d)", refswitch, axis)
@@ -1510,15 +1554,8 @@ class TMCLController(model.Actuator):
                 logging.debug("Leaving ref switch power line %d active", refswitch)
 
             # Set digital axis outputs to latest requested value
-            if not self._leds_on:
-                tsleep = 0  # max transition period for all shutters
-                for an, val in self._expected_do_pos.items():
-                    channel = self._name_to_do_axis[an]
-                    _, hpos, lpos, dur = self._do_axes[channel]
-                    self.SetIO(2, channel, val == hpos)
-                    tsleep = max(tsleep, dur)
-                time.sleep(tsleep)
-                self._updatePosition()
+            if not hasattr(self, "protection") or not self.protection.value:
+                self._switch_led_prot(protected=False)
 
     def _startReferencingStd(self, axis):
         """
@@ -1615,11 +1652,11 @@ class TMCLController(model.Actuator):
             logging.warning("Referencing on axis %d still happening after cancelling it", axis)
 
     # high-level methods (interface)
-    def _updatePosition(self, axes=None, do_axes=None):
+    def _updatePosition(self, axes: Optional[Set[str]] = None, do_axes: Optional[Set[str]] = None) -> None:
         """
         update the position VA
-        axes (set of str): names of the axes to update or None if all should be
-          updated
+        axes (set of str): names of the axes to update or None if all should be updated
+        do_axes (set of str): names of the DO axes to update or None if all should be updated
         """
         # uses the current values (converted to internal representation)
         pos = {}
@@ -1951,15 +1988,16 @@ class TMCLController(model.Actuator):
                 # Check if it's a digital output
                 if an in self._name_to_do_axis:
                     channel = self._name_to_do_axis[an]
-                    _, hpos, lpos, dur = self._do_axes[channel]
-                    with self._refswitch_lock:  # don't start do move at the same time as referencing
-                        if self._leds_on and channel in self._led_prot_do:
-                            # don't move protected do axis now if leds are on, schedule for later
-                            self._expected_do_pos[an] = v
+                    with self._refswitch_lock:
+                        self._expected_do_pos[an] = v  # Update user-requested position
+                        if channel in self._led_prot_do and (self.protection.value or self._leds_on):
+                            # Don't move a protecting DO axes if leds are on, they will be moved
+                            # once the protection is turned off.
                             if v != self._led_prot_do[channel]:
                                 logging.info("Referencing LEDs are on, move on axis %s to %s will be delayed.", an, v)
                         else:
                             # otherwise allow change
+                            _, hpos, lpos, dur = self._do_axes[channel]
                             logging.info("Setting digital output on channel %s to %s." % (channel, v == hpos))
                             self.SetIO(2, channel, v == hpos)
                             moving_do_axes.add(channel)

--- a/src/odemis/gui/conf/data.py
+++ b/src/odemis/gui/conf/data.py
@@ -1161,10 +1161,32 @@ STREAM_SETTINGS_CONFIG = {
         )),
     stream.ScannedTemporalSettingsStream:
         OrderedDict((
+            # From spectrograph, if the time-correlator is coupled after the spectrograph
+            ("wavelength", {
+                "tooltip": "Center wavelength of the spectrograph",
+                "control_type": odemis.gui.CONTROL_FLT,
+                "range": (0.0, 1900e-9),
+                "key_step_min": 1e-9,
+            }),
+            ("grating", {}),
+            ("slit-in", {
+                "label": "Input slit",
+                "tooltip": "Opening size of the spectrograph input slit.\nA wide opening is usually fine.",
+            }),
+            ("filter-in", {  # filter.band axis
+                "label": "Input filter",
+                "tooltip": "Filter before the spectrograph",
+                "choices": util.format_band_choices,
+            }),
+            ("slit-monochromator", {
+                "label": "Output slit",
+                "tooltip": "Opening size of the spectrograph detector slit.\nThe wider, the larger the wavelength bandwidth.",
+            }),
             ("density", {  # from tc-od-filter
                 "tooltip": "Optical density",
             }),
             ("filter", {  # from tc-filter
+                "label": "LAB Cube filter",
                 "choices": util.format_band_choices,
             }),
         )),

--- a/src/odemis/gui/cont/stream_bar.py
+++ b/src/odemis/gui/cont/stream_bar.py
@@ -1675,7 +1675,7 @@ class SparcStreamsController(StreamBarController):
 
         main_data = self._main_data_model
 
-        detvas = get_local_vas(main_data.ccd, self._main_data_model.hw_settings_config)
+        detvas = get_local_vas(main_data.ccd, main_data.hw_settings_config)
 
         if main_data.ccd.exposureTime.range[1] < 3600:  # 1h
             # remove exposureTime from local (GUI) VAs to use a new one, which allows to integrate images
@@ -1690,7 +1690,7 @@ class SparcStreamsController(StreamBarController):
             main_data.ebeam,
             analyzer=main_data.pol_analyzer,
             sstage=main_data.scan_stage,
-            opm=self._main_data_model.opm,
+            opm=main_data.opm,
             axis_map=axes,
             # TODO: add a focuser for the SPARCv2?
             detvas=detvas,
@@ -1719,9 +1719,9 @@ class SparcStreamsController(StreamBarController):
                 main_data.ebic.data,
                 main_data.ebeam,
                 main_data.sed.data,
-                focuser=self._main_data_model.ebeam_focus,
+                focuser=main_data.ebeam_focus,
                 emtvas={"dwellTime"},
-                detvas=get_local_vas(main_data.ebic, self._main_data_model.hw_settings_config),
+                detvas=get_local_vas(main_data.ebic, main_data.hw_settings_config),
             )
         else:
             ebic_stream = acqstream.EBICSettingsStream(
@@ -1730,9 +1730,9 @@ class SparcStreamsController(StreamBarController):
                 main_data.ebic.data,
                 main_data.ebeam,
                 sstage=main_data.scan_stage,
-                focuser=self._main_data_model.ebeam_focus,
+                focuser=main_data.ebeam_focus,
                 emtvas={"dwellTime"},
-                detvas=get_local_vas(main_data.ebic, self._main_data_model.hw_settings_config),
+                detvas=get_local_vas(main_data.ebic, main_data.hw_settings_config),
             )
 
         # Create the equivalent MDStream
@@ -1767,11 +1767,11 @@ class SparcStreamsController(StreamBarController):
             main_data.cld.data,
             main_data.ebeam,
             sstage=main_data.scan_stage,
-            focuser=self._main_data_model.ebeam_focus,
-            opm=self._main_data_model.opm,
+            focuser=main_data.ebeam_focus,
+            opm=main_data.opm,
             axis_map=axes,
             emtvas={"dwellTime"},
-            detvas=get_local_vas(main_data.cld, self._main_data_model.hw_settings_config),
+            detvas=get_local_vas(main_data.cld, main_data.hw_settings_config),
         )
 
         # Special "safety" feature to avoid having a too high gain at start
@@ -1835,10 +1835,10 @@ class SparcStreamsController(StreamBarController):
             main_data.ebeam,
             main_data.light,
             sstage=main_data.scan_stage,
-            opm=self._main_data_model.opm,
+            opm=main_data.opm,
             axis_map=axes,
-            # emtvas=get_local_vas(main_data.ebeam, self._main_data_model.hw_settings_config), # no need
-            detvas=get_local_vas(detector, self._main_data_model.hw_settings_config),
+            # emtvas=get_local_vas(main_data.ebeam, main_data.hw_settings_config), # no need
+            detvas=get_local_vas(detector, main_data.hw_settings_config),
         )
         self._set_default_spectrum_axes(spec_stream)
 
@@ -1856,7 +1856,7 @@ class SparcStreamsController(StreamBarController):
         """
         main_data = self._main_data_model
 
-        detvas = get_local_vas(main_data.ccd, self._main_data_model.hw_settings_config)
+        detvas = get_local_vas(main_data.ccd, main_data.hw_settings_config)
         # For ek acquisition we use a horizontal and a vertical binning
         # which are instantiated in the AngularSpectrumSettingsStream.
         # Removes binning from local (GUI) VAs to use a vertical and horizontal binning
@@ -1886,7 +1886,7 @@ class SparcStreamsController(StreamBarController):
             spectrograph,
             analyzer=main_data.pol_analyzer,
             sstage=main_data.scan_stage,
-            opm=self._main_data_model.opm,
+            opm=main_data.opm,
             axis_map=axes,
             detvas=detvas,
         )
@@ -1905,7 +1905,7 @@ class SparcStreamsController(StreamBarController):
 
         main_data = self._main_data_model
 
-        detvas = get_local_vas(main_data.streak_ccd, self._main_data_model.hw_settings_config)
+        detvas = get_local_vas(main_data.streak_ccd, main_data.hw_settings_config)
 
         if main_data.streak_ccd.exposureTime.range[1] < 86400:  # 24h
             # remove exposureTime from local (GUI) VAs to use a new one, which allows to integrate images
@@ -1936,10 +1936,10 @@ class SparcStreamsController(StreamBarController):
             main_data.streak_unit,
             main_data.streak_delay,
             sstage=main_data.scan_stage,
-            opm=self._main_data_model.opm,
+            opm=main_data.opm,
             axis_map=axes,
             detvas=detvas,
-            streak_unit_vas=get_local_vas(main_data.streak_unit, self._main_data_model.hw_settings_config))
+            streak_unit_vas=get_local_vas(main_data.streak_unit, main_data.hw_settings_config))
         self._set_default_spectrum_axes(ts_stream)
         # For safety, always start with the shutter closed.
         if model.hasVA(ts_stream, "detShutter"):
@@ -1980,10 +1980,10 @@ class SparcStreamsController(StreamBarController):
             main_data.monochromator.data,
             main_data.ebeam,
             sstage=main_data.scan_stage,
-            opm=self._main_data_model.opm,
+            opm=main_data.opm,
             axis_map=axes,
             emtvas={"dwellTime"},
-            detvas=get_local_vas(main_data.monochromator, self._main_data_model.hw_settings_config),
+            detvas=get_local_vas(main_data.monochromator, main_data.hw_settings_config),
         )
         self._set_default_spectrum_axes(monoch_stream)
 
@@ -2027,9 +2027,9 @@ class SparcStreamsController(StreamBarController):
             main_data.time_correlator,
             main_data.time_correlator.data,
             main_data.ebeam,
-            opm=self._main_data_model.opm,
+            opm=main_data.opm,
             axis_map=axes,
-            detvas=get_local_vas(main_data.time_correlator, self._main_data_model.hw_settings_config)
+            detvas=get_local_vas(main_data.time_correlator, main_data.hw_settings_config)
         )
 
         # Create the equivalent MDStream

--- a/src/odemis/odemisd/mdupdater.py
+++ b/src/odemis/odemisd/mdupdater.py
@@ -392,14 +392,14 @@ class MetadataUpdater(model.Component):
         Its metadata will be updated.
         :param filter: a (light) filter-(wheel) component (should have a "band" axis)
         :param spectrograph: a spectrograph component (should have a "wavelength" axis)
-        Only used if the detector has the role "monochromator".
+        Only used if the detector has the role "monochromator", "time-correlator" or "photo-detector".
         """
         filter_pos = self.get_filter_pos(filter)
 
         # We only need to care about the spectrograph in the case of the monochromator, because for
         # the other types of components (eg, spectrometer), MD_OUT_WL is used exclusively for the
         # filter info, and the MD_WL_LIST is used to store the wavelength info (handled separately).
-        if comp_affected.role == "monochromator":
+        if any(comp_affected.role.startswith(r) for r in ("monochromator", "time-correlator", "photo-detector")):
             spec_bandwidth = self.getMonochromatorBandwidth(spectrograph)  # None if wavelength == 0
         else:
             spec_bandwidth = None
@@ -424,11 +424,12 @@ class MetadataUpdater(model.Component):
                 logging.debug("Updating %s with intersection of filter %s and spectrograph %s -> %s",
                               comp_affected.name, filter_bandwidth, spec_bandwidth, bandwidth)
 
+        logging.debug("Updating output wavelength for component %s to %s", comp_affected.name, bandwidth)
         comp_affected.updateMetadata({model.MD_OUT_WL: bandwidth})
 
-    def observeSpectrograph(self, spectrograph, comp_affected):
+    def observeSpectrograph(self, spectrograph, comp_affected) -> bool:
 
-        if comp_affected.role == "monochromator":
+        if any(comp_affected.role.startswith(r) for r in ("monochromator", "time-correlator", "photo-detector")):
             def updateOutWLRange(pos, sp=spectrograph, comp_affected=comp_affected):
                 self.updateOutWavelength(comp_affected,
                                          self._det_to_filter.get(comp_affected.name),


### PR DESCRIPTION
Add support for placing the optical fiber going to the LabCube after spectrograph instead of before. That means that the labcube now receives a very narrow band of the light wavelength. IOW, this allows time correlator acquisitions wavelength specific. 
In practice, this means this changes:
* Show the settings to control the spectrograph in the time correlator stream, if in such configuration
* Metadata of the acquisition contains the wavelength band based on the output slit of the spectrograph
* Automatic protection of the labcube detectors when the spectrograph moves
* Special plugin to help the alignment of the fiber