### PR TITLE
[fix] MeteorPostureManager: only trust the scan rotation is identical on both beams

### DIFF
--- a/src/odemis/acq/move.py
+++ b/src/odemis/acq/move.py
@@ -599,7 +599,7 @@ class MeteorPostureManager(MicroscopePostureManager):
         sr = self._get_scan_rotation()   # Fails if ion-beam and e-beam have different scan rotations
         # Make sure the SEM image is shown without rotation in the UI. This works by setting
         # MD_ROTATION_COR as the same value as MD_ROTATION (automatically set on the image).
-        self._set_scanner_rotation_cor(sr)
+        self._set_scanner_rotation_cor()
         tf_sr, _ = get_rotation_transforms(rz=sr)
 
         # We assume that FM & SEM are rotate by 180°. Let's warn if that's not the case.
@@ -683,10 +683,17 @@ class MeteorPostureManager(MicroscopePostureManager):
     def _get_scan_rotation(self) -> float:
         """
         Get the scan rotation value for SEM/FIB, and ensure they match.
+        If not both e-beam and ion-beam are available, the default scan rotation is used.
         :return: the scan rotation value in radians
+        :raise: ValueError if the scan rotation values for e-beam and ion-beam do not match
         """
+        # We only "trust" the scan rotation, if both the SEM and FIB have the same rotation.
+        # Otherwise, it might mean the user didn't really pay attention to it. The FM is calibrated
+        # for a given scan rotation, so picking the arbitrary scan rotation at startup could cause
+        # the sample stage to go in the wrong direction related to the FM image.
         try:
             ebeam = model.getComponent(role='e-beam')
+            ion_beam = model.getComponent(role='ion-beam')
         except LookupError:
             logging.info("e-beam and/or ion-beam not available, scan rotation assumed to %s°",
                          round(math.degrees(self._default_scan_rotation)))
@@ -694,33 +701,26 @@ class MeteorPostureManager(MicroscopePostureManager):
 
         # check if e-beam and ion-beam have the same rotation
         sr = ebeam.rotation.value
-
-        try:
-            ion_beam = model.getComponent(role='ion-beam')
-        except LookupError:
-            logging.info("ion-beam not available, scan rotation assumed to be the same as e-beam: %s°", math.degrees(sr))
-            return sr
-
         ion_sr = ion_beam.rotation.value
         if not numpy.isclose(sr, ion_sr, atol=ATOL_ROTATION_POS):
             raise ValueError(f"The SEM and FIB rotations do not match {sr} != {ion_sr}")
 
         return sr
 
-    def _set_scanner_rotation_cor(self, rotation: float):
+    def _set_scanner_rotation_cor(self):
         """
-        Set the scanners' MD_ROTATION_COR metadata field to the provided rotation value.
-        :param rotation: rotation in radians
+        Set the scanners' MD_ROTATION_COR metadata field to the current rotation, so that the
+        image is shown without rotation in the UI, as in the SEM UI. This is necessary, as
+        the sample stage compensates for the scan rotation already.
         """
         for scanner_name in ["e-beam", "ion-beam"]:
-            scanner = None
             try:
                 scanner = model.getComponent(role=scanner_name)
             except LookupError:
-                pass
+                continue
 
-            if scanner is not None:
-                scanner.updateMetadata({model.MD_ROTATION_COR: rotation})
+            rotation = scanner.rotation.value
+            scanner.updateMetadata({model.MD_ROTATION_COR: rotation})
 
     def from_sample_stage_to_stage_movement(self, pos: Dict[str, float]) -> Dict[str, float]:
         """
@@ -1754,7 +1754,7 @@ class MeteorTescan1PostureManager(MeteorPostureManager):
 
         # Compensate for the scan rotation (around Z)
         sr = self._get_scan_rotation()  # Fails if ion-beam and e-beam have different scan rotations
-        self._set_scanner_rotation_cor(sr)  # Makes sure total image rotation is 0
+        self._set_scanner_rotation_cor()  # Makes sure total image rotation is 0
         tf_sr, _ = get_rotation_transforms(rz=-sr)
 
         # FM imaging


### PR DESCRIPTION
Commit 42ecdd09bdaa0 (PostureManager: adjust orientation of sample stage
in SEM imaging posture) changed the behaviour with scan rotation. It
introduced a default scan rotation to 180° on some systems (eg, TFS1),
and also accepted the e-beam scan rotation as-is if no ion-beam is
present.

However, until now the TFS1 systems never cared about the e-beam scan
rotation. So users don't pay attention to it. However, the FM movement
assumes the scan rotation is 180°, always. So if TFS1 microscope file
accessed the e-beam (some do, others don't), then the movement of the FM
would depend on the e-beam scan rotation when starting Odemis. That
shouldn't be.

=> Revert to only trust the scan rotation if both e- and ion-beam scna
rotation is the same. If there is only an e-beam, use the default scan
rotation. This should ensure that the stage behaviour stays the same as
on previous version of Odemis, and only use the scan rotation to adjust
the stage movement on FIB/SEM systems, where movement in FIB/SEM
postures matters.