### PR TITLE
[fix] PostureManager.get_posture_orientation() could return None

### DIFF
--- a/src/odemis/acq/move.py
+++ b/src/odemis/acq/move.py
@@ -515,6 +515,8 @@ class MeteorPostureManager(MicroscopePostureManager):
                                                         pre_tilt=self.pre_tilt,
                                                         column_tilt=self.fib_column_tilt)
             return {"rx": rx, "rz": md["rz"]}
+        else:
+            raise ValueError(f"posture {POSITION_NAMES.get(posture, posture)} not supported for orientation retrieval")
 
     def getTargetPosition(self, target_pos_lbl: int) -> Dict[str, float]:
         """


### PR DESCRIPTION
It looks like it would always return a dict (position)... but passing a
unsupported posture would cause it to return None implicitly.

Instead, raise an exception in such case, to catch such error directly.