### PR TITLE
[fix] missing extend arg when loading streams via cli

### DIFF
--- a/src/odemis/gui/cont/tabs/analysis_tab.py
+++ b/src/odemis/gui/cont/tabs/analysis_tab.py
@@ -342,13 +342,18 @@ class AnalysisTab(StreamLoadMixin, Tab):
         return spectrum, temporalspectrum, timecorrelator, angularspectrum
 
     @call_in_wx_main
-    def load_streams(self, das: List[Union[model.DataArray, model.DataArrayShadow]], filename, extend):
+    def load_streams(
+        self,
+        das: List[Union[model.DataArray, model.DataArrayShadow]],
+        filename: os.PathLike,
+        extend: bool = False
+    ) -> None:
         """
         Method to streamline the loading/display of streams with other tabs, without breaking existing code.
         :param das: the data to load
         :param filename: name of the file containing the data, for information display purposes.
         :param extend: if False, will ensure that the previous streams are closed.
-          If True, will add the new file to the current streams opened.
+          If True, will add the new file to the current streams opened. Default is False.
         """
         self.display_new_data(filename, das, extend)
 


### PR DESCRIPTION
Fixes an error introduced in [[MSD-350][feat] Ensure pyramidal tiff on import](https://github.com/delmic/odemis/commit/3a99f3269ffcb0ce0fb9a0d0f7ad019aa9eca8b4) on  Jun 8, 2026. Initial development focused solely on importing files via the GUI tab interfaces. But there is in fact another way of importing data, and that is via the `--file` argument of the Odemis GUI CLI. Reproduction: `odemis-gui --standalone --file <filepath>`. Stack trace:


```
18:30:13 ERROR   main           : Traceback (most recent call last):
  File "/home/piel/.local/lib/python3.12/site-packages/wx/core.py", line 2338, in Notify
    self.notify()
  File "/home/piel/.local/lib/python3.12/site-packages/wx/core.py", line 3550, in Notify
    self.result = self.callable(*self.args, **self.kwargs)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/piel/development/odemis/src/odemis/gui/cont/tabs/stream_load_mixin.py", line 80, in load_data
    self.load_streams(data, filename=filename, **kwargs)
  File "/usr/lib/python3/dist-packages/decorator.py", line 231, in fun
    args, kw = fix(args, kw, sig)
               ^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/decorator.py", line 203, in fix
    ba = sig.bind(*args, **kwargs)
         ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/inspect.py", line 3242, in bind
    return self._bind(args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/inspect.py", line 3212, in _bind
    raise TypeError('missing a required argument: {arg!r}'. \
TypeError: missing a required argument: 'extend'
```

[MSD-350]: https://delmic.atlassian.net/browse/MSD-350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