### PR TITLE
[style] Improve callback names

### DIFF
--- a/doc/develop/coding-guidelines.rst
+++ b/doc/develop/coding-guidelines.rst
@@ -80,6 +80,43 @@ For e.g. 1.2 the implementation of public and private attributes
           print('alias : ', self._alias)
 
 
+Subscriber Callback Naming
+==========================
+
+Callbacks passed to ``.subscribe()`` should always be private methods (leading ``_``) written
+in ``snake_case``. The name should make the purpose clear without having to read the
+implementation. There are two acceptable strategies, ordered by preference:
+
+1. **Action-oriented** — name the callback after what it *does*. This is the preferred style
+   whenever the callback has a clear, single responsibility.
+
+   .. code-block:: python
+
+       # Good: the name tells you what happens when streams change
+       self.tab_data_model.streams.subscribe(self._remove_deleted_acquired_streams)
+
+       # Good: the name tells you what the debug VA triggers
+       main_data.debug.subscribe(self._toggle_fps_overlay)
+
+2. **Trigger-oriented** — name the callback after *when* it is called, using the
+   ``_on_<observable>`` pattern. This is acceptable when the callback is generic or
+   delegates to another method that carries the descriptive name.
+
+   .. code-block:: python
+
+       # Acceptable: generic handler that just calls update_acquisition_time()
+       self.driftCorrector.roi.subscribe(self._on_drift_corrector_change)
+
+       # Acceptable: handler recenters the view, but the trigger name is clear
+       self.view.view_pos.subscribe(self._on_view_pos)
+
+**Avoid** names that mix both strategies badly — e.g. ``_on_acquired_streams`` subscribed to
+*all* streams, or ``_onAnyVA`` subscribed to seven unrelated VAs. These leave the reader
+unable to understand either the trigger or the action.
+
+**Avoid** camelCase (``_onViewPos``) and missing leading underscores (``on_hrange``), both of
+which are inconsistent with the rest of the codebase.
+
 Docstrings
 ==================
 

--- a/src/odemis/gui/comp/miccanvas.py
+++ b/src/odemis/gui/comp/miccanvas.py
@@ -185,7 +185,7 @@ class DblMicroscopeCanvas(canvas.DraggableCanvas):
             # doesn't update the canvas anymore
             tab_data = self._tab_data_model
             tab_data.tool.unsubscribe(self._on_tool)
-            tab_data.main.debug.unsubscribe(self._on_debug)
+            tab_data.main.debug.unsubscribe(self._toggle_fps_overlay)
             self._tab_data_model = None
 
     def clear(self):
@@ -209,7 +209,7 @@ class DblMicroscopeCanvas(canvas.DraggableCanvas):
         self._tab_data_model = tab_data
 
         self.view.mpp.subscribe(self._on_view_mpp, init=True)
-        self.view.view_pos.subscribe(self._onViewPos)
+        self.view.view_pos.subscribe(self._on_view_pos)
         # Update new position immediately, so that fit_to_content() directly
         # gets the correct center
         phys_pos = self.view.view_pos.value
@@ -230,7 +230,7 @@ class DblMicroscopeCanvas(canvas.DraggableCanvas):
 
         self.view.show_pixelvalue.subscribe(self._on_pixel_value_show, init=True)
 
-        tab_data.main.debug.subscribe(self._on_debug, init=True)
+        tab_data.main.debug.subscribe(self._toggle_fps_overlay, init=True)
 
         # Only create the overlays which could possibly be used
         tools_possible = set(tab_data.tool.choices)
@@ -352,7 +352,7 @@ class DblMicroscopeCanvas(canvas.DraggableCanvas):
             self.remove_view_overlay(self._pixelvalue_ol)
 
     @ignore_dead
-    def _on_debug(self, activated):
+    def _toggle_fps_overlay(self, activated):
         """ Called when GUI debug mode changes => display FPS overlay """
         if activated:
             if self._fps_ol is None:
@@ -640,7 +640,7 @@ class DblMicroscopeCanvas(canvas.DraggableCanvas):
             if img is not None:
                 self.view.thumbnail.value = img
 
