### PR TITLE
[test] Fix some static stream test cases

### DIFF
--- a/.github/workflows/unit_tests_cloud.yml
+++ b/.github/workflows/unit_tests_cloud.yml
@@ -219,6 +219,12 @@ jobs:
         export PYTHONPATH="$PWD/src:$PYTHONPATH"
         python3 -m unittest src.odemis.acq.test.fastem_test.TestFastEMAcquisitionTaskMock --verbose
 
+    - name: Run tests for static Streams
+      if: ${{ !cancelled() }}
+      run: |
+        export PYTHONPATH="$PWD/src:$PYTHONPATH"
+        python3 -m unittest src/odemis/acq/test/stream_static_test.py --verbose
+
     - name: Run tests from odemis.util.raster
       if: ${{ !cancelled() }}
       run: |

--- a/src/odemis/acq/test/stream_static_test.py
+++ b/src/odemis/acq/test/stream_static_test.py
@@ -571,7 +571,7 @@ class StaticStreamsTestCase(unittest.TestCase):
                 e.set()
 
         ars_vis_pol.image.subscribe(on_im)  # when .image VA changes, call on_im(.image.value)
-        e.wait(40.0)  # It can take a long time
+        e.wait(90.0)  # It can take a long time (especially since libqhull v8)
         assert e.is_set()
         time.sleep(1.0)  # wait shortly as .image is updated multiple times
 

--- a/src/odemis/acq/test/stream_static_test.py
+++ b/src/odemis/acq/test/stream_static_test.py
@@ -1386,6 +1386,7 @@ class StaticStreamsTestCase(unittest.TestCase):
         line = numpy.linspace(0, 255, num_cols, dtype=dtype)
         column = numpy.linspace(0, 255, num_rows, dtype=dtype)
 
+        # Create a gradient, with red horizontally, and green vertically. Blue is 0 everywhere.
         # each row has values from 0 to 255, linearly distributed
         arr[:, :, 0] = numpy.tile(line, (num_rows, 1))
         # each column has values from 0 to 255, linearly distributed
@@ -1413,7 +1414,7 @@ class StaticStreamsTestCase(unittest.TestCase):
         # change both .rect and .mpp at the same time, to the same values
         # that are set on Stream constructor
         pj.rect.value = full_image_rect  # full image
-        pj.mpp.value = pj.mpp.range[1]  # maximum zoom level
+        pj.mpp.value = pj.mpp.range[1]  # minimum zoom level
 
         # Wait a little bit to make sure the image has been generated
         time.sleep(0.2)
@@ -1422,13 +1423,14 @@ class StaticStreamsTestCase(unittest.TestCase):
         self.assertEqual(len(pj.image.value), 2)
         self.assertEqual(len(pj.image.value[0]), 1)
         # top-left pixel of the left tile
-        numpy.testing.assert_array_equal([0, 0, 0], pj.image.value[0][0][0, 0, :])
-        # top-right pixel of the left tile
-        numpy.testing.assert_array_equal([173, 0, 0], pj.image.value[0][0][0, 255, :])
+        numpy.testing.assert_allclose([0, 0, 0], pj.image.value[0][0][0, 0, :])
+        # top-right pixel of the left tile (which is little bit more half-way as the tile is 256px,
+        # this covers more than the half the 375 px at minimum zoom -> 255*256/375 ~ 174, depending on the rounding)
+        numpy.testing.assert_allclose([174, 0, 0], pj.image.value[0][0][0, 255, :], atol=1)
         # bottom-left pixel of the left tile
-        numpy.testing.assert_array_equal([0, 254, 0], pj.image.value[0][0][249, 0, :])
+        numpy.testing.assert_allclose([0, 255, 0], pj.image.value[0][0][249, 0, :], atol=1)
         # bottom-right pixel of the right tile
