### PR TITLE
[fix] GUI viewer: don't ever share thoughts

### DIFF
--- a/src/odemis/gui/main.py
+++ b/src/odemis/gui/main.py
@@ -185,7 +185,8 @@ class OdemisGUIApp(wx.App):
             self.main_frame.Maximize()  # must be done before Show()
 
             # Only show the dialog if today is the right day, before even showing the main window
-            show_important_thought_dialog(self.main_frame)
+            if not self.main_data.is_viewer:
+                show_important_thought_dialog(self.main_frame)
 
             # List of all possible tabs used in Odemis' main GUI, and only load the tabs depending on
             # the current microscope role.


### PR DESCRIPTION
The viewer is opened many times per day, so it's not fun if every time a
new thought is shown. => Never show it.