-    def _onViewPos(self, phys_pos):
+    def _on_view_pos(self, phys_pos):
         """
         When the view position is updated: recenter the view
         phys_pos (tuple of 2 float): X/Y in physical coordinates (m)
@@ -660,7 +660,7 @@ class DblMicroscopeCanvas(canvas.DraggableCanvas):
         # in case we are not attached to a view yet (shouldn't happen)
         super(DblMicroscopeCanvas, self).recenter_buffer(phys_pos)
         if self.view:
-            # This will call _onViewPos() -> recenter_buffer(), but as
+            # This will call _on_view_pos() -> recenter_buffer(), but as
             # recenter_buffer() has already been called with this position,
             # nothing will happen
             self.view.view_pos.value = phys_pos

--- a/src/odemis/gui/comp/viewport.py
+++ b/src/odemis/gui/comp/viewport.py
@@ -966,10 +966,10 @@ class ARLiveViewport(LiveViewport):
 
     def setView(self, view, tab_data):
         super(ARLiveViewport, self).setView(view, tab_data)
-        view.lastUpdate.subscribe(self._on_stream_update, init=True)
+        view.lastUpdate.subscribe(self._update_play_overlay_visibility, init=True)
 
-    def _on_stream_update(self, _):
-        """ Hide the play icon overlay if no stream are present """
+    def _update_play_overlay_visibility(self, _):
+        """ Hide the play icon overlay if no streams are present """
         if self._view is None:  # In case it's called after being destroyed
             return
         show = len(self._view.stream_tree) > 0
@@ -1014,10 +1014,10 @@ class EKLiveViewport(LiveViewport):
 
     def setView(self, view, tab_data):
         super(EKLiveViewport, self).setView(view, tab_data)
-        view.lastUpdate.subscribe(self._on_stream_update, init=True)
+        view.lastUpdate.subscribe(self._update_play_overlay_visibility, init=True)
 
-    def _on_stream_update(self, _):
-        """ Hide the play icon overlay if no stream are present """
+    def _update_play_overlay_visibility(self, _):
+        """ Hide the play icon overlay if no streams are present """
         if self._view is None:  # In case it's called after being destroyed
             return
         show = len(self._view.stream_tree) > 0
@@ -1118,10 +1118,10 @@ class AngularResolvedViewport(ViewPort):
             logging.debug("Disconnecting %s from ARRawViewport", self._projection)
             if hasattr(self._projection, 'polarization'):
                 logging.debug("Disconnecting %s from polarization VA", proj)
-                self._stream.polarization.unsubscribe(self.on_va_change)
+                self._stream.polarization.unsubscribe(self._update_legend_on_projection_change)
             if hasattr(self._projection, 'polarimetry'):
                 logging.debug("Disconnecting %s from polarimetry VA", proj)
-                self._stream.polarimetry.unsubscribe(self.on_va_change)
+                self._stream.polarimetry.unsubscribe(self._update_legend_on_projection_change)
 
         # Connect the new stream
         self._stream, self._projection = get_original_stream(proj), proj
@@ -1137,7 +1137,7 @@ class AngularResolvedViewport(ViewPort):
                     choices = POL_POSITIONS  # use the ordered tuple to keep legend ordered later
                 cur_value = self._stream.polarization.value
                 self.update_legend_choices(choices, cur_value, name)
-                self._projection.polarization.subscribe(self.on_va_change)
+                self._projection.polarization.subscribe(self._update_legend_on_projection_change)
                 self.bottom_legend.Show(True)
             elif hasattr(proj, "polarimetry"):
                 logging.debug("Connecting %s to polarimetry VA", proj)
@@ -1152,7 +1152,7 @@ class AngularResolvedViewport(ViewPort):
                     ("Degrees of polarization", (MD_POL_DOP, MD_POL_DOLP, MD_POL_DOCP, MD_POL_UP)),
                 ))
                 self.update_legend_choices(choices, cur_value, name)
-                self._projection.polarimetry.subscribe(self.on_va_change)
+                self._projection.polarimetry.subscribe(self._update_legend_on_projection_change)
                 self.bottom_legend.Show(True)
             # if no polarization/polarimetry VA or if no stream (= None)
             else:
@@ -1175,7 +1175,7 @@ class AngularResolvedViewport(ViewPort):
         elif hasattr(self._projection, "polarimetry"):
             self._stream.polarimetry.value = pos
 
-    def on_va_change(self, pos):
+    def _update_legend_on_projection_change(self, pos):
         """
         Called when the VA value has changed.
         Sets the correct selection in the legend if the VA was
