### PR TITLE
[fix] PostureManager: adjust orientation of sample stage in SEM imaging posture

### DIFF
--- a/install/linux/usr/share/odemis/sim/meteor-fibsem-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/meteor-fibsem-sim.odm.yaml
@@ -30,15 +30,20 @@
     role: e-beam,
     init: {
         hfw_nomag: 0.25, # hfw when mag == 1x
-    }
+    },
+    properties: {
+        # Set scan rotation to 180°, which is the standard, to ensure the camera
+        # rotation is matching.
+        rotation: 3.141592653589,  # rad, 180°
+    },
 }
 
 "Electron-Detector": {
     role: se-detector,
     init: {},
     properties: {
-        medianFilter: 3,
-    }
+        # medianFilter: 3,
+    },
 }
 
 "Electron-Focus": {
@@ -51,7 +56,12 @@
     role: "ion-beam",
     init: {
         hfw_nomag: 0.25, # hfw when mag == 1x
-    }
+    },
+    properties: {
+        # Set scan rotation to 180°, which is the standard, to ensure the camera
+        # rotation is matching.
+        rotation: 3.141592653589,  # rad, 180°
+    },
 }
 
 "Ion-Detector": {
@@ -59,7 +69,7 @@
     init: {},
     properties: {
         medianFilter: 3,
-    }
+    },
 }
 
 "Ion-Focus": {

--- a/install/linux/usr/share/odemis/sim/meteor-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/meteor-sim.odm.yaml
@@ -58,7 +58,7 @@
         port: "/dev/fake6",
         address: null,
         axes: ["x", "y", "z", "rx", "rz"],
-        ustepsize: [1.e-7, 1.e-7, 1.e-7, 1.2e-5, 1.2e-5], # unit/µstep
+        ustepsize: [1.e-6, 1.e-6, 1.e-6, 1.2e-4, 1.2e-4], # unit/µstep
         rng: [[-0.1, 0.1], [-0.05, 0.05], [-0.05, 0.1], [-2, 2], [0, 6.28]],
         unit: ["m", "m", "m", "rad", "rad"],
         refproc: "Standard",

--- a/install/linux/usr/share/odemis/sim/meteor-tescan-fibsem-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/meteor-tescan-fibsem-sim.odm.yaml
@@ -31,6 +31,11 @@
     init: {
         fov_range: [200.e-9, 6600.e-6]
     },
+    properties: {
+        # Set scan rotation to 180°, which is the standard, to ensure the camera
+        # rotation is matching.
+        rotation: 3.141592653589,  # rad, 180°
+    },
 }
 
 "Electron-Detector": {
@@ -54,6 +59,11 @@
     role: ion-beam,
     init: {
         fov_range: [196.e-9, 25586.e-6]
+    },
+    properties: {
+        # Set scan rotation to 180°, which is the standard, to ensure the camera
+        # rotation is matching.
+        rotation: 3.141592653589,  # rad, 180°
     },
 }
 

--- a/install/linux/usr/share/odemis/sim/meteor-zeiss-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/meteor-zeiss-sim.odm.yaml
@@ -139,8 +139,7 @@
 }
 
 # Controller for the filter-wheel
-# TMCM-6110: DIP must be configured with address 7 (= 1110000)
-# TMCM-1211: Must be pre-initiliazed with address 17
+# DIP must be configured with address 7 (= 1110000)
 "Optical Actuators": {
     class: tmcm.TMCLController,
     role: null,
@@ -149,7 +148,7 @@
         address: null, # Simulator
         # param_file: "/usr/share/odemis/meteor-tmcm1211-filterwheel.tmcm.tsv",
         axes: ["fw"],
-        ustepsize: [1.227184e-6], # [rad/µstep]
+        ustepsize: [1.227184e-3], # [rad/µstep]  fake value for simulator
         rng: [[-14, 7]], # rad, more than 0->2 Pi, in order to allow one extra rotation in both direction, when quickly switching
         unit: ["rad"],
         refproc: "Standard",

--- a/src/odemis/acq/test/move_tfs3_test.py
+++ b/src/odemis/acq/test/move_tfs3_test.py
@@ -26,7 +26,7 @@ import numpy
 import odemis
 from odemis import model
 from odemis.acq.move import (FM_IMAGING, GRID_1, MILLING, SEM_IMAGING, UNKNOWN, POSITION_NAMES,
-                             MeteorTFS3PostureManager, LOADING)
+                             MeteorTFS3PostureManager, LOADING, GRID_2)
 from odemis.acq.move import MicroscopePostureManager
 from odemis.util import testing
 from odemis.util.driver import isNearPosition
@@ -177,6 +177,38 @@ class TestMeteorTFS3Move(unittest.TestCase):
 
             self.assertTrue(isNearPosition(new_pos, abs_pos,
                                                   axes={"x", "y", "z"}))
