### PR TITLE
[fix] GUI: small issues at start up

### DIFF
--- a/src/odemis/gui/comp/canvas.py
+++ b/src/odemis/gui/comp/canvas.py
@@ -1699,8 +1699,8 @@ class DraggableCanvas(BitmapCanvas):
     # Buffer and drawing methods
     def get_minimum_buffer_size(self):
         """ Return the minimum size needed by the buffer """
-        return (max(self.MinClientSize.x, self.ClientSize.x) + self.default_margin * 2,
-                max(self.MinClientSize.y, self.ClientSize.y) + self.default_margin * 2)
+        return (max(1, self.MinClientSize.x, self.ClientSize.x) + self.default_margin * 2,
+                max(1, self.MinClientSize.y, self.ClientSize.y) + self.default_margin * 2)
 
     def _calc_bg_offset(self, new_pos):
         """ Calculate the offset needed for the checkered background after a canvas shift

--- a/src/odemis/gui/main.py
+++ b/src/odemis/gui/main.py
@@ -368,7 +368,9 @@ class OdemisGUIApp(wx.App):
 
             # making it very late seems to make it smoother
             wx.CallAfter(self.main_frame.Show)
-
+            # Due to a bug in wxPython, sometimes the .Maximize() at the beginning of the function
+            # has no effect. So we call it after the Show() to be sure it works.
+            wx.CallAfter(self.main_frame.Maximize)
         except Exception:
             self.excepthook(*sys.exc_info())
             # Re-raise the exception, so the program will exit. If this is not


### PR DESCRIPTION
The commit dbae6e82b4 (GUI: only load the tabs necessary based on the microscope role) introduced 2 (!) small cosmetic issues when starting the GUI. At least they are noticeable on Ubuntu 24.04 with the SPARCv2 simulator.
