### PR TITLE
[fix] METEOR PostureManager ensure current_posture is up-to-date when the posture switch ends

### DIFF
--- a/src/odemis/acq/move.py
+++ b/src/odemis/acq/move.py
@@ -1206,6 +1206,11 @@ class MeteorTFS1PostureManager(MeteorPostureManager):
             logging.exception("Failure to move to {} position.".format(target_name))
             raise
         finally:
+            try:
+                self._update_posture(self.stage.position.value)
+            except Exception as e:
+                logging.warning("Failed to update posture after move: %s", e)
+
             with future._task_lock:
                 if future._task_state == CANCELLED:
                     raise CancelledError()
@@ -1694,6 +1699,11 @@ class MeteorZeiss1PostureManager(MeteorPostureManager):
             logging.exception("Failure to move to {} position.".format(target_name))
             raise
         finally:
+            try:
+                self._update_posture(self.stage.position.value)
+            except Exception as e:
+                logging.warning("Failed to update posture after move: %s", e)
+
             with future._task_lock:
                 if future._task_state == CANCELLED:
                     raise CancelledError()
@@ -2206,6 +2216,11 @@ class MeteorTescan1PostureManager(MeteorPostureManager):
             logging.exception("Failure to move to %s position.", target_name)
             raise
         finally:
+            try:
+                self._update_posture(self.stage.position.value)
+            except Exception as e:
+                logging.warning("Failed to update posture after move: %s", e)
+
             with future._task_lock:
                 if future._task_state == CANCELLED:
                     raise CancelledError()
@@ -2462,6 +2477,11 @@ class MeteorJeol1PostureManager(MeteorPostureManager):
             logging.exception("Failure to move to %s position.", target_name)
             raise
         finally:
+            try:
+                self._update_posture(self.stage.position.value)
+            except Exception as e:
+                logging.warning("Failed to update posture after move: %s", e)
+
             with future._task_lock:
                 if future._task_state == CANCELLED:
                     raise CancelledError()

--- a/src/odemis/acq/test/move_tfs3_test.py
+++ b/src/odemis/acq/test/move_tfs3_test.py
@@ -79,7 +79,6 @@ class TestMeteorTFS3Move(unittest.TestCase):
         """Test switching between different postures and check that the 3D transformations work as expected"""
         f = self.pm.cryoSwitchSamplePosition(SEM_IMAGING)
         f.result()
-
         self.assertEqual(self.pm.current_posture.value, SEM_IMAGING)
 
         if model.MD_FAV_MILL_POS_ACTIVE in self.stage_md:
@@ -89,7 +88,6 @@ class TestMeteorTFS3Move(unittest.TestCase):
 
         f = self.pm.cryoSwitchSamplePosition(FM_IMAGING)
         f.result()
-
         self.assertEqual(self.pm.current_posture.value, FM_IMAGING)
 
     def test_to_posture(self):


### PR DESCRIPTION
After the posture switch ends, the stage position is updated, and the
current_posture VA gets updated. However, as this happens in the
background, sometimes reading current_posture immediately after the
switch still indicates the previous posture. This can cause some error
in code that immediately check the posture after the posture switch.

=> Force to recompute the posture just when the posture Future ends.

In particular, this fixes intermittent failure in test_switching_movements.