### PR TITLE
[MSD-265][fix] METEOR GUI FIBSEM tab: untangle milling pattern handling

### DIFF
--- a/src/odemis/acq/milling/millmng.py
+++ b/src/odemis/acq/milling/millmng.py
@@ -283,6 +283,8 @@ def get_associated_tasks(wt: MillingWorkflowTask,
     :return: List of associated tasks."""
     associated_tasks = []
     for task in milling_tasks.values():
+        if not task.selected:
+            continue
 
         if wt.value in task.name:
             associated_tasks.append(task)

--- a/src/odemis/acq/milling/tasks.py
+++ b/src/odemis/acq/milling/tasks.py
@@ -71,8 +71,10 @@ class MillingTaskSettings:
 
     def __init__(self, milling: MillingSettings,
                  patterns: List[MillingPatternParameters],
-                 name: str):
+                 name: str,
+                 selected: bool = True):
         self.name: str = name
+        self.selected: bool = selected  # Whether this task should be executed or not
         self.milling: MillingSettings = milling
         self.patterns: List[MillingPatternParameters] = patterns
 
@@ -81,6 +83,7 @@ class MillingTaskSettings:
         :return: dictionary containing the milling task settings
         """
         return {"name": self.name,
+                "selected": self.selected,
                 "milling": self.milling.to_dict(),
                 "patterns": [pattern.to_dict() for pattern in self.patterns]}
 
@@ -91,6 +94,7 @@ class MillingTaskSettings:
         :return: MillingTaskSettings"""
         return MillingTaskSettings(
             name=data.get("name", "Milling Task"),
+            selected=data.get("selected", True),
             milling=MillingSettings.from_dict(data["milling"]),
             patterns=[PATTERN_NAME_TO_CLASS[p["pattern"]].from_dict(p) for p in data["patterns"]])
 
@@ -102,6 +106,9 @@ class MillingTaskSettings:
         :return: list of individual shapes to be drawn on the microscope
         """
         patterns = []
+        if not self.selected:
+            return patterns
+
         for pattern in self.patterns:
             patterns.extend(pattern.generate())
         return patterns

--- a/src/odemis/acq/milling/test/tasks_test.py
+++ b/src/odemis/acq/milling/test/tasks_test.py
@@ -89,6 +89,7 @@ class MillingTaskTestCase(unittest.TestCase):
 
         dict_data = milling_task_settings.to_dict()
         self.assertEqual(dict_data["name"], "Milling Task")
+        self.assertEqual(dict_data["selected"], True)
         self.assertEqual(dict_data["milling"], milling_settings.to_dict())
         self.assertEqual(dict_data["patterns"][0], trench_pattern.to_dict())
 

--- a/src/odemis/gui/cont/acquisition/cryo_acq.py
+++ b/src/odemis/gui/cont/acquisition/cryo_acq.py
@@ -60,6 +60,7 @@ from odemis.gui.cont.acquisition._constants import VAS_NO_ACQUISITION_EFFECT
 from odemis.gui.cont.acquisition.overview_stream_acq import (
     OverviewStreamAcquiController, CorrelationDialogController,
 )
+from odemis.gui.cont.milling import pos_to_relative
 from odemis.gui.util import call_in_wx_main, wxlimit_invocation
 from odemis.gui.util.widgets import (
     ProgressiveFutureConnector,
@@ -805,13 +806,13 @@ class CryoAcquiController(object):
 
             # redraw milling position
             fibsem_tab = self._tab_data.main.getTabByName("meteor-fibsem")
-            if self._tab_data.main.currentFeature.value:
-                correlation_dict = self._tab_data.main.currentFeature.value.correlation_data
+            feature = self._tab_data.main.currentFeature.value
+            if feature:
+                correlation_dict = feature.correlation_data
                 if correlation_dict and correlation_dict.fib_projected_pois:
                     if correlation_dict.fm_pois:
                         # Update feature position according to POI in FM
                         pm = self._tab_data.main.posture_manager
-                        feature = self._tab_data.main.currentFeature.value
                         feature_stage_bare = feature.get_posture_position(FM_IMAGING)
                         poi = correlation_dict.fm_pois[0]
                         poi_coords = poi.coordinates.value
@@ -823,8 +824,8 @@ class CryoAcquiController(object):
                         feature.fm_focus_position.value = {"z": poi_coords[2]}
                     # Draw milling position in FIBSEM tab around the projected POI
                     target = correlation_dict.fib_projected_pois[0]
-                    fibsem_tab.milling_task_controller.draw_milling_tasks(pos=(target.coordinates.value[0],
-                                                                               target.coordinates.value[1]))
+                    rel_pos = pos_to_relative(target.coordinates.value[:2], feature.reference_image)
+                    fibsem_tab.milling_task_controller.move_milling_tasks(rel_pos)
 
     @call_in_wx_main
     def _on_filename(self, name):

--- a/src/odemis/gui/cont/features.py
+++ b/src/odemis/gui/cont/features.py
@@ -214,22 +214,6 @@ class CryoFeatureController(object):
         self._tab_data_model.main.currentFeature.value = None
         self._tab_data_model.main.currentFeature.value = feature
 
-    def save_milling_tasks(self,
-                    milling_tasks: Dict[str, MillingTaskSettings],
-                    selected_milling_tasks: List[str]) -> None:
-        feature: CryoFeature = self._tab_data_model.main.currentFeature.value
-        if feature is None:
-            logging.warning("No feature selected")
-            return
-
-        # filter out the selected tasks
-        milling_tasks = {k: v for k, v in milling_tasks.items() if k in selected_milling_tasks}
-
-        feature.milling_tasks = copy.deepcopy(milling_tasks)
-        save_features(self._tab.conf.pj_last_path, self._tab_data_model.main.features.value)
-
-    # TODO: pattern size not updating
-
     def _display_go_to_feature_warning(self) -> bool:
         box = wx.MessageDialog(self._tab.main_frame,
                                message="The stage is currently in the SEM imaging position. "
@@ -392,10 +376,6 @@ class CryoFeatureController(object):
                                                                     events=wx.EVT_TEXT_ENTER,
                                                                     ctrl_2_va=self._on_ctrl_feature_z_change,
                                                                     va_2_ctrl=self._on_feature_focus_pos)
-
-        # if FIBSEM mode, and milling tasks are available, re-draw
-        if self.acqui_mode is guimod.AcquiMode.FIBSEM:
-            self._tab.milling_task_controller.set_milling_tasks(feature.milling_tasks)
 
     def _on_feature_focus_pos(self, fm_focus_position: dict):
         # Set the feature Z ctrl with the focus position

--- a/src/odemis/gui/cont/milling.py
+++ b/src/odemis/gui/cont/milling.py
@@ -26,7 +26,6 @@ This module contains classes to control the actions related to the milling.
 
 """
 
-import copy
 import logging
 import os
 from concurrent.futures import CancelledError
@@ -35,20 +34,16 @@ from typing import Dict, List, Optional, Tuple
 
 import wx
 
-import odemis.acq.stream as acqstream
 from odemis import model
 from odemis.acq.feature import (
     FEATURE_ACTIVE,
     FEATURE_DEACTIVE,
-    CryoFeature,
+    CryoFeature, save_features,
 )
-from odemis.acq.milling import millmng, DEFAULT_MILLING_TASKS_PATH
+from odemis.acq.milling import millmng
 from odemis.acq.milling.millmng import MillingWorkflowTask, run_automated_milling
 from odemis.acq.milling.patterns import RectanglePatternParameters
-from odemis.acq.milling.tasks import MillingTaskSettings, load_milling_tasks
-from odemis.acq.move import (
-    MILLING,
-)
+from odemis.acq.milling.tasks import MillingTaskSettings
 from odemis.gui.comp.milling import MillingTaskPanel
 from odemis.gui.comp.overlay.base import Vec
 from odemis.gui.comp.overlay.rectangle import RectangleOverlay
@@ -78,10 +73,10 @@ def _get_milling_colour(task_name: str, idx: int) -> str:
         return MILLING_COLOURS_CANONICAL[task_name]
     return MILLING_COLOURS_CYCLE[idx % len(MILLING_COLOURS_CYCLE)]
 
-def _get_pattern_centre(pos: Tuple[float, float], stream: acqstream.Stream) -> Tuple[float, float]:
-    """Convert the position to the centre of the image coordinate (pattern coordinate system)"""
+def pos_to_relative(pos: Tuple[float, float], ref_img: model.DataArray) -> Tuple[float, float]:
+    """Convert the position from absolute position to relative position to the centre of image the given stream"""
     # get the center of the image, center of the pattern
-    stream_pos = stream.raw[0].metadata[model.MD_POS]
+    stream_pos = ref_img.metadata[model.MD_POS]
 
     # get the difference between the two
     center_x = pos[0] - stream_pos[0]
@@ -89,10 +84,10 @@ def _get_pattern_centre(pos: Tuple[float, float], stream: acqstream.Stream) -> T
 
     return center_x, center_y
 
-def _to_physical_position(pos: Tuple[float, float], stream: acqstream.Stream) -> Tuple[float, float]:
-    """Convert the position (pattern coordinates) to the physical coordinate position"""
+def pos_to_absolute(pos: Tuple[float, float], ref_img: model.DataArray) -> Tuple[float, float]:
+    """Convert the position from relative to absolute coordinate position"""
     # get the center of the image, center of the pattern
-    stream_pos = stream.raw[0].metadata[model.MD_POS]
+    stream_pos = ref_img.metadata[model.MD_POS]
 
     # get the difference between the two
     center_x = pos[0] + stream_pos[0]
@@ -102,7 +97,7 @@ def _to_physical_position(pos: Tuple[float, float], stream: acqstream.Stream) ->
 
 # TODO: support other shapes
 def rectangle_pattern_to_shape(canvas,
-                        stream: acqstream.Stream,
+                        ref_img: model.DataArray,
                         pattern: RectanglePatternParameters,
                         colour: str = "#FFFF00",
                         name: str = None) -> EditableShape:
@@ -110,7 +105,7 @@ def rectangle_pattern_to_shape(canvas,
     rect = RectangleOverlay(cnvs=canvas, colour = colour, show_selection_points = False)
     width = pattern.width.value
     height = pattern.height.value
-    x, y = _to_physical_position(pattern.center.value, stream) # image coordinates -> physical coordinates
+    x, y = pos_to_absolute(pattern.center.value, ref_img) # image coordinates -> physical coordinates
     if name is not None:
         rect.name.value = name
 
@@ -134,6 +129,9 @@ def rectangle_pattern_to_shape(canvas,
     return rect
 
 class MillingTaskController:
+    """
+    Takes care of handling the "PATTERNS" collapsible panel, which shows the selected milling tasks, and their settings.
+    """
     def __init__(self, tab_data, tab_panel, tab):
         """
         tab_data (MicroscopyGUIData): the representation of the microscope GUI
@@ -157,8 +155,7 @@ class MillingTaskController:
         self.conf = get_acqui_conf()
 
         # load the milling tasks
-        self.milling_tasks = load_milling_tasks(DEFAULT_MILLING_TASKS_PATH) # TODO: move to main_data
-        self._default_milling_tasks = copy.deepcopy(self.milling_tasks)
+        self.milling_tasks: Dict[str, MillingTaskSettings] = {} # TODO: move to main_data
         self.allow_milling_pattern_move = True
 
         # pattern overlay
@@ -169,17 +166,10 @@ class MillingTaskController:
         self.canvas.add_world_overlay(self.rectangles_overlay)
         self.canvas.Bind(wx.EVT_LEFT_DOWN, self.on_mouse_down) # bind the mouse down event
 
-        # set all the tasks to be checked by default
-        self.selected_tasks = model.ListVA(list(self.milling_tasks.keys())) # all tasks are selected by default
-        self._panel.milling_task_chk_list.SetItems(self.selected_tasks.value)
-        for i in range(self._panel.milling_task_chk_list.GetCount()):
-            self._panel.milling_task_chk_list.Check(i)
-        self._panel.milling_task_chk_list.Bind(wx.EVT_CHECKLISTBOX, self._update_selected_tasks)
-        self.selected_tasks.subscribe(self.draw_milling_tasks, init=True)
-        # self.selected_tasks.subscribe(self._update_mill_btn, init=True)
+        self.selected_tasks = model.ListVA([])  # List of strings, names of the selected milling tasks
+        self._panel.milling_task_chk_list.Bind(wx.EVT_CHECKLISTBOX, handler=self._update_selected_tasks)
 
-        # update the panels for the milling tasks
-        self._update_panels()
+        self._tab_data.main.currentFeature.subscribe(self._on_current_feature_changes, init=True)
 
         # By default, all widgets are hidden => show button + estimated time at initialization
         self._panel.txt_milling_est_time.Hide()
@@ -207,9 +197,20 @@ class MillingTaskController:
         # hide the milling button because we are using it for a workflow
         # self._panel.btn_run_milling.Hide()
 
+    def _on_current_feature_changes(self, feature: Optional[CryoFeature]):
+        """
+        Called when the current feature is changed
+        """
+        # Update the checkbox list of milling tasks based on the ones of the new feature
+        milling_tasks = feature.milling_tasks if feature else {}
+        self.set_milling_tasks(milling_tasks)
+        self._update_pattern_panels()
 
     @call_in_wx_main
-    def _update_panels(self):
+    def _update_pattern_panels(self) -> None:
+        """
+        Update the pattern settings control, when a new feature is selected.
+        """
         if hasattr(self._panel.pnl_patterns, "_panel_sizer"):
             # self._panel.pnl_patterns._panel_sizer.Clear()
             # self._panel.pnl_patterns.Destroy()
@@ -226,8 +227,9 @@ class MillingTaskController:
         # milling params: current, voltage, field of view, mode
         milling_parameters = ["current", "align", "mode"]
 
+        # Note: always create all the panels, but hide for which the task is not selected.
+        # This way, when a task is selected, we can just show the panel without having to create it.
         for task_name, task in self.milling_tasks.items():
-
             parameters = task.patterns[0]
             milling = task.milling
 
@@ -272,8 +274,16 @@ class MillingTaskController:
                 # VA connector, bind events
                 getattr(milling, param).subscribe(self._on_patterns)
 
+            if not task.selected:
+                panel.Hide()
+
         self._panel.pnl_patterns.Layout()
         self._panel.Layout()
+
+        # force the scrolled parent to recompute its layout, otherwise pnl_patterns
+        # keeps the previous virtual size until the user triggers a resize
+        self._panel.scr_win_right.FitInside()
+        self._panel.scr_win_right.SendSizeEvent()
 
     @call_in_wx_main
     def _on_shapes_update(self, shapes):
@@ -297,9 +307,13 @@ class MillingTaskController:
         active_canvas = evt.GetEventObject()
         logging.debug(f"mouse down event, canvas: {active_canvas}")
 
-        # check if shift is pressed, and if a stream is selected
-        if evt.ShiftDown() and evt.ControlDown() and self.allow_milling_pattern_move:
+        feature = self._tab_data.main.currentFeature.value
 
+        # check if shift is pressed, and if a stream is selected
+        if (evt.ShiftDown() and evt.ControlDown()
+                and self.allow_milling_pattern_move
+                and feature and feature.reference_image is not None
+        ):
             # get the position of the mouse, convert to physical position
             pos = evt.GetPosition()
             p_pos = active_canvas.view_to_phys(pos, active_canvas.get_half_buffer_size())
@@ -308,107 +322,89 @@ class MillingTaskController:
             # TODO: validate if click is outside image bounds, don't move the pattern
             # TODO: validate whether the pattern is within the image bounds before moving it
             # move selected stream to position
-            self.draw_milling_tasks(p_pos)
+            self.move_milling_tasks(pos_to_relative(p_pos, feature.reference_image))
             return
 
         # super event passthrough
-        active_canvas.on_left_down(evt)
+        evt.Skip()
 
     @call_in_wx_main
     def set_milling_tasks(self, milling_tasks: Dict[str, MillingTaskSettings]):
+        """
+        Sets the milling tasks displayed to the provided ones
+        """
         # Check if tasks actually changed to avoid the panel to flicker
-        if self.milling_tasks == milling_tasks:
+        if self.milling_tasks is milling_tasks:
             logging.debug("Milling tasks unchanged, skipping update")
             return
 
-        self.milling_tasks = copy.deepcopy(milling_tasks)
+        self.milling_tasks = milling_tasks
+
+        # Update the selected tasks check box list
+
+        all_tasks = []  # names of all the existing tasks
+        selected_tasks = []  # names of the milling task selected (for milling)
+
+        for name, milling_settings in milling_tasks.items():
+            all_tasks.append(name)
+            if milling_settings.selected:
+                selected_tasks.append(name)
 
         # unsubscribe from updates to the selected tasks
-        self.selected_tasks.unsubscribe(self._on_saving_position)
-        self._panel.milling_task_chk_list.Unbind(wx.EVT_CHECKLISTBOX, handler=self._update_selected_tasks)
+        self.selected_tasks.unsubscribe(self._on_selected_tasks)
+        self.selected_tasks.value = selected_tasks
 
-        # update the selected tasks to tasks in milling_tasks
-        self.selected_tasks.value = list(self.milling_tasks.keys())
+        # update the checkbox list
+        self._panel.milling_task_chk_list.SetItems(all_tasks)
+        self._panel.milling_task_chk_list.SetCheckedStrings(selected_tasks)
+        self.selected_tasks.subscribe(self._on_selected_tasks, init=True)
 
-        # update the checkboxes
-        for i in range(self._panel.milling_task_chk_list.GetCount()):
-            is_checked = self._panel.milling_task_chk_list.GetString(i) in self.selected_tasks.value
-            self._panel.milling_task_chk_list.Check(i, is_checked)
-
-        self._panel.milling_task_chk_list.Bind(wx.EVT_CHECKLISTBOX, self._update_selected_tasks)
-        self.selected_tasks.subscribe(self._on_saving_position, init=True)
-
-        self._update_panels()
-        self._panel.Layout()
-
-        # force the scrolled parent to recompute its layout, otherwise pnl_patterns
-        # keeps the previous virtual size until the user triggers a resize
-        scrolled_parent = getattr(self._panel, "scr_win_right", None)
-        if scrolled_parent:
-            scrolled_parent.FitInside()
-            scrolled_parent.SendSizeEvent()
     # NOTE: we should add the bottom right viewport as the feature viewport, to show the saved reference image and the milling patterns
     # it's too confusing to hav the 'live' view and the 'saved' view in the same viewport
     # -> workflow tab is probably easier to use for this purpose
 
-    def _on_saving_position(self, tasks):
+    def _on_selected_tasks(self, tasks: List[str]):
         if self._tab_data.main.currentFeature.value is None:
             return
 
-        feature_stage_bare = self._tab_data.main.currentFeature.value.get_posture_position(MILLING)
-        pos = self.pm.to_sample_stage_from_stage_position(feature_stage_bare, MILLING)
+        for task_name, task in self.milling_tasks.items():
+            task.selected = task_name in tasks
 
-        self.draw_milling_tasks((pos["x"], pos["y"]))
+        save_features(self._tab.conf.pj_last_path, self._tab_data.main.features.value)
+        self.draw_milling_tasks()
+
+    def move_milling_tasks(self, pos: Tuple[float, float]):
+        """
+        Update the position of the milling patterns for the current feature.
+        Also updates the saved positions, and redraws the patterns on the viewport.
+        :param pos: the position to draw the patterns at (in m, as relative coordinates to the center of the ion-beam FoV)
+        """
+        for task in self.milling_tasks.values():
+            for pattern in task.patterns:
+                pattern.center.value = pos
+
+        save_features(self._tab.conf.pj_last_path, self._tab_data.main.features.value)
+        self.draw_milling_tasks()
 
     @call_in_wx_main
-    def draw_milling_tasks(self, pos: Optional[Tuple[float, float]] = None, convert_pos: bool = True):
-        """Redraw all milling tasks on the canvas. Clears the rectangles_overlay first,
-        and then redraws all the patterns. If pos is given, the patterns are drawn at that position,
-        otherwise they are drawn at the existing positions.
-        :param pos: the position to draw the patterns at (Optional)
-        :param convert_pos: whether to convert the position to the centre of the image coordinate (pattern coordinate system)
+    def draw_milling_tasks(self, _=None):
+        """Redraw all milling tasks on the canvas.
         """
+        # Clears the rectangles_overlay first
         self.rectangles_overlay.clear()
         self.rectangles_overlay.clear_labels()
-        tasks_to_draw = self.selected_tasks.value
 
-        # if there are tasks_to_draw that aren't in the milling tasks, add them from default
-        existing_tasks = list(self.milling_tasks.keys())
-        for task_name in tasks_to_draw:
-            if task_name not in existing_tasks:
-                logging.debug(
-                    f"Task {task_name} not found in milling tasks, but requested, adding from default."
-                )
-                self.milling_tasks[task_name] = copy.deepcopy(
-                    self._default_milling_tasks[task_name]
-                )
-                # match the center to the first tasks' center
-                self.milling_tasks[task_name].patterns[0].center.value = (
-                    self.milling_tasks[existing_tasks[0]].patterns[0].center.value
-                )
-
-        # stream
-        if not self.milling_tasks:
-            return
-
-        if not self.acq_cont.stream or not self.acq_cont.stream.raw:
-            return
-
-        if not tasks_to_draw:
+        # then, redraws all the patterns.
+        feature = self._tab_data.main.currentFeature.value
+        selected_tasks = self.selected_tasks.value
+        # The patterns are defined relative to the center of the reference image
+        if not self.milling_tasks or not selected_tasks or not feature or feature.reference_image is None:
             self.canvas.request_drawing_update()
             return
 
-        # convert the position to the centre of the image coordinate (pattern coordinate system)
-        if isinstance(pos, tuple):
-            if convert_pos:
-                pos = _get_pattern_centre(pos, self.acq_cont.stream)
-            for task_name, task in self.milling_tasks.items():
-                for pattern in task.patterns:
-                    pattern.center.value = pos # image center
-
         # redraw all patterns
         for i, (task_name, task) in enumerate(self.milling_tasks.items()):
-            if task_name not in tasks_to_draw:
+            if not task.selected:
                 continue
             for pattern in task.patterns:
                 # logging.debug(f"{task_name}: {pattern.to_json()}")
@@ -416,7 +412,7 @@ class MillingTaskController:
                     name = task_name if j == 0 else None
                     shape = rectangle_pattern_to_shape(
                                             canvas=self.canvas,
-                                            stream=self.acq_cont.stream,
+                                            ref_img=feature.reference_image,
                                             pattern=pshape,
                                             colour=_get_milling_colour(task_name, i),
                                             name=name)
@@ -425,21 +421,8 @@ class MillingTaskController:
         # validate the patterns
         self._on_shapes_update(self.rectangles_overlay._shapes.value)
 
-        # auto save the milling tasks on the feature
-        self.feature_controller.save_milling_tasks(self.milling_tasks, self.selected_tasks.value)
-
-        return
-
-        # notes:
-        # can we fill the rectangles?
-        # can we re-colour / hide the control points?
-        # can we toggle labels visiblility
-        # can we toggle shape visibility
-        # how to rotate the shapes?
-
     def _update_selected_tasks(self, evt: wx.Event):
-        checked_indices = self._panel.milling_task_chk_list.GetCheckedItems()
-        self.selected_tasks.value = [self._panel.milling_task_chk_list.GetString(i) for i in checked_indices]
+        self.selected_tasks.value = list(self._panel.milling_task_chk_list.GetCheckedStrings())
         # Update the 'Pattern' panel
         for task_name, controls in self.controls.items():
             panel = controls["panel"]


### PR DESCRIPTION
There were several issues with the milling patterns:
* changing feature reverts the center position of all the patterns to 0,0
* Only the patterns selected for milling were stored in json, so selecting a new one would add it to the wrong position
* Could end up in situations where a pattern setting is not shown anymore for a given feature
* If no feature is selected, it was still possible to change the pattern settings... but that had no effect.

In order to fix these issues, all at once, the pattern management scheme has been reorganised:
* the milling task has an extra attribute "selected" which indicates whether it should be milling or not. It's recorded to JSON, and so all patterns can be saved to JSON, selected or not.
* separate drawing a pattern from moving a pattern, from converting between relative and absolute position.
* The MillingTaskController is independently listening to the current feature change (not relying on MillingTaskController to call it)
* Whenever a feature is changed, the list of patterns and settings is entirely updated. No attempt to optimize by detecting that the patterns are the same as the previous one.