### PR TITLE
[fix] driver tucsen: Y resolution has to be an even number

### DIFF
--- a/src/odemis/driver/test/tucsen_test.py
+++ b/src/odemis/driver/test/tucsen_test.py
@@ -91,8 +91,8 @@ class TestTUCam(VirtualTestCam, unittest.TestCase):
     def test_resolution_rounding(self):
         self.camera.resolution.value = (199, 103)
         # horizontal res (== second dim as it's transposed) is rounded to multiple of 8
-        # vertical res (== first dim as it's transposed) is accepted as is
-        self.assertEqual(self.camera.resolution.value, (199, 96))
+        # vertical res (== first dim as it's transposed) is rounded to multiple of 2
+        self.assertEqual(self.camera.resolution.value, (198, 96))
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/odemis/driver/tucsen.py
+++ b/src/odemis/driver/tucsen.py
@@ -2267,8 +2267,9 @@ class TUCam(model.DigitalCamera):
         """
         res = self._transposeSizeFromUser(value)
 
-        # The X resolution has to be a multiple of 8
-        res = res[0] - (res[0] % 8), res[1]
+        # From testing on the Dhyana 400BSI, the X resolution has to be a multiple of 8, and
+        # the Y resolution has to be a multiple of 2
+        res = res[0] - (res[0] % 8), res[1] - (res[1] % 2)
         # Clip, according to the current binning (but cannot use .binning VA, as it might not be updated)
         max_res, _ = self._dll.get_max_resolution(self._resolution_idx)  # depends on the binning
         min_res = MIN_RES_DHYANA_400BSI


### PR DESCRIPTION
If passing an odd number, the acquisition sort-of work (which is
probably why we didn't notice it during the original testing), but it's
very slow, and the image wraps around. IOW, it does work properly.

=> Round down to a even number.