### PR TITLE
[fix] bug reporter: avoid use of lsusb -v, and replace by usb-devices

### DIFF
--- a/src/bugreporter/odemis_bugreporter.py
+++ b/src/bugreporter/odemis_bugreporter.py
@@ -424,7 +424,7 @@ class OdemisBugreporter(object):
                 outputs["odemis-hw-status.txt"] = self._get_future_output(['odemis-cli', '--list-prop', '*'], timeout=60)
 
             # Save USB hardware, processes, kernel name, IP address
-            outputs["lsusb.txt"] = self._get_future_output(['/usr/bin/lsusb', '-v'], timeout=60)
+            outputs["usb.txt"] = self._get_future_output(['/usr/bin/usb-devices'], timeout=60)
             outputs["lsusb-tree.txt"] = self._get_future_output(['/usr/bin/lsusb', '-t', '-vv'], timeout=60)
             outputs["ps.txt"] = self._get_future_output(['/bin/ps', 'aux'], timeout=60)
             outputs["uname.txt"] = self._get_future_output(['/bin/uname', '-a'], timeout=5)


### PR DESCRIPTION
It was found out that some Andor camera disconnect when they are in use
in Odemis, and "lsusb -v" is called. That's because lsusb -v actively
send queries to each USB devices, and some handle it less graciously
than others. That can require a restart of the Odemis backend in some
cases. That's not helpful to convince the users to report more issues!

So use the "passive" usb-devices, which only report known information
about the devices. We are loosing a little bit of information, but it's
very rarely useful. In particular, we still can see whether the device
is connected over USB 2 (Ver = 2.10) or 3 (Ver = 3.00).