### PR TITLE
[fix] xt_client: don't log rotations different by 360°

### DIFF
--- a/src/odemis/driver/xt_client.py
+++ b/src/odemis/driver/xt_client.py
@@ -43,7 +43,7 @@ from odemis import util
 from odemis.model import (CancellableFuture, CancellableThreadPoolExecutor,
                           DataArray, HwError, ProgressiveFuture,
                           StringEnumerated, isasync)
-from odemis.util.driver import isNearPosition, estimate_stage_movement_time
+from odemis.util.driver import isNearPosition
 
 Pyro5.api.config.SERIALIZER = 'msgpack'
 msgpack_numpy.patch()
@@ -2488,7 +2488,7 @@ class Stage(model.Actuator):
                                 failures[axis] = (delta, tol_lin_failure_per_axis[axis])
 
                         for axis in rotational_axes_to_check:
-                            delta = abs(current_pos[axis] - target_pos[axis])
+                            delta = abs(util.wrap_to_mpi_ppi(current_pos[axis] - target_pos[axis]))
                             if delta > tol_rot_failure_per_axis[axis]:
                                 failures[axis] = (delta, tol_rot_failure_per_axis[axis])
 


### PR DESCRIPTION
It's handle normally in the comparison, but just not correcly in the
log.
=> make the log also aware of the rotation being the same after 360°