### PR TITLE
[MSD-302][feat] milling patterns takes spot size input

### DIFF
--- a/src/odemis/acq/milling/milling_tasks.yaml
+++ b/src/odemis/acq/milling/milling_tasks.yaml
@@ -14,6 +14,7 @@
     field_of_view: 8e-05
     mode: 'Serial'
     channel: 'ion'
+    spot_size: 5.0e-09
   patterns:
     - name: 'Microexpansion'
       width: 0.5e-06
@@ -31,6 +32,7 @@
     field_of_view: 8e-05
     mode: 'Serial'
     channel: 'ion'
+    spot_size: 5.0e-09
   patterns:
     - name: 'Rough Trench'
       width: 1.0e-05
@@ -48,6 +50,7 @@
     field_of_view: 8e-05
     mode: 'Serial'
     channel: 'ion'
+    spot_size: 5.0e-09
   patterns:
     - name: 'Rough Trench 02'
       width: 9.5e-6
@@ -65,6 +68,7 @@
     field_of_view: 8e-05
     mode: 'Serial'
     channel: 'ion'
+    spot_size: 5.0e-09
   patterns:
     - name: 'Polishing Trench 01'
       width: 9.0e-06
@@ -82,6 +86,7 @@
     field_of_view: 8e-05
     mode: 'Serial'
     channel: 'ion'
+    spot_size: 5.0e-09
   patterns:
     - name: 'Polishing Trench 02'
       width: 8.5e-06

--- a/src/odemis/acq/milling/tasks.py
+++ b/src/odemis/acq/milling/tasks.py
@@ -36,13 +36,15 @@ from odemis.acq.milling.patterns import (
 class MillingSettings:
     """Represents milling settings for a single milling task"""
 
-    def __init__(self, current: float, voltage: float, field_of_view: float, mode: str = "Serial", channel: str = "ion", align: bool = True):
+    def __init__(self, current: float, voltage: float, field_of_view: float, mode: str = "Serial",
+                 channel: str = "ion", align: bool = True, spot_size: float = 5.0e-09):
         self.current = model.FloatContinuous(current, unit="A", range=(20e-12, 120e-9))
         self.voltage = model.FloatContinuous(voltage, unit="V", range=(0, 30e3))
         self.field_of_view = model.FloatContinuous(field_of_view, unit="m", range=(50e-06, 960e-06))
         self.mode = model.StringEnumerated(mode, choices={"Serial", "Parallel"})
         self.channel = model.StringEnumerated(channel, choices={"ion"})
-        self.align = model.BooleanVA(align) # align at the milling current
+        self.align = model.BooleanVA(align)  # align at the milling current
+        self.spot_size = model.FloatContinuous(spot_size, unit="m", range=(5.0e-09, 1.0e-06))  # FIB beam spot size (diameter)
 
     def to_dict(self) -> dict:
         return {"current": self.current.value,
@@ -50,7 +52,8 @@ class MillingSettings:
                 "field_of_view": self.field_of_view.value,
                 "mode": self.mode.value,
                 "channel": self.channel.value,
-                "align": self.align.value}
+                "align": self.align.value,
+                "spot_size": self.spot_size.value}
 
     @staticmethod
     def from_dict(data: dict) -> "MillingSettings":
@@ -59,7 +62,8 @@ class MillingSettings:
                                 field_of_view=data["field_of_view"],
                                 mode=data.get("mode", "Serial"),
                                 channel=data.get("channel", "ion"),
-                                align=data.get("align", True)
+                                align=data.get("align", True),
+                                spot_size=data.get("spot_size", 5.0e-09)
                                 )
 
     def __repr__(self):

--- a/src/odemis/gui/comp/milling.py
+++ b/src/odemis/gui/comp/milling.py
@@ -67,6 +67,7 @@ class MillingTaskPanel(wx.Panel):
             "current": {"label": "Current", "accuracy": 2, "unit": "A"},
             "align": {"label": "Align at milling current"},
             "mode": {"label": "Milling mode"},
+            "spot_size": {"label": "Spot Size", "accuracy": 2, "unit": "m"},
             "width": {"label": "Width", "accuracy": 2, "unit": "m"},
             "height": {"label": "Height", "accuracy": 2, "unit": "m"},
             "depth": {"label": "Depth", "accuracy": 2, "unit": "m"},
@@ -83,8 +84,7 @@ class MillingTaskPanel(wx.Panel):
                 continue
 
             conf = CONFIG.get(param, {})
-            label = conf.get("label", param)
-            del conf["label"]
+            label = conf.pop("label", None)
 
             val = getattr(task.milling, param)
             self._add_value_field(label, val, conf, param=param)
@@ -97,8 +97,7 @@ class MillingTaskPanel(wx.Panel):
                 continue
 
             conf = CONFIG.get(param, {})
