### PR TITLE
[feat] andorcam3: better handling of USB camera opening

### DIFF
--- a/install/linux/lib/udev/rules.d/80-andor-reset.rules
+++ b/install/linux/lib/udev/rules.d/80-andor-reset.rules
@@ -1,0 +1,7 @@
+# This gives rights for the "normal" user to reset the USB connection of Andor
+# devices. Sometimes cameras don't respond, and just resetting the connection
+# (by writing 0 to authorized, followed by 1) allows to recover the connection.
+# The alternative is to manually unplug & replug the USB cable.
+
+SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTRS{idVendor}=="136e", \
+RUN+="/bin/chmod g+w /sys/bus/usb/devices/%k/authorized", RUN+="/bin/chgrp odemis /sys/bus/usb/devices/%k/authorized"

--- a/src/odemis/driver/andorcam3.py
+++ b/src/odemis/driver/andorcam3.py
@@ -35,12 +35,19 @@ import re
 import threading
 import time
 import weakref
-from typing import Dict, Set, List, Optional
+from typing import Dict, Set, List, Optional, Tuple
 
 import numpy
 
 from odemis import model, util
 from odemis.model import HwError, oneway
+
+# USB IDs, used to locate the camera in the USB tree in case of issue.
+# Extend when new cameras are supported.
+ANDOR_VENDOR_ID = "136e"
+ANDOR_ZYLA_PID = "0014"
+ANDOR_SONA_PID = "0021"
+ANDOR_USB_PIDs = {ANDOR_ZYLA_PID, ANDOR_SONA_PID}
 
 
 # Neo encodings (selectable depending on gain selection):
@@ -484,6 +491,80 @@ class AndorCam3(model.DigitalCamera):
                 continue # This VA is not supported
             va.value = va.value  # setter will be called, but not listeners
 
+    def _find_device_usb_path(self, serial: Optional[str] = None) -> Optional[str]:
+        """
+        Find a sysfs USB device path for a supported Andor USB camera.
+
+        :param serial: Optional serial string used to prefer a specific path. If not provided, any
+        device that looks like a supported Andor USB camera will be accepted.
+        :return: Matching sysfs path or ``None`` if nothing valid was found.
+        """
+        valid_paths: List[str] = []
+        for sys_path in glob.glob('/sys/bus/usb/devices/*'):
+            try:
+                with open(os.path.join(sys_path, "idVendor")) as f:
+                    vendor = f.read().strip().lower()
+                if vendor != ANDOR_VENDOR_ID:
+                    continue
+                with open(os.path.join(sys_path, "idProduct")) as f:
+                    product = f.read().strip().lower()
+            except (IOError, UnicodeDecodeError):
+                continue
+            if product in ANDOR_USB_PIDs:
+                valid_paths.append(sys_path)
+
+        if not valid_paths:
+            return None
+        if serial is None or len(valid_paths) == 1:
+            return valid_paths[0]
+
+        # Multiple Andor USB devices found, try to find the one matching the serial.
+        # First pass: look for an exact serial number match.
+        vsc_andor_path: Optional[str] = None
+        for sys_path in valid_paths:
+            try:
+                with open(os.path.join(sys_path, "serial")) as f:
+                    serial_num = f.read().strip()
+            except (IOError, UnicodeDecodeError):
+                continue
+            if serial_num == serial:
+                return sys_path
+            # Some cameras don't have the actual serial number, but just VSC-ANDOR.
+            # Remember the first such path as a fallback for the second pass.
+            if serial_num == "VSC-ANDOR" and not vsc_andor_path:
+                vsc_andor_path = sys_path
+
+        # Second pass: fall back to a VSC-ANDOR device if no exact match was found.
+        if vsc_andor_path:
+            return vsc_andor_path
+
+        logging.debug("Multiple Andor USB devices found but none matched serial %s", serial)
+        return None
+
+    def _reset_usb_connection(self, sys_path: str) -> bool:
+        """
+        Disconnect and reconnect the USB in software for a device path to force re-enumeration.
+
+        :param sys_path: Sysfs USB device path (for example "/sys/bus/usb/devices/3-1"). This is
+        typically the path found by _find_device_usb_path().
+        :return: True if the toggle succeeded, otherwise False.
+        """
+        # Note that normally only root can write to any of the files in sysfs, but we have a dedicated
+        # udev rules that gives right to the "odemis" group (in which the driver should be running)
+        auth_path = os.path.join(sys_path, "authorized")
+        try:
+            with open(auth_path, "w") as f:
+                f.write("0")  # device "unauthorized" -> kernel disconnects it
+            time.sleep(1)
+            with open(auth_path, "w") as f:
+                f.write("1")  # device "authorized" -> kernel re-connects it
+            time.sleep(2)  # Wait a bit for the connection to be back
+        except OSError as ex:
+            logging.warning("Failed to reset USB authorization for %s: %s", sys_path, ex)
+            return False
+        logging.info("Reset USB connection for %s", sys_path)
+        return True
+
     # low level methods, wrapper to the actual SDK functions
     # TODO: not _everything_ is implemented, just what we need
 
