### PR TITLE
[fix] METEOR GUI FIBSEM tab: adjust size of "filename" text box

### DIFF
--- a/src/odemis/gui/cont/acquisition/cryo_acq.py
+++ b/src/odemis/gui/cont/acquisition/cryo_acq.py
@@ -453,7 +453,6 @@ class CryoAcquiController(object):
 
         # toggle file controls when saving is enabled
         enable = self._panel.chkbox_save_acquisition.IsChecked()
-        self._panel.lbl_filename.Enable(enable)
         self._panel.txt_filename.Enable(enable)
         self._panel.btn_cryosecom_change_file.Enable(enable)
 

--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -855,7 +855,6 @@ class xrcpnl_tab_fibsem(wx.Panel):
         self.fp_acquisitions = xrc.XRCCTRL(self, "fp_acquisitions")
         self.streams_chk_list = xrc.XRCCTRL(self, "streams_chk_list")
         self.chkbox_save_acquisition = xrc.XRCCTRL(self, "chkbox_save_acquisition")
-        self.lbl_filename = xrc.XRCCTRL(self, "lbl_filename")
         self.txt_filename = xrc.XRCCTRL(self, "txt_filename")
         self.btn_cryosecom_change_file = xrc.XRCCTRL(self, "btn_cryosecom_change_file")
         self.btn_cryosecom_acquire = xrc.XRCCTRL(self, "btn_cryosecom_acquire")
