### PR TITLE
[feat] Introduce MODEL_OPTIONS variable to odemis.conf

### DIFF
--- a/src/odemis/odemisd/start.py
+++ b/src/odemis/odemisd/start.py
@@ -22,6 +22,7 @@ see http://www.gnu.org/licenses/.
 """
 
 import argparse
+import glob
 import logging
 import os
 import re
@@ -636,6 +637,32 @@ def show_error_box(caption, message):
     app.Yield() # Hides the window
 
 
+def run_model_options(pattern_str: str) -> int:
+    """
+    Expand MODEL_OPTIONS glob patterns and launch odemis-select-mic-start for
+    interactive model selection.
+
+    :param pattern_str: Space-separated glob pattern(s) matching .odm.yaml files,
+      as read from the MODEL_OPTIONS entry in odemis.conf.
+    :returns: The exit code of odemis-select-mic-start.
+    :raises ValueError: If no files match any of the given patterns.
+    """
+    patterns = shlex.split(pattern_str)
+    files = []
+    for pattern in patterns:
+        files.extend(glob.glob(pattern))
+
+    if not files:
+        show_error_box("Error starting Odemis",
+                       "No microscope configuration files found matching MODEL_OPTIONS:\n"
+                       "%s\n\n"
+                       "Check the MODEL_OPTIONS setting in /etc/odemis.conf." % pattern_str)
+        raise ValueError("No files match MODEL_OPTIONS: %s" % pattern_str)
+
+    logging.debug("MODEL_OPTIONS matched files: %s", files)
+    return subprocess.call(["odemis-select-mic-start"] + files)
+
+
 def run_model_selector(cmd_str):
     """
     Gets the model file from the model selector
@@ -721,6 +748,18 @@ def main(args):
     # pyrolog.setLevel(min(pyrolog.getEffectiveLevel(), logging.DEBUG))
 
     try:
+        # If MODEL_OPTIONS is set and no specific model was given on the command line,
+        # delegate to odemis-select-mic-start for interactive model selection.
+        # odemis-select-mic-start will call odemis-start again with the chosen file,
+        # at which point options.model_conf will be set and this block is skipped.
+        # Note: do it even before checking the back-end status, because odemis-select-mic-start
+        # will suggest to restart the back-end if it's already running.
+        if not options.model_conf and not options.model_sel and "MODEL_OPTIONS" in odemis_config:
+            if "MODEL" in odemis_config or "MODEL_SELECTOR" in odemis_config:
+                logging.warning("MODEL_OPTIONS is set alongside MODEL or MODEL_SELECTOR in "
+                                "odemis.conf; MODEL_OPTIONS takes precedence")
+            return run_model_options(odemis_config["MODEL_OPTIONS"])
+
         status = driver.get_backend_status()
         if status != driver.BACKEND_RUNNING:
             starter = BackendStarter(odemis_config, options.nogui)

--- a/src/odemis/odemisd/test/start_test.py
+++ b/src/odemis/odemisd/test/start_test.py
@@ -30,7 +30,7 @@ from unittest import mock
 import notify2
 
 import odemis
-from odemis.odemisd.start import find_window, main
+from odemis.odemisd.start import find_window, main, run_model_options
 from odemis.util import testing
 
 CONFIG_PATH = os.path.dirname(odemis.__file__) + "/../../install/linux/usr/share/odemis/"
@@ -115,6 +115,50 @@ class StartTestCase(unittest.TestCase):
         self.assertFalse(find_window("Odemis"))
         self.assertTrue(hasattr(self, "error_code"))
         self.assertGreater(self.error_code, 0)
+
+
+class RunModelOptionsTestCase(unittest.TestCase):
+    """Unit tests for run_model_options(), exercising glob pattern expansion."""
+
+    def test_glob_expansion_single_pattern(self):
+        """A wildcard pattern matching sim files is expanded and odemis-select-mic-start is called
+        with the resulting file list."""
+        pattern = CONFIG_PATH + "sim/*.yaml"
+        with mock.patch("odemis.odemisd.start.subprocess.call", return_value=0) as mock_call, \
+             mock.patch("odemis.odemisd.start.show_error_box"):
+            ret = run_model_options(pattern)
+
+        self.assertEqual(ret, 0)
+        mock_call.assert_called_once()
+        call_args = mock_call.call_args[0][0]  # positional first arg: the list
+        self.assertEqual(call_args[0], "odemis-select-mic-start")
+        # The known secom-sim file must be among the expanded paths
+        self.assertIn(SECOM_CONFIG, call_args[1:])
+        # There should be multiple files
+        self.assertGreater(len(call_args[1:]), 1)
+
+    def test_glob_expansion_multiple_patterns(self):
+        """Two space-separated patterns are each expanded and all matches are forwarded."""
+        optical_config = CONFIG_PATH + "sim/optical-sim.odm.yaml"
+        pattern = '"%s" "%s"' % (SECOM_CONFIG, optical_config)
+        with mock.patch("odemis.odemisd.start.subprocess.call", return_value=0) as mock_call, \
+             mock.patch("odemis.odemisd.start.show_error_box"):
+            run_model_options(pattern)
+
+        call_args = mock_call.call_args[0][0]
+        self.assertIn(SECOM_CONFIG, call_args)
+        self.assertIn(optical_config, call_args)
+
+    def test_no_match_raises_value_error(self):
+        """A pattern that matches no files raises ValueError and shows an error box."""
+        pattern = "/nonexistent/path/that/does/not/exist/*.yaml"
+        with mock.patch("odemis.odemisd.start.subprocess.call") as mock_call, \
+             mock.patch("odemis.odemisd.start.show_error_box") as mock_error_box:
+            with self.assertRaises(ValueError):
+                run_model_options(pattern)
+
+        mock_error_box.assert_called_once()
+        mock_call.assert_not_called()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This variable should contain a filename pattern of microscope files.
If it's defined, the pattern is used to pass a series of microscope
files to odemis-select-mic-start, which eventually will call
odemis-start with a specific microscope file.

This allows to use odemis-select-mic-start without a special launcher.
Instead, just an extra line on odemis.conf is sufficient.