@@ -494,33 +575,51 @@ class AndorCam3(model.DigitalCamera):
         """
         if device is None:
             self.handle = c_int(ATDLL.HANDLE_SYSTEM)
-        else:
-            logging.info("Opening camera device, might take time...")
-            handle = c_int()
-            try:
-                self.atcore.AT_Open(device, byref(handle))
-            except ATError:
-                # Let's try to diagnose a bit the problem...
-                if self._bitflow_install_dirs is None:
-                    logging.warning("No bitflow_install_dirs value set, so "
-                                    "cameras connected via CameraLink will not "
-                                    "be detected.")
-                    raise
-                if not os.path.isdir(self._bitflow_install_dirs):
-                    logging.error("The directory '%s' is not present. Check "
-                                  "that the libandor3 package is installed, "
-                                  "and the configuration is correct.",
-                                  self._bitflow_install_dirs)
-                    raise
-                # check if bitflow module is loaded
-                fmodules = open("/proc/modules").readlines()
-                if not any(re.match("bitflow", l) for l in fmodules):
-                    logging.error("The bitflow module is not loaded. Check "
-                                  "that libandor3 is correctly installed and "
-                                  "you are using a supported kernel.")
-                    raise
-                raise
-            self.handle = handle
+            return
+
+        logging.info("Opening camera device, might take time...")
+        handle = c_int()
+        try:
+            self.atcore.AT_Open(device, byref(handle))
+        except ATError as exp:
+            if exp.errno == 10:  # ERR_CONNECTION
+                logging.debug("Failed to open camera device %s: %s. Will try to reset USB connection", device, exp)
+                # In some cases, resetting the USB connection helps, so let's try
+                sys_path = self._find_device_usb_path()
+                if sys_path is None:
+                    logging.warning("Failed to find valid Andor USB device in the USB path for reset")
+                elif self._reset_usb_connection(sys_path):
+                    logging.info("Retrying opening camera device %d after USB reset", device)
+                    try:
+                        self.atcore.AT_Open(device, byref(handle))
+                    except ATError as retry_exp:
+                        exp = retry_exp
+                    else:
+                        self.handle = handle
+                        return
+
+            # Let's try to diagnose a bit the problem...
+            # On CameraLink cameras, this can happen if the bitflow driver is not correctly installed
+            if self._bitflow_install_dirs is None:
+                logging.warning("No bitflow_install_dirs value set, so "
+                                "cameras connected via CameraLink will not "
+                                "be detected.")
+                raise exp
+            if not os.path.isdir(self._bitflow_install_dirs):
+                logging.error("The directory '%s' is not present. Check "
+                              "that the libandor3 package is installed, "
+                              "and the configuration is correct.",
+                              self._bitflow_install_dirs)
+                raise exp
+            # check if bitflow module is loaded
+            fmodules = open("/proc/modules").readlines()
+            if not any(re.match("bitflow", l) for l in fmodules):
+                logging.error("The bitflow module is not loaded. Check "
+                              "that libandor3 is correctly installed and "
+                              "you are using a supported kernel.")
+                raise exp
+            raise exp
+        self.handle = handle
 
     def Close(self):
         assert self.handle is not None
@@ -544,26 +643,17 @@ class AndorCam3(model.DigitalCamera):
             # to plug correctly the camera.
 
             # Current USB protocol level is in "/sys/bus/usb/devices/*/version".
-            # However, for the Zyla, we cannot use UsbProductId or UsbDeviceId, so
-            # we just use the serial number (which is also in ./serial)
+            # Find the camera USB path using Andor VID:PID first, then use serial
+            # only as a disambiguation hint (VSC-ANDOR is a valid serial marker).
             try:
                 sn = self.GetString("SerialNumber")
-                sn_paths = glob.glob('/sys/bus/usb/devices/*/serial')
-                for p in sn_paths:
-                    try:
-                        with open(p) as f:
-                            snp = f.read().strip()
-                    except (IOError, UnicodeDecodeError):
-                        logging.debug("Failed to read %s, skipping device", p)
-                    if snp == sn:
-                        break
-                else:
-                    logging.warning("Failed to find USB device %s in the USB path", sn)
+                sys_path = self._find_device_usb_path(sn)
+                if sys_path is None:
+                    logging.warning("Failed to find valid Andor USB device %s in the USB path", sn)
                     return
-                # .../3-1.2/serial => .../3-1.2/3-1.2:1.0/ttyUSB1
-                sys_path = os.path.dirname(p)
-                with open(sys_path + "/version") as f:
+                with open(os.path.join(sys_path, "version")) as f:
                     usbv = float(f.read().strip())
+                logging.debug("Found camera %s in USB path %s with USB version %g", sn, sys_path, usbv)
             except Exception:
                 logging.info("Failed to check USB version for device %s", self.name, exc_info=True)
                 return

--- a/src/odemis/driver/test/andorcam3_test.py
+++ b/src/odemis/driver/test/andorcam3_test.py
@@ -21,14 +21,13 @@ PURPOSE. See the GNU General Public License for more details.
 You should have received a copy of the GNU General Public License along with
 Odemis. If not, see http://www.gnu.org/licenses/.
 '''
+import io
 import logging
-from odemis.driver import andorcam3
 import unittest
-from unittest.case import skip
+from unittest import mock
 
-from cam_test_abs import VirtualTestCam, VirtualStaticTestCam, \
-    VirtualTestSynchronized
-
+from cam_test_abs import VirtualTestCam, VirtualStaticTestCam, VirtualTestSynchronized
+from odemis.driver import andorcam3
 
 logging.basicConfig(format="%(asctime)s  %(levelname)-7s %(module)s:%(lineno)d %(message)s",
                     level=logging.DEBUG,
@@ -84,6 +83,97 @@ class TestSynchronized(VirtualTestSynchronized, unittest.TestCase):
     """
     camera_type = CLASS
     camera_kwargs = KWARGS_EXTRA
