### PR TITLE
[test] SPARC stream test: skip PMT-based test on "4spec" simulator

### DIFF
--- a/src/odemis/acq/test/stream_sparc_test.py
+++ b/src/odemis/acq/test/stream_sparc_test.py
@@ -1061,7 +1061,7 @@ class BaseSPARCTestCase(unittest.TestCase, ABC):
         """
         Test short & long acquisition for SE CL and EBIC acquisition simultaneously
         """
-        self.skipIfNotSupported("ebic")
+        self.skipIfNotSupported("ebic", "cl")
         # create axes
         axes = {"filter": ("band", self.filter)}
 
@@ -2041,7 +2041,7 @@ class SPARC2ScanStageVectorTestCase(BaseSPARCTestCase):
     Tests to be run with a (simulated) SPARCv2 with a scan stage and vector scanning.
     """
     simulator_config = SPARC2_VECTOR_SSTAGE_CONFIG
-    capabilities = {"spec", "vector", "scan-stage"}
+    capabilities = {"cl", "spec", "vector", "scan-stage"}
 
 
 class SPARC2StreakCameraTestCase(BaseSPARCTestCase):


### PR DESCRIPTION
The 4spec simulator doesn't have a PMT, so the test case should not be
tested with it.