-        numpy.testing.assert_array_equal([254, 254, 0], pj.image.value[1][0][249, 117, :])
+        numpy.testing.assert_allclose([255, 255, 0], pj.image.value[1][0][249, 117, :], atol=1)
 
         # really small rect on the center, the tile is in the cache
         pj.rect.value = (POS[0], POS[1], POS[0] + 0.00001, POS[1] + 0.00001)
@@ -1440,11 +1442,11 @@ class StaticStreamsTestCase(unittest.TestCase):
         self.assertEqual(len(pj.image.value), 1)
         self.assertEqual(len(pj.image.value[0]), 1)
         # top-left pixel of the only tile
-        numpy.testing.assert_array_equal([0, 0, 0], pj.image.value[0][0][0, 0, :])
+        numpy.testing.assert_allclose([0, 0, 0], pj.image.value[0][0][0, 0, :], atol=1)
         # top-right pixel of the only tile
-        numpy.testing.assert_array_equal([173, 0, 0], pj.image.value[0][0][0, 255, :])
+        numpy.testing.assert_allclose([174, 0, 0], pj.image.value[0][0][0, 255, :], atol=1)
         # bottom-left pixel of the only tile
-        numpy.testing.assert_array_equal([0, 254, 0], pj.image.value[0][0][249, 0, :])
+        numpy.testing.assert_allclose([0, 255, 0], pj.image.value[0][0][249, 0, :], atol=1)
 
         # Now, just the tiny rect again, but at the minimum mpp (= fully zoomed in)
         # => should just need one new tile
@@ -1457,13 +1459,13 @@ class StaticStreamsTestCase(unittest.TestCase):
         self.assertEqual(len(pj.image.value), 1)
         self.assertEqual(len(pj.image.value[0]), 1)
         # top-left pixel of the only tile
-        numpy.testing.assert_array_equal([108, 97, 0], pj.image.value[0][0][0, 0, :])
+        numpy.testing.assert_allclose([108, 97, 0], pj.image.value[0][0][0, 0, :], atol=1)
         # top-right pixel of the only tile
-        numpy.testing.assert_array_equal([130, 97, 0], pj.image.value[0][0][0, 255, :])
+        numpy.testing.assert_allclose([130, 97, 0], pj.image.value[0][0][0, 255, :], atol=1)
         # bottom-left pixel of the only tile
-        numpy.testing.assert_array_equal([108, 130, 0], pj.image.value[0][0][255, 0, :])
+        numpy.testing.assert_allclose([108, 130, 0], pj.image.value[0][0][255, 0, :], atol=1)
         # bottom-right pixel of the only tile
-        numpy.testing.assert_array_equal([130, 130, 0], pj.image.value[0][0][255, 255, :])
+        numpy.testing.assert_allclose([130, 130, 0], pj.image.value[0][0][255, 255, :], atol=1)
 
         # changing .rect and .mpp simultaneously
         # Note: the recommended way is to first change mpp and then rect, as it
@@ -1489,11 +1491,11 @@ class StaticStreamsTestCase(unittest.TestCase):
         self.assertEqual(len(pj.image.value[0]), 1)
 
         # top-left pixel of the left tile
-        numpy.testing.assert_array_equal([0, 0, 0], pj.image.value[0][0][0, 0, :])
+        numpy.testing.assert_allclose([0, 0, 0], pj.image.value[0][0][0, 0, :], atol=1)
         # bottom-right pixel of the left tile
-        numpy.testing.assert_array_equal([173, 0, 0], pj.image.value[0][0][0, 255, :])
-        # bottom-right pixel of right right
-        numpy.testing.assert_array_equal([254, 254, 0], pj.image.value[1][0][249, 117, :])
+        numpy.testing.assert_allclose([174, 0, 0], pj.image.value[0][0][0, 255, :], atol=1)
+        # bottom-right pixel of right tile
+        numpy.testing.assert_allclose([255, 255, 0], pj.image.value[1][0][249, 117, :], atol=1)
 
         read_tiles = []  # reset, to keep the numbers simple
 