-            label = conf.get("label", param)
-            del conf["label"]
+            label = conf.pop("label", None)
 
             val = getattr(pattern, param)
             self._add_value_field(label, val, conf, param=param)

--- a/src/odemis/gui/cont/milling.py
+++ b/src/odemis/gui/cont/milling.py
@@ -100,13 +100,28 @@ def pos_to_absolute(pos: Tuple[float, float], ref_img: model.DataArray) -> Tuple
 def rectangle_pattern_to_shape(canvas,
                         ref_img: model.DataArray,
                         pattern: RectanglePatternParameters,
+                        spot_size: float,
                         colour: str = "#FFFF00",
                         name: str = None) -> EditableShape:
-    """Convert a rectangle pattern to a shape"""
-    rect = RectangleOverlay(cnvs=canvas, colour = colour, show_selection_points = False)
+    """
+    Convert a rectangle pattern to a shape, taking spot size of the beam into account.
+
+    :param canvas: Canvas object to draw shapes on
+    :param ref_img: Reference image on which the shapes are drawn
+    :param pattern: provide type of shape and its parameters
+    :param spot_size: spot size in m (beam diameter)
+    :param colour: colour of the shape
+    :param name: name of the shape, e.g. Rough Milling, Polishing etc.
+    """
+    rect = RectangleOverlay(cnvs=canvas, colour=colour, show_selection_points=False)
     width = pattern.width.value
     height = pattern.height.value
-    x, y = pos_to_absolute(pattern.center.value, ref_img) # image coordinates -> physical coordinates
+    # Expand each dimension by the spot size (diameter) to circumscribe the beam path
+    # Since spot_size is the beam diameter, the beam will affect the area by half the spot size on each side
+    # of the rectangle, so we add the full spot size to each dimension.
+    width_expanded = width + spot_size
+    height_expanded = height + spot_size
+    x, y = pos_to_absolute(pattern.center.value, ref_img)  # image coordinates -> physical coordinates
     if name is not None:
         rect.name.value = name
 
@@ -115,10 +130,10 @@ def rectangle_pattern_to_shape(canvas,
     # |     |
     # 4  -  3
 
-    rect.p_point1 = Vec(x - width / 2, y + height / 2)
-    rect.p_point2 = Vec(x + width / 2, y + height / 2)
-    rect.p_point3 = Vec(x + width / 2, y - height / 2)
-    rect.p_point4 = Vec(x - width / 2, y - height / 2)
+    rect.p_point1 = Vec(x - width_expanded / 2, y + height_expanded / 2)
+    rect.p_point2 = Vec(x + width_expanded / 2, y + height_expanded / 2)
+    rect.p_point3 = Vec(x + width_expanded / 2, y - height_expanded / 2)
+    rect.p_point4 = Vec(x - width_expanded / 2, y - height_expanded / 2)
 
     # required for initialisation?
     rect._phys_to_view()
@@ -224,9 +239,8 @@ class MillingTaskController:
 
         # create the setting panels, and connectors
         self.controls: Dict[str, MillingTaskPanel] = {}
-        pattern_parameters = ["width", "height", "depth", "spacing"] # TODO: add milling params
-        # milling params: current, voltage, field of view, mode
-        milling_parameters = ["current", "align", "mode"]
+        pattern_parameters = ["width", "height", "depth", "spacing"]
+        milling_parameters = ["current", "align", "mode", "spot_size"]
 
         # Note: always create all the panels, but hide for which the task is not selected.
         # This way, when a task is selected, we can just show the panel without having to create it.
@@ -273,7 +287,7 @@ class MillingTaskController:
                 self.controls[task_name][f"{param}_connector"] = _va_connector
 
                 # VA connector, bind events
-                getattr(milling, param).subscribe(self._on_patterns)
+                val.subscribe(self._on_patterns)
 
             if not task.selected:
                 panel.Hide()
@@ -415,6 +429,7 @@ class MillingTaskController:
                                             canvas=self.canvas,
                                             ref_img=feature.reference_image,
                                             pattern=pshape,
+                                            spot_size=task.milling.spot_size.value,
                                             colour=_get_milling_colour(task_name, i),
                                             name=name)
                     self.rectangles_overlay.add_shape(shape)
@@ -512,8 +527,8 @@ class MillingTaskController:
         """
         Updates milling time and availability of the mill button when there's an update on the patterns
         """
-
         logging.warning(f"Pattern updated: {dat}")
+        save_project(self._tab_data.main)
         self.draw_milling_tasks()
 
     def _cancel_milling_series(self, _):


### PR DESCRIPTION
The “hole size” parameter of the Essence preset (in XML) currently contains the diameter of the orifice that will be milled out by FIB. The milling boxes displayed in Odemis should circumscribe the beam path to account for so-called beam tails.

