### PR TITLE
[fix] GUI METEOR mulit point correlation: don't select non existing row

### DIFF
--- a/src/odemis/gui/cont/multi_point_correlation.py
+++ b/src/odemis/gui/cont/multi_point_correlation.py
@@ -764,7 +764,6 @@ class CorrelationPointsController:
                 self.grid.ClearSelection()
             else:
                 current_row_count = self.grid.GetNumberRows()
-                self.grid.SelectRow(current_row_count)
                 self.grid.AppendRows(1)
                 # Get the pixel coordinates of the target and first set the z value in the grid
                 if target.type.value == TargetType.FibFiducial:


### PR DESCRIPTION
Fixes such error, on wxPython 4.1+:
```
2026-02-12 23:27:29,196 ERROR   main:422:       Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/wx/core.py", line 3427, in <lambda>
    lambda event: event.callable(*event.args, **event.kw) )
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/piel/development/odemis/src/odemis/gui/cont/multi_point_correlation.py", line 767, in _on_target_changes
    self.grid.SelectRow(current_row_count)
wx._core.wxAssertionError: C++ assertion "idx >= 0 && idx < m_numRows" failed at ./src/generic/grid.cpp(5221) in GetRowPos(): invalid row index
```