+
+    def test_sample_stage_invariance(self):
+        """
+        Check the same position on the sample, for all posture results in the same sample stage coordinates
+        """
+        stage_md = self.stage_bare.getMetadata()
+
+        # Grid positions are defined in the stage bare coordinates, on the SEM_IMAGING posture
+        # They only contain the linear axes (x, y, z, m).
+        # The rotation axes are defined on MD_FAV_SEM_POS_ACTIVE.
+        sem_grid1_pos = stage_md[model.MD_SAMPLE_CENTERS][POSITION_NAMES[GRID_1]]
+        sem_grid1_pos.update(stage_md[model.MD_FAV_SEM_POS_ACTIVE])
+
+        sem_grid2_pos = stage_md[model.MD_SAMPLE_CENTERS][POSITION_NAMES[GRID_2]]
+        sem_grid2_pos.update(stage_md[model.MD_FAV_SEM_POS_ACTIVE])
+
+        # "arbitrary" positions on the SEM posture in stage bare coordinates
+        pos_bares = [sem_grid1_pos, sem_grid2_pos]
+
+        for pos_bare in pos_bares:
+            pos_sample_ref = None
+            for posture in self.pm.postures:
+                # Convert the SEM position the same position in the other posture
+                pos_bare_switched = self.pm.to_posture(pos_bare, posture)
+                # Convert to sample stage coordinates
+                pos_sample = self.pm.to_sample_stage_from_stage_position(pos_bare_switched, posture)
+                logging.debug("Position %s in posture %s: %s",  pos_bare, POSITION_NAMES[posture], pos_sample)
+
+                if pos_sample_ref is None:
+                    pos_sample_ref = pos_sample
+                else:
+                    testing.assert_pos_almost_equal(pos_sample, pos_sample_ref, atol=1e-6)
 
 
     def test_scan_rotation(self):

--- a/src/odemis/acq/test/move_tfs3_test.py
+++ b/src/odemis/acq/test/move_tfs3_test.py
@@ -30,7 +30,6 @@ from odemis.acq.move import (FM_IMAGING, GRID_1, MILLING, SEM_IMAGING, UNKNOWN, 
 from odemis.acq.move import MicroscopePostureManager
 from odemis.util import testing
 from odemis.util.driver import isNearPosition
-from odemis.util.transform import get_rotation_transforms
 
 logging.getLogger().setLevel(logging.DEBUG)
 logging.basicConfig(format="%(asctime)s  %(levelname)-7s %(module)s:%(lineno)d %(message)s")
@@ -179,40 +178,6 @@ class TestMeteorTFS3Move(unittest.TestCase):
             self.assertTrue(isNearPosition(new_pos, abs_pos,
                                                   axes={"x", "y", "z"}))
 
-    def test_transformation_calculation(self):
-        """Simple tests for 3D transform calculations"""
-
-        tf, tf_inv = get_rotation_transforms(rx=0)
-        self.assertEqual(tf.shape, (3, 3))
-        self.assertEqual(tf_inv.shape, (3, 3))
-        numpy.testing.assert_array_almost_equal(tf, numpy.eye(3))
-        numpy.testing.assert_array_almost_equal(tf_inv, numpy.eye(3))
-
-        # rotation around x-axis
-        rx = math.radians(45)
-        tf, tf_inv = get_rotation_transforms(rx=rx)
-        tf_rx = numpy.array(
-                [[1, 0, 0],
-                [0, numpy.cos(rx), -numpy.sin(rx)],
-                [0, numpy.sin(rx), numpy.cos(rx)]])
-        numpy.testing.assert_array_almost_equal(tf, tf_rx)
-        numpy.testing.assert_array_almost_equal(tf_inv, numpy.linalg.inv(tf_rx))
-
-        # rotation around z-axis
-        rz = math.radians(180)
-        tf, tf_inv = get_rotation_transforms(rz=rz)
-        tf_rz = numpy.array([
-            [numpy.cos(rz), -numpy.sin(rz), 0],
-            [numpy.sin(rz), numpy.cos(rz), 0],
-            [0, 0, 1]])
-        numpy.testing.assert_array_almost_equal(tf, tf_rz)
-        numpy.testing.assert_array_almost_equal(tf_inv, numpy.linalg.inv(tf_rz))
-
-        # multiply two rotations (rz, rx)
-        tf, tf_inv = get_rotation_transforms(rx=rx, rz=rz)
-        tf_2 = numpy.dot(tf_rz, tf_rx)
-        numpy.testing.assert_array_almost_equal(tf, tf_2)
-        numpy.testing.assert_array_almost_equal(tf_inv, numpy.linalg.inv(tf_2))
 
     def test_scan_rotation(self):
         # TODO: implement once completed

--- a/src/odemis/util/transform.py
+++ b/src/odemis/util/transform.py
@@ -1299,6 +1299,7 @@ class RigidTransform(SimilarityTransform):
     def _estimate_matrix(x: numpy.ndarray, y: numpy.ndarray) -> numpy.ndarray:
         return _optimal_rotation(x, y)
 
+
 def get_rotation_transforms(rx: float = 0, ry: float = 0, rz: float = 0) -> Tuple[numpy.ndarray, numpy.ndarray]:
     """
     Get the transformation matrix (and inverse) for the given set of rotations (around x, y, z).


### PR DESCRIPTION
On TFS1 and Zeiss, the position of the features was shown rotated by 180° in the SEM imaging posture.
    
* Rewrite the transformation matrices formula to be clearer
* FM imaging direction should be 180° opposite to the SEM imaging, as rx is set to +180°
* Similarly to Tescan, assume that if the SEM has scan rotation, then CCD is also rotated, to match SEM orientation
* Also introduce a new default scan rotation. It's 180° on TFS and Zeiss.

In practice, this means that systems with e-beam and ion-beam components with 180° scan rotation, there is not change. On systems with these components, but 0° scan rotation, the sample stage in FM posture will be reversed in XY. There shouldn't be any such system, but if that's the case, the fix is to either use a 180° scan rotation, or adjust "transp" on the CCD.
On systems without these components, there will be no change in FM, but in SEM posture, the feature will be in the same orientation. 
