### PR TITLE
[fix] GUI METEOR correlation window: remove unecessary alignment flag

### DIFF
--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -1937,6 +1937,7 @@ b\xeb\x85\x9f\xb6B\x1d\x0cK\x17\xac\xf0\x12\xfe\xa0\xe5\xee\xe03\xb1\xfa\
             <orient>wxVERTICAL</orient>
             <object class="sizeritem">
               <object class="wxBoxSizer">
+                <orient>wxHORIZONTAL</orient>
                 <object class="spacer">
                   <option>1</option>
                   <flag>wxEXPAND</flag>
@@ -1948,7 +1949,6 @@ b\xeb\x85\x9f\xb6B\x1d\x0cK\x17\xac\xf0\x12\xfe\xa0\xe5\xee\xe03\xb1\xfa\
                       <assign_var>1</assign_var>
                     </XRCED>
                   </object>
-                  <flag>wxALIGN_RIGHT</flag>
                 </object>
                 <object class="spacer">
                   <option>1</option>

--- a/src/odemis/gui/xmlh/resources/dialog_correlation_tdct.xrc
+++ b/src/odemis/gui/xmlh/resources/dialog_correlation_tdct.xrc
@@ -13,6 +13,7 @@
             <orient>wxVERTICAL</orient>
             <object class="sizeritem">
               <object class="wxBoxSizer">
+                <orient>wxHORIZONTAL</orient>
                 <object class="spacer">
                   <option>1</option>
                   <flag>wxEXPAND</flag>
@@ -24,7 +25,6 @@
                       <assign_var>1</assign_var>
                     </XRCED>
                   </object>
-                  <flag>wxALIGN_RIGHT</flag>
                 </object>
                 <object class="spacer">
                   <option>1</option>


### PR DESCRIPTION
This avoids complains by wxPython 4.1+ (as found on Ubuntu 24.04)