### PR TITLE
[test] tmcm_test: don't run test_protection when it's not supported

### DIFF
--- a/src/odemis/driver/test/tmcm_test.py
+++ b/src/odemis/driver/test/tmcm_test.py
@@ -578,6 +578,10 @@ class TestActuatorAbsEnc(TestActuator):
         # don't test led protection on abs enc
         pass
 
+    def test_protection(self):
+        # No support for .protection
+        pass
+
     def test_close_shutter(self):
         pass
 
@@ -593,6 +597,10 @@ class TestActuatorRelEnc(TestActuator):
 
     def test_led_protection_referencing(self):
         # don't test led protection on rel enc
+        pass
+
+    def test_protection(self):
+        # No support for .protection
         pass
 
     def test_close_shutter(self):


### PR DESCRIPTION
Commit cffa06a9fa3 (driver tmcm: add a .protection VA to force the LED
protection) add a test case on the TestActuator class. However, TestActuatorAbsEnc
TestActuatorRelEnc inherit from this class, without having a
TMCLController instance that has .protection.
=> Disable the test on the sub-classes.