### PR TITLE
[fix] driver autoscript_client & xt_client: stop polling thread on termination

### DIFF
--- a/src/odemis/driver/test/xt_client_test.py
+++ b/src/odemis/driver/test/xt_client_test.py
@@ -141,6 +141,7 @@ class TestMicroscope(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        logging.debug("Terminating microscope.")
         cls.microscope.terminate()
 
     def setUp(self):
@@ -188,7 +189,7 @@ class TestMicroscope(unittest.TestCase):
             f = self.stage.moveAbs(position)
             f.result()
         # Move stage back to initial position
-        self.stage.moveAbs(init_pos)
+        self.stage.moveAbsSync(init_pos)
 
     @unittest.skipIf(not TEST_NOHW, "Microscope stage not tested, too dangerous.")
     def test_move_stage_rot_tilt(self):
@@ -222,7 +223,7 @@ class TestMicroscope(unittest.TestCase):
         self.assertAlmostEqual(self.stage.position.value["rz"] % (2 * math.pi),
                                rel_pos["rz"] % (2 * math.pi), places=4)
 
-        self.stage.moveAbs(init_pos)
+        self.stage.moveAbsSync(init_pos)
 
     def test_hfov(self):
         """

--- a/src/odemis/driver/xt_client.py
+++ b/src/odemis/driver/xt_client.py
@@ -355,6 +355,15 @@ class SEM(model.HwComponent):
                 self._detector = Detector(parent=self, daemon=daemon, **ckwargs)
             self.children.value.add(self._detector)
 
+    def terminate(self):
+        for child in self.children.value:
+            child.terminate()
+
+        if hasattr(self, "server"):
+            del self.server  # to let the proxy close the connection
+
+        super().terminate()
+
     def transfer_latest_package(self, data: bytes) -> None:
         """
         Transfer a (new) xtadapter package.
@@ -1477,6 +1486,12 @@ class Scanner(model.Emitter):
         self._va_poll = util.RepeatingTimer(5, self._updateSettings, "Settings polling")
         self._va_poll.start()
 
+    def terminate(self):
+        if self._va_poll:
+            self._va_poll.cancel()
+            self._va_poll = None
+        super().terminate()
+
     def _updateSettings(self) -> None:
         """
         Read all the current settings from the SEM and reflects them on the VAs
@@ -1798,6 +1813,10 @@ class Detector(model.Detector):
             self._genmsg.put(GEN_TERM)
             self._generator.join(5)
             self._generator = None
+        if self._va_poll:
+            self._va_poll.cancel()
+            self._va_poll = None
+        super().terminate()
 
     def start_generate(self) -> None:
         self._genmsg.put(GEN_START)
@@ -2132,7 +2151,14 @@ class Chamber(model.Actuator):
             logging.warning("Couldn't read pressure value, assuming ambient pressure %s.", pressure)
 
     def terminate(self) -> None:
-        self._polling_thread.cancel()
+        if self._executor:
+            self._executor.cancel()
+            self._executor.shutdown()
+            self._executor = None
+        if self._polling_thread:
+            self._polling_thread.cancel()
+            self._polling_thread = None
+        super().terminate()
 
 
 class TerminationRequested(Exception):
@@ -2243,6 +2269,16 @@ class Stage(model.Actuator):
         # Refresh regularly the position
         self._pos_poll = util.RepeatingTimer(5, self._refreshPosition, "Stage position polling")
         self._pos_poll.start()
+
+    def terminate(self):
+        if self._executor:
+            self._executor.cancel()
+            self._executor.shutdown()
+            self._executor = None
+        if self._pos_poll:
+            self._pos_poll.cancel()
+            self._pos_poll = None
+        super().terminate()
 
     def _switch_coordinate_system(self, raw_coordinates: bool) -> None:
         """
@@ -2602,6 +2638,16 @@ class Focus(model.Actuator):
         # Refresh regularly the position
         self._pos_poll = util.RepeatingTimer(5, self._refreshPosition, "Focus position polling")
         self._pos_poll.start()
+
+    def terminate(self) -> None:
+        if self._executor:
+            self._executor.cancel()
+            self._executor.shutdown()
+            self._executor = None
+        if self._pos_poll:
+            self._pos_poll.cancel()
+            self._pos_poll = None
+        super().terminate()
 
     @isasync
     def applyAutofocus(self, detector: model.Detector) -> futures.Future:


### PR DESCRIPTION
Make sure that all components which have a polling thread stop it when
the component is terminated.
It's typically not a big deal as the threads would be ended
automatically when the whole process ends, or as soon as they attempts
to connect via the parent, which is gone. However, the errors can be
confusing.
This avoid such error in the log:
```
2026-02-23 09:57:05,589	ERROR	autoscript_client:1309:	Unexpected failure when polling settings
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/odemis/driver/autoscript_client.py", line 1281, in _updateSettings
    beam_current = self.parent.get_beam_current(self.channel)
AttributeError: 'NoneType' object has no attribute 'get_beam_current'
```