### PR TITLE
[style] Improve method names posture manager

### DIFF
--- a/plugins/meteor_engage_warn.py
+++ b/plugins/meteor_engage_warn.py
@@ -78,7 +78,7 @@ class MeteorEngageWarnPlugin(Plugin):
         pos_str = "\n". join(pos_str)
 
         # Guess (back) which position the users wants to go to
-        target_pos = self.main_app.main_data.posture_manager.getCurrentPostureLabel(end_pos)
+        target_pos = self.main_app.main_data.posture_manager.get_current_posture_label(end_pos)
         stage = self.main_app.main_data.stage_bare
         if target_pos == FM_IMAGING:
             warn_msg = FM_WARN_MSG

--- a/src/odemis/acq/align/test/roi_autofocus_test.py
+++ b/src/odemis/acq/align/test/roi_autofocus_test.py
@@ -49,7 +49,7 @@ class RoiAutofocusTestCase(unittest.TestCase):
 
         # Switch to FM imaging as the focus position will be its "good" position
         # and simulator will autofocus in (almost) focussed images
-        cls.meteor_manager.cryoSwitchSamplePosition(FM_IMAGING).result()
+        cls.meteor_manager.cryo_switch_sample_position(FM_IMAGING).result()
 
         # Assumes the stage is referenced
         cls.init_pos = (cls.stage.position.value["x"], cls.stage.position.value["y"])

--- a/src/odemis/acq/feature.py
+++ b/src/odemis/acq/feature.py
@@ -696,7 +696,7 @@ class CryoFeatureAcquisitionTask(object):
                     raise CancelledError()
 
                 # move to FM IMAGING posture
-                current_posture = self.pm.getCurrentPostureLabel()
+                current_posture = self.pm.get_current_posture_label()
                 logging.debug(f"Current Posture: {POSITION_NAMES[current_posture]}")
 
                 if current_posture != FM_IMAGING:
@@ -705,7 +705,7 @@ class CryoFeatureAcquisitionTask(object):
                     logging.debug(
                         f"Moving to {POSITION_NAMES[FM_IMAGING]} from {POSITION_NAMES[current_posture]}"
                     )
-                    self._future.running_subf = self.pm.cryoSwitchSamplePosition(FM_IMAGING)
+                    self._future.running_subf = self.pm.cryo_switch_sample_position(FM_IMAGING)
                     self._future.running_subf.result()
 
             for feature in self.features:

--- a/src/odemis/acq/milling/millmng.py
+++ b/src/odemis/acq/milling/millmng.py
@@ -345,7 +345,7 @@ class AutomatedMillingManager(object):
             self.current_workflow = workflow_task.value
             logging.info(f"Starting {task_num}/{len(self.task_list)}: {self.current_workflow} for {len(self.features)} features...")
 
-            current_posture = self.pm.getCurrentPostureLabel()
+            current_posture = self.pm.get_current_posture_label()
             if current_posture not in [SEM_IMAGING, MILLING]:
                 error_text = (f"Current posture is {POSITION_NAMES[current_posture]}. "
                                "Please switch to SEM_IMAGING or MILLING before starting automated milling.")

--- a/src/odemis/acq/milling/test/millmng_test.py
+++ b/src/odemis/acq/milling/test/millmng_test.py
@@ -163,7 +163,7 @@ class TestAutomatedMillingManager(unittest.TestCase):
         f.result()
 
         # move to fm imaging