@@ -1513,13 +1515,13 @@ class StaticStreamsTestCase(unittest.TestCase):
         self.assertEqual(len(pj.image.value), 3)
         self.assertEqual(len(pj.image.value[0]), 2)
         # top-left pixel of a center tile
-        numpy.testing.assert_array_equal([87, 0, 0], pj.image.value[1][0][0, 0, :])
+        numpy.testing.assert_allclose([88, 0, 0], pj.image.value[1][0][0, 0, :], atol=1)
         # top-right pixel of a center tile
-        numpy.testing.assert_array_equal([173, 0, 0], pj.image.value[1][0][0, 255, :])
+        numpy.testing.assert_allclose([174, 0, 0], pj.image.value[1][0][0, 255, :], atol=1)
         # bottom-left pixel of a center tile
-        numpy.testing.assert_array_equal([87, 130, 0], pj.image.value[1][0][255, 0, :])
+        numpy.testing.assert_allclose([88, 130, 0], pj.image.value[1][0][255, 0, :], atol=1)
         # bottom pixel of a center tile
-        numpy.testing.assert_array_equal([173, 130, 0], pj.image.value[1][0][255, 255, :])
+        numpy.testing.assert_allclose([174, 130, 0], pj.image.value[1][0][255, 255, :], atol=1)
 
         delta = [d / 8 for d in dfr]
         # this rect is 1/8 the size of the full image, in the center of the image
@@ -1532,18 +1534,18 @@ class StaticStreamsTestCase(unittest.TestCase):
         # Wait a little bit to make sure the image has been generated
         time.sleep(0.5)
 
-        # reads 4 tiles from the disk, no tile is cached becase the zoom changed
+        # reads 4 tiles from the disk, no tile is cached because the zoom changed
         self.assertEqual(10, len(read_tiles))
         self.assertEqual(len(pj.image.value), 2)
         self.assertEqual(len(pj.image.value[0]), 2)
         # top-left pixel of the top-left tile
-        numpy.testing.assert_array_equal([108, 97, 0], pj.image.value[0][0][0, 0, :])
+        numpy.testing.assert_allclose([108, 97, 0], pj.image.value[0][0][0, 0, :], atol=1)
         # top-right pixel of top-left tile
-        numpy.testing.assert_array_equal([130, 97, 0], pj.image.value[0][0][0, 255, :])
+        numpy.testing.assert_allclose([130, 97, 0], pj.image.value[0][0][0, 255, :], atol=1)
         # bottom-left pixel of top-left tile
-        numpy.testing.assert_array_equal([108, 130, 0], pj.image.value[0][0][255, 0, :])
+        numpy.testing.assert_allclose([108, 130, 0], pj.image.value[0][0][255, 0, :], atol=1)
         # bottom pixel of top-left tile
-        numpy.testing.assert_array_equal([130, 130, 0], pj.image.value[0][0][255, 255, :])
+        numpy.testing.assert_allclose([130, 130, 0], pj.image.value[0][0][255, 255, :], atol=1)
 
         # get the old function back to the class
         tiff.DataArrayShadowPyramidalTIFF.getTile = tiff.DataArrayShadowPyramidalTIFF._getTileOldSZ


### PR DESCRIPTION
The test checks the values based on the average of multiple pixels in a
gradient. Just variation on how the smaller images are computed can
cause changes of 1 in the absolute number. For instance, the 256th pixel over 375
used to be 173, but it's now computed as 174. Visually, it was checked
that the computation is still correct. So, let's losen a little bit
the constraints (+- 1).

Most probably this test failed for a very long time. However, it used to
be "shadowed" because of the 30 min limit when running test cases. Now
that it's in a separate file, it's noticeable.

Also let the arpolarimetry test be more patient.
Also add all these static stream test to the cloud CI.