@@ -1243,9 +1243,9 @@ class PlotViewport(ViewPort):
 
         # For the play/pause icon
         view.stream_tree.should_update.subscribe(self._on_streams_play, init=True)
-        view.stream_tree.flat.subscribe(self._on_stream_update, init=True)
+        view.stream_tree.flat.subscribe(self._update_play_overlay_visibility, init=True)
 
-    def _on_stream_update(self, projs):
+    def _update_play_overlay_visibility(self, projs):
         """
         Hide the play icon overlay if no stream are present (or they are all static)
         """
@@ -1377,12 +1377,12 @@ class NavigablePlotViewport(PlotViewport):
         super(NavigablePlotViewport, self).__init__(*args, **kwargs)
 
         self.hrange = model.TupleVA(None, setter=self.set_hrange)
-        self.hrange.subscribe(self.on_hrange)
+        self.hrange.subscribe(self._update_horizontal_axis_display)
         self.hrange_lock = model.BooleanVA(False)
         self.bottom_legend.lock_va = self.hrange_lock
 
         self.vrange = model.TupleVA(None, setter=self.set_vrange)
-        self.vrange.subscribe(self.on_vrange)
+        self.vrange.subscribe(self._update_vertical_axis_display)
         self.vrange_lock = model.BooleanVA(False)
         self.left_legend.lock_va = self.vrange_lock
 
@@ -1452,7 +1452,7 @@ class NavigablePlotViewport(PlotViewport):
             raise ValueError("Bad horizontal range: %s > %s" % (hrange[0], hrange[1]))
         return hrange
 
-    def on_hrange(self, hrange):
+    def _update_horizontal_axis_display(self, hrange):
         """
         Refreshes the plot and axis legend displays with the new scale
         """
@@ -1474,7 +1474,7 @@ class NavigablePlotViewport(PlotViewport):
             raise ValueError("Bad vertical range: %s > %s" % (vrange[0], vrange[1]))
         return vrange
 
-    def on_vrange(self, vrange):
+    def _update_vertical_axis_display(self, vrange):
         """
         Refreshes the plot and axis legend displays with the new scale
         """
@@ -2159,7 +2159,7 @@ class TwoDViewPort(ViewPort):
 
         # For the play/pause icon
         view.stream_tree.should_update.subscribe(self._on_stream_play, init=True)
-        view.lastUpdate.subscribe(self._on_stream_update, init=True)
+        view.lastUpdate.subscribe(self._update_play_overlay_visibility, init=True)
 
     def _on_stream_play(self, is_playing):
         """
@@ -2167,9 +2167,9 @@ class TwoDViewPort(ViewPort):
         """
         self.canvas.play_overlay.hide_pause(is_playing)
 
-    def _on_stream_update(self, _):
+    def _update_play_overlay_visibility(self, _):
         """
-        Hide the play icon overlay if no stream are present (or they are all static)
+        Hide the play icon overlay if no streams are present (or they are all static)
         """
         ss = self._view.getStreams()
         if len(ss) > 0:

--- a/src/odemis/gui/cont/acquisition/sparc_acq.py
+++ b/src/odemis/gui/cont/acquisition/sparc_acq.py
@@ -155,14 +155,14 @@ class SparcAcquiController(object):
         tab_data.streams.subscribe(self._onStreams, init=True)
         # also listen to .semStream, which is not in .streams
         for va in self._get_settings_vas(tab_data.semStream):
-            va.subscribe(self._onAnyVA)
+            va.subscribe(self._recalculate_acquisition_time)
 
         # Extra options affecting the acquisitions globally
-        tab_data.pcdActive.subscribe(self._onAnyVA)
-        tab_data.useScanStage.subscribe(self._onAnyVA)
-        tab_data.driftCorrector.roi.subscribe(self._onAnyVA)
-        tab_data.driftCorrector.period.subscribe(self._onAnyVA)
-        tab_data.driftCorrector.dwellTime.subscribe(self._onAnyVA)
+        tab_data.pcdActive.subscribe(self._recalculate_acquisition_time)
+        tab_data.useScanStage.subscribe(self._recalculate_acquisition_time)
+        tab_data.driftCorrector.roi.subscribe(self._recalculate_acquisition_time)
+        tab_data.driftCorrector.period.subscribe(self._recalculate_acquisition_time)
+        tab_data.driftCorrector.dwellTime.subscribe(self._recalculate_acquisition_time)
 
         self._roa.subscribe(self._onROA, init=True)
         if tab_data.roa_rotation is not None:
