### PR TITLE
[feat] METEOR: allow user to provide default milling tasks

### DIFF
--- a/src/odemis/acq/feature.py
+++ b/src/odemis/acq/feature.py
@@ -48,6 +48,8 @@ FEATURE_ACTIVE, FEATURE_READY_TO_MILL, FEATURE_ROUGH_MILLED, FEATURE_POLISHED, F
 
 REFERENCE_IMAGE_FILENAME = "Reference-Alignment-FIB.ome.tiff"
 
+USER_MILLING_TASKS_PATH = os.path.expanduser("~/.config/odemis/milling_tasks.yaml")
+
 
 # define the target types
 class TargetType(Enum):
@@ -166,7 +168,18 @@ class CryoFeature(object):
         self.posture_positions: Dict[str, Dict[str, float]] = {} # positions for each posture
 
         if milling_tasks is None:
-            milling_tasks = load_milling_tasks(DEFAULT_MILLING_TASKS_PATH)
+            # Find the default milling tasks, starting by looking into the config directory, and then
+            # the fallback file in the package.
+            try:
+                milling_tasks = load_milling_tasks(USER_MILLING_TASKS_PATH)
+            except Exception as e:
+                if not isinstance(e, FileNotFoundError):
+                    logging.warning(f"Error loading milling tasks from user path ({USER_MILLING_TASKS_PATH}): {e}")
+                try:
+                    milling_tasks = load_milling_tasks(DEFAULT_MILLING_TASKS_PATH)
+                except Exception as e:
+                    logging.warning(f"Error loading milling tasks from default path: {e}")
+                    milling_tasks = {}
         self.milling_tasks: Dict[str, MillingTaskSettings] = milling_tasks
 
         self.status = model.StringVA(FEATURE_ACTIVE)


### PR DESCRIPTION
First read the default values from ~/.config/odemis/milling_tasks.yaml ,
and only after fallback to using the file from the package.