### PR TITLE
[fix] SPARC acquisition with spectrum stream would sometimes fail

### DIFF
--- a/src/odemis/acq/stream/_sync.py
+++ b/src/odemis/acq/stream/_sync.py
@@ -3169,14 +3169,14 @@ class SEMCCDAcquirerRectangle(SEMCCDAcquirer):
 
         # If the CCD stream has power, need to temporarily turn it off (otherwise
         # the SEM reading might be incorrect)
-        if hasattr(self._mdstream._sccd, "light") and self._mdstream._sccd.light.value:
+        if hasattr(self._mdstream._sccd, "light") and self._mdstream._sccd.light:
             self._mdstream._sccd._stop_light()
 
     def resume_pixel_acquisition(self) -> None:
         """
         Called just after running the leeches
         """
-        if hasattr(self._mdstream._sccd, "light") and self._mdstream._sccd.light.value:
+        if hasattr(self._mdstream._sccd, "light") and self._mdstream._sccd.light:
             self._mdstream._sccd._setup_light()
 
         # re-use the real trigger


### PR DESCRIPTION
The check for the presence of the light component was incorrect, causing
the acquisition to fail in some configurations.
Solves such error:
```
2026-02-18 14:26:48,529  ERROR   _sync:1331 Software sync acquisition of multiple detectors failed
Traceback (most recent call last):
  File "/home/piel/development/odemis/src/odemis/acq/stream/_sync.py", line 1285, in _run_acquisition_ccd
    self._run_leeches(acquirer, pixel_das)
  File "/home/piel/development/odemis/src/odemis/acq/stream/_sync.py", line 1124, in _run_leeches
    acquirer.resume_pixel_acquisition()
  File "/home/piel/development/odemis/src/odemis/acq/stream/_sync.py", line 3179, in resume_pixel_acquisition
    if hasattr(self._mdstream._sccd, "light") and self._mdstream._sccd.light.value:
                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'value'
```

The place where `.light` is created is here:
https://github.com/delmic/odemis/blob/f8ffc3e8a95e29c832732aaff9ba79f77ff66829/src/odemis/acq/stream/_helper.py#L712