### PR TITLE
[MSD-496][test] JEOL METEOR: adjust axes range to match JEOL simulator

### DIFF
--- a/install/linux/usr/share/odemis/sim/meteor-jeol-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/meteor-jeol-sim.odm.yaml
@@ -33,9 +33,10 @@
         stage_range: {
             # Stage ranges. These are required to be correctly specified for 
             # the stage to be controllable by Odemis
-            "x": [-55.e-3, 10.e-3],  # m
+#            "x": [-55.e-3, 10.e-3],  # m, Standard value
+            "x": [-10.e-3, 10.e-3],  # m, for the simulator
             "y": [-15.e-3, 15.e-3],  # m
-            "z": [0.e-3, 41.5e-3],  # m
+            "z": [1.5e-3, 41.5e-3],  # m
             "rx": [-3.3161, 3.3161],  # rad, angle range in degrees is -190 to +190
             "rz": [-0.2617, 0.9599]  # rad, angle range in degrees is -15 to +55
         },
@@ -51,7 +52,8 @@
             "x_0": 0.e-3,
             "y_0": 0.e-3,
             "z_0": 8.5e-3,
-            "dx": -53.e-3,
+#            "dx": -53.e-3,  # Standard value
+            "dx": -9.5e-3,  # For the simulator
             "dy": 0.0,
             "dz": 0.0,
             "version": "jeol_1"
@@ -70,11 +72,12 @@
             "z": [4.e-3, 41.5e-3]
         },
         FM_IMAGING_RANGE: {
-            "x": [-55.e-3, -44.75e-3],
+#            "x": [-55.e-3, -44.75e-3],  # Standard value
+            "x": [-10.e-3, -3.e-3],  # For the simulator
             "y": [-8.25e-3, 8.25e-3],
             "z": [5.5e-3, 11.5e-3]
         },
-        FAV_POS_DEACTIVE: {"x": 0.0, "y": 0.0, "z": 0.0, "rx": 0.0, "rz": 0.0 }
+        FAV_POS_DEACTIVE: {"x": 0.0, "y": 0.0, "z": 4.0e-3, "rx": 0.0, "rz": 0.0 }
     },
 }
 

--- a/src/odemis/acq/test/move_jeol_test.py
+++ b/src/odemis/acq/test/move_jeol_test.py
@@ -279,7 +279,7 @@ class TestMeteorJeol1Move(unittest.TestCase):
         self._check_focus_position(model.MD_FAV_POS_DEACTIVE)
 
     def test_unknown_label_at_initialization(self):
-        arbitrary_position = {"x": 0.0, "y": 0.01, "z": 0.85e-3}
+        arbitrary_position = {"x": 0.0, "y": 0.01, "z": 4.85e-3}
         self.stage_bare.moveAbs(arbitrary_position).result()
         current_imaging_mode = self.posture_manager.getCurrentPostureLabel()
         self.assertEqual(UNKNOWN, current_imaging_mode)


### PR DESCRIPTION
The new version of the simple JEOL simulator v1.0.7 is more picky about
the axes ranges, and more realistic. Z can never go as low as 0.
=> update the ranges, and positions, and adjust the test case to always stay within the
"Base" range.