### PR TITLE
[refactor] GUI: don't directly import Cryo classes in gui.acquisition

### DIFF
--- a/src/odemis/gui/cont/acquisition/__init__.py
+++ b/src/odemis/gui/cont/acquisition/__init__.py
@@ -27,8 +27,6 @@ of microscope images.
 
 """
 
-from .cryo_acq import CryoAcquiController
-from .cryo_z_localization import CryoZLocalizationController
 from .fastem_acq import (FastEMCalibrationController, FastEMMultiBeamAcquiController,
                          FastEMOverviewAcquiController, FastEMSingleBeamAcquiController)
 from .overview_stream_acq import OverviewStreamAcquiController

--- a/src/odemis/gui/cont/acquisition/cryo_z_localization.py
+++ b/src/odemis/gui/cont/acquisition/cryo_z_localization.py
@@ -27,7 +27,6 @@ of microscope images.
 
 """
 import logging
-import math
 from concurrent.futures._base import CancelledError
 from typing import List, Optional
 
@@ -40,17 +39,12 @@ from odemis.acq.feature import Target, TargetType, save_features
 from odemis.acq.move import FM_IMAGING
 from odemis.acq.stream import FluoStream
 from odemis.gui import conf
-from odemis.gui.comp import popup
 from odemis.gui.cont.multi_point_correlation import update_feature_correlation_target
 from odemis.gui.model import TOOL_FIDUCIAL
 from odemis.gui.util import call_in_wx_main
-from odemis.gui.util.widgets import (
-    ProgressiveFutureConnector,
-    VigilantAttributeConnector,
-)
+from odemis.gui.util.widgets import ProgressiveFutureConnector, VigilantAttributeConnector
 from odemis.model import ListVA
 from odemis.util import units
-from odemis.util.filename import create_filename
 
 
 class CryoZLocalizationController(object):

--- a/src/odemis/gui/cont/correlation.py
+++ b/src/odemis/gui/cont/correlation.py
@@ -38,7 +38,6 @@ import odemis.acq.stream as acqstream
 import odemis.gui.model as guimod
 from odemis import model
 from odemis.acq.stream import RGBStream, StaticFluoStream, StaticSEMStream, StaticStream
-from odemis.gui.cont.tabs.localization_tab import LocalizationTab
 from odemis.gui.util import call_in_wx_main
 from odemis.acq.move import FM_IMAGING
 
@@ -135,7 +134,7 @@ class CorrelationController(object):
             vp.canvas.Bind(wx.EVT_LEFT_DOWN, self.on_mouse_down)
 
         # localization tab
-        self.localization_tab: LocalizationTab = None
+        self.localization_tab: "LocalizationTab" = None
         self.fibsem_tab = None
 
         # auto correlation SEM<>FM, based on the  stage-bare position found in the image metadata
