### PR TITLE
[fix] driver technolution:  remove redundant assignment

### DIFF
--- a/src/odemis/driver/technolution.py
+++ b/src/odemis/driver/technolution.py
@@ -1983,10 +1983,8 @@ class AsmApiException(Exception):
         :param response (requests.models.Response object): full/raw response from the ASM API
         :param expected_status (int): the expected status code
         """
-        url = url
         status_code = response.status_code
         reason = response.reason
-        expected_status = expected_status
 
         try:
             content_translated = json.loads(response.content)


### PR DESCRIPTION
The best fix is to remove the redundant self-assignment(s) in `AsmApiException.__init__` while preserving behavior.  
Specifically in `src/odemis/driver/technolution.py` around lines 1986–1990, delete `url = url` (and the same-pattern redundant `expected_status = expected_status`, which is the same defect class). Keep meaningful assignments from `response` (`status_code`, `reason`) untouched. No imports, new methods, or dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._