### PR TITLE
[fix] SPARC alignment tab: adjust the tooltips of the Light Out buttons

### DIFF
--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -16361,7 +16361,7 @@ b\xeb\x85\x9f\xb6B\x1d\x0cK\x17\xac\xf0\x12\xfe\xa0\xe5\xee\xe03\xb1\xfa\
                           <height>24</height>
                           <face_colour>def</face_colour>
                           <label>Retract</label>
-                          <tooltip>If active allows to manually focus the spectrometer for the selected grating and detector.</tooltip>
+                          <tooltip>Moves the selector mirror away, so that the light goes to the internal spectrograph.</tooltip>
                           <style>wxALIGN_CENTRE</style>
                           <XRCED>
                             <assign_var>1</assign_var>
@@ -16376,7 +16376,7 @@ b\xeb\x85\x9f\xb6B\x1d\x0cK\x17\xac\xf0\x12\xfe\xa0\xe5\xee\xe03\xb1\xfa\
                           <height>24</height>
                           <face_colour>def</face_colour>
                           <label>Engage</label>
-                          <tooltip>If active allows to manually focus the spectrometer for the selected grating and detector.</tooltip>
+                          <tooltip>Moves the selector mirror so that the light goes out. It is then possible to align it.</tooltip>
                           <style>wxALIGN_CENTRE</style>
                           <XRCED>
                             <assign_var>1</assign_var>

--- a/src/odemis/gui/xmlh/resources/panel_tab_sparc2_align.xrc
+++ b/src/odemis/gui/xmlh/resources/panel_tab_sparc2_align.xrc
@@ -1570,7 +1570,7 @@
                           <height>24</height>
                           <face_colour>def</face_colour>
                           <label>Retract</label>
-                          <tooltip>If active allows to manually focus the spectrometer for the selected grating and detector.</tooltip>
+                          <tooltip>Moves the selector mirror away, so that the light goes to the internal spectrograph.</tooltip>
                           <style>wxALIGN_CENTRE</style>
                           <XRCED>
                             <assign_var>1</assign_var>
@@ -1585,7 +1585,7 @@
                           <height>24</height>
                           <face_colour>def</face_colour>
                           <label>Engage</label>
-                          <tooltip>If active allows to manually focus the spectrometer for the selected grating and detector.</tooltip>
+                          <tooltip>Moves the selector mirror so that the light goes out. It is then possible to align it.</tooltip>
                           <style>wxALIGN_CENTRE</style>
                           <XRCED>
                             <assign_var>1</assign_var>


### PR DESCRIPTION
The "Retract" and "Engage" buttons had the same tooltips as for the
manual focus mode.
=> Put some proper explanations