@@ -214,19 +214,20 @@ class SparcAcquiController(object):
         # remove subscription for streams that were deleted
         for s in (self._prev_streams - streams):
             for va in self._get_settings_vas(s):
-                va.unsubscribe(self._onAnyVA)
+                va.unsubscribe(self._recalculate_acquisition_time)
 
         # add subscription for new streams
         for s in (streams - self._prev_streams):
             for va in self._get_settings_vas(s):
-                va.subscribe(self._onAnyVA)
+                va.subscribe(self._recalculate_acquisition_time)
 
         self._prev_streams = streams
         self.update_acquisition_time()  # to update the message
 
-    def _onAnyVA(self, val):
+    def _recalculate_acquisition_time(self, val):
         """
-        Called whenever a VA which might affect the acquisition is modified
+        Recalculate and update the estimated acquisition time whenever a
+        VA that affects the acquisition duration is modified.
         """
         self.update_acquisition_time()  # to update the message
 

--- a/src/odemis/gui/cont/tabs/fastem_setup_tab.py
+++ b/src/odemis/gui/cont/tabs/fastem_setup_tab.py
@@ -141,10 +141,10 @@ class FastEMSetupTab(Tab):
 
         # For Optical Autofocus calibration
         self.tab_data.main.is_acquiring.subscribe(
-            self._on_is_acquiring
+            self._toggle_controls_on_calibration
         )  # enable/disable button if acquiring
         self.tab_data.is_calibrating.subscribe(
-            self._on_is_acquiring
+            self._toggle_controls_on_calibration
         )  # enable/disable button if calibrating
 
         # Acquisition controller
@@ -230,12 +230,12 @@ class FastEMSetupTab(Tab):
         self.sem_stream_cont.pause()
 
         # calibrate
-        self.tab_data.is_calibrating.unsubscribe(self._on_is_acquiring)
+        self.tab_data.is_calibrating.unsubscribe(self._toggle_controls_on_calibration)
         # Don't catch this event (is_calibrating = True) - this would disable the button,
         # but it should be still enabled in order to be able to cancel the calibration
         # make sure the acquire/tab buttons are disabled
         self.tab_data.is_calibrating.value = True
-        self.tab_data.is_calibrating.subscribe(self._on_is_acquiring)
+        self.tab_data.is_calibrating.subscribe(self._toggle_controls_on_calibration)
         self.reference_stage_future = self.tab_data.main.stage.reference({"x", "y"})
         self.reference_stage_future.add_done_callback(self._on_reference_stage_done)
         self._update_button_controls(self.btn_reference_stage)
@@ -281,12 +281,12 @@ class FastEMSetupTab(Tab):
         self.sem_stream_cont.enable(False)
         self.sem_stream_cont.stream_panel.enable(False)
         # calibrate
-        self.tab_data.is_calibrating.unsubscribe(self._on_is_acquiring)
+        self.tab_data.is_calibrating.unsubscribe(self._toggle_controls_on_calibration)
         # Don't catch this event (is_calibrating = True) - this would disable the button,
         # but it should be still enabled in order to be able to cancel the calibration
         # make sure the acquire/tab buttons are disabled
         self.tab_data.is_calibrating.value = True
