### PR TITLE
[config] Modernize some METEOR simulators

### DIFF
--- a/install/linux/usr/share/odemis/sim/meteor-jeol-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/meteor-jeol-sim.odm.yaml
@@ -99,28 +99,23 @@
     affects: ["Camera"]
 }
 
-# Andor Zyla
 "Camera": {
-    class: andorcam2.AndorCam2,
+    class: tucsen.TUCam,
     role: ccd,
     init: {
-        # device: 0,  # if a real camera is plugged in, it's usually 0
         device: "fake",
-        # TODO: adjust the axes so that they match the SEM orientation (with scan rotation = 0)
-        transp: [2, 1], # To swap/invert axes
-        # TODO: adjust the cropping (use multiple of 4, for a better handling of the binning)
-        # Calibrate per system to obtain right balance between uniform image and large field of view.
-        # max_res: [2048, 2048], # Crop the image as the optical FoV is smaller than the whole CMOS area
+        transp: [-2, 1], # To swap/invert axes
     },
     properties: {
-        # To change some default settings
-#        targetTemperature: 0,
+        targetTemperature: -10,  # °C
+        fanSpeed: 0  # Water cooling -> no fan needed
     },
     metadata: {
         # If the camera is not exactly parallel to the stage axes, the angle can be adjusted
         ROTATION: 0, # [rad] (=0°)
     },
 }
+
 
 # Controller for the filter-wheel
 # DIP must be configured with address 7 (= 1110000)

--- a/install/linux/usr/share/odemis/sim/meteor-tfs3-sim.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/meteor-tfs3-sim.odm.yaml
@@ -176,14 +176,14 @@
             "stig": 20.e-3,  # rad of move
         },
     },
-    children: {"slave": "Stigmator Actuator"},
+    dependencies: {"slave": "Stigmator Actuator"},
 }
 
 "Stigmator": {
     class: actuator.RotationActuator,
     role: stigmator,
     affects: ["Camera"],
-    children: {"rz": "AntiBacklash for Stigmator"},
+    dependencies: {"rz": "AntiBacklash for Stigmator"},
     init: {
         axis_name: "stig",
         #cycle: 2 * pi, # rad


### PR DESCRIPTION
Use a Tucsen camera instead of Andor, to make the simulator more
realistic.

Also use "dependencies" instead of "children" (deprecated a long time
ago).