### PR TITLE
[fix] SPARC alignment tab: don't expect the labcube to have a filter wheel

### DIFF
--- a/src/odemis/gui/cont/tabs/sparc2_align_tab.py
+++ b/src/odemis/gui/cont/tabs/sparc2_align_tab.py
@@ -727,6 +727,7 @@ class Sparc2AlignTab(Tab):
 
                 if main_data.tc_od_filter:
                     speccnt_spe.add_axis_entry("density", main_data.tc_od_filter)
+                if main_data.tc_filter:
                     speccnt_spe.add_axis_entry("band", main_data.tc_filter)
                 speccnt_spe.stream_panel.flatten()
                 self._speccnt_stream = speccnts


### PR DESCRIPTION
It did check that the OD filter was there, but assumed that in this case
the filter wheel is there too. In some experiments, it's helpful to
remove the filter wheel (aka cl-filter), so let's be extra careful.

Without this change, such error happen:
```
2026-03-13 18:34:54,159	DEBUG	util:1003:	Adding Axis control Band
2026-03-13 18:34:54,162	ERROR	main:471:	Traceback (most recent call last):
  File "/home/piel/development/odemis/src/odemis/gui/main.py", line 328, in init_gui
    self.tab_controller = tabs.TabBarController(tab_defs, self.main_frame, self.main_data)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/piel/development/odemis/src/odemis/gui/cont/tabs/tab_bar_controller.py", line 148, in __init__
    tab_list, default_tab = self._create_needed_tabs(tab_defs, main_frame, main_data)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/piel/development/odemis/src/odemis/gui/cont/tabs/tab_bar_controller.py", line 178, in _create_needed_tabs
    tab = tab_def["controller"](tab_def["name"], tab_def["button"],
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/piel/development/odemis/src/odemis/gui/cont/tabs/sparc2_align_tab.py", line 730, in __init__
    speccnt_spe.add_axis_entry("band", main_data.tc_filter)
  File "/home/piel/development/odemis/src/odemis/gui/cont/stream.py", line 435, in add_axis_entry
    ae = create_axis_entry(self.stream_panel, name, comp, conf)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/piel/development/odemis/src/odemis/gui/conf/util.py", line 1005, in create_axis_entry
    ad = comp.axes[name]
         ^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'axes'
```