### PR TITLE
[SWM-220][perf] GUI: only load the tabs necessary based on the microscope role

### DIFF
--- a/src/odemis/gui/cont/tabs/__init__.py
+++ b/src/odemis/gui/cont/tabs/__init__.py
@@ -4,7 +4,7 @@
 @author: Rinze de Laat, Éric Piel, Philip Winkler, Victoria Mavrikopoulou,
          Anders Muskens, Bassim Lazem
 
-Copyright © 2012-2022 Rinze de Laat, Éric Piel, Delmic
+Copyright © 2012-2026 Rinze de Laat, Éric Piel, Delmic
 
 Handles the switch of the content of the main GUI tabs.
 
@@ -24,28 +24,5 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 """
 
 from ._constants import *
-from .analysis_tab import AnalysisTab
-from .correlation_tab import CorrelationTab
-from .cryo_chamber_tab import CryoChamberTab
-from .enzel_align_tab import EnzelAlignTab
-from .fastem_acquisition_tab import FastEMAcquisitionTab
-from .fastem_main_tab import FastEMMainTab
-from .fastem_project_ribbons_tab import FastEMProjectRibbonsTab
-from .fastem_project_roas_tab import FastEMProjectROAsTab
-from .fastem_project_sections_tab import FastEMProjectSectionsTab
-from .fastem_project_settings_tab import FastEMProjectSettingsTab
-from .fastem_setup_tab import FastEMSetupTab
-from .fibsem_tab import FibsemTab
-from .fastem_single_beam_tab import FastEMSingleBeamTab
-from .fastem_multi_beam_tab import FastEMMultiBeamTab
-from .fastem_project_toas_tab import FastEMProjectTOAsTab
-from .localization_tab import LocalizationTab
-from .mimas_align_tab import MimasAlignTab
-from .secom_align_tab import SecomAlignTab
-from .secom_streams_tab import SecomStreamsTab
-from .sparc_acquisition_tab import SparcAcquisitionTab
-from .sparc_align_tab import SparcAlignTab
-from .sparc2_align_tab import Sparc2AlignTab
-from .sparc2_chamber_tab import ChamberTab
 from .tab_bar_controller import TabBarController
 from .tab import Tab

--- a/src/odemis/gui/cont/tabs/secom_streams_tab.py
+++ b/src/odemis/gui/cont/tabs/secom_streams_tab.py
@@ -555,9 +555,7 @@ class SecomStreamsTab(Tab):
     @classmethod
     def get_display_priority(cls, main_data):
         # For SECOM/DELPHI and all simple microscopes
-        if main_data.role in ("enzel", "meteor"):
-            return None
-        elif main_data.role in ("secom", "delphi", "sem", "optical"):
+        if main_data.role in ("secom", "delphi", "sem", "optical"):
             return 2
         else:
             return None

--- a/src/odemis/gui/cont/tabs/tab_bar_controller.py
+++ b/src/odemis/gui/cont/tabs/tab_bar_controller.py
@@ -179,12 +179,7 @@ class TabBarController(TabController):
                 tabs.append(tab)
                 assert tab.button not in buttons
                 buttons.add(tab.button)
-
-        # Hides the buttons which are not used
-        for tab_def in tab_defs:
-            b = tab_def["button"]
-            if b not in buttons:
-                b.Hide()
+                tab.button.Show()
 
         # The Odemis Viewer has Analysis and Correlation tabs. The Correlation tab is disabled
         # by default and in this case hide the tab buttons panel. In general, hide the tab buttons

--- a/src/odemis/gui/main.py
+++ b/src/odemis/gui/main.py
@@ -182,97 +182,146 @@ class OdemisGUIApp(wx.App):
             self.main_frame.SetMinSize((1000, 550))
             self.main_frame.Maximize()  # must be done before Show()
 
-            # List of all possible tabs used in Odemis' main GUI
+            # List of all possible tabs used in Odemis' main GUI, and only load the tabs depending on
+            # the current microscope role.
+            from odemis.gui.cont.tabs.analysis_tab import AnalysisTab
+
             tab_defs = [
-                {
-                    # Unique name of the tab
-                    "name": "secom_live",
-                    # Tab controller for this tab
-                    "controller": tabs.SecomStreamsTab,
-                    # Tab button for this tab
-                    "button": self.main_frame.btn_tab_secom_streams,
-                    # Constructor of the tab panel
-                    "panel": main_xrc.xrcpnl_tab_secom_streams
-                },
-                {
-                    "name": "cryosecom-localization",
-                    "controller": tabs.LocalizationTab,
-                    "button": self.main_frame.btn_tab_localization,
-                    "panel": main_xrc.xrcpnl_tab_localization
-                },
-                {
-                    "name": "meteor-correlation",
-                    "controller": tabs.CorrelationTab,
-                    "button": self.main_frame.btn_tab_correlation,
-                    "panel": main_xrc.xrcpnl_tab_correlation
-                },
-                {
-                    "name": "meteor-fibsem",
-                    "controller": tabs.FibsemTab,
-                    "button": self.main_frame.btn_tab_fibsem,
-                    "panel": main_xrc.xrcpnl_tab_fibsem
-                },
-                {
-                    "name": "secom_align",
-                    "controller": tabs.SecomAlignTab,
-                    "button": self.main_frame.btn_tab_align,
-                    "panel": main_xrc.xrcpnl_tab_secom_align
-                },
-                {
-                    "name"      : "enzel_align",
-                    "controller": tabs.EnzelAlignTab,
-                    "button"    : self.main_frame.btn_tab_align_enzel,
-                    "panel"     : main_xrc.xrcpnl_tab_enzel_align
-                },
-                {
-                    "name": "mimas_align",
-                    "controller": tabs.MimasAlignTab,
-                    "button": self.main_frame.btn_tab_align_enzel,  # enzel alignment button is fine
-                    "panel": main_xrc.xrcpnl_tab_mimas_align
-                },
-                {
-                    "name": "sparc_align",
-                    "controller": tabs.SparcAlignTab,
-                    "button": self.main_frame.btn_tab_align,
-                    "panel": main_xrc.xrcpnl_tab_sparc_align
-                },
-                {
-                    "name": "sparc2_align",
-                    "controller": tabs.Sparc2AlignTab,
-                    "button": self.main_frame.btn_tab_align,
-                    "panel": main_xrc.xrcpnl_tab_sparc2_align
-                },
-                {
-                    "name": "sparc_acqui",
-                    "controller": tabs.SparcAcquisitionTab,
-                    "button": self.main_frame.btn_tab_sparc_acqui,
-                    "panel": main_xrc.xrcpnl_tab_sparc_acqui
-                },
-                {
-                    "name": "fastem_main",
-                    "controller": tabs.FastEMMainTab,
-                    "button": self.main_frame.btn_tab_fastem_main,
-                    "panel": main_xrc.xrcpnl_tab_fastem_main
-                },
-                {
-                    "name": "sparc_chamber",
-                    "controller": tabs.ChamberTab,
-                    "button": self.main_frame.btn_tab_sparc_chamber,
-                    "panel": main_xrc.xrcpnl_tab_sparc_chamber
-                },
-                {
-                    "name": "cryosecom_chamber",
-                    "controller": tabs.CryoChamberTab,
-                    "button": self.main_frame.btn_tab_cryosecom_chamber,
-                    "panel": main_xrc.xrcpnl_tab_cryosecom_chamber
-                },
+                # Analysis tab is common to almost all roles, so always load it.
+                # (the mbsem actually doesn't use it, but it's simpler to load it all the time)
                 {
                     "name": "analysis",
-                    "controller": tabs.AnalysisTab,
+                    "controller": AnalysisTab,
                     "button": self.main_frame.btn_tab_inspection,
                     "panel": main_xrc.xrcpnl_tab_inspection
-                },
+                }
             ]
+            if self.main_data.role in ("secom", "delphi", "sem", "optical"):
+                from odemis.gui.cont.tabs.secom_streams_tab import SecomStreamsTab
+                from odemis.gui.cont.tabs.secom_align_tab import SecomAlignTab
+
+                tab_defs.extend([
+                    {
+                        # Unique name of the tab
+                        "name": "secom_live",
+                        # Tab controller for this tab
+                        "controller": SecomStreamsTab,
+                        # Tab button for this tab
+                        "button": self.main_frame.btn_tab_secom_streams,
+                        # Constructor of the tab panel
+                        "panel": main_xrc.xrcpnl_tab_secom_streams
+                    },
+                    {
+                        "name": "secom_align",
+                        "controller": SecomAlignTab,
+                        "button": self.main_frame.btn_tab_align,
+                        "panel": main_xrc.xrcpnl_tab_secom_align
+                    },
+                ])
+            elif self.main_data.role in ("sparc-simplex", "sparc", "sparc2"):
+                from odemis.gui.cont.tabs.sparc_acquisition_tab import SparcAcquisitionTab
+                from odemis.gui.cont.tabs.sparc_align_tab import SparcAlignTab
+                from odemis.gui.cont.tabs.sparc2_align_tab import Sparc2AlignTab
+                from odemis.gui.cont.tabs.sparc2_chamber_tab import ChamberTab
+
+                tab_defs.extend([
+                    {
+                        "name": "sparc_acqui",
+                        "controller": SparcAcquisitionTab,
+                        "button": self.main_frame.btn_tab_sparc_acqui,
+                        "panel": main_xrc.xrcpnl_tab_sparc_acqui
+                    },
+                    {
+                        "name": "sparc_chamber",
+                        "controller": ChamberTab,
+                        "button": self.main_frame.btn_tab_sparc_chamber,
+                        "panel": main_xrc.xrcpnl_tab_sparc_chamber
+                    },
+                    {
+                        "name": "sparc_align",
+                        "controller": SparcAlignTab,
+                        "button": self.main_frame.btn_tab_align,
+                        "panel": main_xrc.xrcpnl_tab_sparc_align
+                    },
+                    {
+                        "name": "sparc2_align",
+                        "controller": Sparc2AlignTab,
+                        "button": self.main_frame.btn_tab_align,
+                        "panel": main_xrc.xrcpnl_tab_sparc2_align
+                    },
+                ])
+
+            elif self.main_data.role in ("meteor",):  # mimas and enzel are deprecated
+                from odemis.gui.cont.tabs.correlation_tab import CorrelationTab
+                from odemis.gui.cont.tabs.cryo_chamber_tab import CryoChamberTab
+                from odemis.gui.cont.tabs.localization_tab import LocalizationTab
+                from odemis.gui.cont.tabs.fibsem_tab import FibsemTab
+
+                tab_defs.extend([
+                    {
+                        "name": "meteor-correlation",
+                        "controller": CorrelationTab,
+                        "button": self.main_frame.btn_tab_correlation,
+                        "panel": main_xrc.xrcpnl_tab_correlation
+                    },
+                    {
+                        "name": "cryosecom_chamber",
+                        "controller": CryoChamberTab,
+                        "button": self.main_frame.btn_tab_cryosecom_chamber,
+                        "panel": main_xrc.xrcpnl_tab_cryosecom_chamber
+                    },
+                    {
+                        "name": "cryosecom-localization",
+                        "controller": LocalizationTab,
+                        "button": self.main_frame.btn_tab_localization,
+                        "panel": main_xrc.xrcpnl_tab_localization
+                    },
+                    {
+                        "name": "meteor-fibsem",
+                        "controller": FibsemTab,
+                        "button": self.main_frame.btn_tab_fibsem,
+                        "panel": main_xrc.xrcpnl_tab_fibsem
+                    },
+                    # Currently unused (enzel and mimas are deprecated)
+                    # {
+                    #     "name": "enzel_align",
+                    #     "controller": EnzelAlignTab,
+                    #     "button": self.main_frame.btn_tab_align_enzel,
+                    #     "panel": main_xrc.xrcpnl_tab_enzel_align
+                    # },
+                    # {
+                    #     "name": "mimas_align",
+                    #     "controller": MimasAlignTab,
+                    #     "button": self.main_frame.btn_tab_align_enzel,  # enzel alignment button is fine
+                    #     "panel": main_xrc.xrcpnl_tab_mimas_align
+                    # },
+                ])
+
+            elif self.main_data.role == "mbsem":
+                from odemis.gui.cont.tabs.fastem_main_tab import FastEMMainTab
+
+                tab_defs.extend([
+                    {
+                        "name": "fastem_main",
+                        "controller": FastEMMainTab,
+                        "button": self.main_frame.btn_tab_fastem_main,
+                        "panel": main_xrc.xrcpnl_tab_fastem_main
+                    },
+                ])
+            elif self.main_data.role is None:  # viewer
+                # Correlation tab is also an option on the viewer.
+                from odemis.gui.cont.tabs.correlation_tab import CorrelationTab
+
+                tab_defs.extend([
+                    {
+                        "name": "meteor-correlation",
+                        "controller": CorrelationTab,
+                        "button": self.main_frame.btn_tab_correlation,
+                        "panel": main_xrc.xrcpnl_tab_correlation
+                    },
+                ])
+            else:
+                logging.warning("Unknown microscope role '%s', no specific tab will be loaded", self.main_data.role)
 
             # Create the main tab controller and store a global reference
             # in the odemis.gui.cont package

--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -3101,6 +3101,7 @@ b\xeb\x85\x9f\xb6B\x1d\x0cK\x17\xac\xf0\x12\xfe\xa0\xe5\xee\xe03\xb1\xfa\
             <object class="sizeritem">
               <object class="TabButton" name="btn_tab_cryosecom_chamber">
                 <size>160,30</size>
+                <hidden>1</hidden>
                 <face_colour>def</face_colour>
                 <label>CHAMBER</label>
                 <fg>#E5E5E5</fg>
@@ -3120,6 +3121,7 @@ b\xeb\x85\x9f\xb6B\x1d\x0cK\x17\xac\xf0\x12\xfe\xa0\xe5\xee\xe03\xb1\xfa\
             <object class="sizeritem">
               <object class="TabButton" name="btn_tab_align_enzel">
                 <size>160,30</size>
+                <hidden>1</hidden>
                 <face_colour>def</face_colour>
                 <label>ALIGNMENT</label>
                 <fg>#E5E5E5</fg>
@@ -3139,6 +3141,7 @@ b\xeb\x85\x9f\xb6B\x1d\x0cK\x17\xac\xf0\x12\xfe\xa0\xe5\xee\xe03\xb1\xfa\
             <object class="sizeritem">
               <object class="TabButton" name="btn_tab_secom_streams">
                 <size>160,30</size>
+                <hidden>1</hidden>
                 <face_colour>def</face_colour>
                 <label>STREAMS</label>
                 <fg>#E5E5E5</fg>
@@ -3157,6 +3160,7 @@ b\xeb\x85\x9f\xb6B\x1d\x0cK\x17\xac\xf0\x12\xfe\xa0\xe5\xee\xe03\xb1\xfa\
             <object class="sizeritem">
               <object class="TabButton" name="btn_tab_localization">
                 <size>160,30</size>
+                <hidden>1</hidden>
                 <face_colour>def</face_colour>
                 <label>LOCALIZATION</label>
                 <fg>#E5E5E5</fg>
@@ -3175,6 +3179,7 @@ b\xeb\x85\x9f\xb6B\x1d\x0cK\x17\xac\xf0\x12\xfe\xa0\xe5\xee\xe03\xb1\xfa\
             <object class="sizeritem">
               <object class="TabButton" name="btn_tab_correlation">
                 <size>160,30</size>
+                <hidden>1</hidden>
                 <face_colour>def</face_colour>
                 <label>CORRELATION</label>
                 <fg>#E5E5E5</fg>
@@ -3193,6 +3198,7 @@ b\xeb\x85\x9f\xb6B\x1d\x0cK\x17\xac\xf0\x12\xfe\xa0\xe5\xee\xe03\xb1\xfa\
             <object class="sizeritem">
               <object class="TabButton" name="btn_tab_fibsem">
                 <size>160,30</size>
+                <hidden>1</hidden>
                 <face_colour>def</face_colour>
                 <label>FIBSEM</label>
                 <fg>#E5E5E5</fg>
@@ -3211,6 +3217,7 @@ b\xeb\x85\x9f\xb6B\x1d\x0cK\x17\xac\xf0\x12\xfe\xa0\xe5\xee\xe03\xb1\xfa\
             <object class="sizeritem">
               <object class="TabButton" name="btn_tab_sparc_acqui">
                 <size>160,30</size>
+                <hidden>1</hidden>
                 <face_colour>def</face_colour>
                 <label>ACQUISITION</label>
                 <fg>#E5E5E5</fg>
@@ -3229,6 +3236,7 @@ b\xeb\x85\x9f\xb6B\x1d\x0cK\x17\xac\xf0\x12\xfe\xa0\xe5\xee\xe03\xb1\xfa\
             <object class="sizeritem">
               <object class="TabButton" name="btn_tab_fastem_main">
                 <size>160,30</size>
+                <hidden>1</hidden>
                 <face_colour>def</face_colour>
                 <label>MAIN</label>
                 <fg>#E5E5E5</fg>
@@ -3247,6 +3255,7 @@ b\xeb\x85\x9f\xb6B\x1d\x0cK\x17\xac\xf0\x12\xfe\xa0\xe5\xee\xe03\xb1\xfa\
             <object class="sizeritem">
               <object class="TabButton" name="btn_tab_inspection">
                 <size>160,30</size>
+                <hidden>1</hidden>
                 <face_colour>def</face_colour>
                 <label>ANALYSIS</label>
                 <fg>#E5E5E5</fg>
@@ -3269,6 +3278,7 @@ b\xeb\x85\x9f\xb6B\x1d\x0cK\x17\xac\xf0\x12\xfe\xa0\xe5\xee\xe03\xb1\xfa\
             <object class="sizeritem">
               <object class="TabButton" name="btn_tab_sparc_chamber">
                 <size>160,30</size>
+                <hidden>1</hidden>
                 <face_colour>def</face_colour>
                 <label>CHAMBER</label>
                 <fg>#E5E5E5</fg>
@@ -3306,6 +3316,7 @@ b\xeb\x85\x9f\xb6B\x1d\x0cK\x17\xac\xf0\x12\xfe\xa0\xe5\xee\xe03\xb1\xfa\
             <object class="sizeritem">
               <object class="TabButton" name="btn_tab_align">
                 <size>160,30</size>
+                <hidden>1</hidden>
                 <face_colour>def</face_colour>
                 <label>ALIGNMENT</label>
                 <fg>#E5E5E5</fg>

--- a/src/odemis/gui/xmlh/resources/frame_main.xrc
+++ b/src/odemis/gui/xmlh/resources/frame_main.xrc
@@ -221,6 +221,7 @@
             <object class="sizeritem">
               <object class="TabButton" name="btn_tab_cryosecom_chamber">
                 <size>160,30</size>
+                <hidden>1</hidden>
                 <face_colour>def</face_colour>
                 <label>CHAMBER</label>
                 <fg>#E5E5E5</fg>
@@ -240,6 +241,7 @@
             <object class="sizeritem">
               <object class="TabButton" name="btn_tab_align_enzel">
                 <size>160,30</size>
+                <hidden>1</hidden>
                 <face_colour>def</face_colour>
                 <label>ALIGNMENT</label>
                 <fg>#E5E5E5</fg>
@@ -259,6 +261,7 @@
             <object class="sizeritem">
               <object class="TabButton" name="btn_tab_secom_streams">
                 <size>160,30</size>
+                <hidden>1</hidden>
                 <face_colour>def</face_colour>
                 <label>STREAMS</label>
                 <fg>#E5E5E5</fg>
@@ -277,6 +280,7 @@
             <object class="sizeritem">
               <object class="TabButton" name="btn_tab_localization">
                 <size>160,30</size>
+                <hidden>1</hidden>
                 <face_colour>def</face_colour>
                 <label>LOCALIZATION</label>
                 <fg>#E5E5E5</fg>
@@ -295,6 +299,7 @@
             <object class="sizeritem">
               <object class="TabButton" name="btn_tab_correlation">
                 <size>160,30</size>
+                <hidden>1</hidden>
                 <face_colour>def</face_colour>
                 <label>CORRELATION</label>
                 <fg>#E5E5E5</fg>
@@ -313,6 +318,7 @@
             <object class="sizeritem">
               <object class="TabButton" name="btn_tab_fibsem">
                 <size>160,30</size>
+                <hidden>1</hidden>
                 <face_colour>def</face_colour>
                 <label>FIBSEM</label>
                 <fg>#E5E5E5</fg>
@@ -331,6 +337,7 @@
             <object class="sizeritem">
               <object class="TabButton" name="btn_tab_sparc_acqui">
                 <size>160,30</size>
+                <hidden>1</hidden>
                 <face_colour>def</face_colour>
                 <label>ACQUISITION</label>
                 <fg>#E5E5E5</fg>
@@ -349,6 +356,7 @@
             <object class="sizeritem">
               <object class="TabButton" name="btn_tab_fastem_main">
                 <size>160,30</size>
+                <hidden>1</hidden>
                 <face_colour>def</face_colour>
                 <label>MAIN</label>
                 <fg>#E5E5E5</fg>
@@ -367,6 +375,7 @@
             <object class="sizeritem">
               <object class="TabButton" name="btn_tab_inspection">
                 <size>160,30</size>
+                <hidden>1</hidden>
                 <face_colour>def</face_colour>
                 <label>ANALYSIS</label>
                 <fg>#E5E5E5</fg>
@@ -389,6 +398,7 @@
             <object class="sizeritem">
               <object class="TabButton" name="btn_tab_sparc_chamber">
                 <size>160,30</size>
+                <hidden>1</hidden>
                 <face_colour>def</face_colour>
                 <label>CHAMBER</label>
                 <fg>#E5E5E5</fg>
@@ -426,6 +436,7 @@
             <object class="sizeritem">
               <object class="TabButton" name="btn_tab_align">
                 <size>160,30</size>
+                <hidden>1</hidden>
                 <face_colour>def</face_colour>
                 <label>ALIGNMENT</label>
                 <fg>#E5E5E5</fg>


### PR DESCRIPTION
Each tab is shown or not depending the hardware. However, until now, all the tab were loaded, and then a call to get_display_priority() by the tab controller would decide whether it's worthy showing or not.

However, just based on the microscope role, we can have already a pretty good idea of which tab is certainly not useful.

=> load only the tabs that could be used for the current microscope role.

This mainly avoids failures due to a missing an external module imported by a non-used tab.
In theory, it should also improve the loading time of the GUI. However, tests on the viewer (were the saving should be most noticeable) show it barely improved: going from ~3.34 to ~3.28 (-> 0.06s faster)