@@ -10169,54 +10168,43 @@ B`\x82'''
                             <object class="sizeritem">
                               <object class="wxBoxSizer">
                                 <object class="sizeritem">
-                                  <object class="wxFlexGridSizer">
-                                    <object class="sizeritem">
-                                      <object class="wxStaticText" name="lbl_filename">
-                                        <label>Filename</label>
-                                        <fg>#E5E5E5</fg>
-                                      </object>
-                                      <flag>wxTOP</flag>
-                                      <border>4</border>
-                                    </object>
-                                    <object class="sizeritem">
-                                      <object class="wxTextCtrl" name="txt_filename">
-                                        <size>150,20</size>
-                                        <value>Select a destination file</value>
-                                        <fg>#2FA7D4</fg>
-                                        <bg>#333333</bg>
-                                        <style>wxBORDER_NONE|wxTE_READONLY</style>
-                                        <XRCED>
-                                          <assign_var>1</assign_var>
-                                        </XRCED>
-                                      </object>
-                                      <flag>wxLEFT|wxEXPAND</flag>
-                                      <border>1</border>
-                                    </object>
-                                    <object class="sizeritem">
+                                  <object class="wxStaticText">
+                                    <label>Filename</label>
+                                    <fg>#E5E5E5</fg>
+                                  </object>
+                                  <flag>wxALIGN_CENTER_VERTICAL</flag>
+                                </object>
+                                <object class="sizeritem">
+                                  <object class="wxTextCtrl" name="txt_filename">
+                                    <size>-1,20</size>
+                                    <value>Select a destination file</value>
+                                    <fg>#2FA7D4</fg>
+                                    <bg>#333333</bg>
+                                    <style>wxBORDER_NONE|wxTE_READONLY</style>
+                                    <XRCED>
+                                      <assign_var>1</assign_var>
+                                    </XRCED>
+                                  </object>
+                                  <flag>wxLEFT|wxEXPAND</flag>
+                                  <border>5</border>
+                                  <option>1</option>
+                                </object>
+                                <object class="sizeritem">
                                       <object class="ImageTextButton" name="btn_cryosecom_change_file">
                                         <height>24</height>
                                         <face_colour>def</face_colour>
-                                        <label>Change…</label>
+                                        <label>change…</label>
                                         <XRCED>
                                           <assign_var>1</assign_var>
                                         </XRCED>
                                       </object>
                                       <flag>wxLEFT</flag>
-                                      <border>85</border>
+                                      <border>5</border>
                                     </object>
-                                    <cols>3</cols>
-                                    <rows>1</rows>
-                                    <vgap>5</vgap>
-                                    <hgap>10</hgap>
-                                    <growablecols>1</growablecols>
-                                  </object>
-                                  <flag>wxLEFT</flag>
-                                  <border>10</border>
-                                </object>
                                 <orient>wxHORIZONTAL</orient>
                               </object>
                               <option>0</option>
-                              <flag>wxTOP</flag>
+                              <flag>wxTOP|wxLEFT|wxRIGHT|wxEXPAND</flag>
                               <border>10</border>
                             </object>
                             <object class="sizeritem">

--- a/src/odemis/gui/xmlh/resources/panel_tab_fibsem.xrc
+++ b/src/odemis/gui/xmlh/resources/panel_tab_fibsem.xrc
@@ -689,54 +689,43 @@
                             <object class="sizeritem">
                               <object class="wxBoxSizer">
                                 <object class="sizeritem">
-                                  <object class="wxFlexGridSizer">
-                                    <object class="sizeritem">
-                                      <object class="wxStaticText" name="lbl_filename">
-                                        <label>Filename</label>
-                                        <fg>#E5E5E5</fg>
-                                      </object>
-                                      <flag>wxTOP</flag>
-                                      <border>4</border>
-                                    </object>
-                                    <object class="sizeritem">
-                                      <object class="wxTextCtrl" name="txt_filename">
-                                        <size>150,20</size>
-                                        <value>Select a destination file</value>
-                                        <fg>#2FA7D4</fg>
-                                        <bg>#333333</bg>
-                                        <style>wxBORDER_NONE|wxTE_READONLY</style>
-                                        <XRCED>
-                                          <assign_var>1</assign_var>
-                                        </XRCED>
-                                      </object>
-                                      <flag>wxLEFT|wxEXPAND</flag>
-                                      <border>1</border>
-                                    </object>
-                                    <object class="sizeritem">
+                                  <object class="wxStaticText">
+                                    <label>Filename</label>
+                                    <fg>#E5E5E5</fg>
+                                  </object>
+                                  <flag>wxALIGN_CENTER_VERTICAL</flag>
+                                </object>
+                                <object class="sizeritem">
+                                  <object class="wxTextCtrl" name="txt_filename">
+                                    <size>-1,20</size>
+                                    <value>Select a destination file</value>
+                                    <fg>#2FA7D4</fg>
+                                    <bg>#333333</bg>
+                                    <style>wxBORDER_NONE|wxTE_READONLY</style>
+                                    <XRCED>
+                                      <assign_var>1</assign_var>
+                                    </XRCED>
+                                  </object>
+                                  <flag>wxLEFT|wxEXPAND</flag>
+                                  <border>5</border>
+                                  <option>1</option>
+                                </object>
+                                <object class="sizeritem">
                                       <object class="ImageTextButton" name="btn_cryosecom_change_file">
                                         <height>24</height>
                                         <face_colour>def</face_colour>
-                                        <label>Change…</label>
+                                        <label>change…</label>
                                         <XRCED>
                                           <assign_var>1</assign_var>
                                         </XRCED>
                                       </object>
                                       <flag>wxLEFT</flag>
-                                      <border>85</border>
+                                      <border>5</border>
                                     </object>
-                                    <cols>3</cols>
-                                    <rows>1</rows>
-                                    <vgap>5</vgap>
-                                    <hgap>10</hgap>
-                                    <growablecols>1</growablecols>
-                                  </object>
-                                  <flag>wxLEFT</flag>
-                                  <border>10</border>
-                                </object>
                                 <orient>wxHORIZONTAL</orient>
                               </object>
                               <option>0</option>
-                              <flag>wxTOP</flag>
+                              <flag>wxTOP|wxLEFT|wxRIGHT|wxEXPAND</flag>
                               <border>10</border>
                             </object>
                             <object class="sizeritem">


### PR DESCRIPTION
Same change as in commit fe84c852ff, but for the FIBSEM tab, instead of
the Localization tab.
The filename text box was fixed to 150px, which left a lot of empty space between
the field and the "change..." button. In many case, because of this, the filename was clipped.
=> Adjust the sizer to let the text box expand to the entire available space.