### PR TITLE
[refactor] Use builtin TimeoutError instead of our own

### DIFF
--- a/scripts/demo_overlay.py
+++ b/scripts/demo_overlay.py
@@ -28,7 +28,7 @@ import math
 import numpy
 from odemis import model
 from odemis.acq.align import find_overlay
-from odemis.util import TimeoutError, executeAsyncTask
+from odemis.util import executeAsyncTask
 import sys
 import threading
 

--- a/src/odemis/acq/align/find_overlay.py
+++ b/src/odemis/acq/align/find_overlay.py
@@ -30,7 +30,7 @@ import numpy
 from odemis import model
 from odemis import util
 from odemis.dataio import tiff
-from odemis.util import TimeoutError, spot, executeAsyncTask
+from odemis.util import spot, executeAsyncTask
 from odemis.util.img import Subtract
 import os
 import threading

--- a/src/odemis/acq/fastem.py
+++ b/src/odemis/acq/fastem.py
@@ -46,7 +46,7 @@ from odemis.acq import fastem_conf, stitching
 from odemis.acq.align.fastem import align, estimate_calibration_time
 from odemis.acq.stitching import REGISTER_IDENTITY, FocusingMethod, WEAVER_COLLAGE
 from odemis.acq.stream import SEMStream
-from odemis.util import TimeoutError, transform
+from odemis.util import transform
 from odemis.util.driver import guessActuatorMoveDuration
 from odemis.util.registration import estimate_grid_orientation_from_img
 from odemis.util.transform import SimilarityTransform, to_physical_space

--- a/src/odemis/acq/path.py
+++ b/src/odemis/acq/path.py
@@ -33,7 +33,7 @@ from odemis import model, util
 from odemis.acq import move, stream
 from odemis.acq.move import FM_IMAGING, IMAGING, MILLING, POSITION_NAMES, MicroscopePostureManager
 from odemis.model import BAND_PASS_THROUGH, MD_POL_NONE
-from odemis.util import TimeoutError
+
 
 GRATING_NOT_MIRROR = "CONST:NOTMIRROR"  # A special string so that no grating position can be like this
 MAX_POSITION = "CONST:MAXPOSITION"  # To indicate that the maximum in the axis range should be used

--- a/src/odemis/driver/avantes.py
+++ b/src/odemis/driver/avantes.py
@@ -36,7 +36,7 @@ import numpy
 
 from odemis import model, util
 from odemis.model import oneway
-from odemis.util import TimeoutError
+
 
 
 class AvantesError(IOError):

--- a/src/odemis/driver/hamamatsurx.py
+++ b/src/odemis/driver/hamamatsurx.py
@@ -1389,7 +1389,7 @@ class StreakCamera(model.HwComponent):
                     # the command as we don't know whether it was received, and
                     # whether it's safe to send twice the same command. So still
                     # report a timeout, but hopefully the next command works again.
-                    raise util.TimeoutError("No answer received after %s s for command %s."
+                    raise TimeoutError("No answer received after %s s for command %s."
                                             % (timeout, to_str_escape(command)))
 
                 # save the latest response in case we don't receive any other response before timeout

--- a/src/odemis/driver/picoquant.py
+++ b/src/odemis/driver/picoquant.py
@@ -40,7 +40,7 @@ from decorator import decorator
 
 from odemis import model, util
 from odemis.model import HwError
-from odemis.util import TimeoutError
+
 
 # Based on phdefin.h for PicoHarp 300 DLL
 PH_MAXDEVNUM = 8

--- a/src/odemis/driver/pigcs.py
+++ b/src/odemis/driver/pigcs.py
@@ -25,7 +25,7 @@ import glob
 import logging
 from odemis import model
 from odemis.model import isasync, CancellableFuture, CancellableThreadPoolExecutor
-from odemis.util import driver, TimeoutError, to_str_escape
+from odemis.util import driver, to_str_escape
 import os
 # import random
 import re

--- a/src/odemis/driver/tescan.py
+++ b/src/odemis/driver/tescan.py
@@ -43,7 +43,7 @@ except ModuleNotFoundError:
 from odemis import model, util
 from odemis.model import (HwError, isasync, CancellableThreadPoolExecutor,
                           roattribute, oneway)
-from odemis.util import TimeoutError
+
 from odemis.util.driver import isNearPosition
 
 ACQ_CMD_UPD = 1

--- a/src/odemis/driver/test/hamamatsurx_test.py
+++ b/src/odemis/driver/test/hamamatsurx_test.py
@@ -194,7 +194,7 @@ class TestHamamatsurxNoReadoutCamera(unittest.TestCase):
     def test_error(self):
         """Test the different RemoteEx errors possible."""
         # send wrong command, will timeout
-        with self.assertRaises(util.TimeoutError):
+        with self.assertRaises(TimeoutError):
             self.streakcam.sendCommand("Appinfoo", "type")
 
     def test_SendCommandSimple(self):
@@ -329,7 +329,7 @@ class TestHamamatsurxCam(unittest.TestCase):
     def test_error(self):
         """Test the different RemoteEx errors possible."""
         # send wrong command, will timeout
-        with self.assertRaises(util.TimeoutError):
+        with self.assertRaises(TimeoutError):
             self.streakcam.sendCommand("Appinfoo", "type")
 
     ### General commands #####################################################

--- a/src/odemis/driver/tmcm.py
+++ b/src/odemis/driver/tmcm.py
@@ -59,7 +59,7 @@ import odemis
 from odemis import model, util
 from odemis.model import (isasync, ParallelThreadPoolExecutor, CancellableThreadPoolExecutor,
                           CancellableFuture, HwError)
-from odemis.util import driver, TimeoutError, to_str_escape, mock
+from odemis.util import driver, to_str_escape, mock
 
 
 class TMCLError(Exception):

--- a/src/odemis/util/__init__.py
+++ b/src/odemis/util/__init__.py
@@ -760,8 +760,6 @@ else:
         results.sort(key=lambda pair: pair[0])
         return results
 
-class TimeoutError(Exception):
-    pass
 
 
 # TODO: only works on Unix, needs a fallback on windows (at least, don't complain)

--- a/src/odemis/util/test/util_test.py
+++ b/src/odemis/util/test/util_test.py
@@ -32,7 +32,6 @@ import numpy.random
 from odemis import util
 from odemis.model import CancellableFuture
 from odemis.util import (
-    TimeoutError,
     executeAsyncTask,
     limit_invocation,
     perpendicular_distance,


### PR DESCRIPTION
Python 2 didn't have a `TimeoutError`, so we introduced our own. Now there is a builtin version, let's use that one, which has the nice advantage of reducing the chances of mixing up the 2 different exceptions.

Note there is yet another one: `concurrent.futures.TimeoutError`. On Python 3.12, it's now the same as the builtin one, but on older Pythons, it wasn't. So for now, we keep them separated.