-        self.tab_data.is_calibrating.subscribe(self._on_is_acquiring)
+        self.tab_data.is_calibrating.subscribe(self._toggle_controls_on_calibration)
         logging.debug("Starting Optical Autofocus calibration")
         # Start alignment
         f = fastem.align(
@@ -358,12 +358,12 @@ class FastEMSetupTab(Tab):
         self.sem_stream_cont.pause()
 
         # calibrate
-        self.tab_data.is_calibrating.unsubscribe(self._on_is_acquiring)
+        self.tab_data.is_calibrating.unsubscribe(self._toggle_controls_on_calibration)
         # Don't catch this event (is_calibrating = True) - this would disable the button,
         # but it should be still enabled in order to be able to cancel the calibration
         # make sure the acquire/tab buttons are disabled
         self.tab_data.is_calibrating.value = True
-        self.tab_data.is_calibrating.subscribe(self._on_is_acquiring)
+        self.tab_data.is_calibrating.subscribe(self._toggle_controls_on_calibration)
         f = fastem.align(
             self.tab_data.main.ebeam,
             self.tab_data.main.multibeam,
@@ -416,12 +416,12 @@ class FastEMSetupTab(Tab):
         self.sem_stream_cont.pause()
 
         # calibrate
-        self.tab_data.is_calibrating.unsubscribe(self._on_is_acquiring)
+        self.tab_data.is_calibrating.unsubscribe(self._toggle_controls_on_calibration)
         # Don't catch this event (is_calibrating = True) - this would disable the button,
         # but it should be still enabled in order to be able to cancel the calibration
         # make sure the acquire/tab buttons are disabled
         self.tab_data.is_calibrating.value = True
-        self.tab_data.is_calibrating.subscribe(self._on_is_acquiring)
+        self.tab_data.is_calibrating.subscribe(self._toggle_controls_on_calibration)
         self.autobc_future = self.sem_stream_cont.stream.detector.applyAutoContrastBrightness()
         self.autobc_future.add_done_callback(self._on_autobc_done)
         self._update_button_controls(self.btn_autobc)
@@ -464,12 +464,12 @@ class FastEMSetupTab(Tab):
         self.sem_stream_cont.pause()
 
         # calibrate
-        self.tab_data.is_calibrating.unsubscribe(self._on_is_acquiring)
+        self.tab_data.is_calibrating.unsubscribe(self._toggle_controls_on_calibration)
         # Don't catch this event (is_calibrating = True) - this would disable the button,
         # but it should be still enabled in order to be able to cancel the calibration
         # make sure the acquire/tab buttons are disabled
         self.tab_data.is_calibrating.value = True
-        self.tab_data.is_calibrating.subscribe(self._on_is_acquiring)
+        self.tab_data.is_calibrating.subscribe(self._toggle_controls_on_calibration)
         f = fastem.align(
             self.tab_data.main.ebeam,
             self.tab_data.main.multibeam,
@@ -528,7 +528,7 @@ class FastEMSetupTab(Tab):
         self.sem_stream_cont.stream_panel.Refresh()
 
     @call_in_wx_main
-    def _on_is_acquiring(self, mode):
+    def _toggle_controls_on_calibration(self, mode):
         """
         Enable or disable relevant wx objects depending on whether
         a calibration or acquisition is already ongoing or not.

--- a/src/odemis/gui/cont/tabs/fibsem_tab.py
+++ b/src/odemis/gui/cont/tabs/fibsem_tab.py
@@ -195,7 +195,7 @@ class FibsemTab(Tab):
         self._update_milling_angle(None)
         self.panel.btn_switch_milling.Bind(wx.EVT_BUTTON, self._move_to_milling_posture)
         self.panel.btn_switch_sem_imaging.Bind(wx.EVT_BUTTON, self._move_to_sem_posture)
-        self.tab_data_model.streams.subscribe(self._on_acquired_streams)
+        self.tab_data_model.streams.subscribe(self._remove_deleted_acquired_streams)
 
     @call_in_wx_main
     def _on_view(self, view):
@@ -298,7 +298,7 @@ class FibsemTab(Tab):
             correlation_tab.correlation_controller.add_streams(streams)
 
     @call_in_wx_main
-    def _on_acquired_streams(self, streams):
+    def _remove_deleted_acquired_streams(self, streams):
         """
         Filter out deleted acquired streams (features and overview) from their respective origin
         :param streams: list(Stream) updated list of tab streams
@@ -323,10 +323,10 @@ class FibsemTab(Tab):
             self._streambar_controller.update_stream_settings()
 
     def _stop_streams_subscriber(self):
-        self.tab_data_model.streams.unsubscribe(self._on_acquired_streams)
+        self.tab_data_model.streams.unsubscribe(self._remove_deleted_acquired_streams)
 
     def _start_streams_subscriber(self):
-        self.tab_data_model.streams.subscribe(self._on_acquired_streams)
+        self.tab_data_model.streams.subscribe(self._remove_deleted_acquired_streams)
 
     def on_dbl_click(self, evt):
 

--- a/src/odemis/gui/cont/tabs/localization_tab.py
+++ b/src/odemis/gui/cont/tabs/localization_tab.py
@@ -141,7 +141,7 @@ class LocalizationTab(Tab):
         self._feature_panel_controller = CryoFeatureController(tab_data, panel, self,
                                                                mode=guimod.AcquiMode.FLM)
         self._zloc_controller = CryoZLocalizationController(tab_data, panel, self)
-        self.tab_data_model.streams.subscribe(self._on_acquired_streams)
+        self.tab_data_model.streams.subscribe(self._remove_deleted_acquired_streams)
         self.conf = conf.get_acqui_conf()
 
         # Toolbar
@@ -407,7 +407,7 @@ class LocalizationTab(Tab):
         wx.CallAfter(self.tb.enable_button, TOOL_AUTO_FOCUS, f_enable)
 
     @call_in_wx_main
-    def _on_acquired_streams(self, streams):
+    def _remove_deleted_acquired_streams(self, streams):
         """
         Filter out deleted acquired streams (features and overview) from their respective origin
         :param streams: list(Stream) updated list of tab streams
@@ -451,10 +451,10 @@ class LocalizationTab(Tab):
         self.panel.vp_secom_tr.canvas.fit_view_to_content()
 
     def _stop_streams_subscriber(self):
-        self.tab_data_model.streams.unsubscribe(self._on_acquired_streams)
+        self.tab_data_model.streams.unsubscribe(self._remove_deleted_acquired_streams)
 
     def _start_streams_subscriber(self):
-        self.tab_data_model.streams.subscribe(self._on_acquired_streams)
+        self.tab_data_model.streams.subscribe(self._remove_deleted_acquired_streams)
 
     def _on_acquisition(self, is_acquiring):
         # When acquiring, the tab is automatically disabled and should be left as-is

--- a/src/odemis/gui/model/stream_view.py
+++ b/src/odemis/gui/model/stream_view.py
@@ -172,12 +172,12 @@ class StreamView(View):
             self.zPos = zPos
 
         self.mpp.subscribe(self._onMpp, init=True)
-        self.view_pos.subscribe(self._onViewPos, init=True)
+        self.view_pos.subscribe(self._on_view_pos, init=True)
 
     def _onFovBuffer(self, fov):
         self._updateStreamsViewParams()
 
-    def _onViewPos(self, view_pos):
+    def _on_view_pos(self, view_pos):
         self._updateStreamsViewParams()
 
     def _onMpp(self, mpp):


### PR DESCRIPTION
Renamed subscriber callbacks to better reflect what they actually do, rather than the event that triggers them. 

| File | Old Name | New Name | Reason |
|---|---|---|---|
| `cont/acquisition/sparc_acq.py` | `_onAnyVA` | `_recalculate_acquisition_time` | Was subscribed to 7+ unrelated VAs; name gave no hint of trigger or action. camelCase inconsistent with codebase style. |
| `cont/tabs/localization_tab.py` | `_on_acquired_streams` | `_remove_deleted_acquired_streams` | Fires on *all* stream list changes, not just acquired streams. The name implies a narrower trigger than reality. |
| `cont/tabs/fibsem_tab.py` | `_on_acquired_streams` | `_remove_deleted_acquired_streams` | Same issue as above. |
| `cont/tabs/fastem_setup_tab.py` | `_on_is_acquiring` | `_toggle_controls_on_calibration` | Was subscribed to `is_calibrating`, not `is_acquiring`. Misleading name given a separate `_on_is_calibrating` also exists in the same class. |
| `comp/viewport.py` | `_on_stream_update` | `_update_play_overlay_visibility` | Suggests stream data is being updated; it actually shows/hides the play icon overlay. Affects 4 viewport classes. |
| `comp/viewport.py` | `on_va_change` | `_update_legend_on_projection_change` | Completely generic; applicable to any VA anywhere. Also lacked the leading `_` required for private methods. |
| `comp/viewport.py` | `on_hrange` | `_update_horizontal_axis_display` | Describes only the trigger, not the action (updates legend range, canvas axis, and ellipsis indicators). Missing leading `_`. |
| `comp/viewport.py` | `on_vrange` | `_update_vertical_axis_display` | Same issue as `on_hrange`. Missing leading `_`. |
| `comp/miccanvas.py` | `_onViewPos` | `_on_view_pos` | camelCase inconsistent with the snake_case convention used throughout the codebase. |
| `comp/miccanvas.py` | `_on_debug` | `_toggle_fps_overlay` | Vague trigger name. The actual action is toggling the FPS text overlay on the canvas. |
| `model/stream_view.py` | `_onViewPos` | `_on_view_pos` | Same camelCase inconsistency as above. |
