### PR TITLE
[feat] use sample stage on all METEOR types

### DIFF
--- a/src/odemis/acq/move.py
+++ b/src/odemis/acq/move.py
@@ -869,6 +869,7 @@ class MeteorTFS1PostureManager(MeteorPostureManager):
         self.pre_tilt = comp.getMetadata()[model.MD_ROTATION_COR]
         self.postures = [SEM_IMAGING, FM_IMAGING]
         self._initialise_transformation(axes=["y", "z"], rotation=self.pre_tilt)
+        self.create_sample_stage()
 
     def getTargetPosition(self, target_pos_lbl: int) -> Dict[str, float]:
         """
@@ -1326,6 +1327,7 @@ class MeteorZeiss1PostureManager(MeteorPostureManager):
         self.postures = [SEM_IMAGING, FM_IMAGING]
         # Automatic conversion to sample-stage axes
         self._initialise_transformation(axes=["y", "m"], rotation=self.pre_tilt)
+        self.create_sample_stage()
 
     def from_sample_stage_to_stage_position(self, pos: Dict[str, float]) -> Dict[str, float]:
         new_pos = super().from_sample_stage_to_stage_position(pos)

--- a/src/odemis/odemisd/mdupdater.py
+++ b/src/odemis/odemisd/mdupdater.py
@@ -156,6 +156,9 @@ class MetadataUpdater(model.Component):
         return bool: True if will actually update the affected component,
                      False if the affect is not supported (here)
         """
+        if self._mic.role == "meteor":
+            logging.warning("Stage on METEOR is deprecated, not using it for the MD_POS")
+            return False
 
         # we need to keep the information on the detector to update
         def updateStagePos(pos, comp_affected=comp_affected):


### PR DESCRIPTION
TFS1 and Zeiss were not yet (fully) using the sample stage. However, there is too
many assumption in the rest of the GUI about using the sample stage,
which caused these systems to not work anymore. In particular creating a Feature failed.

The issue was introduced when computing the offset to have the same
position of the feature in the sample stage independent of the posture.

=> Also provide sample stage on the (last) type of METEOR which didn't
have it.

Need to also add a trick to the mdupdater to avoid the original "stage"
component from updating the ccd MD_POS, as it would interfere with the
MD_POS from the sample stage.