### PR TITLE
[fix] Making sure feature is present before acquiring

### DIFF
--- a/src/odemis/gui/cont/acquisition/cryo_acq.py
+++ b/src/odemis/gui/cont/acquisition/cryo_acq.py
@@ -274,6 +274,9 @@ class CryoAcquiController(object):
         """
         called when the button "acquire" is pressed
         """
+        if self.acqui_mode is guimod.AcquiMode.FLM:
+            self._tab.tab_data_model.select_current_position_feature()
+
         # store the focuser position
         self._good_focus_pos = self._tab_data.main.focus.position.value["z"]
 
@@ -317,9 +320,6 @@ class CryoAcquiController(object):
         Called when the acquisition process is
         done, failed or canceled
         """
-        if self.acqui_mode is guimod.AcquiMode.FLM:
-            self._tab.tab_data_model.select_current_position_feature()
-
         self._acq_future = None
         self._gauge_future_conn = None
         self._tab_data.main.is_acquiring.value = False


### PR DESCRIPTION
We found that due to recent lazy-loading changes, acquiring without a feature present caused issues. Making sure a feature is present before acquiring instead of after, resolves the problem it seems.

[Screencast from 2026-04-09 19-07-31.webm](https://github.com/user-attachments/assets/d28905bb-4c33-4536-8c28-aa09d0a988b4)
