### PR TITLE
[fix] Import annotations from future for typing compatibility with python 3.8

### DIFF
--- a/src/odemis/gui/cont/multi_point_correlation.py
+++ b/src/odemis/gui/cont/multi_point_correlation.py
@@ -20,6 +20,8 @@ You should have received a copy of the GNU General Public License along with
 Odemis. If not, see http://www.gnu.org/licenses/.
 
 """
+from __future__ import annotations  # allows the use of Python3.9 style typing in Python3.8
+
 import logging
 import queue
 import re

--- a/src/odemis/util/dataio.py
+++ b/src/odemis/util/dataio.py
@@ -19,6 +19,8 @@ You should have received a copy of the GNU General Public License along with Ode
 see http://www.gnu.org/licenses/.
 
 """
+from __future__ import annotations  # allows the use of Python3.9 style typing in Python3.8
+
 import json
 import logging
 import os


### PR DESCRIPTION
Using lower-case dict, list, and tuple for type hinting is not supported in Python 3.8

In Python 3.8, these are built-in collection types, but they do not support indexing (the [] syntax) for typing. That specific feature was introduced in Python 3.9