@@ -262,7 +261,7 @@ class CorrelationController(object):
         """
         if self.localization_tab is None:
             try:
-                self.localization_tab: LocalizationTab = self._main_data_model.getTabByName("cryosecom-localization")
+                self.localization_tab: "LocalizationTab" = self._main_data_model.getTabByName("cryosecom-localization")
             except LookupError:
                 return  # Localization tab doesn't exist (eg, on the Viewer) => nothing to do
 
@@ -467,7 +466,7 @@ class CorrelationController(object):
 
         if self.localization_tab is None:
             try:
-                self.localization_tab: LocalizationTab = self._main_data_model.getTabByName("cryosecom-localization")
+                self.localization_tab: "LocalizationTab" = self._main_data_model.getTabByName("cryosecom-localization")
             except LookupError:
                 return  # Localization tab doesn't exist (eg, on the Viewer) => nothing to do
 

--- a/src/odemis/gui/cont/tabs/fibsem_tab.py
+++ b/src/odemis/gui/cont/tabs/fibsem_tab.py
@@ -22,17 +22,15 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 import collections
 import logging
 import math
-from typing import Dict
 from concurrent.futures import CancelledError
+from typing import Dict
 
 import numpy
 import wx
 
-import odemis.gui.cont.acquisition as acqcont
 import odemis.gui.cont.views as viewcont
 import odemis.gui.model as guimod
 import odemis.gui.util as guiutil
-from odemis.gui.conf.data import get_local_vas
 from odemis import model
 from odemis.acq.move import FIB_IMAGING, MILLING, MILLING_RANGE, POSITION_NAMES, SEM_IMAGING
 from odemis.acq.stream import (
@@ -44,13 +42,12 @@ from odemis.acq.stream import (
 )
 from odemis.gui import conf
 from odemis.gui.comp.buttons import BTN_TOGGLE_COMPLETE, BTN_TOGGLE_OFF, BTN_TOGGLE_PROGRESS
+from odemis.gui.conf.data import get_local_vas
 from odemis.gui.conf.licences import LICENCE_FIBSEM_ENABLED, LICENCE_MILLING_ENABLED
 from odemis.gui.cont import milling, settings
+from odemis.gui.cont.acquisition.cryo_acq import CryoAcquiController
 from odemis.gui.cont.features import CryoFeatureController
-from odemis.gui.cont.stream_bar import (
-    CryoFIBAcquiredStreamsController,
-    CryoStreamsController,
-)
+from odemis.gui.cont.stream_bar import CryoFIBAcquiredStreamsController, CryoStreamsController
 from odemis.gui.cont.tabs.tab import Tab
 from odemis.gui.model import TOOL_ACT_ZOOM_FIT
 from odemis.gui.util import call_in_wx_main
@@ -121,8 +118,7 @@ class FibsemTab(Tab):
         )
         self._streambar_controller._stream_bar.btn_add_stream.Hide()
 
-        self._acquisition_controller = acqcont.CryoAcquiController(
-            tab_data, panel, self, mode=guimod.AcquiMode.FIBSEM)
+        self._acquisition_controller = CryoAcquiController(tab_data, panel, self, mode=guimod.AcquiMode.FIBSEM)
         self.conf = conf.get_acqui_conf()
 
         # Toolbar

--- a/src/odemis/gui/cont/tabs/localization_tab.py
+++ b/src/odemis/gui/cont/tabs/localization_tab.py
@@ -25,28 +25,27 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 
 import collections
 import logging
+from typing import List
+
 import numpy
 import wx
 
-from typing import List
-from odemis.gui import conf
-from odemis.gui.cont.features import CryoFeatureController
-
-from odemis import model
 import odemis.acq.stream as acqstream
 import odemis.gui
-import odemis.gui.cont.acquisition as acqcont
-from odemis.gui.cont.stream_bar import CryoAcquiredStreamsController, CryoStreamsController
 import odemis.gui.cont.views as viewcont
 import odemis.gui.model as guimod
 import odemis.gui.util as guiutil
+from odemis import model
 from odemis.acq.align import AutoFocus
-from odemis.acq.move import MILLING, ALIGNMENT, \
-    FM_IMAGING, SEM_IMAGING, THREE_BEAMS
+from odemis.acq.move import MILLING, ALIGNMENT, FM_IMAGING, SEM_IMAGING, THREE_BEAMS
 from odemis.acq.stream import LiveStream, StaticStream
+from odemis.gui import conf
 from odemis.gui.conf.data import get_local_vas
 from odemis.gui.cont import settings
-from odemis.gui.cont.acquisition import CryoZLocalizationController
+from odemis.gui.cont.acquisition.cryo_acq import CryoAcquiController
+from odemis.gui.cont.acquisition.cryo_z_localization import CryoZLocalizationController
+from odemis.gui.cont.features import CryoFeatureController
+from odemis.gui.cont.stream_bar import CryoAcquiredStreamsController, CryoStreamsController
 from odemis.gui.cont.tabs.tab import Tab
 from odemis.gui.model import TOOL_ACT_ZOOM_FIT, TOOL_AUTO_FOCUS, TOOL_FIDUCIAL
 from odemis.gui.util import call_in_wx_main
@@ -128,8 +127,7 @@ class LocalizationTab(Tab):
             view_ctrl=self.view_controller
         )
 
-        self._acquisition_controller = acqcont.CryoAcquiController(
-            tab_data, panel, self, mode=guimod.AcquiMode.FLM)
+        self._acquisition_controller = CryoAcquiController(tab_data, panel, self, mode=guimod.AcquiMode.FLM)
 
         self._acquired_stream_controller = CryoAcquiredStreamsController(
             tab_data,


### PR DESCRIPTION
Having all controllers available in gui.acquisition is handy as it makes
the import slightly faster to read, but that also means that any import
of gui.acquisition automatically imports all the controllers.
The Cryo controllers then imports all the acq.milling, which is quite
large, as it imports fibsemOS (if available).

So, to avoid importing too much, let the users of the Cryo controllers
explicitly import the submodules in gui acquisition.
This avoids trying to load (and failing) fibsemOS on the SPARC, FASTEM
or viewer.