### PR TITLE
[MSD-443][feat] 3D correlation improvements

### DIFF
--- a/src/odemis/acq/feature.py
+++ b/src/odemis/acq/feature.py
@@ -811,7 +811,8 @@ def acquire_at_features(
 
 
 class Target:
-    def __init__(self, x: float, y: float, z: float, name: str, type: TargetType, index: int, fm_focus_position: float, superz_focused: Optional[bool] = None):
+    def __init__(self, x: float, y: float, z: float, name: str, type: TargetType, index: int, fm_focus_position: float,
+                 superz_focused: Optional[bool] = None, needs_refinement: Optional[bool] = False) -> None:
         """
         Target class to store the target information for multipoint correlation. The target can be a fiducial, point of
         interest, surface fiducial, projected fiducial or projected point of interest. The target information is used to
@@ -826,6 +827,7 @@ class Target:
         :param fm_focus_position: position of the focus (objective in cased of Meteor) in meters
         :param superz_focused: True if super z focus has high accuracy, False otherwise. If None, it means that the
           super z focus was not used.
+        :param needs_refinement: Whether target needs further algorithmic refinement.
         """
         self.coordinates = model.ListVA((x, y, z), unit="m")
         self.type = model.VAEnumerated(type, choices={t for t in TargetType})
@@ -833,6 +835,8 @@ class Target:
         self.index = model.IntContinuous(index, range=(1, 99))
         self.fm_focus_position = model.FloatVA(fm_focus_position, unit="m")
         self.superz_focused = superz_focused
+        # No need to store this on disk, so leaving it out of to/from_dict methods
+        self.needs_refinement = model.BooleanVA(needs_refinement)
 
     def to_dict(self) -> dict:
         return {

--- a/src/odemis/gui/comp/overlay/cryo_feature.py
+++ b/src/odemis/gui/comp/overlay/cryo_feature.py
@@ -509,6 +509,7 @@ class CryoCorrelationPointsOverlay(WorldOverlay, DragMixin):
                     self.cnvs.set_dynamic_cursor(gui.DRAG_CURSOR)
                 else:
                     self.tab_data.add_new_target(p_pos[0], p_pos[1], type=TargetType.PointOfInterest)
+
             elif self._mode == MODE_EDIT_REFRACTIVE_INDEX and TargetType.SurfaceFiducial in self.allowed_targets:
                 # Check for existing surface fiducial in order to change the position or introduce a new one.
                 existing_surface = next((target for target in self.tab_data.main.targets.value if target.type.value == TargetType.SurfaceFiducial), None)

--- a/src/odemis/gui/cont/acquisition/cryo_z_localization.py
+++ b/src/odemis/gui/cont/acquisition/cryo_z_localization.py
@@ -243,7 +243,7 @@ class CryoZLocalizationController(object):
         """
         # Set the target Z ctrl with the focus position
         self._panel.ctrl_target_z.SetValue(target_coordinates[2])
-        save_project(self._tab_data_model.main)
+        save_project(self._tab_data.main)
 
     def _on_ctrl_target_z_change(self) -> List[float]:
         """

--- a/src/odemis/gui/cont/multi_point_correlation.py
+++ b/src/odemis/gui/cont/multi_point_correlation.py
@@ -35,7 +35,7 @@ import wx
 # This is not related to any particular wxPython version and is most likely permanent.
 
 from odemis import model, util
-from odemis.acq.align.tdct import get_optimized_z_gauss, _convert_das_to_numpy_stack, run_tdct_correlation
+from odemis.acq.align.tdct import _convert_das_to_numpy_stack, run_tdct_correlation
 from odemis.acq.feature import save_features, FIBFMCorrelationData, Target, TargetType
 from odemis.acq.stream import StaticFluoStream, StaticSEMStream, StaticFIBStream, FluoStream
 from odemis.gui import conf
@@ -43,7 +43,7 @@ from odemis.gui.model import CryoGUIData
 from odemis.gui.util import call_in_wx_main
 from odemis.model import ListVA
 from odemis.util.dataio import data_to_static_streams
-from odemis.util.interpolation import interpolate_z_stack
+from odemis.util.img import get_bounding_box_slice, get_brightest_channel, compute_local_center_of_mass
 from odemis.util.units import readable_str
 
 # create an enum with column labels and position
@@ -61,12 +61,14 @@ GRID_PRECISION = 2  # Number of decimal places to display in the grid
 FIDUCIAL_PATTERN = r"^[^-]+-"
 RIM_COR_DEFAULT = 0.495  # See MD_RIM_COR. This value works fine for 50x objectives, which are common
 
-# Both functions getPixel3DCoordinates(args*, kwargs*) and getPhysical3DCoordinates(args*, kwargs*) need special
+# Both functions get_pixel_3d_coordinates(args*, kwargs*) and get_physical_3d_coordinates(args*, kwargs*) need special
 # conditions to convert between physical and pixel coordinate systems in order for multipoint correlation to operate.
 # For coordinate conversions, we assume the pixels in 3D are isosymmetric
 # i.e. size in pixel[0]=pixel[1]=pixel[2].
+COM_ROI_PADDING = 12  # Padding (pixels) for center of mass ROI extraction
+# TODO: Could adapt padding based on pixel spacing for more flexibility if needed
 
-def getPixel3DCoordinates(stream: FluoStream, p_pos: Tuple[float, float, float], check_bbox: bool = False) \
+def get_pixel_3d_coordinates(stream: FluoStream, p_pos: Tuple[float, float, float], check_bbox: bool = False) \
         -> Optional[Tuple[float, float, float]]:
     """
     Translate 3D physical coordinates into 3D pixel coordinates. The z coordinate is computed assuming iso-voxel
@@ -96,7 +98,7 @@ def getPixel3DCoordinates(stream: FluoStream, p_pos: Tuple[float, float, float],
     pixel_pos = (pixel_pos[0], pixel_pos[1], z)
     return pixel_pos
 
-def getPhysical3DCoordinates(stream: FluoStream, pixel_pos: Tuple[float, float, float])\
+def get_physical_3d_coordinates(stream: FluoStream, pixel_pos: Tuple[float, float, float])\
                              -> Optional[Tuple[float, float, float]]:
     """
     Translate 3D pixel coordinates into 3D physical coordinates. The z coordinate is computed assuming iso-voxel
@@ -175,18 +177,18 @@ class CorrelationPointsController:
         # Access the correlation points table (wxListCtrl)
         self.grid = self._panel.table_grid
 
-        # Access the Refine Z text (to check if refine_z is working or not)
+        # Access the Refine XYZ status text (to check if XYZ targeting is working or not)
         self.txt_refinez_active = self._panel.txt_refinez_active
         self.txt_refinez_active.Show(True)
 
-        # Access the Z-targeting button
+        # Access the XYZ-targeting button
         self.z_targeting_btn = self._panel.btn_z_targeting
         self.z_targeting_btn.Bind(wx.EVT_BUTTON, self._on_z_targeting)
         self.z_targeting_btn.Enable(False)
-        # Disable Z-targeting button if super z stream is available as Z-targeting is not required in that case
+        # Disable XYZ-targeting button if super z stream is available as XYZ-targeting is not required in that case
         self.refinez_active = True
         if self._tab_data_model.main.currentFeature.value.superz_stream_name:
-            self.z_targeting_btn.SetToolTip("Super Z information available, Refine Z disabled")
+            self.z_targeting_btn.SetToolTip("Super Z information available, Refine XYZ disabled")
             self.txt_refinez_active.SetLabel("Super Z information in use")
             self.refinez_active = False
 
@@ -479,11 +481,11 @@ class CorrelationPointsController:
             fib_coords.append(fib_coord)
         fib_coords = numpy.array(fib_coords, dtype=numpy.float32)
         for fm_coord in self.correlation_target.fm_fiducials:
-            fm_coord_px = getPixel3DCoordinates(self.correlation_target.fm_streams[0], fm_coord.coordinates.value)
+            fm_coord_px = get_pixel_3d_coordinates(self.correlation_target.fm_streams[0], fm_coord.coordinates.value)
             fm_coords.append(fm_coord_px)
         fm_coords = numpy.array(fm_coords, dtype=numpy.float32)
         poi_coord = self.correlation_target.fm_pois[0]
-        poi_coord_px = getPixel3DCoordinates(self.correlation_target.fm_streams[0], poi_coord.coordinates.value)
+        poi_coord_px = get_pixel_3d_coordinates(self.correlation_target.fm_streams[0], poi_coord.coordinates.value)
         poi_coords.append(poi_coord_px)
         poi_coords = numpy.array(poi_coords, dtype=numpy.float32)
         # Run the correlation
@@ -664,7 +666,7 @@ class CorrelationPointsController:
                 elif col_name == GridColumns.Z.name and (
                         self._tab_data_model.main.currentTarget.value.type.value != TargetType.FibFiducial):
                     self._tab_data_model.main.currentTarget.value.coordinates.value[2] = \
-                    getPhysical3DCoordinates(self.correlation_target.fm_streams[0], (x, y, float(new_value)))[2]
+                    get_physical_3d_coordinates(self.correlation_target.fm_streams[0], (x, y, float(new_value)))[2]
             except ValueError:
                 wx.MessageBox("X, Y, Z values must be a float!", "Invalid Input", wx.OK | wx.ICON_ERROR)
                 event.Veto()  # Prevent the change
@@ -701,7 +703,7 @@ class CorrelationPointsController:
 
         mip_enabled = any([stream.max_projection.value for stream in self.correlation_target.fm_streams])
 
-        # Refine z should be disabled if the the Z information was obtained using SuperZ
+        # Refine xyz should be disabled if the the Z information was obtained using SuperZ
         if self.refinez_active and (target.type.value in self.grid_targets):
             if TargetType.FibFiducial == target.type.value:
                 self.z_targeting_btn.Enable(False)
@@ -740,7 +742,7 @@ class CorrelationPointsController:
                     pixel_coords = self.correlation_target.fib_stream.getPixelCoordinates(
                         (target.coordinates.value[0], target.coordinates.value[1]), check_bbox=False)
                 else:
-                    pixel_coords = getPixel3DCoordinates(self.correlation_target.fm_streams[0], target.coordinates.value)
+                    pixel_coords = get_pixel_3d_coordinates(self.correlation_target.fm_streams[0], target.coordinates.value)
                     if (self.grid.GetCellValue(row,
                                                GridColumns.Z.value)) != f"{pixel_coords[2]:.{GRID_PRECISION}f}":
                         temp_check = True
@@ -781,7 +783,7 @@ class CorrelationPointsController:
                         (target.coordinates.value[0], target.coordinates.value[1]), check_bbox=False)
                     self.grid.SetCellValue(current_row_count, GridColumns.Z.value, "")
                 else:
-                    pixel_coords = getPixel3DCoordinates(self.correlation_target.fm_streams[0], target.coordinates.value)
+                    pixel_coords = get_pixel_3d_coordinates(self.correlation_target.fm_streams[0], target.coordinates.value)
                     self.grid.SetCellValue(current_row_count, GridColumns.Z.value,
                                            f"{pixel_coords[2]:.{GRID_PRECISION}f}")
                 # Set x and y position in the grid
@@ -804,32 +806,61 @@ class CorrelationPointsController:
 
     def _on_z_targeting(self, evt) -> None:
         """
-        Handle Z-targeting when the Z-targeting button is clicked.
+        Handle targeting when the targeting button is clicked.
+        Refactored to perform full 3D Center of Mass targeting (X, Y, Z).
         """
         if self._tab_data_model.main.currentTarget.value:
 
-            # Select the streams which are visible in the view for Z-targeting
+            # Select the streams which are visible in the view for targeting
             streams_projections = self._tab_data_model.views.value[0].stream_tree.flat.value
             if not streams_projections:
-                wx.MessageBox("FM streams are not available for refining Z", "Error", wx.OK | wx.ICON_ERROR)
+                wx.MessageBox("FM streams are not available for refining targets", "Error", wx.OK | wx.ICON_ERROR)
                 return
 
             self.txt_refinez_active.SetLabel("active ...")
             wx.CallLater(1000, self.txt_refinez_active.SetLabel, "")
 
             coords = self._tab_data_model.main.currentTarget.value.coordinates.value
-            pixel_coords = getPixel3DCoordinates(self.correlation_target.fm_streams[0], coords)
-            das = [interpolate_z_stack(da=stream_projection.stream.raw[0]
-                                       [:,
-                                       int(pixel_coords[1]):int(pixel_coords[1])+1,
-                                       int(pixel_coords[0]):int(pixel_coords[0])+1],
-                                       method="linear")
-                   for stream_projection in streams_projections]
+            pixel_coords = get_pixel_3d_coordinates(self.correlation_target.fm_streams[0], coords)
 
-            z = float(get_optimized_z_gauss(das, int(0), int(0), int(pixel_coords[2])))
-            z_p = getPhysical3DCoordinates(self.correlation_target.fm_streams[0],
-                                 (pixel_coords[0],pixel_coords[1], z))[2]
-            self._tab_data_model.main.currentTarget.value.coordinates.value[2] = z_p
+            target_x, target_y = int(pixel_coords[0]), int(pixel_coords[1])
+
+            # Ensure multi-channel compatibility (reshape to 4D if necessary)
+            raw_multi = numpy.asarray(streams_projections[1].stream.raw)
+            if raw_multi.ndim == 3:
+                raw_multi = raw_multi[numpy.newaxis, ...]
+
+            shape_y, shape_x = raw_multi.shape[2], raw_multi.shape[3]
+
+            # Get boundary-safe slice & crop
+            roi = get_bounding_box_slice(target_x, target_y, COM_ROI_PADDING, COM_ROI_PADDING, shape_x, shape_y)
+            multi_crop = raw_multi[(slice(None),) + roi]
+
+            # Find best channel and compute COM
+            best_c = get_brightest_channel(multi_crop)
+            com_pixel_z, com_pixel_y, com_pixel_x = compute_local_center_of_mass(
+                multi_crop[best_c], roi, baseline_percentile=95.0
+            )
+
+            # Account for iso-voxel enforcement using best channel's metadata
+            # Z array indices must be scaled to match the iso-voxel pixel size
+            best_stream = streams_projections[best_c].stream
+            best_channel_raw = best_stream.raw[0]
+            md = best_stream._find_metadata(best_channel_raw.metadata)
+            pxs = md.get(model.MD_PIXEL_SIZE, (1e-6, 1e-6))
+            com_pixel_z_iso = com_pixel_z * pxs[2] / pxs[0]
+
+            # Map back to physical coordinates using optimized X, Y, and Z
+            physical_coords = get_physical_3d_coordinates(
+                self.correlation_target.fm_streams[0],
+                (com_pixel_x, com_pixel_y, com_pixel_z_iso)
+            )
+
+            # Update the model with the refined 3D coordinates
+            target_coords = self._tab_data_model.main.currentTarget.value.coordinates.value
+            target_coords[0] = physical_coords[0]
+            target_coords[1] = physical_coords[1]
+            target_coords[2] = physical_coords[2]
 
     def _reorder_grid(self) -> None:
         """

--- a/src/odemis/gui/cont/multi_point_correlation.py
+++ b/src/odemis/gui/cont/multi_point_correlation.py
@@ -35,7 +35,7 @@ import wx
 # This is not related to any particular wxPython version and is most likely permanent.
 
 from odemis import model, util
-from odemis.acq.align.tdct import get_optimized_z_gauss, _convert_das_to_numpy_stack, run_tdct_correlation
+from odemis.acq.align.tdct import _convert_das_to_numpy_stack, run_tdct_correlation
 from odemis.acq.feature import FIBFMCorrelationData, Target, TargetType
 from odemis.acq.stream import StaticFluoStream, StaticSEMStream, StaticFIBStream, FluoStream
 from odemis.gui import conf
@@ -44,7 +44,7 @@ from odemis.gui.cont.features import save_project
 from odemis.gui.util import call_in_wx_main
 from odemis.model import ListVA
 from odemis.util.dataio import data_to_static_streams
-from odemis.util.interpolation import interpolate_z_stack
+from odemis.util.img import get_brightest_channel, compute_center_of_mass
 from odemis.util.units import readable_str
 
 # create an enum with column labels and position
@@ -62,16 +62,17 @@ GRID_PRECISION = 2  # Number of decimal places to display in the grid
 FIDUCIAL_PATTERN = r"^[^-]+-"
 RIM_COR_DEFAULT = 0.495  # See MD_RIM_COR. This value works fine for 50x objectives, which are common
 
-# Both functions getPixel3DCoordinates(args*, kwargs*) and getPhysical3DCoordinates(args*, kwargs*) need special
+# Both functions get_pixel_3d_coordinates(args*, kwargs*) and get_physical_3d_coordinates(args*, kwargs*) need special
 # conditions to convert between physical and pixel coordinate systems in order for multipoint correlation to operate.
 # For coordinate conversions, we assume the pixels in 3D are isosymmetric
 # i.e. size in pixel[0]=pixel[1]=pixel[2].
+COM_ROI_PADDING = 12  # Padding (pixels) for center of mass ROI extraction
+# TODO: Could adapt padding based on pixel spacing for more flexibility if needed
 
-def getPixel3DCoordinates(stream: FluoStream, p_pos: Tuple[float, float, float], check_bbox: bool = False) \
+def get_pixel_3d_coordinates(stream: FluoStream, p_pos: Tuple[float, float, float], check_bbox: bool = False) \
         -> Optional[Tuple[float, float, float]]:
     """
-    Translate 3D physical coordinates into 3D pixel coordinates. The z coordinate is computed assuming iso-voxel
-    between x, y and z.
+    Translate 3D physical coordinates into 3D pixel coordinates.
     :param stream: Stream which is used as reference for coordinate conversion
     :param p_pos: the position in physical coordinates (m). x and y are the sample position, z is the focus position
     :param check_bbox: if True, the function will return None if the position is outside of the image
@@ -84,24 +85,22 @@ def getPixel3DCoordinates(stream: FluoStream, p_pos: Tuple[float, float, float],
 
     raw = stream.raw[0]
     md = stream._find_metadata(raw.metadata)
-    pxs = md.get(model.MD_PIXEL_SIZE, (1e-6, 1e-6))
+    pxs = md.get(model.MD_PIXEL_SIZE, (1e-6, 1e-6, 1e-6))
     # For multipoint correlation, we assume that the pixel size in x is the same as in y
     if not util.almost_equal(pxs[0], pxs[1], atol=1e-9):
         logging.warning("Pixel size in x and y are not equal while computing pixel coordinates")
 
-    # Z position is found by taking into account MD_POS and subtracting it from the physical coordinates.
-    # Pixel value used for Z enforces the iso-voxel condition between x, y and z. It is not the real pixel value in z.
     tpos = md.get(model.MD_POS, (0, 0, 0))
     tpos_z = tpos[2] if len(tpos) >= 3 else 0.0
-    z = (p_pos[2] - tpos_z) / pxs[1]
+    z = (p_pos[2] - tpos_z) / pxs[2]
     pixel_pos = (pixel_pos[0], pixel_pos[1], z)
+
     return pixel_pos
 
-def getPhysical3DCoordinates(stream: FluoStream, pixel_pos: Tuple[float, float, float])\
+def get_physical_3d_coordinates(stream: FluoStream, pixel_pos: Tuple[float, float, float])\
                              -> Optional[Tuple[float, float, float]]:
     """
-    Translate 3D pixel coordinates into 3D physical coordinates. The z coordinate is computed assuming iso-voxel
-    between x, y and z.
+    Translate 3D pixel coordinates into 3D physical coordinates.
     :param stream: Stream which is used as reference for coordinate conversion
     :param pixel_pos: the position in pixel coordinates (x, y, z)
     :returns: the position in physical coordinates (x, y, z) in meters
@@ -109,10 +108,11 @@ def getPhysical3DCoordinates(stream: FluoStream, pixel_pos: Tuple[float, float, 
     p_pos = stream.getPhysicalCoordinates(pixel_pos[:2])
     raw = stream.raw[0]
     md = stream._find_metadata(raw.metadata)
-    pxs = md.get(model.MD_PIXEL_SIZE, (1e-6, 1e-6))[0:2]
+    pxs = md.get(model.MD_PIXEL_SIZE, (1e-6, 1e-6, 1e-6))
     tpos = md.get(model.MD_POS, (0, 0, 0))
     tpos_z = tpos[2] if len(tpos) >= 3 else 0.0
-    p_pos_z = pixel_pos[2] * pxs[1] + tpos_z
+    # Account for slice thickness, aka, the z distance between slices
+    p_pos_z = pixel_pos[2] * pxs[2] + tpos_z
     return (p_pos[0], p_pos[1], p_pos_z)
 
 def update_feature_correlation_target(correlation_target: FIBFMCorrelationData,
@@ -146,8 +146,7 @@ def update_feature_correlation_target(correlation_target: FIBFMCorrelationData,
         fm_fiducials.sort(key=lambda x: x.index.value)
     correlation_target.fm_fiducials = fm_fiducials
 
-    acq_conf = conf.get_acqui_conf()
-    save_project(acq_conf.pj_last_path, tab_data.main.features.value, tab_data.main.overviews.value)
+    save_project(tab_data.main)
 
     return correlation_target
 
@@ -176,20 +175,20 @@ class CorrelationPointsController:
         # Access the correlation points table (wxListCtrl)
         self.grid = self._panel.table_grid
 
-        # Access the Refine Z text (to check if refine_z is working or not)
-        self.txt_refinez_active = self._panel.txt_refinez_active
-        self.txt_refinez_active.Show(True)
+        # Access the Refine XYZ status text (to check if XYZ targeting is working or not)
+        self.txt_refine_xyz_active = self._panel.txt_refine_xyz_active
+        self.txt_refine_xyz_active.Show(True)
 
-        # Access the Z-targeting button
-        self.z_targeting_btn = self._panel.btn_z_targeting
-        self.z_targeting_btn.Bind(wx.EVT_BUTTON, self._on_z_targeting)
-        self.z_targeting_btn.Enable(False)
-        # Disable Z-targeting button if super z stream is available as Z-targeting is not required in that case
-        self.refinez_active = True
+        # Access the XYZ-targeting button
+        self.xyz_targeting_btn = self._panel.btn_xyz_targeting
+        self.xyz_targeting_btn.Bind(wx.EVT_BUTTON, self._on_xyz_targeting)
+        self.xyz_targeting_btn.Enable(False)
+        # Disable XYZ-targeting button if super z stream is available as XYZ-targeting is not required in that case
+        self.refine_xyz_active = True
         if self._tab_data_model.main.currentFeature.value.superz_stream_name:
-            self.z_targeting_btn.SetToolTip("Super Z information available, Refine Z disabled")
-            self.txt_refinez_active.SetLabel("Super Z information in use")
-            self.refinez_active = False
+            self.xyz_targeting_btn.SetToolTip("Super Z information available, Refine XYZ disabled")
+            self.txt_refine_xyz_active.SetLabel("Super Z information in use")
+            self.refine_xyz_active = False
 
         self._panel.btn_delete_row.Bind(wx.EVT_BUTTON, self._on_delete_row)
 
@@ -378,7 +377,7 @@ class CorrelationPointsController:
 
     def _on_key_down_grid(self, event) -> None:
         """Handle key down events on the grid, especially to suppress Enter key default behavior."""
-        if event.GetKeyCode() == wx.WXK_RETURN:
+        if event.GetKeyCode() in [wx.WXK_RETURN, wx.WXK_NUMPAD_ENTER]:
             # Commit the value in the currently edited cell
             if self.grid.IsCellEditControlEnabled():
                 self.grid.DisableCellEditControl()
@@ -407,7 +406,7 @@ class CorrelationPointsController:
                 self._panel.Layout()
                 # Update the FIB viewport because it shows the output overlays
                 # It is the second viewport out of total two viewports
-                self._viewports[1].canvas.update_drawing()
+                self._viewports[1].canvas.request_drawing_update()
                 return False
         else:
             return False
@@ -478,14 +477,17 @@ class CorrelationPointsController:
             fib_coords.append(fib_coord)
         fib_coords = numpy.array(fib_coords, dtype=numpy.float32)
         for fm_coord in self.correlation_target.fm_fiducials:
-            fm_coord_px = getPixel3DCoordinates(self.correlation_target.fm_streams[0], fm_coord.coordinates.value)
+            fm_coord_px = get_pixel_3d_coordinates(self.correlation_target.fm_streams[0], fm_coord.coordinates.value)
             fm_coords.append(fm_coord_px)
         fm_coords = numpy.array(fm_coords, dtype=numpy.float32)
         poi_coord = self.correlation_target.fm_pois[0]
-        poi_coord_px = getPixel3DCoordinates(self.correlation_target.fm_streams[0], poi_coord.coordinates.value)
+        poi_coord_px = get_pixel_3d_coordinates(self.correlation_target.fm_streams[0], poi_coord.coordinates.value)
         poi_coords.append(poi_coord_px)
         poi_coords = numpy.array(poi_coords, dtype=numpy.float32)
-        # Run the correlation
+        # Fixing seed, and thus basically resetting randomness, to get more consistent results
+        numpy.random.seed(0)
+        # Run the correlation. Note that our z pixel spacing for the fm_coords is not equal to x and y, but internal
+        # scaling in the affine registration logic should handle this just fine.
         self.correlation_target.correlation_result = run_tdct_correlation(fib_coords=fib_coords, fm_coords=fm_coords,
                                                                           poi_coords=poi_coords,
                                                                           fib_image=fib_da, fm_image=fm_image,
@@ -563,7 +565,7 @@ class CorrelationPointsController:
                 break
 
         for vp in self._viewports:
-            vp.canvas.update_drawing()
+            vp.canvas.request_drawing_update()
 
         # Highlight the selected row
         # Note: as of wxPython 4.1, when AppendRow() is called on an empty grid, this event is
@@ -663,7 +665,7 @@ class CorrelationPointsController:
                 elif col_name == GridColumns.Z.name and (
                         self._tab_data_model.main.currentTarget.value.type.value != TargetType.FibFiducial):
                     self._tab_data_model.main.currentTarget.value.coordinates.value[2] = \
-                    getPhysical3DCoordinates(self.correlation_target.fm_streams[0], (x, y, float(new_value)))[2]
+                    get_physical_3d_coordinates(self.correlation_target.fm_streams[0], (x, y, float(new_value)))[2]
             except ValueError:
                 wx.MessageBox("X, Y, Z values must be a float!", "Invalid Input", wx.OK | wx.ICON_ERROR)
                 event.Veto()  # Prevent the change
@@ -675,7 +677,7 @@ class CorrelationPointsController:
         """Get the cell column of the modified cell and reorder the grid/table based on the index column."""
         # Refresh the canvas to update the target overlays in the viewports
         for vp in self._viewports:
-            vp.canvas.update_drawing()
+            vp.canvas.request_drawing_update()
         # If the index column is modified, reorder the grid based on the index column
         col = event.GetCol()
         col_name = self.grid.GetColLabelValue(col)
@@ -695,19 +697,37 @@ class CorrelationPointsController:
         # For new targets, automatically perform Z targeting if MIP is checked for at least one FM stream
         if not target:
             self.grid.ClearSelection()
-            self.z_targeting_btn.Enable(False)
+            self.xyz_targeting_btn.Enable(False)
             return
 
-        mip_enabled = any([stream.max_projection.value for stream in self.correlation_target.fm_streams])
+        # Only check for visible and non-reflective streams, since the refinement method is discarding other streams
+        # anyway. Doesn't make sense to check for MIP value of a stream that is not used in refining a fiducial.
+        visible_streams = [
+            s.stream for s in self._tab_data_model.views.value[0].stream_tree.flat.value
+            if s.stream.getRawMetadata()[0].get(model.MD_OUT_WL) != model.BAND_PASS_THROUGH
+        ]
+        mip_enabled = any(stream.max_projection.value for stream in visible_streams)
 
-        # Refine z should be disabled if the the Z information was obtained using SuperZ
-        if self.refinez_active and (target.type.value in self.grid_targets):
+        self.xyz_targeting_btn.Enable(False)
+        # Refine xyz should be disabled if the Z information was obtained using SuperZ
+        if self.refine_xyz_active and (target.type.value in self.grid_targets):
             if TargetType.FibFiducial == target.type.value:
-                self.z_targeting_btn.Enable(False)
+                self.xyz_targeting_btn.Enable(False)
             else:
-                self.z_targeting_btn.Enable(True)
-                if mip_enabled:
-                    self._on_z_targeting(None)
+                self.xyz_targeting_btn.Enable(True)
+                if target.needs_refinement.value:
+                    if mip_enabled:
+                        self._on_xyz_targeting()
+                    # When there is just one stream without MIP, use the currently selected z index
+                    elif len(visible_streams) == 1 and hasattr(visible_streams[0], "zIndex"):
+                        # We only care about z, so pass placeholders for x and y
+                        physical_coords = get_physical_3d_coordinates(
+                            visible_streams[0], (0, 0, visible_streams[0].zIndex.value))
+                        # Update the model with the refined 3D coordinates
+                        target_coords = target.coordinates.value
+                        target_coords[2] = physical_coords[2]
+                    # Reset refinement
+                    target.needs_refinement.value = False
 
         for row in range(self.grid.GetNumberRows()):
             if self._selected_target_in_grid(target, row):
@@ -715,7 +735,7 @@ class CorrelationPointsController:
                 break
 
         for vp in self._viewports:
-            vp.canvas.update_drawing()
+            vp.canvas.request_drawing_update()
 
         if self._subscribed_target is not None:
             self._subscribed_target.coordinates.unsubscribe(self._on_current_coordinates_changes)
@@ -739,7 +759,7 @@ class CorrelationPointsController:
                     pixel_coords = self.correlation_target.fib_stream.getPixelCoordinates(
                         (target.coordinates.value[0], target.coordinates.value[1]), check_bbox=False)
                 else:
-                    pixel_coords = getPixel3DCoordinates(self.correlation_target.fm_streams[0], target.coordinates.value)
+                    pixel_coords = get_pixel_3d_coordinates(self.correlation_target.fm_streams[0], target.coordinates.value)
                     if (self.grid.GetCellValue(row,
                                                GridColumns.Z.value)) != f"{pixel_coords[2]:.{GRID_PRECISION}f}":
                         temp_check = True
@@ -756,6 +776,9 @@ class CorrelationPointsController:
 
         if self.check_correlation_conditions() and (temp_check or target.type.value == TargetType.SurfaceFiducial):
             self._need_reprocessing()
+
+        for vp in self._viewports:
+            vp.canvas.request_drawing_update()
 
     @call_in_wx_main
     def _on_target_changes(self, targets: List[Target]) -> None:
@@ -783,7 +806,7 @@ class CorrelationPointsController:
                         (target.coordinates.value[0], target.coordinates.value[1]), check_bbox=False)
                     self.grid.SetCellValue(current_row_count, GridColumns.Z.value, "")
                 else:
-                    pixel_coords = getPixel3DCoordinates(self.correlation_target.fm_streams[0], target.coordinates.value)
+                    pixel_coords = get_pixel_3d_coordinates(self.correlation_target.fm_streams[0], target.coordinates.value)
                     self.grid.SetCellValue(current_row_count, GridColumns.Z.value,
                                            f"{pixel_coords[2]:.{GRID_PRECISION}f}")
                 # Set x and y position in the grid
@@ -801,40 +824,56 @@ class CorrelationPointsController:
         self._panel.Layout()
         self.correlation_target = update_feature_correlation_target(self.correlation_target, self._tab_data_model)
 
-        for vp in self._viewports:
-            vp.canvas.update_drawing()
-
         if self.check_correlation_conditions():
             self._need_reprocessing()
 
-    def _on_z_targeting(self, evt) -> None:
+        for vp in self._viewports:
+            vp.canvas.request_drawing_update()
+
+    def _on_xyz_targeting(self, evt: Optional[wx.Event] = None) -> None:
         """
-        Handle Z-targeting when the Z-targeting button is clicked.
+        Handle targeting when the targeting button is clicked, or automatically triggered for MIP streams.
+        Performs 3D Center of Mass targeting (X, Y, Z).
         """
         if self._tab_data_model.main.currentTarget.value:
-
-            # Select the streams which are visible in the view for Z-targeting
-            streams_projections = self._tab_data_model.views.value[0].stream_tree.flat.value
-            if not streams_projections:
-                wx.MessageBox("FM streams are not available for refining Z", "Error", wx.OK | wx.ICON_ERROR)
+            # Select the non-reflective streams visible in the view for targeting
+            streams = [
+                s.stream for s in self._tab_data_model.views.value[0].stream_tree.flat.value
+                if s.stream.getRawMetadata()[0].get(model.MD_OUT_WL) != model.BAND_PASS_THROUGH
+            ]
+            if not streams:
+                wx.MessageBox("FM streams are not available for refining targets", "Error", wx.OK | wx.ICON_ERROR)
                 return
 
-            self.txt_refinez_active.SetLabel("active ...")
-            wx.CallLater(1000, self.txt_refinez_active.SetLabel, "")
+            self.txt_refine_xyz_active.SetLabel("active ...")
+            wx.CallLater(1000, self.txt_refine_xyz_active.SetLabel, "")
 
             coords = self._tab_data_model.main.currentTarget.value.coordinates.value
-            pixel_coords = getPixel3DCoordinates(self.correlation_target.fm_streams[0], coords)
-            das = [interpolate_z_stack(da=stream_projection.stream.raw[0]
-                                       [:,
-                                       int(pixel_coords[1]):int(pixel_coords[1])+1,
-                                       int(pixel_coords[0]):int(pixel_coords[0])+1],
-                                       method="linear")
-                   for stream_projection in streams_projections]
+            pixel_coords = get_pixel_3d_coordinates(streams[0], coords)
 
-            z = float(get_optimized_z_gauss(das, int(0), int(0), int(pixel_coords[2])))
-            z_p = getPhysical3DCoordinates(self.correlation_target.fm_streams[0],
-                                 (pixel_coords[0],pixel_coords[1], z))[2]
-            self._tab_data_model.main.currentTarget.value.coordinates.value[2] = z_p
+            # We are going to refine around the clicked position
+            target_x, target_y = int(pixel_coords[0]), int(pixel_coords[1])
+            # Ensure multi-channel compatibility
+            raw_multi = numpy.asarray([s.raw[0] for s in streams])
+            shape_y, shape_x = raw_multi.shape[-2], raw_multi.shape[-1]
+            # Get boundary-safe slice & crop
+            y_start = max(0, target_y - COM_ROI_PADDING)
+            y_end = min(shape_y, target_y + COM_ROI_PADDING + 1)
+            x_start = max(0, target_x - COM_ROI_PADDING)
+            x_end = min(shape_x, target_x + COM_ROI_PADDING + 1)
+            roi = numpy.s_[:, y_start:y_end, x_start:x_end]
+            multi_crop = raw_multi[(slice(None),) + roi]  # We search along all stack slices (first axis)
+            # Find best channel and compute COM
+            best_c = get_brightest_channel(multi_crop)
+            com = compute_center_of_mass(multi_crop[best_c], baseline_ratio=0.95)
+            com_z = com[0]
+            com_y_crop = com[1] + roi[1].start
+            com_x_crop = com[2] + roi[2].start
+            # Map back to physical coordinates using optimized X, Y, and Z
+            physical_coords = get_physical_3d_coordinates(streams[0],(com_x_crop, com_y_crop, com_z))
+            # Update the model with the refined 3D coordinates
+            target_coords = self._tab_data_model.main.currentTarget.value.coordinates.value
+            target_coords[:] = physical_coords[:]
 
     def _reorder_grid(self) -> None:
         """

--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -2010,10 +2010,10 @@ b\xeb\x85\x9f\xb6B\x1d\x0cK\x17\xac\xf0\x12\xfe\xa0\xe5\xee\xe03\xb1\xfa\
                                   <flag>wxALL|wxEXPAND</flag>
                                   <border>10</border>
                                 </object>
-                                <!-- Z-targeting button -->
+                                <!-- XYZ-targeting button -->
                                 <object class="sizeritem">
                                   <object class="wxButton" name="btn_z_targeting">
-                                    <label>Refine Z</label>
+                                    <label>Refine</label>
                                   </object>
                                 </object>
                                 <object class="sizeritem">

--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -118,8 +118,8 @@ class xrcfr_correlation(wx.Dialog):
         self.fp_correlation_panel = xrc.XRCCTRL(self, "fp_correlation_panel")
         self.pnl_correlation = xrc.XRCCTRL(self, "pnl_correlation")
         self.btn_delete_row = xrc.XRCCTRL(self, "btn_delete_row")
-        self.btn_z_targeting = xrc.XRCCTRL(self, "btn_z_targeting")
-        self.txt_refinez_active = xrc.XRCCTRL(self, "txt_refinez_active")
+        self.btn_xyz_targeting = xrc.XRCCTRL(self, "btn_xyz_targeting")
+        self.txt_refine_xyz_active = xrc.XRCCTRL(self, "txt_refine_xyz_active")
         self.table_grid = xrc.XRCCTRL(self, "table_grid")
         self.txt_correlation_rms = xrc.XRCCTRL(self, "txt_correlation_rms")
         self.fp_correlation_streams = xrc.XRCCTRL(self, "fp_correlation_streams")
@@ -2010,14 +2010,14 @@ b\xeb\x85\x9f\xb6B\x1d\x0cK\x17\xac\xf0\x12\xfe\xa0\xe5\xee\xe03\xb1\xfa\
                                   <flag>wxALL|wxEXPAND</flag>
                                   <border>10</border>
                                 </object>
-                                <!-- Z-targeting button -->
+                                <!-- XYZ-targeting button -->
                                 <object class="sizeritem">
-                                  <object class="wxButton" name="btn_z_targeting">
-                                    <label>Refine Z</label>
+                                  <object class="wxButton" name="btn_xyz_targeting">
+                                    <label>Refine</label>
                                   </object>
                                 </object>
                                 <object class="sizeritem">
-                                  <object class="wxStaticText" name="txt_refinez_active">
+                                  <object class="wxStaticText" name="txt_refine_xyz_active">
                                   <label> </label>
                                   <fg>#E5E5E5</fg>
                                   <hidden>1</hidden>

--- a/src/odemis/gui/model/tab_gui_data.py
+++ b/src/odemis/gui/model/tab_gui_data.py
@@ -294,11 +294,11 @@ class CryoGUIData(MicroscopyGUIData):
             t_name = make_unique_name("FM-1", existing_names)
             index = int(re.search(TARGET_INDEX, t_name).group(1))
             target = Target(x, y, z=z_val, name=t_name, type=type,
-                            index=index, fm_focus_position=fm_focus_position)
+                            index=index, fm_focus_position=fm_focus_position, needs_refinement=True)
 
         elif type == TargetType.PointOfInterest:
             target = Target(x, y, z=z_val, name="POI-1", type=type,
-                            index=1, fm_focus_position=fm_focus_position)
+                            index=1, fm_focus_position=fm_focus_position, needs_refinement=True)
 
         elif type == TargetType.SurfaceFiducial:
             target = Target(x, y, z=0, name="FIB_surface", type=type, index=1,

--- a/src/odemis/gui/xmlh/resources/dialog_correlation_tdct.xrc
+++ b/src/odemis/gui/xmlh/resources/dialog_correlation_tdct.xrc
@@ -86,10 +86,10 @@
                                   <flag>wxALL|wxEXPAND</flag>
                                   <border>10</border>
                                 </object>
-                                <!-- Z-targeting button -->
+                                <!-- XYZ-targeting button -->
                                 <object class="sizeritem">
                                   <object class="wxButton" name="btn_z_targeting">
-                                    <label>Refine Z</label>
+                                    <label>Refine</label>
                                   </object>
                                 </object>
                                 <object class="sizeritem">

--- a/src/odemis/gui/xmlh/resources/dialog_correlation_tdct.xrc
+++ b/src/odemis/gui/xmlh/resources/dialog_correlation_tdct.xrc
@@ -86,14 +86,14 @@
                                   <flag>wxALL|wxEXPAND</flag>
                                   <border>10</border>
                                 </object>
-                                <!-- Z-targeting button -->
+                                <!-- XYZ-targeting button -->
                                 <object class="sizeritem">
-                                  <object class="wxButton" name="btn_z_targeting">
-                                    <label>Refine Z</label>
+                                  <object class="wxButton" name="btn_xyz_targeting">
+                                    <label>Refine</label>
                                   </object>
                                 </object>
                                 <object class="sizeritem">
-                                  <object class="wxStaticText" name="txt_refinez_active">
+                                  <object class="wxStaticText" name="txt_refine_xyz_active">
                                   <label> </label>
                                   <fg>#E5E5E5</fg>
                                   <hidden>1</hidden>

--- a/src/odemis/util/img.py
+++ b/src/odemis/util/img.py
@@ -1441,3 +1441,62 @@ def apply_zoom_on_image_coordinates(rect: List[int], z:int) -> List[int]:
     :return: (list of int) the rectangle in image pixel coordinates at the given zoom level
     """
     return [px // (2 ** z) for px in rect]
+
+
+def get_bounding_box_slice(target_x: int, target_y: int, pad_x: int, pad_y: int,
+                           shape_x: int, shape_y: int) -> tuple:
+    """
+    Generates a boundary-safe 3D slice object for extracting a region of interest.
+    Automatically clamps the bounding box to the image dimensions.
+
+    :param target_x: Target X pixel coordinate
+    :param target_y: Target Y pixel coordinate
+    :param pad_x: Two directional padding in X direction (pixels)
+    :param pad_y: Two directional padding in Y direction (pixels)
+    :param shape_x: Total width of the image (pixels)
+    :param shape_y: Total height of the image (pixels)
+    :returns: A tuple of slice objects (z_slice, y_slice, x_slice) for array indexing
+    """
+    y_start = max(0, target_y - pad_y)
+    y_end = min(shape_y, target_y + pad_y + 1)
+    x_start = max(0, target_x - pad_x)
+    x_end = min(shape_x, target_x + pad_x + 1)
+    return numpy.s_[:, y_start:y_end, x_start:x_end]
+
+
+def get_brightest_channel(sub_image_multi: numpy.ndarray) -> int:
+    """
+    Finds the index of the channel with the highest maximum intensity.
+    Useful for multi-channel imaging to select the brightest channel for analysis.
+
+    :param sub_image_multi: Multi-channel sub-image as (C, Z, Y, X) array
+    :returns: Index of the channel with the highest intensity
+    """
+    channel_maxes = numpy.max(sub_image_multi, axis=(1, 2, 3))
+    return int(numpy.argmax(channel_maxes))
+
+
+def compute_local_center_of_mass(sub_image: numpy.ndarray, roi_slice: tuple,
+                                 baseline_percentile: float = 95.0) -> Tuple[float, float, float]:
+    """
+    Computes center of mass with baselining and maps back to global pixel coordinates.
+    Uses the brightest pixels (above the baseline percentile) as weights for COM calculation,
+    effectively filtering background noise.
+
+    :param sub_image: Single-channel 3D sub-image as (Z, Y, X) array
+    :param roi_slice: Slice object returned from get_bounding_box_slice
+    :param baseline_percentile: Percentile threshold for background separation (0-100)
+    :returns: Tuple of (global_z, global_y, global_x) in pixel coordinates maintaining input order.
+    """
+    baseline = numpy.percentile(sub_image, baseline_percentile)
+    sub_image_weights = numpy.where(sub_image > baseline, sub_image - baseline, 0)
+    com_sub = scipy.ndimage.center_of_mass(numpy.asarray(sub_image_weights))
+
+    y_start = roi_slice[1].start
+    x_start = roi_slice[2].start
+
+    return (
+        com_sub[0],              # Global Pixel Z (array indices, not iso-voxel)
+        com_sub[1] + y_start,    # Global Pixel Y
+        com_sub[2] + x_start     # Global Pixel X
+    )

--- a/src/odemis/util/img.py
+++ b/src/odemis/util/img.py
@@ -1441,3 +1441,33 @@ def apply_zoom_on_image_coordinates(rect: List[int], z:int) -> List[int]:
     :return: (list of int) the rectangle in image pixel coordinates at the given zoom level
     """
     return [px // (2 ** z) for px in rect]
+
+
+def get_brightest_channel(sub_image_multi: numpy.ndarray) -> int:
+    """
+    Finds the index of the channel with the highest maximum intensity.
+    Useful for multi-channel imaging to select the brightest channel for analysis.
+
+    :param sub_image_multi: Multi-channel sub-image as (C, Z, Y, X) array
+    :returns: Index of the channel with the highest maximum intensity.
+    """
+    channel_maxes = numpy.max(sub_image_multi, axis=(1, 2, 3))
+    return int(numpy.argmax(channel_maxes))
+
+
+def compute_center_of_mass(image: numpy.ndarray,
+                           baseline_ratio: float = 0.95, roi_slice: tuple = None) -> Tuple[float, float, float]:
+    """
+    Computes center of mass with baselining.
+    Uses the brightest pixels (above the baseline percentile) as weights for center of mass calculation,
+    effectively filtering background noise.
+
+    :param image: Single-channel 3D sub-image as (Z, Y, X) array
+    :param baseline_ratio: Ratio for background separation (0-1). Values lower than the baseline
+        will be discarded.
+    :returns: Tuple of (global_z, global_y, global_x) in pixel coordinates maintaining input order.
+    """
+    baseline = numpy.percentile(image, baseline_ratio * 100)
+    image_weights = numpy.where(image > baseline, image - baseline, 0)
+    com = scipy.ndimage.center_of_mass(numpy.asarray(image_weights))
+    return com

--- a/src/odemis/util/test/img_test.py
+++ b/src/odemis/util/test/img_test.py
@@ -2318,5 +2318,65 @@ class TestProjectYXC2RGB8(unittest.TestCase):
         # red becomes black (255*0, 0*1, 0*0), alpha preserved
         numpy.testing.assert_array_equal(out[1, 1], [0, 0, 0, 255])
 
+
+class TestCenterOfMassTargeting(unittest.TestCase):
+    """Test 3D Center of Mass targeting helper functions."""
+
+    def test_bounding_box_slice(self):
+        """Test boundary-safe ROI extraction."""
+        # Normal case
+        roi = img.get_bounding_box_slice(50, 50, 10, 10, 100, 100)
+        self.assertEqual(roi[1].start, 40)
+        self.assertEqual(roi[1].stop, 61)
+        self.assertEqual(roi[2].start, 40)
+        self.assertEqual(roi[2].stop, 61)
+
+        # Boundary clipping at origin
+        roi = img.get_bounding_box_slice(5, 5, 10, 10, 100, 100)
+        self.assertEqual(roi[1].start, 0)
+        self.assertEqual(roi[1].stop, 16)
+        self.assertEqual(roi[2].start, 0)
+        self.assertEqual(roi[2].stop, 16)
+
+        # Boundary clipping at max
+        roi = img.get_bounding_box_slice(95, 95, 10, 10, 100, 100)
+        self.assertEqual(roi[1].start, 85)
+        self.assertEqual(roi[1].stop, 100)
+        self.assertEqual(roi[2].start, 85)
+        self.assertEqual(roi[2].stop, 100)
+
+    def test_brightest_channel(self):
+        """Test channel selection by maximum intensity."""
+        # 4D array: (C, Z, Y, X)
+        multi_channel = numpy.random.rand(3, 10, 20, 20)
+        multi_channel[1] = numpy.ones((10, 20, 20)) * 100  # Make channel 1 bright
+        best_c = img.get_brightest_channel(multi_channel)
+        self.assertEqual(best_c, 1)
+
+    def test_compute_local_center_of_mass_with_noise(self):
+        """Test COM computation correctly filters background noise."""
+        # Create 3D image with strong peak and weak noise
+        sub_image = numpy.zeros((10, 20, 20))
+        # Add signal (strong)
+        for z in range(4, 7):
+            for y in range(8, 13):
+                for x in range(8, 13):
+                    sub_image[z, y, x] = 100.0
+        # Add weak noise (much smaller than signal)
+        sub_image += numpy.random.rand(10, 20, 20) * 2.0
+
+        roi = img.get_bounding_box_slice(10, 10, 5, 5, 20, 20)
+        com_z, com_y, com_x = img.compute_local_center_of_mass(
+            sub_image, roi, baseline_percentile=95.0
+        )
+
+        # COM z should be near peak (z=4-6, center at 5)
+        self.assertAlmostEqual(com_z, 5.0, delta=1.0)
+        # COM should be within the extracted ROI [5:16] range
+        self.assertGreaterEqual(com_x, 5)
+        self.assertLess(com_x, 16)
+        self.assertGreaterEqual(com_y, 5)
+        self.assertLess(com_y, 16)
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/odemis/util/test/img_test.py
+++ b/src/odemis/util/test/img_test.py
@@ -2318,5 +2318,54 @@ class TestProjectYXC2RGB8(unittest.TestCase):
         # red becomes black (255*0, 0*1, 0*0), alpha preserved
         numpy.testing.assert_array_equal(out[1, 1], [0, 0, 0, 255])
 
+
+class TestCenterOfMassTargeting(unittest.TestCase):
+    """Test 3D Center of Mass methods."""
+
+    def test_brightest_channel(self):
+        """Test channel selection by maximum intensity."""
+        # 4D array: (C, Z, Y, X)
+        multi_channel = numpy.random.rand(3, 10, 20, 20)
+        multi_channel[1] = numpy.ones((10, 20, 20)) * 100  # Make channel 1 bright
+        best_c = img.get_brightest_channel(multi_channel)
+        self.assertEqual(best_c, 1)
+
+    def test_compute_local_center_of_mass_with_noise(self):
+        """Test COM computation correctly filters background noise."""
+        # Create 3D image with strong peak and weak noise
+        sub_image = numpy.zeros((10, 20, 20))
+        # Add signal (strong)
+        for z in range(4, 7):
+            for y in range(8, 13):
+                for x in range(8, 13):
+                    sub_image[z, y, x] = 100.0
+        # Add weak noise (much smaller than signal)
+        sub_image += numpy.random.rand(10, 20, 20) * 2.0
+
+        target_y = 5
+        target_x = 10
+        pad_y = 5
+        pad_x = 10
+        shape_y = 20
+        shape_x = 20
+        # Get boundary-safe slice & crop
+        y_start = max(0, target_y - pad_y)
+        y_end = min(shape_y, target_y + pad_y + 1)
+        x_start = max(0, target_x - pad_x)
+        x_end = min(shape_x, target_x + pad_x + 1)
+        roi = numpy.s_[:, y_start:y_end, x_start:x_end]
+
+        com = img.compute_center_of_mass(sub_image, baseline_ratio=0.95)
+        com_y_crop = com[1] + roi[1].start
+        com_x_crop = com[2] + roi[2].start
+
+        # COM z should be near peak (z=4-6, center at 5)
+        self.assertAlmostEqual(com[0], 5.0, delta=1.0)
+        # COM should be within the extracted ROI [5:16] range
+        self.assertGreaterEqual(com_x_crop, 5)
+        self.assertLess(com_x_crop, 16)
+        self.assertGreaterEqual(com_y_crop, 5)
+        self.assertLess(com_y_crop, 16)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR introduces a variety of improvements to the 3D correlation workflow:
- Improve Refine Z method → Using more robust 3D method
- Improve Z value in table → Z column now shows slice index. This means that the automatically found position can now be verified using the slice slider when MIP is disabled.
- Improve timely rendering (sometimes needing click in viewport to update the scene)
→ Now using improved drawing calls that automatically update the viewports when fiducials change
- Remove usage of reflection images in refine method → Only using non-reflective streams now
- Remove auto refinement trigger
→ Auto refinement overwrote manual edits, which is undesirable
- Improve randomness → Making sure to reset random seed before every 3dct call, although unsure what the impact is at this point.
- Placing a FM fiducial when MIP is disabled should inherit the z index of the currently selected slice, but doesn't→ Fiducial now inherits slice index when only one non-reflective stream is visible when MIP is disabled.
- Fixed bug where numpad enter did not trigger 3dct algorithm


## Comparison
### Bad input
We see that the new algorithm is very good at recovering from bad user input. This makes placement of fiducials really simple. New method: Center of Mass (new), Gauss fit 1d (old).
<img width="1400" height="500" alt="debug_6_1" src="https://github.com/user-attachments/assets/b9dd6caf-21ca-4290-95c4-8a135cca6681" />
<img width="1400" height="500" alt="debug_6_2" src="https://github.com/user-attachments/assets/5ee6db4b-9a6c-4e18-aed6-dce449c971c2" />
### Other examples
See JIRA task for more examples

## Out of scope
I encountered various peculiar UX related things (listed in the JIRA ticket) that I'm not touching right now. We could improve upon them later.