-        f = self.pm.cryoSwitchSamplePosition(FM_IMAGING)
+        f = self.pm.cryo_switch_sample_position(FM_IMAGING)
         f.result()
 
         f = run_automated_milling(
@@ -178,7 +178,7 @@ class TestAutomatedMillingManager(unittest.TestCase):
         with self.assertRaises(ValueError):
             f.result()
 
-        f = self.pm.cryoSwitchSamplePosition(SEM_IMAGING)
+        f = self.pm.cryo_switch_sample_position(SEM_IMAGING)
         f.result()
 
         f = run_automated_milling(
@@ -231,11 +231,11 @@ class TestAutomatedMillingManager(unittest.TestCase):
         features = deepcopy(self.features)
 
         # Make sure to start from a valid SEM position. If due to a previous test the stage would be at an UNKNOWN
-        # posture, the cryoSwitchSamplePosition could fail.
+        # posture, the cryo_switch_sample_position could fail.
         f = self.pm.stage.moveAbs(self.sem_grid1)
         f.result()
 
-        f = self.pm.cryoSwitchSamplePosition(MILLING)
+        f = self.pm.cryo_switch_sample_position(MILLING)
         f.result()
 
         f = run_automated_milling(

--- a/src/odemis/acq/move.py
+++ b/src/odemis/acq/move.py
@@ -70,7 +70,7 @@ LINEAR_AXES = {'x', 'y', 'z', 'm'}
 ROTATION_AXES = {'rx', 'ry', 'rz', 'rm'}
 
 # Tolerance for the difference between the current position and the target position
-# these should only be used for TFS1MeteorPostureManager _transformFromSEMToMeteor / _transformFromMeteorToSEM
+# these should only be used for TFS1MeteorPostureManager _transform_from_sem_to_fm / _transform_from_fm_to_sem
 ATOL_ROTATION_TRANSFORM = 0.04  # rad ~2.5 deg
 ATOL_LINEAR_TRANSFORM = 5e-6  # 5 um
 
@@ -125,7 +125,7 @@ class MicroscopePostureManager:
         pass
 
     @abstractmethod
-    def getCurrentPostureLabel(self, pos: Dict[str, float] = None) -> int:
+    def get_current_posture_label(self, pos: Dict[str, float] = None) -> int:
         """
         Determine where lies the current stage position
         :param pos: (dict str->float) the stage position in which the label needs to be found. If None, it uses the
@@ -134,7 +134,7 @@ class MicroscopePostureManager:
         """
         pass
 
-    def cryoSwitchSamplePosition(self, target: int):
+    def cryo_switch_sample_position(self, target: int):
         """
         Provide the ability to switch between different positions, without bumping into anything.
         :param target: (int) target position either one of the constants: LOADING, IMAGING,
@@ -143,25 +143,25 @@ class MicroscopePostureManager:
         ValueError exception
         """
         f = model.CancellableFuture()
-        f.task_canceller = self._cancelCryoMoveSample
+        f.task_canceller = self._cancel_cryo_move_sample
         f._task_state = RUNNING
         f._task_lock = threading.Lock()
         f._running_subf = model.InstantaneousFuture()
         # Run in separate thread
-        executeAsyncTask(f, self._doCryoSwitchSamplePosition, args=(f, target))
+        executeAsyncTask(f, self._do_cryo_switch_sample_position, args=(f, target))
         return f
 
     @abstractmethod
-    def _doCryoSwitchSamplePosition(self, future, target_pos: int):
+    def _do_cryo_switch_sample_position(self, future, target_pos: int):
         """
-        Do the actual switching procedure for cryoSwitchSamplePosition
+        Do the actual switching procedure for cryo_switch_sample_position
         :param future: cancellable future of the move
         :param target: (int) target position either one of the constants: LOADING, IMAGING,
            ALIGNMENT, COATING, LOADING_PATH, MILLING, SEM_IMAGING, FM_IMAGING.
         """
         pass
 
-    def getMovementProgress(self, current_pos: Dict[str, float], start_pos: Dict[str, float],
+    def get_movement_progress(self, current_pos: Dict[str, float], start_pos: Dict[str, float],
                             end_pos: Dict[str, float]) -> Union[float, None]:
         """
         Compute the position on the path between start and end positions of a stage movement (such as LOADING to IMAGING)
@@ -172,9 +172,9 @@ class MicroscopePostureManager:
         :return: (0<=float<=1, or None) Ratio of the progress, None if it's too far away from of the path
         """
         # Get distance for current point in respect to start and end
-        from_start = self._getDistance(start_pos, current_pos)
-        to_end = self._getDistance(current_pos, end_pos)
-        total_length = self._getDistance(start_pos, end_pos)
+        from_start = self._get_distance(start_pos, current_pos)
+        to_end = self._get_distance(current_pos, end_pos)
+        total_length = self._get_distance(start_pos, end_pos)
         if total_length == 0:  # same value
             return 1
         # Check if current position is on the line from start to end position
@@ -184,7 +184,7 @@ class MicroscopePostureManager:
         else:
             return None
 
-    def _getDistance(self, start: dict, end: dict) -> float:
+    def _get_distance(self, start: dict, end: dict) -> float:
         """
         Calculate the difference between two 3D postures with x, y, z, m, rx, ry, rz, rm axes
         or a subset of these axes. If there are no common axes between the two passed
@@ -239,9 +239,9 @@ class MicroscopePostureManager:
             missing_keys = required_keys - calibrated_md.keys()
             raise ValueError(f"Stage metadata {model.MD_CALIB} is missing the following required keys: {missing_keys}.")
 
-    def _cancelCryoMoveSample(self, future):
+    def _cancel_cryo_move_sample(self, future):
         """
-        Canceller of _doCryoSwitchAlignPosition and _doCryoSwitchSamplePosition tasks
+        Canceller of _do_cryo_switch_align_position and _do_cryo_switch_sample_position tasks
         """
         logging.debug("Cancelling cryo switch move...")
 
@@ -306,7 +306,7 @@ class MicroscopePostureManager:
         """
         Update the current posture of the microscope
         """
-        self.current_posture.value = self.getCurrentPostureLabel(position)
+        self.current_posture.value = self.get_current_posture_label(position)
 
 
 class MeteorPostureManager(MicroscopePostureManager):
@@ -378,26 +378,26 @@ class MeteorPostureManager(MicroscopePostureManager):
         # set the transforms between different postures
         self._posture_transforms = {
             FM_IMAGING: {
-                SEM_IMAGING: self._transformFromMeteorToSEM,
-                MILLING: self._transformFromMeteorToMilling,
-                FIB_IMAGING: self._transformFromMeteorToFIB,
+                SEM_IMAGING: self._transform_from_fm_to_sem,
+                MILLING: self._transform_from_fm_to_milling,
+                FIB_IMAGING: self._transform_from_fm_to_fib,
             },
             SEM_IMAGING: {
-                FM_IMAGING: self._transformFromSEMToMeteor,
-                MILLING: self._transformFromSEMToMilling,
-                FIB_IMAGING: self._transformFromSEMToFIB,
+                FM_IMAGING: self._transform_from_sem_to_fm,
+                MILLING: self._transform_from_sem_to_milling,
+                FIB_IMAGING: self._transform_from_sem_to_fib,
             },
             MILLING: {
-                SEM_IMAGING: self._transformFromMillingToSEM,
-                FM_IMAGING: self._transformFromMillingToFM,
+                SEM_IMAGING: self._transform_from_milling_to_sem,
+                FM_IMAGING: self._transform_from_milling_to_fm,
                 # milling position can be dynamically updated, so we need to support this recalculation
-                MILLING: self._transformFromSEMToMilling,
-                FIB_IMAGING: self._transformFromMillingToFIB,
+                MILLING: self._transform_from_sem_to_milling,
+                FIB_IMAGING: self._transform_from_milling_to_fib,
             },
             FIB_IMAGING: {
-                SEM_IMAGING: self._transformFromFIBToSEM,
-                FM_IMAGING: self._transformFromFIBToMeteor,
-                MILLING: self._transformFromFIBToMilling,
+                SEM_IMAGING: self._transform_from_fib_to_sem,
+                FM_IMAGING: self._transform_from_fib_to_fm,
+                MILLING: self._transform_from_fib_to_milling,
             },
             UNKNOWN: {
                 UNKNOWN: lambda x: x
@@ -410,7 +410,7 @@ class MeteorPostureManager(MicroscopePostureManager):
                                         stage_bare=self.stage,
                                         posture_manager=self)
 
-    def getCurrentPostureLabel(self, pos: Dict[str, float] = None) -> int:
+    def get_current_posture_label(self, pos: Dict[str, float] = None) -> int:
         """
         Detects the current stage position of meteor
         :param pos: (dict str->float) the stage position in which the label needs to be found. If None, it uses the
@@ -437,14 +437,14 @@ class MeteorPostureManager(MicroscopePostureManager):
         # None of the above -> unknown position
         return UNKNOWN
 
-    def getCurrentGridLabel(self) -> Optional[int]:
+    def get_current_grid_label(self) -> Optional[int]:
         """
         Detects which grid on the sample shuttle of meteor being viewed
         :return: (GRID_* or None) the guessed grid. If current posture doesn't allow to distinguish,
         for instance because it's in LOADING posture, None is returned.
         """
         current_pos = self.stage.position.value
-        current_posture = self.getCurrentPostureLabel(current_pos)
+        current_posture = self.get_current_posture_label(current_pos)
         if current_posture not in self.postures:
             logging.warning("Cannot detect current grid in posture %s",
                             POSITION_NAMES[current_posture])
@@ -468,8 +468,8 @@ class MeteorPostureManager(MicroscopePostureManager):
                             POSITION_NAMES[current_posture], ex)
             return None
 
-        distance_to_grid1 = self._getDistance(current_pos, grid1_pos)
-        distance_to_grid2 = self._getDistance(current_pos, grid2_pos)
+        distance_to_grid1 = self._get_distance(current_pos, grid1_pos)
+        distance_to_grid2 = self._get_distance(current_pos, grid2_pos)
 
         return GRID_1 if distance_to_grid2 > distance_to_grid1 else GRID_2
 
@@ -525,7 +525,7 @@ class MeteorPostureManager(MicroscopePostureManager):
         else:
             raise ValueError(f"posture {POSITION_NAMES.get(posture, posture)} not supported for orientation retrieval")
 
-    def getTargetPosition(self, target_pos_lbl: int) -> Dict[str, float]:
+    def get_target_position(self, target_pos_lbl: int) -> Dict[str, float]:
         """
         Returns the position that the stage would go to.
         target_pos_lbl (int): a label representing a position (SEM_IMAGING, FM_IMAGING, GRID_1 or GRID_2)
@@ -534,7 +534,7 @@ class MeteorPostureManager(MicroscopePostureManager):
         """
         pass
 
-    def _transformFromSEMToMeteor(self, pos: Dict[str, float]) -> Dict[str, float]:
+    def _transform_from_sem_to_fm(self, pos: Dict[str, float]) -> Dict[str, float]:
         """
         Transforms the current stage position from the SEM imaging area to the
             meteor/FM imaging area.
@@ -556,7 +556,7 @@ class MeteorPostureManager(MicroscopePostureManager):
         self.stage.updateMetadata({model.MD_FAV_MILL_POS_ACTIVE: rotations})
         return angle
 
-    def _transformFromMeteorToSEM(self, pos: Dict[str, float]) -> Dict[str, float]:
+    def _transform_from_fm_to_sem(self, pos: Dict[str, float]) -> Dict[str, float]:
         """
         Transforms the current stage position from the meteor/FM imaging area
             to the SEM imaging area.
@@ -782,7 +782,7 @@ class MeteorPostureManager(MicroscopePostureManager):
         :param posture: (int) the target posture of the stage
         :return: stage-bare position in the target posture"""
 
-        position_posture = self.getCurrentPostureLabel(pos)
+        position_posture = self.get_current_posture_label(pos)
 
         logging.info(f"Position Posture: {POSITION_NAMES[position_posture]}, Target Posture: {POSITION_NAMES[posture]}")
 
@@ -801,7 +801,7 @@ class MeteorPostureManager(MicroscopePostureManager):
 
         return tf(pos)
 
-    def _transformFromSEMToMilling(self, pos: Dict[str, float]) -> Dict[str, float]:
+    def _transform_from_sem_to_milling(self, pos: Dict[str, float]) -> Dict[str, float]:
         """
         Transforms the stage position from sem imaging to milling position
         :param pos: (dict str->float) the current stage position
@@ -813,7 +813,7 @@ class MeteorPostureManager(MicroscopePostureManager):
 
         return position
 
-    def _transformFromMillingToSEM(self, pos: Dict[str, float]) -> Dict[str, float]:
+    def _transform_from_milling_to_sem(self, pos: Dict[str, float]) -> Dict[str, float]:
         """
         Transforms the stage position from milling to sem imaging position
         :param pos: (dict str->float) the current stage position
@@ -825,27 +825,27 @@ class MeteorPostureManager(MicroscopePostureManager):
 
         return position
 
-    def _transformFromMeteorToMilling(self, pos: Dict[str, float]) -> Dict[str, float]:
+    def _transform_from_fm_to_milling(self, pos: Dict[str, float]) -> Dict[str, float]:
         """
         Transforms the stage position from fm imaging to milling position
         :param pos: (dict str->float) the current stage position
         :return: (dict str->float) the transformed stage position.
         """
         # simple chain of fm->sem->milling
-        sem_pos = self._transformFromMeteorToSEM(pos)
-        return self._transformFromSEMToMilling(sem_pos)
+        sem_pos = self._transform_from_fm_to_sem(pos)
+        return self._transform_from_sem_to_milling(sem_pos)
 
-    def _transformFromMillingToFM(self, pos: Dict[str, float]) -> Dict[str, float]:
+    def _transform_from_milling_to_fm(self, pos: Dict[str, float]) -> Dict[str, float]:
         """
         Transforms the stage position from milling to fm imaging position
         :param pos: (dict str->float) the current stage position
         :return: (dict str->float) the transformed stage position.
         """
         # simple chain of milling->sem->fm
-        sem_pos = self._transformFromMillingToSEM(pos)
-        return self._transformFromSEMToMeteor(sem_pos)
+        sem_pos = self._transform_from_milling_to_sem(pos)
+        return self._transform_from_sem_to_fm(sem_pos)
 
-    def _transformFromSEMToFIB(self, pos: Dict[str, float]) -> Dict[str, float]:
+    def _transform_from_sem_to_fib(self, pos: Dict[str, float]) -> Dict[str, float]:
         """
         Transforms the stage position from SEM imaging to FIB imaging position
         :param pos: (dict str->float) the current stage position
@@ -853,7 +853,7 @@ class MeteorPostureManager(MicroscopePostureManager):
         """
         raise NotImplementedError()
 
-    def _transformFromFIBToSEM(self, pos: Dict[str, float]) -> Dict[str, float]:
+    def _transform_from_fib_to_sem(self, pos: Dict[str, float]) -> Dict[str, float]:
         """
         Transforms the stage position from FIB imaging to SEM imaging position
         :param pos: (dict str->float) the current stage position
@@ -861,7 +861,7 @@ class MeteorPostureManager(MicroscopePostureManager):
         """
         raise NotImplementedError()
 
-    def _transformFromMeteorToFIB(self, pos: Dict[str, float]) -> Dict[str, float]:
+    def _transform_from_fm_to_fib(self, pos: Dict[str, float]) -> Dict[str, float]:
         """
         Transforms the stage position from meteor to FIB imaging position
         :param pos: (dict str->float) the current stage position
@@ -869,7 +869,7 @@ class MeteorPostureManager(MicroscopePostureManager):
         """
         raise NotImplementedError()
 
-    def _transformFromFIBToMeteor(self, pos: Dict[str, float]) -> Dict[str, float]:
+    def _transform_from_fib_to_fm(self, pos: Dict[str, float]) -> Dict[str, float]:
         """
         Transforms the stage position from FIB imaging to meteor position
         :param pos: (dict str->float) the current stage position
@@ -877,25 +877,25 @@ class MeteorPostureManager(MicroscopePostureManager):
         """
         raise NotImplementedError()
 
-    def _transformFromMillingToFIB(self, pos: Dict[str, float]) -> Dict[str, float]:
+    def _transform_from_milling_to_fib(self, pos: Dict[str, float]) -> Dict[str, float]:
         """
         Transforms the stage position from milling to fib imaging position"
         :param pos: (dict str->float) the current stage position
         :return: (dict str->float) the transformed stage position.
         """
         # simple chain of milling->sem->fib
-        sem_pos = self._transformFromMillingToSEM(pos)
-        return self._transformFromSEMToFIB(sem_pos)
+        sem_pos = self._transform_from_milling_to_sem(pos)
+        return self._transform_from_sem_to_fib(sem_pos)
 
-    def _transformFromFIBToMilling(self, pos: Dict[str, float]) -> Dict[str, float]:
+    def _transform_from_fib_to_milling(self, pos: Dict[str, float]) -> Dict[str, float]:
         """
         Transforms the stage position from fib imaging to milling position"
         :param pos: (dict str->float) the current stage position
         :return: (dict str->float) the transformed stage position.
         """
         # simple chain of fib->sem->milling
-        sem_pos = self._transformFromFIBToSEM(pos)
-        return self._transformFromSEMToMilling(sem_pos)
+        sem_pos = self._transform_from_fib_to_sem(pos)
+        return self._transform_from_sem_to_milling(sem_pos)
 
 
 class MeteorTFS1PostureManager(MeteorPostureManager):
@@ -919,7 +919,7 @@ class MeteorTFS1PostureManager(MeteorPostureManager):
         self._initialise_transformation(axes=["y", "z"], rotation=self.pre_tilt)
         self.create_sample_stage()
 
-    def getTargetPosition(self, target_pos_lbl: int) -> Dict[str, float]:
+    def get_target_position(self, target_pos_lbl: int) -> Dict[str, float]:
         """
         Returns the position that the stage would go to.
         :param target_pos_lbl: (int) a label representing a position (SEM_IMAGING, FM_IMAGING, GRID_1 or GRID_2)
@@ -928,7 +928,7 @@ class MeteorTFS1PostureManager(MeteorPostureManager):
         """
         stage_md = self.stage.getMetadata()
         stage_position = self.stage.position.value
-        current_posture = self.getCurrentPostureLabel(stage_position)
+        current_posture = self.get_current_posture_label(stage_position)
         end_pos = None
 
         if target_pos_lbl in (GRID_1, GRID_2):
@@ -976,7 +976,7 @@ class MeteorTFS1PostureManager(MeteorPostureManager):
     # correction/shifting parameters existing in metadata "FM_POS_ACTIVE".
     # This correction parameters can change every session. They are calibrated
     # at the beginning of each run.
-    def _transformFromSEMToMeteor(self, pos: Dict[str, float]) -> Dict[str, float]:
+    def _transform_from_sem_to_fm(self, pos: Dict[str, float]) -> Dict[str, float]:
         """
         Transforms the current stage position from the SEM imaging area to the
         meteor/FM imaging area.
@@ -1024,7 +1024,7 @@ class MeteorTFS1PostureManager(MeteorPostureManager):
     # The rotation angles are 180 degree around rz axis, and a rotation angle
     # around rx axis which should also be calibrated at the beginning of the run.
     # The rx angle is actually the same as the milling angle.
-    def _transformFromMeteorToSEM(self, pos: Dict[str, float]) -> Dict[str, float]:
+    def _transform_from_fm_to_sem(self, pos: Dict[str, float]) -> Dict[str, float]:
         """
         Transforms the current stage position from the meteor/FM imaging area
         to the SEM imaging area.
@@ -1066,9 +1066,9 @@ class MeteorTFS1PostureManager(MeteorPostureManager):
 
         return transformed_pos
 
-    def _doCryoSwitchSamplePosition(self, future, target):
+    def _do_cryo_switch_sample_position(self, future, target):
         """
-        Do the actual switching procedure for cryoSwitchSamplePosition
+        Do the actual switching procedure for cryo_switch_sample_position
         :param future: cancellable future of the move
         :param target: (int) target position either one of the constants: LOADING, SEM_IMAGING, FM_IMAGING.
         """
@@ -1087,7 +1087,7 @@ class MeteorTFS1PostureManager(MeteorPostureManager):
             sub_moves = []  # list of tuples (component, position)
 
             # get the current label
-            current_label = self.getCurrentPostureLabel()
+            current_label = self.get_current_posture_label()
             current_name = POSITION_NAMES[current_label]
 
             if current_label == target:
@@ -1095,7 +1095,7 @@ class MeteorTFS1PostureManager(MeteorPostureManager):
 
             # get the set point position
             current_pos = self.stage.position.value
-            target_pos = self.getTargetPosition(target)
+            target_pos = self.get_target_position(target)
 
             # If at some "weird" position, it's quite unsafe. We consider the targets
             # LOADING and SEM_IMAGING safe to go. So if not going there, first pass
@@ -1104,7 +1104,7 @@ class MeteorTFS1PostureManager(MeteorPostureManager):
                 logging.warning("Moving stage while current position is unknown.")
                 if target not in (LOADING, SEM_IMAGING):
                     logging.debug("Moving first to SEM_IMAGING position")
-                    target_pos_sem = self.getTargetPosition(SEM_IMAGING)
+                    target_pos_sem = self.get_target_position(SEM_IMAGING)
                     if not isNearPosition(self.focus.position.value, focus_deactive, self.focus.axes):
                         sub_moves.append((self.focus, focus_deactive))
                     sub_moves.append((self.stage, filter_dict({'x', 'y', 'z'}, target_pos_sem)))
@@ -1150,7 +1150,7 @@ class MeteorTFS1PostureManager(MeteorPostureManager):
                         # We record it by computing its projection in FM sample coordinates, without the fixed plane
                         # correction. As Z is the same for SEM, Milling or FIB, and it's fine to just use SEM to Meteor
                         # for all occasions.
-                        target_pos_unfixed = self._transformFromSEMToMeteor(current_pos, fix_fm_plane=False)
+                        target_pos_unfixed = self._transform_from_sem_to_fm(current_pos, fix_fm_plane=False)
                         sample_stage_pos = self.to_sample_stage_from_stage_position(target_pos_unfixed, posture=FM_IMAGING)
                         sample_stage_pos = {"z": sample_stage_pos["z"]}  # Drop x and y, to make clear only z is used
                         self.stage.updateMetadata({model.MD_FM_POS_SAMPLE_DEACTIVE: sample_stage_pos})
@@ -1239,17 +1239,17 @@ class MeteorTFS3PostureManager(MeteorTFS1PostureManager):
             self.postures.append(FIB_IMAGING)
 
         # Hack warning: during initialization of the transforms, the offset is computed by calling
-        # to_posture(), which calls _transformFromSEMToMeteor() for the SEM->FM transform. If
+        # to_posture(), which calls _transform_from_sem_to_fm() for the SEM->FM transform. If
         # MD_FM_POS_SAMPLE_ACTIVE is already present, the fix_fm_plane logic is triggered, which
         # uses the sample plane transformations, which aren't fully initialized yet. This can cause
         # an incorrect offset computation, and eventually an incorrect movement to FM.
         # To avoid this, we temporarily set to_posture() to not use the fix_fm_plane logic.
-        _transformFromSEMToMeteorNoFixFM = functools.partial(self._transformFromSEMToMeteor, fix_fm_plane=False)
-        self._posture_transforms[SEM_IMAGING][FM_IMAGING] = _transformFromSEMToMeteorNoFixFM
+        _transform_from_sem_to_fm_no_fix_fm = functools.partial(self._transform_from_sem_to_fm, fix_fm_plane=False)
+        self._posture_transforms[SEM_IMAGING][FM_IMAGING] = _transform_from_sem_to_fm_no_fix_fm
         self._initialise_transformation(axes=["y", "z"], rotation=self.pre_tilt)
         self.create_sample_stage()
         # Reset to the standard function (with fixed FM plane)
-        self._posture_transforms[SEM_IMAGING][FM_IMAGING] = self._transformFromSEMToMeteor
+        self._posture_transforms[SEM_IMAGING][FM_IMAGING] = self._transform_from_sem_to_fm
 
         # If there is no known fixed sample z for FM, compute it here and store it for later use
         if not stage_md.get(model.MD_FM_POS_SAMPLE_ACTIVE):
@@ -1257,12 +1257,12 @@ class MeteorTFS3PostureManager(MeteorTFS1PostureManager):
             # Pick a sane default for the sample stage z using grid 1.
             sem_grid1_pos = dict(stage_md[model.MD_SAMPLE_CENTERS][POSITION_NAMES[GRID_1]])
             sem_grid1_pos.update(stage_md[model.MD_FAV_SEM_POS_ACTIVE])
-            sem_grid1_pos_fm = self._transformFromSEMToMeteor(sem_grid1_pos, fix_fm_plane=False)
+            sem_grid1_pos_fm = self._transform_from_sem_to_fm(sem_grid1_pos, fix_fm_plane=False)
             fixed_fm_sample = self.to_sample_stage_from_stage_position(sem_grid1_pos_fm, posture=FM_IMAGING)
             fixed_fm_sample = {"z": fixed_fm_sample["z"]}  # Drop x and y, to make clear only z is used
             self.stage.updateMetadata({model.MD_FM_POS_SAMPLE_ACTIVE: fixed_fm_sample})
 
-    def _transformFromSEMToMeteor(self, pos: Dict[str, float], fix_fm_plane: bool = True) -> Dict[str, float]:
+    def _transform_from_sem_to_fm(self, pos: Dict[str, float], fix_fm_plane: bool = True) -> Dict[str, float]:
         """
         Transforms the current stage position from the SEM imaging area to the meteor/FM imaging area.
         :param pos: the initial stage position.
@@ -1294,7 +1294,7 @@ class MeteorTFS3PostureManager(MeteorTFS1PostureManager):
 
         return transformed_pos
 
-    def _transformFromMeteorToSEM(self, pos: Dict[str, float]) -> Dict[str, float]:
+    def _transform_from_fm_to_sem(self, pos: Dict[str, float]) -> Dict[str, float]:
         """
         Transforms the current stage position from the meteor/FM imaging area
         to the SEM imaging area.
@@ -1318,7 +1318,7 @@ class MeteorTFS3PostureManager(MeteorTFS1PostureManager):
 
         return transformed_pos
 
-    def _transformFromFIBToMeteor(self, pos: Dict[str, float]) -> Dict[str, float]:
+    def _transform_from_fib_to_fm(self, pos: Dict[str, float]) -> Dict[str, float]:
         """
         Transforms the current stage position from the FIB imaging area to the
         meteor/FM imaging area.
@@ -1326,18 +1326,18 @@ class MeteorTFS3PostureManager(MeteorTFS1PostureManager):
         :return: (dict str->float) the transformed position.
         """
         # TODO: check this is correct
-        return self._transformFromSEMToMeteor(self._transformFromFIBToSEM(pos))
+        return self._transform_from_sem_to_fm(self._transform_from_fib_to_sem(pos))
 
-    def _transformFromMeteorToFIB(self, pos: Dict[str, float]) -> Dict[str, float]:
+    def _transform_from_fm_to_fib(self, pos: Dict[str, float]) -> Dict[str, float]:
         """
         Transforms the current stage position from the meteor/FM imaging area to the FIB imaging area.
         :param pos: (dict str->float) the initial stage position.
         :return: (dict str->float) the transformed stage position.
         """
         # TODO: check this is correct
-        return self._transformFromSEMToFIB(self._transformFromMeteorToSEM(pos))
+        return self._transform_from_sem_to_fib(self._transform_from_fm_to_sem(pos))
 
-    def _transformFromSEMToFIB(self, pos: Dict[str, float]) -> Dict[str, float]:
+    def _transform_from_sem_to_fib(self, pos: Dict[str, float]) -> Dict[str, float]:
         """
         Transforms the current stage position from SEM imaging to the FIB imaging area.
         :param pos: (dict str->float) the initial stage position.
@@ -1353,7 +1353,7 @@ class MeteorTFS3PostureManager(MeteorTFS1PostureManager):
         transformed_pos["y"] = -transformed_pos["y"]
         return transformed_pos
 
-    def _transformFromFIBToSEM(self, pos: Dict[str, float]) -> Dict[str, float]:
+    def _transform_from_fib_to_sem(self, pos: Dict[str, float]) -> Dict[str, float]:
         """
         Transforms the current stage position from FIB imaging to the SEM imaging area.
         :param pos: (dict str->float) the initial stage position.
@@ -1370,7 +1370,7 @@ class MeteorTFS3PostureManager(MeteorTFS1PostureManager):
 
         return transformed_pos
 
-    def _transformFromChamberToStage(self, shift: Dict[str, float]) -> Dict[str, float]:
+    def _transform_from_chamber_to_stage(self, shift: Dict[str, float]) -> Dict[str, float]:
         """Transform the shift from chamber to stage bare coordinates.
         Used for moving the stage vertically in the chamber.
         :param shift: The shift to be transformed
@@ -1433,7 +1433,7 @@ class MeteorZeiss1PostureManager(MeteorPostureManager):
             missing_keys = required_keys - calibrated_md.keys()
             raise ValueError(f"Stage metadata {model.MD_CALIB} is missing the following required keys: {missing_keys}.")
 
-    def getTargetPosition(self, target_pos_lbl: int) -> Dict[str, float]:
+    def get_target_position(self, target_pos_lbl: int) -> Dict[str, float]:
         """
         Returns the position that the stage would go to.
         :param target_pos_lbl: (int) a label representing a position (SEM_IMAGING, FM_IMAGING, GRID_1 or GRID_2)
@@ -1441,7 +1441,7 @@ class MeteorZeiss1PostureManager(MeteorPostureManager):
         :raises ValueError: if the target position is not supported
         """
         stage_md = self.stage.getMetadata()
-        current_position = self.getCurrentPostureLabel()
+        current_position = self.get_current_posture_label()
         end_pos = None
 
         if target_pos_lbl == LOADING:
@@ -1461,21 +1461,21 @@ class MeteorZeiss1PostureManager(MeteorPostureManager):
                     # if at loading and fm is pressed, choose grid1 by default
                     sem_grid1_pos = stage_md[model.MD_FAV_SEM_POS_ACTIVE]
                     sem_grid1_pos.update(stage_md[model.MD_SAMPLE_CENTERS][POSITION_NAMES[GRID_1]])
-                    fm_target_pos = self._transformFromSEMToMeteor(sem_grid1_pos)
+                    fm_target_pos = self._transform_from_sem_to_fm(sem_grid1_pos)
                 elif current_position == SEM_IMAGING:
-                    fm_target_pos = self._transformFromSEMToMeteor(self.stage.position.value)
+                    fm_target_pos = self._transform_from_sem_to_fm(self.stage.position.value)
                 end_pos = fm_target_pos
         elif current_position == FM_IMAGING:
             if target_pos_lbl == GRID_1:
                 sem_grid1_pos = stage_md[model.MD_FAV_SEM_POS_ACTIVE]  # get the base
                 sem_grid1_pos.update(stage_md[model.MD_SAMPLE_CENTERS][POSITION_NAMES[GRID_1]])
-                end_pos = self._transformFromSEMToMeteor(sem_grid1_pos)
+                end_pos = self._transform_from_sem_to_fm(sem_grid1_pos)
             elif target_pos_lbl == GRID_2:
                 sem_grid2_pos = stage_md[model.MD_FAV_SEM_POS_ACTIVE]
                 sem_grid2_pos.update(stage_md[model.MD_SAMPLE_CENTERS][POSITION_NAMES[GRID_2]])
-                end_pos = self._transformFromSEMToMeteor(sem_grid2_pos)
+                end_pos = self._transform_from_sem_to_fm(sem_grid2_pos)
             elif target_pos_lbl == SEM_IMAGING:
-                end_pos = self._transformFromMeteorToSEM(self.stage.position.value)
+                end_pos = self._transform_from_fm_to_sem(self.stage.position.value)
 
         if end_pos is None:
             raise ValueError("Unknown target position {} when in {}".format(
@@ -1490,7 +1490,7 @@ class MeteorZeiss1PostureManager(MeteorPostureManager):
     # the current position and some calibrated values existing in metadata "CALIB".
     # The rotations are 180 degree around the rm axis, and a calibrated angle around the rx axis.
     # These angles exist in the metadata "FM_POS_ACTIVE".
-    def _transformFromSEMToMeteor(self, pos: Dict[str, float]) -> Dict[str, float]:
+    def _transform_from_sem_to_fm(self, pos: Dict[str, float]) -> Dict[str, float]:
         """
         Transforms the current stage position from the SEM imaging area to the
         meteor/FM imaging area.
@@ -1546,7 +1546,7 @@ class MeteorZeiss1PostureManager(MeteorPostureManager):
     # the current position and some calibrated values existing in metadata "CALIB".
     # The rotations are 180 degree around the rm axis, and a calibrated angle around the rx axis.
     # These angles exist in the metadata "FM_POS_ACTIVE" and "SEM_POS_ACTIVE".
-    def _transformFromMeteorToSEM(self, pos: Dict[str, float]) -> Dict[str, float]:
+    def _transform_from_fm_to_sem(self, pos: Dict[str, float]) -> Dict[str, float]:
         """
         Transforms the current stage position from the meteor/FM imaging area
         to the SEM imaging area.
@@ -1592,7 +1592,7 @@ class MeteorZeiss1PostureManager(MeteorPostureManager):
         # Return transformed_pos (containing the new x, y, m, rx, rm coordinates, as well as the unchanged z coordinate)
         return transformed_pos
 
-    def _doCryoSwitchSamplePosition(self, future, target):
+    def _do_cryo_switch_sample_position(self, future, target):
         try:
             try:
                 target_name = POSITION_NAMES[target]
@@ -1609,14 +1609,14 @@ class MeteorZeiss1PostureManager(MeteorPostureManager):
             sub_moves = []  # list of tuples (component, position)
 
             # get the current label
-            current_label = self.getCurrentPostureLabel()
+            current_label = self.get_current_posture_label()
             current_name = POSITION_NAMES[current_label]
 
             if current_label == target:
                 logging.warning(f"Requested move to the same position as current: {target_name}")
 
             # get the set point position
-            target_pos = self.getTargetPosition(target)
+            target_pos = self.get_target_position(target)
 
             # If at some "weird" position, it's quite unsafe. We consider the targets
             # LOADING and SEM_IMAGING safe to go. So if not going there, first pass
@@ -1625,7 +1625,7 @@ class MeteorZeiss1PostureManager(MeteorPostureManager):
                 logging.warning("Moving stage while current position is unknown.")
                 if target not in (LOADING, SEM_IMAGING):
                     logging.debug("Moving first to SEM_IMAGING position")
-                    target_pos_sem = self.getTargetPosition(SEM_IMAGING)
+                    target_pos_sem = self.get_target_position(SEM_IMAGING)
                     if not isNearPosition(focus.position.value, focus_deactive, focus.axes):
                         sub_moves.append((focus, focus_deactive))
                     sub_moves.append((stage, filter_dict({'z', 'm'}, target_pos)))
@@ -1659,7 +1659,7 @@ class MeteorZeiss1PostureManager(MeteorPostureManager):
                         # but will go through SEM_IMAGING first. But just in case, we handle the case
                         # where the current position is LOADING and the target is FM_IMAGING, do the following:
                         # First switch from Loading to SEM_IMAGING
-                        sem_int_posit = self.getTargetPosition(SEM_IMAGING)
+                        sem_int_posit = self.get_target_position(SEM_IMAGING)
                         sub_moves.append((stage, filter_dict({'rx'}, sem_int_posit)))
                         sub_moves.append((stage, filter_dict({'rm', 'x', 'y'}, sem_int_posit)))
                         sub_moves.append((stage, filter_dict({'m', 'z'}, sem_int_posit)))
@@ -1857,7 +1857,7 @@ class MeteorTescan1PostureManager(MeteorPostureManager):
             missing_keys = required_keys - calibrated_md.keys()
             raise ValueError(f"Stage metadata {model.MD_CALIB} is missing the following required keys: {missing_keys}.")
 
-    def getTargetPosition(self, target_pos_lbl: int) -> Dict[str, float]:
+    def get_target_position(self, target_pos_lbl: int) -> Dict[str, float]:
         """
         Returns the position that the stage would go to.
         :param target_pos_lbl: (int) a label representing a position (SEM_IMAGING, FM_IMAGING, GRID_1 or GRID_2)
@@ -1866,7 +1866,7 @@ class MeteorTescan1PostureManager(MeteorPostureManager):
         """
         stage_md = self.stage.getMetadata()
         stage_position = self.stage.position.value
-        current_posture = self.getCurrentPostureLabel(stage_position)
+        current_posture = self.get_current_posture_label(stage_position)
 
         if target_pos_lbl in (GRID_1, GRID_2):
             # Go to grid center: only works if in a supported sample stage posture
@@ -1892,7 +1892,7 @@ class MeteorTescan1PostureManager(MeteorPostureManager):
 
         return end_pos
 
-    def _transformFromSEMToMeteor(self, pos: Dict[str, float]) -> Dict[str, float]:
+    def _transform_from_sem_to_fm(self, pos: Dict[str, float]) -> Dict[str, float]:
         """
         Transforms the current stage position from the SEM imaging area to the
         meteor/FM imaging area.
@@ -1946,7 +1946,7 @@ class MeteorTescan1PostureManager(MeteorPostureManager):
     # the current position and some calibrated values existing in metadata "CALIB".
     # The rotations are 180 degree around the rm axis, and a calibrated angle around the rx axis.
     # These angles exist in the metadata "FM_POS_ACTIVE" and "SEM_POS_ACTIVE".
-    def _transformFromMeteorToSEM(self, pos: Dict[str, float]) -> Dict[str, float]:
+    def _transform_from_fm_to_sem(self, pos: Dict[str, float]) -> Dict[str, float]:
         """
         Transforms the current stage position from the meteor/FM imaging area
         to the SEM imaging area.
@@ -1992,7 +1992,7 @@ class MeteorTescan1PostureManager(MeteorPostureManager):
 
         return transformed_pos
 
-    def _transformFromSEMToMilling(self, pos: Dict[str, float]) -> Dict[str, float]:
+    def _transform_from_sem_to_milling(self, pos: Dict[str, float]) -> Dict[str, float]:
         """
         Transforms the current stage position from the SEM imaging area to the
         milling imaging area.
@@ -2040,7 +2040,7 @@ class MeteorTescan1PostureManager(MeteorPostureManager):
 
         return transformed_pos
 
-    def _transformFromMillingToSEM(self, pos: Dict[str, float]) -> Dict[str, float]:
+    def _transform_from_milling_to_sem(self, pos: Dict[str, float]) -> Dict[str, float]:
         """
         Transforms the current stage position from the milling imaging area
         to the SEM imaging area.
@@ -2084,7 +2084,7 @@ class MeteorTescan1PostureManager(MeteorPostureManager):
 
         return transformed_pos
 
-    def _doCryoSwitchSamplePosition(self, future, target):
+    def _do_cryo_switch_sample_position(self, future, target):
         try:
             target_name = POSITION_NAMES[target]
         except KeyError:
@@ -2100,14 +2100,14 @@ class MeteorTescan1PostureManager(MeteorPostureManager):
 
             # get the current label
             current_pos = self.stage.position.value
-            current_posture = self.getCurrentPostureLabel(current_pos)
+            current_posture = self.get_current_posture_label(current_pos)
             current_name = POSITION_NAMES[current_posture]
 
             if current_posture == target:
                 logging.warning(f"Requested move to the same position as current: {target_name}")
 
             # get the set point position
-            target_pos = self.getTargetPosition(target)
+            target_pos = self.get_target_position(target)
 
             # In many cases, to move safely, we force the stage Z to go down first + extra margin,
             # do the actual moves, and then move back up. But on Tescan (stage-bare), the Z axis
@@ -2127,7 +2127,7 @@ class MeteorTescan1PostureManager(MeteorPostureManager):
                 logging.warning("Moving stage while current position is unknown (at %s).", current_pos)
                 if target not in (LOADING, SEM_IMAGING):
                     logging.debug("Moving first to SEM_IMAGING position")
-                    target_pos_sem = self.getTargetPosition(SEM_IMAGING)
+                    target_pos_sem = self.get_target_position(SEM_IMAGING)
                     if not isNearPosition(self.focus.position.value, focus_deactive, self.focus.axes):
                         sub_moves.append((self.focus, focus_deactive))
 
@@ -2211,7 +2211,7 @@ class MeteorTescan1PostureManager(MeteorPostureManager):
                     raise CancelledError()
                 future._task_state = FINISHED
 
-    def _transformFromChamberToStage(self, shift: Dict[str, float]) -> Dict[str, float]:
+    def _transform_from_chamber_to_stage(self, shift: Dict[str, float]) -> Dict[str, float]:
         """Transform the shift from stage bare to chamber coordinates.
         Used for moving the stage vertically in the chamber.
         For tescan, the z-axis is already aligned with the chamber axis,
@@ -2287,7 +2287,7 @@ class MeteorJeol1PostureManager(MeteorPostureManager):
                                 SEM_IMAGING: tf_sem_inv,
                                 UNKNOWN: tf_id}
 
-    def getTargetPosition(self, target_pos_lbl: int) -> Dict[str, float]:
+    def get_target_position(self, target_pos_lbl: int) -> Dict[str, float]:
         """
         Returns the position that the stage would go to.
         :param target_pos_lbl: (int) a label representing a position (SEM_IMAGING, FM_IMAGING, GRID_1 or GRID_2)
@@ -2295,7 +2295,7 @@ class MeteorJeol1PostureManager(MeteorPostureManager):
         :raises ValueError: if the target position is not supported
         """
         stage_md = self.stage.getMetadata()
-        current_position = self.getCurrentPostureLabel()
+        current_position = self.get_current_posture_label()
         end_pos = None
 
         # SEM posture + grid center
@@ -2314,16 +2314,16 @@ class MeteorJeol1PostureManager(MeteorPostureManager):
             elif target_pos_lbl == FM_IMAGING:
                 if current_position == LOADING:
                     # if at loading and fm is pressed, choose grid1 by default
-                    end_pos = self._transformFromSEMToMeteor(get_sem_grid(GRID_1))
+                    end_pos = self._transform_from_sem_to_fm(get_sem_grid(GRID_1))
                 else:
-                    end_pos = self._transformFromSEMToMeteor(self.stage.position.value)
+                    end_pos = self._transform_from_sem_to_fm(self.stage.position.value)
         elif current_position == FM_IMAGING:
             if target_pos_lbl == GRID_1:
-                end_pos = self._transformFromSEMToMeteor(get_sem_grid(GRID_1))
+                end_pos = self._transform_from_sem_to_fm(get_sem_grid(GRID_1))
             elif target_pos_lbl == GRID_2:
-                end_pos = self._transformFromSEMToMeteor(get_sem_grid(GRID_2))
+                end_pos = self._transform_from_sem_to_fm(get_sem_grid(GRID_2))
             elif target_pos_lbl == SEM_IMAGING:
-                end_pos = self._transformFromMeteorToSEM(self.stage.position.value)
+                end_pos = self._transform_from_fm_to_sem(self.stage.position.value)
 
         if end_pos is None:
             raise ValueError(
@@ -2332,7 +2332,7 @@ class MeteorJeol1PostureManager(MeteorPostureManager):
 
         return end_pos
 
-    def _transformFromSEMToMeteor(self, pos: Dict[str, float]) -> Dict[str, float]:
+    def _transform_from_sem_to_fm(self, pos: Dict[str, float]) -> Dict[str, float]:
         """
         Transforms the current stage position from the SEM imaging area to the
         meteor/FM imaging area.
@@ -2375,7 +2375,7 @@ class MeteorJeol1PostureManager(MeteorPostureManager):
 
         return transformed_pos
 
-    def _transformFromMeteorToSEM(self, pos: Dict[str, float]) -> Dict[str, float]:
+    def _transform_from_fm_to_sem(self, pos: Dict[str, float]) -> Dict[str, float]:
         """
         Transforms the current stage position from the meteor/FM imaging area
         to the SEM imaging area.
@@ -2415,9 +2415,9 @@ class MeteorJeol1PostureManager(MeteorPostureManager):
 
         return transformed_pos
 
-    def _doCryoSwitchSamplePosition(self, future, target_posture: int):
+    def _do_cryo_switch_sample_position(self, future, target_posture: int):
         """
-        Do the actual switching procedure for cryoSwitchSamplePosition
+        Do the actual switching procedure for cryo_switch_sample_position
         :param future: cancellable future of the move
         :param target_posture: target posture
         """
@@ -2431,7 +2431,7 @@ class MeteorJeol1PostureManager(MeteorPostureManager):
             sub_moves: List[Tuple[model.Actuator, Dict[str, float]]] = []  # series of component + position
             current_name = POSITION_NAMES[self.current_posture.value]
 
-            target_position = self.getTargetPosition(target_posture)  # raises an exception if move is unsupported
+            target_position = self.get_target_position(target_posture)  # raises an exception if move is unsupported
 
             if target_posture in (GRID_1, GRID_2):
                 sub_moves.append((self.stage, target_position))
@@ -2467,14 +2467,14 @@ class MeteorJeol1PostureManager(MeteorPostureManager):
                     raise CancelledError()
                 future._task_state = FINISHED
 
-    def _transformFromChamberToStage(self, shift: Dict[str, float]) -> Dict[str, float]:
+    def _transform_from_chamber_to_stage(self, shift: Dict[str, float]) -> Dict[str, float]:
         """Transform the shift from stage bare to chamber coordinates.
         Used for moving the stage vertically in the chamber.
         Should not be used in JEOL1 configuration.
         :param shift: The shift to be transformed
         :return: The transformed shift
         """
-        raise NotImplementedError("_transformFromChamberToStage is not used in JEOL1 configuration")
+        raise NotImplementedError("_transform_from_chamber_to_stage is not used in JEOL1 configuration")
 
 
 class SampleStage(model.Actuator):
@@ -2541,7 +2541,7 @@ class SampleStage(model.Actuator):
         """
         # Explicitly computes the posture, as .current_posture is updated by a subscriber that might be
         # called after this one.
-        posture = self._pm.getCurrentPostureLabel(pos_dep)
+        posture = self._pm.get_current_posture_label(pos_dep)
         if posture not in self._pm.postures:
             logging.info("Not updating stage sample position for unsupported posture %s", posture)
             return
@@ -2628,7 +2628,7 @@ class SampleStage(model.Actuator):
         """
         # TODO: account for scan rotation
         # transform the shift from stage bare to chamber coordinates
-        vshift = self._pm._transformFromChamberToStage(shift)
+        vshift = self._pm._transform_from_chamber_to_stage(shift)
         return self._stage_bare.moveRel(vshift)
 
     def stop(self, axes=None):

--- a/src/odemis/acq/path.py
+++ b/src/odemis/acq/path.py
@@ -1156,11 +1156,11 @@ class _MimasOpticalPathManager(OpticalPathManager):
 
         # Only accept moving if the stage is already within the "IMAGING" area (which means FM_IMAGING & MILLING)
         # as this means the stage will not move, but only the optical lens.
-        current_pos = self._posture_manager.getCurrentPostureLabel()
+        current_pos = self._posture_manager.get_current_posture_label()
         if current_pos not in (IMAGING, FM_IMAGING, MILLING):
             logging.warning("Optical path cannot be changed while in position %s", POSITION_NAMES[current_pos])
             return
 
-        f = self._posture_manager.cryoSwitchSamplePosition(mode_position)
+        f = self._posture_manager.cryo_switch_sample_position(mode_position)
         f.result()
         logging.debug("Move to position %s completed", mode_position)

--- a/src/odemis/acq/stitching/test/tiledacq_test.py
+++ b/src/odemis/acq/stitching/test/tiledacq_test.py
@@ -177,7 +177,7 @@ class CRYOSECOMTestCase(unittest.TestCase):
         """
         Test moving the stage to a tile based on its index
         """
-        self.posture_manager.cryoSwitchSamplePosition(FM_IMAGING).result()
+        self.posture_manager.cryo_switch_sample_position(FM_IMAGING).result()
         area = (-0.001, -0.001, 0.001, 0.001)
         overlap = 0.2
         tiled_acq_task = TiledAcquisitionTask(self.fm_streams, self.stage,

--- a/src/odemis/acq/test/acq_test.py
+++ b/src/odemis/acq/test/acq_test.py
@@ -694,9 +694,9 @@ class MeteorTestCase(unittest.TestCase):
         cls.fm_focus_pos = 0.5e-6  # arbitrary current focus position
         # MD_POS in the stream metadata should be in the same reference as the focuser, so we need to switch to the
         # FM Imaging position such that MD_POS metadata exists in the acquired data.
-        cls.posture_manager.cryoSwitchSamplePosition(LOADING).result()
-        cls.posture_manager.cryoSwitchSamplePosition(SEM_IMAGING).result()
-        cls.posture_manager.cryoSwitchSamplePosition(FM_IMAGING).result()
+        cls.posture_manager.cryo_switch_sample_position(LOADING).result()
+        cls.posture_manager.cryo_switch_sample_position(SEM_IMAGING).result()
+        cls.posture_manager.cryo_switch_sample_position(FM_IMAGING).result()
 
     def setUp(self):
         self._nb_updates = 0

--- a/src/odemis/acq/test/feature_acq_test.py
+++ b/src/odemis/acq/test/feature_acq_test.py
@@ -120,8 +120,8 @@ class TestCryoFeatureAcquisitionTask(unittest.TestCase):
         # move to FM IMAGING posture
         pm = MicroscopePostureManager(model.getMicroscope())
 
-        if pm.getCurrentPostureLabel() != FM_IMAGING:
-            f = pm.cryoSwitchSamplePosition(FM_IMAGING)
+        if pm.get_current_posture_label() != FM_IMAGING:
+            f = pm.cryo_switch_sample_position(FM_IMAGING)
             f.result()
 
         f = acquire_at_features(
@@ -205,7 +205,7 @@ class TestCryoFeaturePosturePositions(unittest.TestCase):
             self.assertTrue(isNearPosition(ppos,
                                            feature.get_posture_position(posture),
                                            axes=self.all_axes))
-            self.assertEqual(self.pm.getCurrentPostureLabel(ppos), posture)
+            self.assertEqual(self.pm.get_current_posture_label(ppos), posture)
 
 
 if __name__ == "__main__":

--- a/src/odemis/acq/test/move_jeol_test.py
+++ b/src/odemis/acq/test/move_jeol_test.py
@@ -75,13 +75,13 @@ class TestMeteorJeol1Move(unittest.TestCase):
         # Check the instantiation of correct posture manager
         self.assertIsInstance(self.posture_manager, MeteorPostureManager)
         # move the stage to the loading position
-        f = self.posture_manager.cryoSwitchSamplePosition(LOADING)
+        f = self.posture_manager.cryo_switch_sample_position(LOADING)
         f.result()
         # move the stage to the sem imaging area, and grid1 will be chosen by default.
-        f = self.posture_manager.cryoSwitchSamplePosition(SEM_IMAGING)
+        f = self.posture_manager.cryo_switch_sample_position(SEM_IMAGING)
         f.result()
-        position_label = self.posture_manager.getCurrentPostureLabel()
-        grid_label = self.posture_manager.getCurrentGridLabel()
+        position_label = self.posture_manager.get_current_posture_label()
+        grid_label = self.posture_manager.get_current_grid_label()
         self.assertEqual(position_label, SEM_IMAGING)
         self.assertEqual(grid_label, GRID_1)
         # check the values of tilt and rotation
@@ -94,12 +94,12 @@ class TestMeteorJeol1Move(unittest.TestCase):
     def test_moving_in_grid1_fm_imaging_area_after_loading(self):
         """Check if the stage moves in the right direction when moving in the fm imaging grid 1 area."""
         # move the stage to the loading position
-        f = self.posture_manager.cryoSwitchSamplePosition(LOADING)
+        f = self.posture_manager.cryo_switch_sample_position(LOADING)
         f.result()
         # move the stage to the fm imaging area, and grid1 will be chosen by default
-        f = self.posture_manager.cryoSwitchSamplePosition(FM_IMAGING)
+        f = self.posture_manager.cryo_switch_sample_position(FM_IMAGING)
         f.result()
-        position_label = self.posture_manager.getCurrentPostureLabel()
+        position_label = self.posture_manager.get_current_posture_label()
         self.assertEqual(position_label, FM_IMAGING)
         # check the values of tilt and rotation
         fm_angles = self.stage_bare.getMetadata()[model.MD_FAV_FM_POS_ACTIVE]
@@ -122,13 +122,13 @@ class TestMeteorJeol1Move(unittest.TestCase):
 
     def test_moving_to_grid1_in_fm_imaging_area_after_loading(self):
         # move the stage to the loading position
-        f = self.posture_manager.cryoSwitchSamplePosition(LOADING)
+        f = self.posture_manager.cryo_switch_sample_position(LOADING)
         f.result()
         # move the stage to the fm imaging area, and grid1 will be chosen by default
-        f = self.posture_manager.cryoSwitchSamplePosition(FM_IMAGING)
+        f = self.posture_manager.cryo_switch_sample_position(FM_IMAGING)
         f.result()
-        position_label = self.posture_manager.getCurrentPostureLabel()
-        grid_label = self.posture_manager.getCurrentGridLabel()
+        position_label = self.posture_manager.get_current_posture_label()
+        grid_label = self.posture_manager.get_current_grid_label()
         self.assertEqual(position_label, FM_IMAGING)
         self.assertEqual(grid_label, GRID_1)
         # check the values of tilt and rotation
@@ -140,23 +140,23 @@ class TestMeteorJeol1Move(unittest.TestCase):
 
     def test_moving_from_grid1_to_grid2_in_sem_imaging_area(self):
         # move to loading position
-        f = self.posture_manager.cryoSwitchSamplePosition(LOADING)
+        f = self.posture_manager.cryo_switch_sample_position(LOADING)
         f.result()
         # move the stage to the sem imaging area
-        f = self.posture_manager.cryoSwitchSamplePosition(SEM_IMAGING)
+        f = self.posture_manager.cryo_switch_sample_position(SEM_IMAGING)
         f.result()
-        current_imaging_mode = self.posture_manager.getCurrentPostureLabel()
+        current_imaging_mode = self.posture_manager.get_current_posture_label()
         self.assertEqual(SEM_IMAGING, current_imaging_mode)
         # now the selected grid is already the grid1
-        current_grid = self.posture_manager.getCurrentGridLabel()
+        current_grid = self.posture_manager.get_current_grid_label()
         self.assertEqual(GRID_1, current_grid)
         # move the stage to grid2
-        f = self.posture_manager.cryoSwitchSamplePosition(GRID_2)
+        f = self.posture_manager.cryo_switch_sample_position(GRID_2)
         f.result()
-        current_grid = self.posture_manager.getCurrentGridLabel()
+        current_grid = self.posture_manager.get_current_grid_label()
         self.assertEqual(GRID_2, current_grid)
         # make sure we are still in sem  imaging area
-        current_imaging_mode = self.posture_manager.getCurrentPostureLabel()
+        current_imaging_mode = self.posture_manager.get_current_posture_label()
         self.assertEqual(SEM_IMAGING, current_imaging_mode)
         sem_angles = self.stage_bare.getMetadata()[model.MD_FAV_SEM_POS_ACTIVE]
         for axis in self.ROTATION_AXES:
@@ -164,25 +164,25 @@ class TestMeteorJeol1Move(unittest.TestCase):
 
     def test_moving_from_grid2_to_grid1_in_sem_imaging_area(self):
         # move to loading position
-        f = self.posture_manager.cryoSwitchSamplePosition(LOADING)
+        f = self.posture_manager.cryo_switch_sample_position(LOADING)
         f.result()
         # move the stage to the sem imaging area
-        f = self.posture_manager.cryoSwitchSamplePosition(SEM_IMAGING)
+        f = self.posture_manager.cryo_switch_sample_position(SEM_IMAGING)
         f.result()
-        current_imaging_mode = self.posture_manager.getCurrentPostureLabel()
+        current_imaging_mode = self.posture_manager.get_current_posture_label()
         self.assertEqual(SEM_IMAGING, current_imaging_mode)
         # move the stage to grid2
-        f = self.posture_manager.cryoSwitchSamplePosition(GRID_2)
+        f = self.posture_manager.cryo_switch_sample_position(GRID_2)
         f.result()
-        current_grid = self.posture_manager.getCurrentGridLabel()
+        current_grid = self.posture_manager.get_current_grid_label()
         self.assertEqual(GRID_2, current_grid)
         # move the stage back to grid1
-        f = self.posture_manager.cryoSwitchSamplePosition(GRID_1)
+        f = self.posture_manager.cryo_switch_sample_position(GRID_1)
         f.result()
-        current_grid = self.posture_manager.getCurrentGridLabel()
+        current_grid = self.posture_manager.get_current_grid_label()
         self.assertEqual(GRID_1, current_grid)
         # make sure we are still in the sem imaging area
-        current_imaging_mode = self.posture_manager.getCurrentPostureLabel()
+        current_imaging_mode = self.posture_manager.get_current_posture_label()
         self.assertEqual(SEM_IMAGING, current_imaging_mode)
         sem_angles = self.stage_bare.getMetadata()[model.MD_FAV_SEM_POS_ACTIVE]
         for axis in self.ROTATION_AXES:
@@ -190,17 +190,17 @@ class TestMeteorJeol1Move(unittest.TestCase):
 
     def test_moving_from_sem_to_fm(self):
         # move to loading position
-        f = self.posture_manager.cryoSwitchSamplePosition(LOADING)
+        f = self.posture_manager.cryo_switch_sample_position(LOADING)
         f.result()
         # move the stage to the sem imaging area
-        f = self.posture_manager.cryoSwitchSamplePosition(SEM_IMAGING)
+        f = self.posture_manager.cryo_switch_sample_position(SEM_IMAGING)
         f.result()
-        current_imaging_mode = self.posture_manager.getCurrentPostureLabel()
+        current_imaging_mode = self.posture_manager.get_current_posture_label()
         self.assertEqual(SEM_IMAGING, current_imaging_mode)
         # move to the fm imaging area
-        f = self.posture_manager.cryoSwitchSamplePosition(FM_IMAGING)
+        f = self.posture_manager.cryo_switch_sample_position(FM_IMAGING)
         f.result()
-        current_imaging_mode = self.posture_manager.getCurrentPostureLabel()
+        current_imaging_mode = self.posture_manager.get_current_posture_label()
         self.assertEqual(FM_IMAGING, current_imaging_mode)
         # check the values of tilt and rotation
         fm_angles = self.stage_bare.getMetadata()[model.MD_FAV_FM_POS_ACTIVE]
@@ -210,23 +210,23 @@ class TestMeteorJeol1Move(unittest.TestCase):
         self._check_focus_position(model.MD_FAV_POS_ACTIVE)
 
     def test_moving_from_grid1_to_grid2_in_fm_imaging_area(self):
-        f = self.posture_manager.cryoSwitchSamplePosition(LOADING)
+        f = self.posture_manager.cryo_switch_sample_position(LOADING)
         f.result()
         # move to the fm imaging area
-        f = self.posture_manager.cryoSwitchSamplePosition(FM_IMAGING)
+        f = self.posture_manager.cryo_switch_sample_position(FM_IMAGING)
         f.result()
-        current_imaging_mode = self.posture_manager.getCurrentPostureLabel()
+        current_imaging_mode = self.posture_manager.get_current_posture_label()
         self.assertEqual(FM_IMAGING, current_imaging_mode)
         # now the grid is grid1 by default
-        current_grid = self.posture_manager.getCurrentGridLabel()
+        current_grid = self.posture_manager.get_current_grid_label()
         self.assertEqual(GRID_1, current_grid)
         # move to the grid2
-        f = self.posture_manager.cryoSwitchSamplePosition(GRID_2)
+        f = self.posture_manager.cryo_switch_sample_position(GRID_2)
         f.result()
-        current_grid = self.posture_manager.getCurrentGridLabel()
+        current_grid = self.posture_manager.get_current_grid_label()
         self.assertEqual(GRID_2, current_grid)
         # make sure we are still in fm imaging area
-        current_imaging_mode = self.posture_manager.getCurrentPostureLabel()
+        current_imaging_mode = self.posture_manager.get_current_posture_label()
         self.assertEqual(FM_IMAGING, current_imaging_mode)
         # check the values of tilt and rotation
         fm_angles = self.stage_bare.getMetadata()[model.MD_FAV_FM_POS_ACTIVE]
@@ -234,25 +234,25 @@ class TestMeteorJeol1Move(unittest.TestCase):
             self.assertAlmostEqual(self.stage_bare.position.value[axis], fm_angles[axis], places=4)
 
     def test_moving_from_grid2_to_grid1_in_fm_imaging_area(self):
-        f = self.posture_manager.cryoSwitchSamplePosition(LOADING)
+        f = self.posture_manager.cryo_switch_sample_position(LOADING)
         f.result()
         # move to the fm imaging area
-        f = self.posture_manager.cryoSwitchSamplePosition(FM_IMAGING)
+        f = self.posture_manager.cryo_switch_sample_position(FM_IMAGING)
         f.result()
-        current_imaging_mode = self.posture_manager.getCurrentPostureLabel()
+        current_imaging_mode = self.posture_manager.get_current_posture_label()
         self.assertEqual(FM_IMAGING, current_imaging_mode)
         # move to the grid2
-        f = self.posture_manager.cryoSwitchSamplePosition(GRID_2)
+        f = self.posture_manager.cryo_switch_sample_position(GRID_2)
         f.result()
-        current_grid = self.posture_manager.getCurrentGridLabel()
+        current_grid = self.posture_manager.get_current_grid_label()
         self.assertEqual(GRID_2, current_grid)
         # move back to the grid1
-        f = self.posture_manager.cryoSwitchSamplePosition(GRID_1)
+        f = self.posture_manager.cryo_switch_sample_position(GRID_1)
         f.result()
-        current_grid = self.posture_manager.getCurrentGridLabel()
+        current_grid = self.posture_manager.get_current_grid_label()
         self.assertEqual(GRID_1, current_grid)
         # make sure we are still in fm imaging area
-        current_imaging_mode = self.posture_manager.getCurrentPostureLabel()
+        current_imaging_mode = self.posture_manager.get_current_posture_label()
         self.assertEqual(FM_IMAGING, current_imaging_mode)
         # check the values of tilt and rotation
         fm_angles = self.stage_bare.getMetadata()[model.MD_FAV_FM_POS_ACTIVE]
@@ -260,17 +260,17 @@ class TestMeteorJeol1Move(unittest.TestCase):
             self.assertAlmostEqual(self.stage_bare.position.value[axis], fm_angles[axis], places=4)
 
     def test_moving_to_sem_from_fm(self):
-        f = self.posture_manager.cryoSwitchSamplePosition(LOADING)
+        f = self.posture_manager.cryo_switch_sample_position(LOADING)
         f.result()
         # move to the fm imaging area
-        f = self.posture_manager.cryoSwitchSamplePosition(FM_IMAGING)
+        f = self.posture_manager.cryo_switch_sample_position(FM_IMAGING)
         f.result()
-        current_imaging_mode = self.posture_manager.getCurrentPostureLabel()
+        current_imaging_mode = self.posture_manager.get_current_posture_label()
         self.assertEqual(FM_IMAGING, current_imaging_mode)
         # move to sem
-        f = self.posture_manager.cryoSwitchSamplePosition(SEM_IMAGING)
+        f = self.posture_manager.cryo_switch_sample_position(SEM_IMAGING)
         f.result()
-        current_imaging_mode = self.posture_manager.getCurrentPostureLabel()
+        current_imaging_mode = self.posture_manager.get_current_posture_label()
         self.assertEqual(SEM_IMAGING, current_imaging_mode)
         sem_angles = self.stage_bare.getMetadata()[model.MD_FAV_SEM_POS_ACTIVE]
         for axis in self.ROTATION_AXES:
@@ -281,20 +281,20 @@ class TestMeteorJeol1Move(unittest.TestCase):
     def test_unknown_label_at_initialization(self):
         arbitrary_position = {"x": 0.0, "y": 0.01, "z": 4.85e-3}
         self.stage_bare.moveAbs(arbitrary_position).result()
-        current_imaging_mode = self.posture_manager.getCurrentPostureLabel()
+        current_imaging_mode = self.posture_manager.get_current_posture_label()
         self.assertEqual(UNKNOWN, current_imaging_mode)
-        current_grid = self.posture_manager.getCurrentGridLabel()
+        current_grid = self.posture_manager.get_current_grid_label()
         self.assertEqual(current_grid, None)
 
-    def test_transformFromSEMToMeteor(self):
+    def test_transform_from_sem_to_fm(self):
         # assert that raises value error when no rz
         stage_md = self.stage_bare.getMetadata()
         grid1_pos = stage_md[model.MD_SAMPLE_CENTERS][POSITION_NAMES[GRID_1]]
         grid2_pos = stage_md[model.MD_SAMPLE_CENTERS][POSITION_NAMES[GRID_2]]
         with self.assertRaises(ValueError):
-            self.posture_manager._transformFromSEMToMeteor(grid1_pos)
+            self.posture_manager._transform_from_sem_to_fm(grid1_pos)
         with self.assertRaises(ValueError):
-            self.posture_manager._transformFromSEMToMeteor(grid2_pos)
+            self.posture_manager._transform_from_sem_to_fm(grid2_pos)
 
         # assert that it doesn't raise error when rz is added
         grid1_pos.update(stage_md[model.MD_FAV_SEM_POS_ACTIVE])
@@ -302,10 +302,10 @@ class TestMeteorJeol1Move(unittest.TestCase):
 
         # check if no error is raised (test fails if error is raised)
         try:
-            self.posture_manager._transformFromSEMToMeteor(grid1_pos)
-            self.posture_manager._transformFromSEMToMeteor(grid2_pos)
+            self.posture_manager._transform_from_sem_to_fm(grid1_pos)
+            self.posture_manager._transform_from_sem_to_fm(grid2_pos)
         except Exception as e:
-            self.fail(f"_transformFromSEMToMeteor raised error when it shouldn't: {e}")
+            self.fail(f"_transform_from_sem_to_fm raised error when it shouldn't: {e}")
 
 
 if __name__ == "__main__":

--- a/src/odemis/acq/test/move_tescan_test.py
+++ b/src/odemis/acq/test/move_tescan_test.py
@@ -62,7 +62,7 @@ class TestMeteorTescan1Move(move_tfs1_test.TestMeteorTFS1Move):
         """Test if switching to and from sem results in the same stage coordinates"""
 
         # Update the stage metadata according to the example
-        # Note: this works for switching posture because the metadata is re-read every time in cryoSwitchSamplePosition()
+        # Note: this works for switching posture because the metadata is re-read every time in cryo_switch_sample_position()
         # However, for moving along the sample stage, this would not be sufficient, as the transformations are cached.
         self.stage.updateMetadata({model.MD_CALIB: {"x_0": 1.77472e-03, "y_0": -0.05993e-03, "b_y": -0.297e-03,
                                                     "z_ct": 4.774e-03, "dx": -40.1e-03, "dy": 0.157e-03,
@@ -86,32 +86,32 @@ class TestMeteorTescan1Move(move_tfs1_test.TestMeteorTFS1Move):
             sem_position = sem_positions[i]
             self.stage.moveAbs(sem_position).result()
             current_stage_position = self.stage.position.value
-            current_imaging_mode = self.posture_manager.getCurrentPostureLabel()
+            current_imaging_mode = self.posture_manager.get_current_posture_label()
             self.assertEqual(SEM_IMAGING, current_imaging_mode)
             for axis in sem_position.keys():
                 self.assertAlmostEqual(sem_position[axis], current_stage_position[axis], places=4)
             # move to fm
-            f = self.posture_manager.cryoSwitchSamplePosition(FM_IMAGING)
+            f = self.posture_manager.cryo_switch_sample_position(FM_IMAGING)
             f.result()
-            current_imaging_mode = self.posture_manager.getCurrentPostureLabel()
+            current_imaging_mode = self.posture_manager.get_current_posture_label()
             self.assertEqual(FM_IMAGING, current_imaging_mode)
             fm_position = fm_positions[i]
             current_stage_position = self.stage.position.value
             for axis in fm_position.keys():
                 self.assertAlmostEqual(fm_position[axis], current_stage_position[axis], places=4)
             # move back to sem
-            f = self.posture_manager.cryoSwitchSamplePosition(SEM_IMAGING)
+            f = self.posture_manager.cryo_switch_sample_position(SEM_IMAGING)
             f.result()
             current_stage_position = self.stage.position.value
-            current_imaging_mode = self.posture_manager.getCurrentPostureLabel()
+            current_imaging_mode = self.posture_manager.get_current_posture_label()
             self.assertEqual(SEM_IMAGING, current_imaging_mode)
             for axis in sem_position.keys():
                 self.assertAlmostEqual(sem_position[axis], current_stage_position[axis], places=4)
 
     def test_rel_move_fm_posture(self):
-        f = self.posture_manager.cryoSwitchSamplePosition(FM_IMAGING)
+        f = self.posture_manager.cryo_switch_sample_position(FM_IMAGING)
         f.result()
-        current_imaging_mode = self.posture_manager.getCurrentPostureLabel()
+        current_imaging_mode = self.posture_manager.get_current_posture_label()
         self.assertEqual(FM_IMAGING, current_imaging_mode)
 
         # relative moves in sample stage coordinates
@@ -159,14 +159,14 @@ class TestMeteorTescan1Move(move_tfs1_test.TestMeteorTFS1Move):
     def test_unknown_label_at_initialization(self):
         arbitrary_position = {'rx': 0.0, 'rz': math.radians(-60), 'x': 0, 'y': 0, 'z': 40.e-3}
         self.stage.moveAbs(arbitrary_position).result()
-        current_imaging_mode = self.posture_manager.getCurrentPostureLabel()
+        current_imaging_mode = self.posture_manager.get_current_posture_label()
         self.assertEqual(UNKNOWN, current_imaging_mode)
-        current_grid = self.posture_manager.getCurrentGridLabel()
+        current_grid = self.posture_manager.get_current_grid_label()
         self.assertEqual(current_grid, None)
 
     def test_stage_to_chamber(self):
         shift = {"x": 100e-6, "z": 50e-6}
-        zshift = self.posture_manager._transformFromChamberToStage(shift)
+        zshift = self.posture_manager._transform_from_chamber_to_stage(shift)
         self.assertAlmostEqual(zshift["x"], shift["x"], places=5)
         self.assertAlmostEqual(zshift["z"], -shift["z"], places=5)
 
@@ -195,7 +195,7 @@ class TestMeteorTescan1FibsemMove(move_tfs3_test.TestMeteorTFS3Move):
         cls.stage_loading = cls.stage_md[model.MD_FAV_POS_DEACTIVE]
 
         # Reset to loading position (in case the backend was already running and in a different posture)
-        f = cls.pm.cryoSwitchSamplePosition(LOADING)
+        f = cls.pm.cryo_switch_sample_position(LOADING)
         f.result()
 
     def test_fixed_fm_z(self):
@@ -210,20 +210,20 @@ class TestMeteorTescan1FibsemMove(move_tfs3_test.TestMeteorTFS3Move):
     def test_stage_to_chamber(self):
         # Override, as Tescan has different behaviour: the Z axis is inversely connected the chamber Z
         # go to sem imaging
-        f = self.pm.cryoSwitchSamplePosition(SEM_IMAGING)
+        f = self.pm.cryo_switch_sample_position(SEM_IMAGING)
         f.result()
         time.sleep(0.1)
 
         # calculate the vertical shift in chamber coordinates
         shift = {"x": 100e-6, "z": 50e-6}
-        zshift = self.pm._transformFromChamberToStage(shift)
+        zshift = self.pm._transform_from_chamber_to_stage(shift)
         # Should return the same movement, but with z inverted
         testing.assert_pos_almost_equal(zshift, {"x": shift["x"], "z": -shift["z"]})
 
     def test_rel_move_fm_posture(self):
-        f = self.pm.cryoSwitchSamplePosition(FM_IMAGING)
+        f = self.pm.cryo_switch_sample_position(FM_IMAGING)
         f.result()
-        current_imaging_mode = self.pm.getCurrentPostureLabel()
+        current_imaging_mode = self.pm.get_current_posture_label()
         self.assertEqual(FM_IMAGING, current_imaging_mode)
 
         # relative moves in sample stage coordinates
@@ -253,20 +253,20 @@ class TestMeteorTescan1FibsemMove(move_tfs3_test.TestMeteorTFS3Move):
             self.skipTest("Shutter not available")
 
         # Move to safe start position
-        self.pm.cryoSwitchSamplePosition(LOADING).result()
+        self.pm.cryo_switch_sample_position(LOADING).result()
 
         # Ensure shutter is engaged before engaging the objective, to make it more interesting
         self.pm.shutter.value = True  # True = engaged (closed)
         # Move to FM_IMAGING and check shutter is retracted
-        self.pm.cryoSwitchSamplePosition(FM_IMAGING).result()
+        self.pm.cryo_switch_sample_position(FM_IMAGING).result()
         self.assertEqual(self.pm.shutter.value, False, "Shutter should be retracted for FM")
 
         # Move to MILLING and check shutter is in auto mode
-        self.pm.cryoSwitchSamplePosition(MILLING).result()
+        self.pm.cryo_switch_sample_position(MILLING).result()
         self.assertEqual(self.pm.shutter.value, None, "Shutter should be in auto mode")
 
         # Move back to SEM_IMAGING and check shutter mode is unaltered (auto)
-        self.pm.cryoSwitchSamplePosition(SEM_IMAGING).result()
+        self.pm.cryo_switch_sample_position(SEM_IMAGING).result()
         self.assertEqual(self.pm.shutter.value, None, "Shutter should remain in auto mode for SEM")
 
     def test_milling_angle_callback(self):
@@ -281,30 +281,30 @@ class TestMeteorTescan1FibsemMove(move_tfs3_test.TestMeteorTFS3Move):
 
     def test_milling_angle_stable_pos(self):
         # Make sure to start from a valid position
-        self.pm.cryoSwitchSamplePosition(LOADING).result()
+        self.pm.cryo_switch_sample_position(LOADING).result()
         # Transform to milling posture
-        self.pm.cryoSwitchSamplePosition(MILLING).result()
+        self.pm.cryo_switch_sample_position(MILLING).result()
         # Store shorthand for sample stage
         sample_stage = self.pm.sample_stage
         # Take note of sample stage pos
         initial_sample_stage_pos = sample_stage.position.value
         # Switch to SEM posture
-        self.pm.cryoSwitchSamplePosition(SEM_IMAGING).result()
+        self.pm.cryo_switch_sample_position(SEM_IMAGING).result()
         # Compare sample stage pos to previous pos
         testing.assert_pos_almost_equal(sample_stage.position.value, initial_sample_stage_pos, atol=1e-6)
         # Switch back to milling posture
-        self.pm.cryoSwitchSamplePosition(MILLING).result()
+        self.pm.cryo_switch_sample_position(MILLING).result()
         testing.assert_pos_almost_equal(sample_stage.position.value, initial_sample_stage_pos, atol=1e-6)
         # TODO: uncomment the following section once all the sample stage problems are resolved
         # # Now change milling angle to check stability; sample stage pos should remain the same.
         # milling_angle = math.radians(30)
         # self.pm.milling_angle.value = milling_angle
         # # Switch to SEM posture
-        # self.pm.cryoSwitchSamplePosition(SEM_IMAGING).result()
+        # self.pm.cryo_switch_sample_position(SEM_IMAGING).result()
         # # Compare sample stage pos to previous pos
         # testing.assert_pos_almost_equal(sample_stage.position.value, initial_sample_stage_pos, atol=1e-6)
         # # Switch back to milling posture
-        # self.pm.cryoSwitchSamplePosition(MILLING).result()
+        # self.pm.cryo_switch_sample_position(MILLING).result()
         # testing.assert_pos_almost_equal(sample_stage.position.value, initial_sample_stage_pos, atol=1e-6)
 
 

--- a/src/odemis/acq/test/move_tfs1_test.py
+++ b/src/odemis/acq/test/move_tfs1_test.py
@@ -94,13 +94,13 @@ class TestMeteorTFS1Move(unittest.TestCase):
         # Check the instantiation of correct posture manager
         self.assertIsInstance(self.posture_manager, MeteorPostureManager)
         # move the stage to the loading position
-        f = self.posture_manager.cryoSwitchSamplePosition(LOADING)
+        f = self.posture_manager.cryo_switch_sample_position(LOADING)
         f.result()
         # move the stage to the sem imaging area, and grid1 will be chosen by default.
-        f = self.posture_manager.cryoSwitchSamplePosition(SEM_IMAGING)
+        f = self.posture_manager.cryo_switch_sample_position(SEM_IMAGING)
         f.result()
-        position_label = self.posture_manager.getCurrentPostureLabel()
-        grid_label = self.posture_manager.getCurrentGridLabel()
+        position_label = self.posture_manager.get_current_posture_label()
+        grid_label = self.posture_manager.get_current_grid_label()
         self.assertEqual(position_label, SEM_IMAGING)
         self.assertEqual(grid_label, GRID_1)
         # check the values of tilt and rotation
@@ -112,12 +112,12 @@ class TestMeteorTFS1Move(unittest.TestCase):
     def test_moving_in_grid1_fm_imaging_area_after_loading(self):
         """Check if the stage moves in the right direction when moving in the fm imaging grid 1 area."""
         # move the stage to the loading position
-        f = self.posture_manager.cryoSwitchSamplePosition(LOADING)
+        f = self.posture_manager.cryo_switch_sample_position(LOADING)
         f.result()
         # move the stage to the fm imaging area, and grid1 will be chosen by default
-        f = self.posture_manager.cryoSwitchSamplePosition(FM_IMAGING)
+        f = self.posture_manager.cryo_switch_sample_position(FM_IMAGING)
         f.result()
-        position_label = self.posture_manager.getCurrentPostureLabel()
+        position_label = self.posture_manager.get_current_posture_label()
         self.assertEqual(position_label, FM_IMAGING)
         # check the values of tilt and rotation
         fm_angles = self.stage.getMetadata()[model.MD_FAV_FM_POS_ACTIVE]
@@ -136,13 +136,13 @@ class TestMeteorTFS1Move(unittest.TestCase):
 
     def test_moving_to_grid1_in_fm_imaging_area_after_loading(self):
         # move the stage to the loading position
-        f = self.posture_manager.cryoSwitchSamplePosition(LOADING)
+        f = self.posture_manager.cryo_switch_sample_position(LOADING)
         f.result()
         # move the stage to the fm imaging area, and grid1 will be chosen by default
-        f = self.posture_manager.cryoSwitchSamplePosition(FM_IMAGING)
+        f = self.posture_manager.cryo_switch_sample_position(FM_IMAGING)
         f.result()
-        position_label = self.posture_manager.getCurrentPostureLabel()
-        grid_label = self.posture_manager.getCurrentGridLabel()
+        position_label = self.posture_manager.get_current_posture_label()
+        grid_label = self.posture_manager.get_current_grid_label()
         self.assertEqual(position_label, FM_IMAGING)
         self.assertEqual(grid_label, GRID_1)
         # check the values of tilt and rotation
@@ -152,23 +152,23 @@ class TestMeteorTFS1Move(unittest.TestCase):
 
     def test_moving_from_grid1_to_grid2_in_sem_imaging_area(self):
         # move to loading position
-        f = self.posture_manager.cryoSwitchSamplePosition(LOADING)
+        f = self.posture_manager.cryo_switch_sample_position(LOADING)
         f.result()
         # move the stage to the sem imaging area
-        f = self.posture_manager.cryoSwitchSamplePosition(SEM_IMAGING)
+        f = self.posture_manager.cryo_switch_sample_position(SEM_IMAGING)
         f.result()
-        current_imaging_mode = self.posture_manager.getCurrentPostureLabel()
+        current_imaging_mode = self.posture_manager.get_current_posture_label()
         self.assertEqual(SEM_IMAGING, current_imaging_mode)
         # now the selected grid is already the grid1
-        current_grid = self.posture_manager.getCurrentGridLabel()
+        current_grid = self.posture_manager.get_current_grid_label()
         self.assertEqual(GRID_1, current_grid)
         # move the stage to grid2
-        f = self.posture_manager.cryoSwitchSamplePosition(GRID_2)
+        f = self.posture_manager.cryo_switch_sample_position(GRID_2)
         f.result()
-        current_grid = self.posture_manager.getCurrentGridLabel()
+        current_grid = self.posture_manager.get_current_grid_label()
         self.assertEqual(GRID_2, current_grid)
         # make sure we are still in sem  imaging area
-        current_imaging_mode = self.posture_manager.getCurrentPostureLabel()
+        current_imaging_mode = self.posture_manager.get_current_posture_label()
         self.assertEqual(SEM_IMAGING, current_imaging_mode)
         sem_angles = self.stage.getMetadata()[model.MD_FAV_SEM_POS_ACTIVE]
         for axis in self.ROTATION_AXES:
@@ -176,25 +176,25 @@ class TestMeteorTFS1Move(unittest.TestCase):
 
     def test_moving_from_grid2_to_grid1_in_sem_imaging_area(self):
         # move to loading position
-        f = self.posture_manager.cryoSwitchSamplePosition(LOADING)
+        f = self.posture_manager.cryo_switch_sample_position(LOADING)
         f.result()
         # move the stage to the sem imaging area
-        f = self.posture_manager.cryoSwitchSamplePosition(SEM_IMAGING)
+        f = self.posture_manager.cryo_switch_sample_position(SEM_IMAGING)
         f.result()
-        current_imaging_mode = self.posture_manager.getCurrentPostureLabel()
+        current_imaging_mode = self.posture_manager.get_current_posture_label()
         self.assertEqual(SEM_IMAGING, current_imaging_mode)
         # move the stage to grid2
-        f = self.posture_manager.cryoSwitchSamplePosition(GRID_2)
+        f = self.posture_manager.cryo_switch_sample_position(GRID_2)
         f.result()
-        current_grid = self.posture_manager.getCurrentGridLabel()
+        current_grid = self.posture_manager.get_current_grid_label()
         self.assertEqual(GRID_2, current_grid)
         # move the stage back to grid1
-        f = self.posture_manager.cryoSwitchSamplePosition(GRID_1)
+        f = self.posture_manager.cryo_switch_sample_position(GRID_1)
         f.result()
-        current_grid = self.posture_manager.getCurrentGridLabel()
+        current_grid = self.posture_manager.get_current_grid_label()
         self.assertEqual(GRID_1, current_grid)
         # make sure we are still in the sem imaging area
-        current_imaging_mode = self.posture_manager.getCurrentPostureLabel()
+        current_imaging_mode = self.posture_manager.get_current_posture_label()
         self.assertEqual(SEM_IMAGING, current_imaging_mode)
         sem_angles = self.stage.getMetadata()[model.MD_FAV_SEM_POS_ACTIVE]
         for axis in self.ROTATION_AXES:
@@ -202,17 +202,17 @@ class TestMeteorTFS1Move(unittest.TestCase):
 
     def test_moving_from_sem_to_fm(self):
         # move to loading position
-        f = self.posture_manager.cryoSwitchSamplePosition(LOADING)
+        f = self.posture_manager.cryo_switch_sample_position(LOADING)
         f.result()
         # move the stage to the sem imaging area
-        f = self.posture_manager.cryoSwitchSamplePosition(SEM_IMAGING)
+        f = self.posture_manager.cryo_switch_sample_position(SEM_IMAGING)
         f.result()
-        current_imaging_mode = self.posture_manager.getCurrentPostureLabel()
+        current_imaging_mode = self.posture_manager.get_current_posture_label()
         self.assertEqual(SEM_IMAGING, current_imaging_mode)
         # move to the fm imaging area
-        f = self.posture_manager.cryoSwitchSamplePosition(FM_IMAGING)
+        f = self.posture_manager.cryo_switch_sample_position(FM_IMAGING)
         f.result()
-        current_imaging_mode = self.posture_manager.getCurrentPostureLabel()
+        current_imaging_mode = self.posture_manager.get_current_posture_label()
         self.assertEqual(FM_IMAGING, current_imaging_mode)
         # check the values of tilt and rotation
         fm_angles = self.stage.getMetadata()[model.MD_FAV_FM_POS_ACTIVE]
@@ -220,23 +220,23 @@ class TestMeteorTFS1Move(unittest.TestCase):
             self.assertAlmostEqual(self.stage.position.value[axis], fm_angles[axis], places=4)
 
     def test_moving_from_grid1_to_grid2_in_fm_imaging_Area(self):
-        f = self.posture_manager.cryoSwitchSamplePosition(LOADING)
+        f = self.posture_manager.cryo_switch_sample_position(LOADING)
         f.result()
         # move to the fm imaging area
-        f = self.posture_manager.cryoSwitchSamplePosition(FM_IMAGING)
+        f = self.posture_manager.cryo_switch_sample_position(FM_IMAGING)
         f.result()
-        current_imaging_mode = self.posture_manager.getCurrentPostureLabel()
+        current_imaging_mode = self.posture_manager.get_current_posture_label()
         self.assertEqual(FM_IMAGING, current_imaging_mode)
         # now the grid is grid1 by default
-        current_grid = self.posture_manager.getCurrentGridLabel()
+        current_grid = self.posture_manager.get_current_grid_label()
         self.assertEqual(GRID_1, current_grid)
         # move to the grid2
-        f = self.posture_manager.cryoSwitchSamplePosition(GRID_2)
+        f = self.posture_manager.cryo_switch_sample_position(GRID_2)
         f.result()
-        current_grid = self.posture_manager.getCurrentGridLabel()
+        current_grid = self.posture_manager.get_current_grid_label()
         self.assertEqual(GRID_2, current_grid)
         # make sure we are still in fm imaging area
-        current_imaging_mode = self.posture_manager.getCurrentPostureLabel()
+        current_imaging_mode = self.posture_manager.get_current_posture_label()
         self.assertEqual(FM_IMAGING, current_imaging_mode)
         # check the values of tilt and rotation
         fm_angles = self.stage.getMetadata()[model.MD_FAV_FM_POS_ACTIVE]
@@ -244,25 +244,25 @@ class TestMeteorTFS1Move(unittest.TestCase):
             self.assertAlmostEqual(self.stage.position.value[axis], fm_angles[axis], places=4)
 
     def test_moving_from_grid2_to_grid1_in_fm_imaging_Area(self):
-        f = self.posture_manager.cryoSwitchSamplePosition(LOADING)
+        f = self.posture_manager.cryo_switch_sample_position(LOADING)
         f.result()
         # move to the fm imaging area
-        f = self.posture_manager.cryoSwitchSamplePosition(FM_IMAGING)
+        f = self.posture_manager.cryo_switch_sample_position(FM_IMAGING)
         f.result()
-        current_imaging_mode = self.posture_manager.getCurrentPostureLabel()
+        current_imaging_mode = self.posture_manager.get_current_posture_label()
         self.assertEqual(FM_IMAGING, current_imaging_mode)
         # move to the grid2
-        f = self.posture_manager.cryoSwitchSamplePosition(GRID_2)
+        f = self.posture_manager.cryo_switch_sample_position(GRID_2)
         f.result()
-        current_grid = self.posture_manager.getCurrentGridLabel()
+        current_grid = self.posture_manager.get_current_grid_label()
         self.assertEqual(GRID_2, current_grid)
         # move back to the grid1
-        f = self.posture_manager.cryoSwitchSamplePosition(GRID_1)
+        f = self.posture_manager.cryo_switch_sample_position(GRID_1)
         f.result()
-        current_grid = self.posture_manager.getCurrentGridLabel()
+        current_grid = self.posture_manager.get_current_grid_label()
         self.assertEqual(GRID_1, current_grid)
         # make sure we are still in fm imaging area
-        current_imaging_mode = self.posture_manager.getCurrentPostureLabel()
+        current_imaging_mode = self.posture_manager.get_current_posture_label()
         self.assertEqual(FM_IMAGING, current_imaging_mode)
         # check the values of tilt and rotation
         fm_angles = self.stage.getMetadata()[model.MD_FAV_FM_POS_ACTIVE]
@@ -270,17 +270,17 @@ class TestMeteorTFS1Move(unittest.TestCase):
             self.assertAlmostEqual(self.stage.position.value[axis], fm_angles[axis], places=4)
 
     def test_moving_to_sem_from_fm(self):
-        f = self.posture_manager.cryoSwitchSamplePosition(LOADING)
+        f = self.posture_manager.cryo_switch_sample_position(LOADING)
         f.result()
         # move to the fm imaging area
-        f = self.posture_manager.cryoSwitchSamplePosition(FM_IMAGING)
+        f = self.posture_manager.cryo_switch_sample_position(FM_IMAGING)
         f.result()
-        current_imaging_mode = self.posture_manager.getCurrentPostureLabel()
+        current_imaging_mode = self.posture_manager.get_current_posture_label()
         self.assertEqual(FM_IMAGING, current_imaging_mode)
         # move to sem
-        f = self.posture_manager.cryoSwitchSamplePosition(SEM_IMAGING)
+        f = self.posture_manager.cryo_switch_sample_position(SEM_IMAGING)
         f.result()
-        current_imaging_mode = self.posture_manager.getCurrentPostureLabel()
+        current_imaging_mode = self.posture_manager.get_current_posture_label()
         self.assertEqual(SEM_IMAGING, current_imaging_mode)
         sem_angles = self.stage.getMetadata()[model.MD_FAV_SEM_POS_ACTIVE]
         for axis in self.ROTATION_AXES:
@@ -289,12 +289,12 @@ class TestMeteorTFS1Move(unittest.TestCase):
     def test_unknown_label_at_initialization(self):
         arbitrary_position = {"x": 0.0, "y": 0.0, "z": -3.0e-3}
         self.stage.moveAbs(arbitrary_position).result()
-        current_imaging_mode = self.posture_manager.getCurrentPostureLabel()
+        current_imaging_mode = self.posture_manager.get_current_posture_label()
         self.assertEqual(UNKNOWN, current_imaging_mode)
-        current_grid = self.posture_manager.getCurrentGridLabel()
+        current_grid = self.posture_manager.get_current_grid_label()
         self.assertEqual(current_grid, None)
 
-    def test_transformFromSEMToMeteor(self):
+    def test_transform_from_sem_to_fm(self):
 
         # previously, the transformFromSEMToMeteor function accepted positions without rz axes.
         # now, it checks compares the current and target rz axes for the required transformation.
@@ -310,9 +310,9 @@ class TestMeteorTFS1Move(unittest.TestCase):
         grid1_pos = stage_md[model.MD_SAMPLE_CENTERS][POSITION_NAMES[GRID_1]]
         grid2_pos = stage_md[model.MD_SAMPLE_CENTERS][POSITION_NAMES[GRID_2]]
         with self.assertRaises(ValueError):
-            self.posture_manager._transformFromSEMToMeteor(grid1_pos)
+            self.posture_manager._transform_from_sem_to_fm(grid1_pos)
         with self.assertRaises(ValueError):
-            self.posture_manager._transformFromSEMToMeteor(grid2_pos)
+            self.posture_manager._transform_from_sem_to_fm(grid2_pos)
 
         # assert that it doesn't raise error when rz is added
         grid1_pos.update(stage_md[model.MD_FAV_SEM_POS_ACTIVE])
@@ -320,10 +320,10 @@ class TestMeteorTFS1Move(unittest.TestCase):
 
         # check if no error is raised (test fails if error is raised)
         try:
-            self.posture_manager._transformFromSEMToMeteor(grid1_pos)
-            self.posture_manager._transformFromSEMToMeteor(grid2_pos)
+            self.posture_manager._transform_from_sem_to_fm(grid1_pos)
+            self.posture_manager._transform_from_sem_to_fm(grid2_pos)
         except Exception as e:
-            self.fail(f"_transformFromSEMToMeteor raised error when it shouldn't: {e}")
+            self.fail(f"_transform_from_sem_to_fm raised error when it shouldn't: {e}")
 
 
 if __name__ == "__main__":

--- a/src/odemis/acq/test/move_tfs3_test.py
+++ b/src/odemis/acq/test/move_tfs3_test.py
@@ -69,25 +69,25 @@ class TestMeteorTFS3Move(unittest.TestCase):
         if self.pm.current_posture.value == UNKNOWN:
             logging.info("Test setup: posture is UNKNOWN, resetting to SEM_IMAGING")
             # Reset to loading position before each test
-            f = self.pm.cryoSwitchSamplePosition(LOADING)
+            f = self.pm.cryo_switch_sample_position(LOADING)
             f.result()
             # From loading, going to SEM IMAGING will use GRID 1 as base position
-            f = self.pm.cryoSwitchSamplePosition(SEM_IMAGING)
+            f = self.pm.cryo_switch_sample_position(SEM_IMAGING)
             f.result()
 
     def test_switching_movements(self):
         """Test switching between different postures and check that the 3D transformations work as expected"""
-        f = self.pm.cryoSwitchSamplePosition(SEM_IMAGING)
+        f = self.pm.cryo_switch_sample_position(SEM_IMAGING)
         f.result()
 
         self.assertEqual(self.pm.current_posture.value, SEM_IMAGING)
 
         if model.MD_FAV_MILL_POS_ACTIVE in self.stage_md:
-            f = self.pm.cryoSwitchSamplePosition(MILLING)
+            f = self.pm.cryo_switch_sample_position(MILLING)
             f.result()
             self.assertEqual(self.pm.current_posture.value, MILLING)
 
-        f = self.pm.cryoSwitchSamplePosition(FM_IMAGING)
+        f = self.pm.cryo_switch_sample_position(FM_IMAGING)
         f.result()
 
         self.assertEqual(self.pm.current_posture.value, FM_IMAGING)
@@ -96,33 +96,33 @@ class TestMeteorTFS3Move(unittest.TestCase):
         """Test that posture projection is the same as moving to the posture"""
 
         # move to SEM imaging posture
-        f = self.pm.cryoSwitchSamplePosition(SEM_IMAGING)
+        f = self.pm.cryo_switch_sample_position(SEM_IMAGING)
         f.result()
 
         # first move back to grid-1 to make sure we are in a known position
         f = self.stage_bare.moveAbs(self.stage_grid_centers[POSITION_NAMES[GRID_1]])
         f.result()
 
-        # Check that getCurrentPostureLabel() with a given stage-bare position returns the expected posture
+        # Check that get_current_posture_label() with a given stage-bare position returns the expected posture
         pos = self.stage_bare.position.value
-        self.assertEqual(self.pm.getCurrentPostureLabel(pos), SEM_IMAGING)
+        self.assertEqual(self.pm.get_current_posture_label(pos), SEM_IMAGING)
 
         fm_pos = self.pm.to_posture(pos, FM_IMAGING)
-        self.assertEqual(self.pm.getCurrentPostureLabel(fm_pos), FM_IMAGING)
+        self.assertEqual(self.pm.get_current_posture_label(fm_pos), FM_IMAGING)
 
         if model.MD_FAV_MILL_POS_ACTIVE in self.stage_md:
             milling_pos = self.pm.to_posture(pos, MILLING)
-            self.assertEqual(self.pm.getCurrentPostureLabel(milling_pos), MILLING)
+            self.assertEqual(self.pm.get_current_posture_label(milling_pos), MILLING)
 
         # Move to the postures and check that the position is close to the expected positions
-        f = self.pm.cryoSwitchSamplePosition(FM_IMAGING)
+        f = self.pm.cryo_switch_sample_position(FM_IMAGING)
         f.result()
         fm_pos_after_move = self.stage_bare.position.value
         self.assertTrue(isNearPosition(fm_pos_after_move, fm_pos,
                                        axes={"x", "y", "z", "rx", "rz"}))
 
         if model.MD_FAV_MILL_POS_ACTIVE in self.stage_md:
-            f = self.pm.cryoSwitchSamplePosition(MILLING)
+            f = self.pm.cryo_switch_sample_position(MILLING)
             f.result()
             milling_pos_after_move = self.stage_bare.position.value
             self.assertTrue(isNearPosition(milling_pos_after_move, milling_pos,
@@ -131,7 +131,7 @@ class TestMeteorTFS3Move(unittest.TestCase):
     def test_sample_stage_movement(self):
         """Test sample stage movements in different postures match the expected movements"""
         # move to SEM/GRID 1
-        f = self.pm.cryoSwitchSamplePosition(SEM_IMAGING)
+        f = self.pm.cryo_switch_sample_position(SEM_IMAGING)
         f.result()
         f = self.stage_bare.moveAbs(self.stage_grid_centers[POSITION_NAMES[GRID_1]])
         f.result()
@@ -140,10 +140,10 @@ class TestMeteorTFS3Move(unittest.TestCase):
         for posture in [SEM_IMAGING, FM_IMAGING]:
 
             if self.pm.current_posture.value != posture:
-                f = self.pm.cryoSwitchSamplePosition(posture)
+                f = self.pm.cryo_switch_sample_position(posture)
                 f.result()
 
-            f = self.pm.cryoSwitchSamplePosition(GRID_1)
+            f = self.pm.cryo_switch_sample_position(GRID_1)
             f.result()
             time.sleep(0.1) # simulated stage moves too fast, needs time to update
 
@@ -163,7 +163,7 @@ class TestMeteorTFS3Move(unittest.TestCase):
             self.assertAlmostEqual(new_pos["y"], init_ss_pos["y"] + dy, places=5)
 
             # test absolute movement
-            f = self.pm.cryoSwitchSamplePosition(GRID_1)
+            f = self.pm.cryo_switch_sample_position(GRID_1)
             f.result()
             time.sleep(0.1) # simulated stage moves too fast, needs time to update
 
@@ -232,13 +232,13 @@ class TestMeteorTFS3Move(unittest.TestCase):
         """Test the sample-stage to chamber transformation used for vertical movements."""
 
         # go to sem imaging
-        f = self.pm.cryoSwitchSamplePosition(SEM_IMAGING)
+        f = self.pm.cryo_switch_sample_position(SEM_IMAGING)
         f.result()
         time.sleep(0.1)
 
         # calculate the vertical shift in chamber coordinates
         shift = {"x": 100e-6, "z": 50e-6}
-        zshift = self.pm._transformFromChamberToStage(shift)
+        zshift = self.pm._transform_from_chamber_to_stage(shift)
 
         # calculate axis components
         theta = self.stage_bare.position.value["rx"] # tilt, in radians (stage-bare)
@@ -268,12 +268,12 @@ class TestMeteorTFS3Move(unittest.TestCase):
         # Test when fixing the fixed fm z, the fm sample z does not change between different positions
         # with distinct z.
         self.stage_bare.moveAbs(position_a).result()
-        self.pm.cryoSwitchSamplePosition(FM_IMAGING).result()
+        self.pm.cryo_switch_sample_position(FM_IMAGING).result()
         position_fm_a = self.stage_bare.position.value
         sample_z_a = self.pm.to_sample_stage_from_stage_position(position_fm_a, posture=FM_IMAGING)["z"]
 
         self.stage_bare.moveAbs(position_b).result()
-        self.pm.cryoSwitchSamplePosition(FM_IMAGING).result()
+        self.pm.cryo_switch_sample_position(FM_IMAGING).result()
         position_fm_b = self.stage_bare.position.value
         sample_z_b = self.pm.to_sample_stage_from_stage_position(position_fm_b, posture=FM_IMAGING)["z"]
 
@@ -282,12 +282,12 @@ class TestMeteorTFS3Move(unittest.TestCase):
         # Now clear fixed fm position to see if sample z actually changes for same scenario.
         self.stage_bare.updateMetadata({model.MD_FM_POS_SAMPLE_ACTIVE: None})
         self.stage_bare.moveAbs(position_a).result()
-        self.pm.cryoSwitchSamplePosition(FM_IMAGING).result()
+        self.pm.cryo_switch_sample_position(FM_IMAGING).result()
         position_fm_a = self.stage_bare.position.value
         sample_z_a = self.pm.to_sample_stage_from_stage_position(position_fm_a, posture=FM_IMAGING)["z"]
 
         self.stage_bare.moveAbs(position_b).result()
-        self.pm.cryoSwitchSamplePosition(FM_IMAGING).result()
+        self.pm.cryo_switch_sample_position(FM_IMAGING).result()
         position_fm_b = self.stage_bare.position.value
         sample_z_b = self.pm.to_sample_stage_from_stage_position(position_fm_b, posture=FM_IMAGING)["z"]
 
@@ -304,18 +304,18 @@ class TestMeteorTFS3Move(unittest.TestCase):
         self.stage_bare.moveAbs(position_requested).result()
         position_initial = self.stage_bare.position.value
         # Go from SEM posture to METEOR, and back. Check that we end up at the same spot as before
-        self.pm.cryoSwitchSamplePosition(FM_IMAGING).result()
-        self.pm.cryoSwitchSamplePosition(SEM_IMAGING).result()
+        self.pm.cryo_switch_sample_position(FM_IMAGING).result()
+        self.pm.cryo_switch_sample_position(SEM_IMAGING).result()
         position_reverted = self.stage_bare.position.value
         testing.assert_pos_almost_equal(position_reverted, position_initial, atol=1e-9)
         # Also for milling to METEOR
-        self.pm.cryoSwitchSamplePosition(MILLING).result()
+        self.pm.cryo_switch_sample_position(MILLING).result()
         position_milling_initial = self.stage_bare.position.value
-        self.pm.cryoSwitchSamplePosition(FM_IMAGING).result()
-        self.pm.cryoSwitchSamplePosition(MILLING).result()
+        self.pm.cryo_switch_sample_position(FM_IMAGING).result()
+        self.pm.cryo_switch_sample_position(MILLING).result()
         position_reverted = self.stage_bare.position.value
         testing.assert_pos_almost_equal(position_reverted, position_milling_initial, atol=1e-9)
-        self.pm.cryoSwitchSamplePosition(SEM_IMAGING).result()
+        self.pm.cryo_switch_sample_position(SEM_IMAGING).result()
         position_reverted = self.stage_bare.position.value
         testing.assert_pos_almost_equal(position_reverted, position_initial, atol=1e-9)
 
@@ -324,28 +324,28 @@ class TestMeteorTFS3Move(unittest.TestCase):
         Check that the fixed FM Z works correctly even when GUI (and PostureManager) is restarted.
         """
         # move to SEM/GRID 1 (mostly to start at a known position)
-        f = self.pm.cryoSwitchSamplePosition(SEM_IMAGING)
+        f = self.pm.cryo_switch_sample_position(SEM_IMAGING)
         f.result()
         f = self.stage_bare.moveAbs(self.stage_grid_centers[POSITION_NAMES[GRID_1]])
         f.result()
         pos_grid1_sem = self.stage_bare.position.value
         # Go to FM
-        f = self.pm.cryoSwitchSamplePosition(FM_IMAGING)
+        f = self.pm.cryo_switch_sample_position(FM_IMAGING)
         f.result()
         pos_grid1_fm = self.stage_bare.position.value
         # Go to SEM (also happens when going to MILLING)
-        f = self.pm.cryoSwitchSamplePosition(SEM_IMAGING)
+        f = self.pm.cryo_switch_sample_position(SEM_IMAGING)
         f.result()
         pos_grid1_sem_back = self.stage_bare.position.value
         testing.assert_pos_almost_equal(pos_grid1_sem, pos_grid1_sem_back, atol=1e-9)
 
-        pos_grid1_fm_pm1 = self.pm.getTargetPosition(FM_IMAGING)
+        pos_grid1_fm_pm1 = self.pm.get_target_position(FM_IMAGING)
         testing.assert_pos_almost_equal(pos_grid1_fm, pos_grid1_fm_pm1, atol=1e-9)
 
         # Simulate a restart by creating a new PostureManager instance
         pm2 = MicroscopePostureManager(microscope=self.microscope)
 
-        pos_grid1_fm_pm2 = pm2.getTargetPosition(FM_IMAGING)
+        pos_grid1_fm_pm2 = pm2.get_target_position(FM_IMAGING)
         testing.assert_pos_almost_equal(pos_grid1_fm_pm1, pos_grid1_fm_pm2, atol=1e-9)
 
 

--- a/src/odemis/acq/test/move_util_test.py
+++ b/src/odemis/acq/test/move_util_test.py
@@ -41,7 +41,7 @@ METEOR_TFS1_CONFIG = CONFIG_PATH + "sim/meteor-sim.odm.yaml"
 
 class TestGetDifferenceFunction(unittest.TestCase):
     """
-    This class is to test _getDistance() function in the move module
+    This class is to test _get_distance() function in the move module
     """
 
     @classmethod
@@ -57,21 +57,21 @@ class TestGetDifferenceFunction(unittest.TestCase):
         pos1 = numpy.array([point1[a] for a in list(point1.keys())])
         pos2 = numpy.array([point2[a] for a in list(point2.keys())])
         expected_distance = scipy.spatial.distance.euclidean(pos1, pos2)
-        actual_distance = self.posture_manager._getDistance(point1, point2)
+        actual_distance = self.posture_manager._get_distance(point1, point2)
         self.assertAlmostEqual(expected_distance, actual_distance)
 
     def test_only_linear_axes_but_without_difference(self):
         point1 = {'x': 0.082, 'y': 0.01, 'z': 0.028}
         point2 = {'x': 0.082, 'y': 0.01, 'z': 0.028}
         expected_distance = 0
-        actual_distance = self.posture_manager._getDistance(point1, point2)
+        actual_distance = self.posture_manager._get_distance(point1, point2)
         self.assertAlmostEqual(expected_distance, actual_distance)
 
     def test_only_linear_axes_but_without_common_axes(self):
         point1 = {'x': 0.023, 'y': 0.032}
         point2 = {'x': 0.023, 'y': 0.032, 'z': 1}
         expected_distance = 0
-        actual_distance = self.posture_manager._getDistance(point1, point2)
+        actual_distance = self.posture_manager._get_distance(point1, point2)
         self.assertAlmostEqual(expected_distance, actual_distance)
 
     def test_only_rotation_axes(self):
@@ -79,11 +79,11 @@ class TestGetDifferenceFunction(unittest.TestCase):
         point2 = {'rx': numpy.radians(60), 'rz': 0}  # 60 degree
         # the rotation difference is 30 degree
         exp_rot_dist = ROT_DIST_SCALING_FACTOR * numpy.radians(30)
-        act_rot_dist = self.posture_manager._getDistance(point2, point1)
+        act_rot_dist = self.posture_manager._get_distance(point2, point1)
         self.assertAlmostEqual(exp_rot_dist, act_rot_dist)
 
         # Same in the other direction
-        act_rot_dist = self.posture_manager._getDistance(point2, point1)
+        act_rot_dist = self.posture_manager._get_distance(point2, point1)
         self.assertAlmostEqual(exp_rot_dist, act_rot_dist)
 
     def test_rotation_axes_no_difference(self):
@@ -91,11 +91,11 @@ class TestGetDifferenceFunction(unittest.TestCase):
         point2 = {'rx': 0, 'rz': numpy.radians(30)}  # 30 degree
         # the rotation difference is 0 degree
         exp_rot_error = 0
-        act_rot_error = self.posture_manager._getDistance(point2, point1)
+        act_rot_error = self.posture_manager._get_distance(point2, point1)
         self.assertAlmostEqual(exp_rot_error, act_rot_error)
 
         # Same in the other direction
-        act_rot_error = self.posture_manager._getDistance(point1, point2)
+        act_rot_error = self.posture_manager._get_distance(point1, point2)
         self.assertAlmostEqual(exp_rot_error, act_rot_error)
 
     def test_rotation_axes_missing_axis(self):
@@ -103,18 +103,18 @@ class TestGetDifferenceFunction(unittest.TestCase):
         # No rx => doesn't count it
         point2 = {'rz': numpy.radians(60)}  # 60 degree
         exp_rot_dist = ROT_DIST_SCALING_FACTOR * numpy.radians(30)
-        act_rot_dist = self.posture_manager._getDistance(point2, point1)
+        act_rot_dist = self.posture_manager._get_distance(point2, point1)
         self.assertAlmostEqual(exp_rot_dist, act_rot_dist)
 
         # Same in the other direction
-        act_rot_dist = self.posture_manager._getDistance(point2, point1)
+        act_rot_dist = self.posture_manager._get_distance(point2, point1)
         self.assertAlmostEqual(exp_rot_dist, act_rot_dist)
 
     def test_no_common_axes(self):
         point1 = {'rx': numpy.radians(30), 'rz': numpy.radians(30)}
         point2 = {'x': 0.082, 'y': 0.01}
         with self.assertRaises(ValueError):
-            self.posture_manager._getDistance(point1, point2)
+            self.posture_manager._get_distance(point1, point2)
 
     def test_lin_rot_axes(self):
         point1 = {'rx': 0, 'rz': numpy.radians(30), 'x': -0.02, 'y': 0.05, 'z': 0.019}
@@ -122,42 +122,42 @@ class TestGetDifferenceFunction(unittest.TestCase):
         # The rotation difference is 30 degree
         # The linear difference is 0.01
         exp_dist = ROT_DIST_SCALING_FACTOR * numpy.radians(30) + 0.01
-        act_dist = self.posture_manager._getDistance(point1, point2)
+        act_dist = self.posture_manager._get_distance(point1, point2)
         self.assertAlmostEqual(exp_dist, act_dist)
 
         # Same in the other direction
-        act_dist = self.posture_manager._getDistance(point2, point1)
+        act_dist = self.posture_manager._get_distance(point2, point1)
         self.assertAlmostEqual(exp_dist, act_dist)
 
     def test_get_progress(self):
         """
-        Test getMovementProgress function behaves as expected
+        Test get_movement_progress function behaves as expected
         """
         start_point = {'x': 0, 'y': 0, 'z': 0}
         end_point = {'x': 2, 'y': 2, 'z': 2}
         current_point = {'x': 1, 'y': 1, 'z': 1}
-        progress = self.posture_manager.getMovementProgress(current_point, start_point, end_point)
+        progress = self.posture_manager.get_movement_progress(current_point, start_point, end_point)
         self.assertTrue(util.almost_equal(progress, 0.5, rtol=RTOL_PROGRESS))
 
         current_point = {'x': .998, 'y': .999, 'z': .999}  # slightly off the line
-        progress = self.posture_manager.getMovementProgress(current_point, start_point, end_point)
+        progress = self.posture_manager.get_movement_progress(current_point, start_point, end_point)
         self.assertTrue(util.almost_equal(progress, 0.5, rtol=RTOL_PROGRESS))
 
         current_point = {'x': 3, 'y': 3, 'z': 3}  # away from the line
-        progress = self.posture_manager.getMovementProgress(current_point, start_point, end_point)
+        progress = self.posture_manager.get_movement_progress(current_point, start_point, end_point)
         self.assertIsNone(progress)
 
         current_point = {'x': 1, 'y': 1, 'z': 3}  # away from the line
-        progress = self.posture_manager.getMovementProgress(current_point, start_point, end_point)
+        progress = self.posture_manager.get_movement_progress(current_point, start_point, end_point)
         self.assertIsNone(progress)
 
         current_point = {'x': -1, 'y': 0, 'z': 0}  # away from the line
-        progress = self.posture_manager.getMovementProgress(current_point, start_point, end_point)
+        progress = self.posture_manager.get_movement_progress(current_point, start_point, end_point)
         self.assertIsNone(progress)
 
     def test_get_progress_lin_rot(self):
         """
-        Test getMovementProgress return sorted values along a path with linear and
+        Test get_movement_progress return sorted values along a path with linear and
         rotational axes.
         """
         # Test also rotations
@@ -168,18 +168,18 @@ class TestGetDifferenceFunction(unittest.TestCase):
         end_point = {'x': 2, 'rx': 0.2, 'rz': -0.2}
 
         # start_point = 0 < Point 1 < Point 2 < Point 3 < 1 = end_point
-        progress_0 = self.posture_manager.getMovementProgress(start_point, start_point, end_point)
+        progress_0 = self.posture_manager.get_movement_progress(start_point, start_point, end_point)
         self.assertAlmostEqual(progress_0, 0)
 
-        progress_1 = self.posture_manager.getMovementProgress(point_1, start_point, end_point)
+        progress_1 = self.posture_manager.get_movement_progress(point_1, start_point, end_point)
 
         # Point 2 should be in the middle
-        progress_2 = self.posture_manager.getMovementProgress(point_2, start_point, end_point)
+        progress_2 = self.posture_manager.get_movement_progress(point_2, start_point, end_point)
         self.assertTrue(util.almost_equal(progress_2, 0.5, rtol=RTOL_PROGRESS))
 
-        progress_3 = self.posture_manager.getMovementProgress(point_3, start_point, end_point)
+        progress_3 = self.posture_manager.get_movement_progress(point_3, start_point, end_point)
 
-        progress_end = self.posture_manager.getMovementProgress(end_point, start_point, end_point)
+        progress_end = self.posture_manager.get_movement_progress(end_point, start_point, end_point)
         self.assertAlmostEqual(progress_end, 1)
 
         assert progress_0 < progress_1 < progress_2 < progress_3 < progress_end

--- a/src/odemis/acq/test/move_zeiss_test.py
+++ b/src/odemis/acq/test/move_zeiss_test.py
@@ -57,9 +57,9 @@ class TestMeteorZeiss1Move(move_tfs1_test.TestMeteorTFS1Move):
         self.assertAlmostEqual(beta, estimated_beta, places=5, msg="The stage moved in the wrong direction in "
                                                                    "the FM imaging grid 1 area.")
 
-    def test_transformFromSEMToMeteor(self):
+    def test_transform_from_sem_to_fm(self):
         """
-        Test the keys in stage position for _transformFromSEMToMeteor.
+        Test the keys in stage position for _transform_from_sem_to_fm.
         """
         stage_md = self.stage.getMetadata()
         grid1_pos = stage_md[model.MD_SAMPLE_CENTERS][POSITION_NAMES[GRID_1]]
@@ -67,31 +67,31 @@ class TestMeteorZeiss1Move(move_tfs1_test.TestMeteorTFS1Move):
         # Above position are updated in linear axes and do not have rotation axes,
         # so should raise KeyError when rotation axes are accessed
         with self.assertRaises(KeyError):
-            self.posture_manager._transformFromSEMToMeteor(grid1_pos)
+            self.posture_manager._transform_from_sem_to_fm(grid1_pos)
         with self.assertRaises(KeyError):
-            self.posture_manager._transformFromSEMToMeteor(grid2_pos)
+            self.posture_manager._transform_from_sem_to_fm(grid2_pos)
 
         # update the stage with rotation axes
         grid1_pos.update(stage_md[model.MD_FAV_SEM_POS_ACTIVE])
         grid2_pos.update(stage_md[model.MD_FAV_SEM_POS_ACTIVE])
 
         # check if no error is raised (test fails if error is raised)
-        fm_grid_1_pos = self.posture_manager._transformFromSEMToMeteor(grid1_pos)
+        fm_grid_1_pos = self.posture_manager._transform_from_sem_to_fm(grid1_pos)
         self.stage.moveAbs(fm_grid_1_pos).result()
-        current_grid = self.posture_manager.getCurrentGridLabel()
+        current_grid = self.posture_manager.get_current_grid_label()
         self.assertEqual(GRID_1, current_grid)
-        fm_grid_2_pos = self.posture_manager._transformFromSEMToMeteor(grid2_pos)
+        fm_grid_2_pos = self.posture_manager._transform_from_sem_to_fm(grid2_pos)
         self.stage.moveAbs(fm_grid_2_pos).result()
-        current_grid = self.posture_manager.getCurrentGridLabel()
+        current_grid = self.posture_manager.get_current_grid_label()
         self.assertEqual(GRID_2, current_grid)
 
     def test_unknown_label_at_initialization(self):
         # Find a position that is not in any defined posture i.e. it is outside the imaging range
         arbitrary_position = {"x": 0.0, "y": 0.0, "z": 0.0e-3}
         self.stage.moveAbs(arbitrary_position).result()
-        current_imaging_mode = self.posture_manager.getCurrentPostureLabel()
+        current_imaging_mode = self.posture_manager.get_current_posture_label()
         self.assertEqual(UNKNOWN, current_imaging_mode)
-        current_grid = self.posture_manager.getCurrentGridLabel()
+        current_grid = self.posture_manager.get_current_grid_label()
         self.assertEqual(current_grid, None)
 
 

--- a/src/odemis/gui/cont/acquisition/cryo_z_localization.py
+++ b/src/odemis/gui/cont/acquisition/cryo_z_localization.py
@@ -205,7 +205,7 @@ class CryoZLocalizationController(object):
         if not target:
             return None
 
-        current_posture = self._tab_data.main.posture_manager.getCurrentPostureLabel()
+        current_posture = self._tab_data.main.posture_manager.get_current_posture_label()
         fm_focus_position = {'z': target.coordinates.value[2]}
         # move to target focus position
         logging.info(f"Moving to focus position: {fm_focus_position}, Target: {target.name.value}")

--- a/src/odemis/gui/cont/features.py
+++ b/src/odemis/gui/cont/features.py
@@ -148,7 +148,7 @@ class CryoFeatureController(object):
         if not feature:
             return
 
-        current_posture = self.pm.getCurrentPostureLabel()
+        current_posture = self.pm.get_current_posture_label()
         if self._main_data_model.microscope.role != "meteor":
             role = self._main_data_model.microscope.role
             logging.info(f"Currently under {POSITION_NAMES[current_posture]}, moving to feature position is not yet supported for {role}.")
@@ -263,7 +263,7 @@ class CryoFeatureController(object):
             self._panel.ctrl_feature_z.Enable(enable)
             self._panel.btn_use_current_z.Enable(enable)
         if self.acqui_mode is guimod.AcquiMode.FIBSEM:
-            current_posture = self.pm.getCurrentPostureLabel()
+            current_posture = self.pm.get_current_posture_label()
             # TODO: check if current position is near the feature position, if not, disable and show warning to user
             # TODO: acquire a new fib image for the reference, dont use the existing.
             self._panel.btn_feature_save_position.Enable(enable and current_posture == MILLING)

--- a/src/odemis/gui/cont/tabs/cryo_chamber_tab.py
+++ b/src/odemis/gui/cont/tabs/cryo_chamber_tab.py
@@ -586,7 +586,7 @@ class CryoChamberTab(Tab):
         if not self._start_pos or not self._end_pos:
             return
         # Get the ratio of the current position in respect to the start/end position
-        val = self.posture_manager.getMovementProgress(pos, self._start_pos, self._end_pos)
+        val = self.posture_manager.get_movement_progress(pos, self._start_pos, self._end_pos)
         if val is None:
             return
         val = min(max(0, int(round(val * 100))), 100)
@@ -720,7 +720,7 @@ class CryoChamberTab(Tab):
                             break
 
             # Turn on (green) the Grid button
-            current_grid_label = self.posture_manager.getCurrentGridLabel()
+            current_grid_label = self.posture_manager.get_current_grid_label()
             btn = self._grid_btns.get(current_grid_label)
             self._toggle_grid_buttons(btn)
 
@@ -893,7 +893,7 @@ class CryoChamberTab(Tab):
         self._start_pos = self._stage.position.value
         current_posture = self.posture_manager.current_posture.value
         # determine the end position for the gauge
-        end_pos = self.posture_manager.getTargetPosition(self._target_posture)
+        end_pos = self.posture_manager.get_target_position(self._target_posture)
 
         if self._role == 'enzel':
             if (
@@ -911,7 +911,7 @@ class CryoChamberTab(Tab):
                 return None
 
         self._end_pos = end_pos
-        return self.posture_manager.cryoSwitchSamplePosition(self._target_posture)
+        return self.posture_manager.cryo_switch_sample_position(self._target_posture)
 
     @call_in_wx_main
     def _on_posture(self, posture: int) -> None:

--- a/src/odemis/gui/cont/tabs/fibsem_tab.py
+++ b/src/odemis/gui/cont/tabs/fibsem_tab.py
@@ -373,7 +373,7 @@ class FibsemTab(Tab):
         # update stage pos label
         rx = math.degrees(pos["rx"])
         rz = math.degrees(pos["rz"])
-        posture = self.pm.getCurrentPostureLabel(pos)  # Cannot use current_posture as it may be not yet updated
+        posture = self.pm.get_current_posture_label(pos)  # Cannot use current_posture as it may be not yet updated
         pos_name = POSITION_NAMES[posture]
 
         # TODO: move this to legend.py
@@ -413,7 +413,7 @@ class FibsemTab(Tab):
 
     def _update_milling_angle(self, evt: wx.Event):
         # Check if already at milling posture
-        already_at_milling = self.pm.getCurrentPostureLabel() == MILLING
+        already_at_milling = self.pm.get_current_posture_label() == MILLING
 
         # update the metadata of the stage
         milling_angle = math.radians(self.panel.ctrl_milling_angle.GetValue())
@@ -442,13 +442,13 @@ class FibsemTab(Tab):
             self._move_to_milling_posture(None)
 
     def _move_to_milling_posture(self, evt: wx.Event):
-        self._posture_switch_future = self.pm.cryoSwitchSamplePosition(MILLING)
+        self._posture_switch_future = self.pm.cryo_switch_sample_position(MILLING)
 
         # Do NOT call f.result(). Instead, add a callback:
         self._posture_switch_future.add_done_callback(self._on_move_complete)
 
     def _move_to_sem_posture(self, evt: wx.Event):
-        self._posture_switch_future = self.pm.cryoSwitchSamplePosition(SEM_IMAGING)
+        self._posture_switch_future = self.pm.cryo_switch_sample_position(SEM_IMAGING)
         self._posture_switch_future.add_done_callback(self._on_move_complete)
 
     @call_in_wx_main

--- a/src/odemis/gui/cont/tabs/mimas_align_tab.py
+++ b/src/odemis/gui/cont/tabs/mimas_align_tab.py
@@ -169,7 +169,7 @@ class MimasAlignTab(Tab):
         # starting the first move, add a "done_callback" to handle the moves in
         # the background.
 
-        current_pos_label = self.posture_manager.getCurrentPostureLabel()
+        current_pos_label = self.posture_manager.get_current_posture_label()
 
         if current_pos_label not in (FM_IMAGING, MILLING):
             logging.warning("Cannot reset Z alignment while current position is %s.",
@@ -220,7 +220,7 @@ class MimasAlignTab(Tab):
         self.panel.btn_position_opt.SetValue(0)
 
         # create a future and update the appropriate controls after it is called
-        self._move_future = self.posture_manager.cryoSwitchSamplePosition(MILLING)
+        self._move_future = self.posture_manager.cryo_switch_sample_position(MILLING)
         self._move_future.add_done_callback(self._on_pos_move_done)
 
     def _set_flm_alignment_mode(self, evt):
@@ -233,7 +233,7 @@ class MimasAlignTab(Tab):
         self.panel.btn_position_fib.SetValue(0)
 
         # create a future and update the appropriate controls after it is called
-        self._move_future = self.posture_manager.cryoSwitchSamplePosition(FM_IMAGING)
+        self._move_future = self.posture_manager.cryo_switch_sample_position(FM_IMAGING)
         self._move_future.add_done_callback(self._on_pos_move_done)
 
     @call_in_wx_main
@@ -252,7 +252,7 @@ class MimasAlignTab(Tab):
         self.tab_data_model.main.is_acquiring.value = False
 
         # Automatically activates the Optical stream at the end of a move
-        current_pos_label = self.posture_manager.getCurrentPostureLabel()
+        current_pos_label = self.posture_manager.get_current_posture_label()
         if current_pos_label == FM_IMAGING:
             self._opt_spe.stream.should_update.value = True
 
@@ -292,7 +292,7 @@ class MimasAlignTab(Tab):
         disabling other buttons.
         """
         # Check the status of objective/aligner
-        current_pos_label = self.posture_manager.getCurrentPostureLabel()
+        current_pos_label = self.posture_manager.get_current_posture_label()
 
         # turn green from orange icon when the position is reached
         # Keep the current button pressed and other buttons unpressed - toggle switch action

--- a/src/odemis/gui/model/tab_gui_data.py
+++ b/src/odemis/gui/model/tab_gui_data.py
@@ -329,7 +329,7 @@ class CryoGUIData(MicroscopyGUIData):
         """
         # set the posture position
         pm = self.main.posture_manager
-        posture = pm.getCurrentPostureLabel(stage_position)
+        posture = pm.get_current_posture_label(stage_position)
 
         if not f_name:
             existing_names = [f.name.value for f in self.main.features.value]

--- a/src/odemis/gui/util/__init__.py
+++ b/src/odemis/gui/util/__init__.py
@@ -290,7 +290,7 @@ def enable_tab_on_stage_position(tab, posture_manager, target, tooltip=None):
     :param target: (list) target position labels for which the tab button is enabled [IMAGING, FM_IMAGING]
     :param tooltip: (str or None) Tooltip message to show when disabled
     """
-    within_target = posture_manager.getCurrentPostureLabel() in target
+    within_target = posture_manager.get_current_posture_label() in target
     tab.should_be_enabled = within_target
     tab.button.Enable(within_target)
 


### PR DESCRIPTION
The meteor posture manager located at `src/odemis/acq/move.py` has a lot of methods not complying with PEP8. Furthermore there is inconsistency in how we use METEOR and FM. The PR refactors the module to improve on these aspects.

# Tests
## move_tescan_test.py
```
Ran 28 tests in 1086.295s

OK (skipped=3)
```

## move_tfs3_test.py
```
======================================================================
FAIL: test_switching_movements (__main__.TestMeteorTFS3FIBSEMMove.test_switching_movements)
Test switching between different postures and check that the 3D transformations work as expected
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/tim/development/odemis/src/odemis/acq/test/move_tfs3_test.py", line 88, in test_switching_movements
    self.assertEqual(self.pm.current_posture.value, MILLING)
AssertionError: 6 != 5

----------------------------------------------------------------------
Ran 18 tests in 242.138s

FAILED (failures=1)

```

I guess this is an known failure not introduced by this PR