### PR TITLE
Fix for Redundant assignment

### DIFF
--- a/src/odemis/driver/technolution.py
+++ b/src/odemis/driver/technolution.py
@@ -1986,7 +1986,6 @@ class AsmApiException(Exception):
         url = url
         status_code = response.status_code
         reason = response.reason
-        expected_status = expected_status
 
         try:
             content_translated = json.loads(response.content)


### PR DESCRIPTION
The best fix is to remove the redundant self-assignment(s) in `AsmApiException.__init__`, specifically the flagged `expected_status = expected_status` line (and similarly redundant `url = url` if included in same cleanup). This preserves existing functionality because the constructor already receives these values as parameters and uses them directly in subsequent method calls.

In `src/odemis/driver/technolution.py`, within `AsmApiException.__init__` around lines 1986–1989, delete the self-assignment line for `expected_status`. No imports, helper methods, or new definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._