### PR TITLE
[test] PostureManager test: avoid running TFS tests also in the Zeiss and Tescan tests

### DIFF
--- a/src/odemis/acq/test/move_tescan_test.py
+++ b/src/odemis/acq/test/move_tescan_test.py
@@ -23,9 +23,9 @@ import unittest
 
 import odemis
 from odemis import model
-from odemis.acq.move import (FM_IMAGING, SEM_IMAGING, UNKNOWN, MicroscopePostureManager, MeteorTescan1PostureManager, LOADING, MILLING)
-from odemis.acq.test.move_tfs1_test import TestMeteorTFS1Move
-from odemis.acq.test.move_tfs3_test import TestMeteorTFS3Move
+from odemis.acq.move import (FM_IMAGING, SEM_IMAGING, UNKNOWN, MicroscopePostureManager,
+                             MeteorTescan1PostureManager, LOADING, MILLING)
+from odemis.acq.test import move_tfs1_test, move_tfs3_test
 from odemis.util import testing
 
 logging.getLogger().setLevel(logging.DEBUG)
@@ -38,7 +38,7 @@ METEOR_TESCAN1_SIM_CONFIG = CONFIG_PATH + "sim/meteor-tescan-fibsem-full-sim.odm
 TEST_NOHW = (os.environ.get("TEST_NOHW", "0") != "0")  # Default to Hw testing
 
 
-class TestMeteorTescan1Move(TestMeteorTFS1Move):
+class TestMeteorTescan1Move(move_tfs1_test.TestMeteorTFS1Move):
     """
     Test the MeteorPostureManager functions for Tescan 1
     """
@@ -173,7 +173,7 @@ class TestMeteorTescan1Move(TestMeteorTFS1Move):
         self.assertAlmostEqual(zshift["z"], shift["z"], places=5)
 
 
-class TestMeteorTescan1FibsemMove(TestMeteorTFS3Move):
+class TestMeteorTescan1FibsemMove(move_tfs3_test.TestMeteorTFS3Move):
     if TEST_NOHW:
         MIC_CONFIG = METEOR_TESCAN1_SIM_CONFIG
     else:

--- a/src/odemis/acq/test/move_tfs3_test.py
+++ b/src/odemis/acq/test/move_tfs3_test.py
@@ -21,8 +21,6 @@ import os
 import time
 import unittest
 
-import numpy
-
 import odemis
 from odemis import model
 from odemis.acq.move import (FM_IMAGING, GRID_1, MILLING, SEM_IMAGING, UNKNOWN, POSITION_NAMES,

--- a/src/odemis/acq/test/move_zeiss_test.py
+++ b/src/odemis/acq/test/move_zeiss_test.py
@@ -22,9 +22,8 @@ import unittest
 
 import odemis
 from odemis import model
-from odemis.acq.move import (GRID_1, GRID_2, UNKNOWN, POSITION_NAMES,
-)
-from odemis.acq.test.move_tfs1_test import TestMeteorTFS1Move
+from odemis.acq.move import GRID_1, GRID_2, UNKNOWN, POSITION_NAMES
+from odemis.acq.test import move_tfs1_test
 
 logging.getLogger().setLevel(logging.DEBUG)
 logging.basicConfig(format="%(asctime)s  %(levelname)-7s %(module)s:%(lineno)d %(message)s")
@@ -34,7 +33,7 @@ CONFIG_PATH = os.path.dirname(odemis.__file__) + "/../../install/linux/usr/share
 METEOR_ZEISS1_CONFIG = CONFIG_PATH + "sim/meteor-zeiss-sim.odm.yaml"
 
 
-class TestMeteorZeiss1Move(TestMeteorTFS1Move):
+class TestMeteorZeiss1Move(move_tfs1_test.TestMeteorTFS1Move):
     """
     Test the MeteorPostureManager functions for Zeiss 1
     """


### PR DESCRIPTION
The Zeiss and Tescan tests inherits from the TFS tests, to avoid code
duplication.
However, because the files imported directly the test classes (eg, TestMeteorTFS1Move),
these classes were concidered part of the file, and so also run during
the testing.

=> Import only the module containing the classes, so that the test classes are
not directly in the main module, and so they won't be automatically run
by pytest (or unittest)