### PR TITLE
[fix] SPARC GUI: Alignment tab fails to get enabled when engaging the mirror

### DIFF
--- a/src/odemis/gui/cont/tabs/sparc2_chamber_tab.py
+++ b/src/odemis/gui/cont/tabs/sparc2_chamber_tab.py
@@ -350,7 +350,8 @@ class ChamberTab(Tab):
 
         try:
             tab_align = self.tab_data_model.main.getTabByName("sparc2_align")
-            tab_align.button.Enable(mstate == MIRROR_ENGAGED)
+            tab_align.should_be_enabled = (mstate == MIRROR_ENGAGED)
+            tab_align.button.Enable(tab_align.should_be_enabled)
         except LookupError:
             logging.debug("Failed to find the alignment tab")
 

--- a/src/odemis/gui/cont/tabs/tab_bar_controller.py
+++ b/src/odemis/gui/cont/tabs/tab_bar_controller.py
@@ -83,8 +83,12 @@ class TabController(object):
         else:
             for tab in self._tab.choices:
                 # Check if button should be enabled based on its state
-                # (which may have been set by stage position callback)
-                tab.button.Enable(tab.should_be_enabled)
+                # (which may have been changed while the acquisition was running)
+                # Only re-enable the buttons, as they were all disabled at the start of the acquisition,
+                # so if one button is now already enabled, it means another part of the GUI decided
+                # to enable it, and we should respect that.
+                if tab.should_be_enabled:
+                    tab.button.Enable(tab.should_be_enabled)
 
     @call_in_wx_main
     def _on_tab_change(self, tab):


### PR DESCRIPTION
Commit eba4cf7e7 ([fix] tab state race conditions) changed the behaviour
of the tab controller to always reset the state of the tab after the
"acquisition" is complete.
However, when engaging/parking the mirror in the chamber tab of the
SPARC, the alignment tab become enable/disabled as the result of the move. So
the previous state is incorrect.

Fix it by using the new should_be_enabled option

Also make the tab controller less prone to errors by not disabling a tab
that got enable during the "acquisition", which should reduce the
possibilities of other similar bugs.

Check the rest of the GUI code, and it seems to be the only place to
update related to enabling the state of a tab.