+
+
+class TestAndorCam3ConnectionCheck(unittest.TestCase):
+    """
+    Unit tests for USB connection validation in AndorCam3._check_connection().
+    """
+
+    def _make_camera(self, serial_number: str) -> andorcam3.AndorCam3:
+        """
+        Build a minimal camera instance for connection checks.
+
+        :param serial_number: Serial number returned by GetString("SerialNumber").
+        :return: Partially initialized camera object suitable for unit tests.
+        """
+        camera = andorcam3.AndorCam3.__new__(andorcam3.AndorCam3)
+        camera._name = "camera"
+        camera.isImplemented = lambda feature: feature == "InterfaceType"
+        camera.GetString = lambda feature: "USB3" if feature == "InterfaceType" else serial_number
+        return camera
+
+    def test_check_connection_valid_vid_pid_usb2_raises(self) -> None:
+        """
+        Ensure valid Andor VID:PID on USB2 triggers a connection error.
+        """
+        camera = self._make_camera("VSC-01959")
+        paths = ["/sys/bus/usb/devices/3-1.2"]
+        files = {
+            "/sys/bus/usb/devices/3-1.2/idVendor": "136e\n",
+            "/sys/bus/usb/devices/3-1.2/idProduct": "0014\n",
+            "/sys/bus/usb/devices/3-1.2/version": "2.00\n",
+        }
+
+        def _open(path: str, *args, **kwargs) -> io.StringIO:
+            if path in files:
+                return io.StringIO(files[path])
+            raise IOError(path)
+
+        with mock.patch.object(andorcam3.glob, "glob", return_value=paths), \
+                mock.patch("builtins.open", side_effect=_open):
+            with self.assertRaises(andorcam3.HwError):
+                camera._check_connection()
+
+    def test_check_connection_vsc_andor_serial_is_accepted(self) -> None:
+        """
+        Ensure "VSC-ANDOR" serial is accepted when VID:PID is valid.
+        """
+        camera = self._make_camera("VSC-01959")
+        paths = ["/sys/bus/usb/devices/3-1.2", "/sys/bus/usb/devices/4-1.3"]
+        files = {
+            "/sys/bus/usb/devices/3-1.2/idVendor": "136e\n",
+            "/sys/bus/usb/devices/3-1.2/idProduct": "0014\n",
+            "/sys/bus/usb/devices/3-1.2/serial": "VSC-ANDOR\n",
+            "/sys/bus/usb/devices/3-1.2/version": "2.10\n",
+            "/sys/bus/usb/devices/4-1.3/idVendor": "136e\n",
+            "/sys/bus/usb/devices/4-1.3/idProduct": "0021\n",
+            "/sys/bus/usb/devices/4-1.3/serial": "OTHER\n",
+            "/sys/bus/usb/devices/4-1.3/version": "3.10\n",
+        }
+
+        def _open(path: str, *args, **kwargs) -> io.StringIO:
+            if path in files:
+                return io.StringIO(files[path])
+            raise IOError(path)
+
+        with mock.patch.object(andorcam3.glob, "glob", return_value=paths), \
+                mock.patch("builtins.open", side_effect=_open):
+            with self.assertRaises(andorcam3.HwError):
+                camera._check_connection()
+
+    def test_check_connection_vsc_andor_without_valid_vid_pid_is_ignored(self) -> None:
+        """
+        Ensure "VSC-ANDOR" is ignored when VID:PID is not an Andor pair.
+        """
+        camera = self._make_camera("VSC-01959")
+        paths = ["/sys/bus/usb/devices/3-1.2"]
+        files = {
+            "/sys/bus/usb/devices/3-1.2/idVendor": "1234\n",
+            "/sys/bus/usb/devices/3-1.2/idProduct": "abcd\n",
+            "/sys/bus/usb/devices/3-1.2/serial": "VSC-ANDOR\n",
+            "/sys/bus/usb/devices/3-1.2/version": "2.00\n",
+        }
+
+        def _open(path: str, *args, **kwargs) -> io.StringIO:
+            if path in files:
+                return io.StringIO(files[path])
+            raise IOError(path)
+
+        with mock.patch.object(andorcam3.glob, "glob", return_value=paths), \
+                mock.patch("builtins.open", side_effect=_open):
+            camera._check_connection()
+
 
 # Notes on testing the reconnection (which is pretty impossible to do non-manually):
 # * Test both cable disconnect/reconnect and turning off/on


### PR DESCRIPTION
Some USB cameras, instead of reporting their actual serial number have
"VSC-ANDOR" as serial number. => Concider it as a valid serial number
too. We check also the USB product ID to be extra careful.

Also, some cameras have sometimes a bad mood and don't connect at init.
From testing, it appears that just resetting the USB connection in
software helps the connection. So detect such case, and try it.
This helps in particular with the Zyla 5.5.