### PR TITLE
[MSD-616][feat] FIB-view FM correlation workflow

### DIFF
--- a/src/odemis/acq/move.py
+++ b/src/odemis/acq/move.py
@@ -379,7 +379,7 @@ class MeteorPostureManager(MicroscopePostureManager):
         self.has_fib_view_fm_objective = False
         try:
             lens = model.getComponent(role='lens')
-            if model.hasVA(lens, "workingDistance") and lens.workingDistance.value > MIN_LENS_WD_FIB_VIEW_FM:
+            if model.hasVA(lens, "workingDistance") and lens.workingDistance.value >= MIN_LENS_WD_FIB_VIEW_FM:
                 self.has_fib_view_fm_objective = True
         except LookupError:
             pass
@@ -1120,7 +1120,6 @@ class MeteorPostureManager(MicroscopePostureManager):
         elif source_posture == FIB_VIEW_FM and target_posture != MILLING:
             return False
         elif source_posture == LOADING:
-            # From loading, we always allow to go to SEM imaging
             if target_posture == SEM_IMAGING:
                 return True
             # When we are at the loading position, we internally work with the SEM imaging source posture
@@ -1128,7 +1127,7 @@ class MeteorPostureManager(MicroscopePostureManager):
             else:
                 source_posture = SEM_IMAGING
 
-        # Otherwise, check for availability in posture transforms
+        # Check for availability in posture transforms
         transform_available = bool(
             self._posture_transforms.get(source_posture, {}).get(target_posture, False)
         )

--- a/src/odemis/gui/cont/features.py
+++ b/src/odemis/gui/cont/features.py
@@ -39,11 +39,12 @@ from odemis.acq.feature import (
     TargetType
 )
 from odemis.acq.move import (
+    FIB_IMAGING,
+    FIB_VIEW_FM,
     FM_IMAGING,
     MILLING,
     POSITION_NAMES,
     SEM_IMAGING,
-    FIB_IMAGING,
 )
 from odemis.gui import model as guimod
 from odemis.gui.conf.licences import LICENCE_MILLING_ENABLED
@@ -53,7 +54,7 @@ from odemis.gui.util import call_in_wx_main
 from odemis.gui.util.widgets import VigilantAttributeConnector
 
 
-SUPPORTED_POSTURES = [SEM_IMAGING, FM_IMAGING, MILLING, FIB_IMAGING]
+SUPPORTED_POSTURES = [SEM_IMAGING, FM_IMAGING, MILLING, FIB_IMAGING, FIB_VIEW_FM]
 
 class CryoFeatureController(object):
     """ controller to handle the cryo feature panel elements

--- a/src/odemis/gui/cont/multi_point_correlation.py
+++ b/src/odemis/gui/cont/multi_point_correlation.py
@@ -23,6 +23,7 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 from __future__ import annotations  # allows the use of Python3.9 style typing in Python3.8
 
 import logging
+import math
 import queue
 import re
 import threading
@@ -32,21 +33,20 @@ from typing import List, Union, Optional, Tuple, Dict, Set
 
 import numpy
 import wx
-# IMPORTANT: wx.html needs to be imported for the HTMLWindow defined in the XRC
-# file to be correctly identified. See: http://trac.wxwidgets.org/ticket/3626
-# This is not related to any particular wxPython version and is most likely permanent.
 
 from odemis import model, util
 from odemis.acq.align.tdct import _convert_das_to_numpy_stack, run_tdct_correlation
 from odemis.acq.feature import FIBFMCorrelationData, Target, TargetType
+from odemis.acq.move import POSITION_NAMES, FM_IMAGING, FIB_VIEW_FM
 from odemis.acq.stream import StaticFluoStream, StaticSEMStream, StaticFIBStream, FluoStream
-from odemis.gui import conf
-from odemis.gui.model import CryoGUIData
 from odemis.gui.cont.features import save_project
+from odemis.gui.img import getBitmap
+from odemis.gui.model import CryoGUIData
 from odemis.gui.util import call_in_wx_main
 from odemis.model import ListVA
 from odemis.util.dataio import data_to_static_streams
 from odemis.util.img import get_brightest_channel, compute_center_of_mass
+from odemis.util.transform import SimilarityTransform
 from odemis.util.units import readable_str
 
 # create an enum with column labels and position
@@ -68,8 +68,11 @@ RIM_COR_DEFAULT = 0.495  # See MD_RIM_COR. This value works fine for 50x objecti
 # conditions to convert between physical and pixel coordinate systems in order for multipoint correlation to operate.
 # For coordinate conversions, we assume the pixels in 3D are isosymmetric
 # i.e. size in pixel[0]=pixel[1]=pixel[2].
-COM_ROI_PADDING = 12  # Padding (pixels) for center of mass ROI extraction
-# TODO: Could adapt padding based on pixel spacing for more flexibility if needed
+REFINE_SEARCH_RANGE = 2.5e-6  # m, search range for fiducial refinement
+
+# If the milling angle of a FIB image and an FM z-stack are below the tolerance, they are considered to be matching.
+MILLING_ANGLE_TOLERANCE = math.radians(0.1)  # Now 0.1 degree, but this depends on stage accuracy, so might need to update this later.
+
 
 def get_pixel_3d_coordinates(stream: FluoStream, p_pos: Tuple[float, float, float], check_bbox: bool = False) \
         -> Optional[Tuple[float, float, float]]:
@@ -168,6 +171,42 @@ class CorrelationPointsController:
         self._main_data_model = self._tab_data_model.main
         self._panel = frame
         self._viewports = frame.pnl_correlation_grid.viewports
+
+        streams = self._main_data_model.currentFeature.value.streams.value
+        z_stacks = [s for s in streams if isinstance(s, StaticFluoStream) and hasattr(s, "zIndex")]
+        pm = self._main_data_model.posture_manager
+        # Determine milling angle of reference FIB image, directly accessing without safeguards, since earlier checks
+        # should have made sure everything is present.
+        fib_pos = self._main_data_model.currentFeature.value.reference_image.metadata[model.MD_STAGE_POSITION_RAW]
+        fib_rx = fib_pos["rx"]
+        fib_mill_angle = pm.calculate_milling_angle(stage_tilt=fib_rx, column_tilt=pm.fib_column_tilt)
+        # Iterate over al z-stacks and check if there are any that are acquired at the milling angle matching the
+        # reference FIB image.
+        z_stacks_at_milling = []
+        for z_stack in z_stacks:
+            # Directly indexing without safeguards, since everything should be there.
+            z_stack_pos = z_stack.getRawMetadata()[0][model.MD_STAGE_POSITION_RAW]
+            z_stack_mill_angle = pm.calculate_milling_angle(stage_tilt=z_stack_pos["rx"], column_tilt=pm.fm_column_tilt)
+            # Consider a z-stack to be acquired at milling angle when it is acquired at the same tilt as the FIB image.
+            if (math.isclose(fib_mill_angle, z_stack_mill_angle, abs_tol=MILLING_ANGLE_TOLERANCE) and
+                math.isclose(fib_pos["rz"], z_stack_pos["rz"], abs_tol=MILLING_ANGLE_TOLERANCE)):
+                z_stacks_at_milling.append(z_stack)
+
+        at_fib_view_fm = False
+        if any(z_stacks_at_milling):
+            at_fib_view_fm = True
+
+        self.at_fib_view_fm = model.BooleanVA(at_fib_view_fm)
+
+        if self.at_fib_view_fm.value:
+            self._panel.lbl_fm_posture.SetLabel(POSITION_NAMES[FIB_VIEW_FM])
+            bmp_fib_view_fm = getBitmap("icon/ico_meteor_fib_view_fm.png")
+            self._panel.bmp_fm_posture.SetBitmap(bmp_fib_view_fm)
+        else:
+            self._panel.lbl_fm_posture.SetLabel(POSITION_NAMES[FM_IMAGING])
+            bmp_fm_imaging = getBitmap("icon/ico_meteorimaging.png")
+            self._panel.bmp_fm_posture.SetBitmap(bmp_fm_imaging)
+
         self.grid_targets = (TargetType.PointOfInterest, TargetType.Fiducial, TargetType.FibFiducial)
 
         lens_md = self._main_data_model.lens.getMetadata()
@@ -179,18 +218,14 @@ class CorrelationPointsController:
 
         # Access the Refine XYZ status text (to check if XYZ targeting is working or not)
         self.txt_refine_xyz_active = self._panel.txt_refine_xyz_active
-        self.txt_refine_xyz_active.Show(True)
 
         # Access the XYZ-targeting button
         self.xyz_targeting_btn = self._panel.btn_xyz_targeting
         self.xyz_targeting_btn.Bind(wx.EVT_BUTTON, self._on_xyz_targeting)
-        self.xyz_targeting_btn.Enable(False)
         # Disable XYZ-targeting button if super z stream is available as XYZ-targeting is not required in that case
-        self.refine_xyz_active = True
+        self.has_super_z = model.BooleanVA(False)
         if self._tab_data_model.main.currentFeature.value.superz_stream_name:
-            self.xyz_targeting_btn.SetToolTip("Super Z information available, Refine XYZ disabled")
-            self.txt_refine_xyz_active.SetLabel("Super Z information in use")
-            self.refine_xyz_active = False
+            self.has_super_z.value = True
 
         self._panel.btn_delete_row.Bind(wx.EVT_BUTTON, self._on_delete_row)
 
@@ -209,6 +244,10 @@ class CorrelationPointsController:
         self.grid.Bind(wx.EVT_KEY_DOWN, self._on_key_down_grid)
         self.grid.EnableEditing(True)
 
+        # Hide the z-column for the FIB-view FM workflow, since we only perform 2d correlation.
+        if self.at_fib_view_fm.value:
+            self.hide_grid_column(GridColumns.Z.value)
+
         # Parameters to keep track of the latest changes and process the correlation result with the latest change
         self.correlation_txt = self._panel.txt_correlation_rms
         self.correlation_txt.Show(True)
@@ -224,10 +263,7 @@ class CorrelationPointsController:
         self.previous_group: Optional[Tuple[Tuple[int, ...], Tuple[float, float]]] = None
 
         # Interpolate the fm streams such that the pixel size in z is the same as in x and y
-        streams_list = []
-        for stream in self._tab_data_model.main.currentFeature.value.streams.value:
-            if isinstance(stream, StaticFluoStream) and hasattr(stream, "zIndex"):
-                streams_list.append(StaticFluoStream(stream.name.value, stream.raw[0]))
+        streams_list = z_stacks_at_milling if self.at_fib_view_fm.value else z_stacks
 
         self.streams_list = streams_list
         self.correlation_target = self._tab_data_model.main.currentFeature.value.correlation_data
@@ -247,6 +283,51 @@ class CorrelationPointsController:
         self._add_stream_group()
 
         self._panel.fp_correlation_panel.Show(True)
+        self._update_refine_controls()
+
+    @call_in_wx_main
+    def _update_refine_controls(self) -> None:
+        if self.at_fib_view_fm.value:
+            self.xyz_targeting_btn.Enable(False)
+            self.txt_refine_xyz_active.SetLabel("")
+            self.xyz_targeting_btn.SetToolTip("Refinement disabled when using FIB-view FM streams")
+        elif self.has_super_z.value:
+            self.xyz_targeting_btn.SetToolTip("Super Z information available, Refinement disabled")
+            self.xyz_targeting_btn.Enable(False)
+            self.txt_refine_xyz_active.SetLabel("Super Z information in use")
+        elif TargetType.FibFiducial == self._tab_data_model.main.currentTarget.value.type.value:
+            self.xyz_targeting_btn.Enable(False)
+            self.txt_refine_xyz_active.SetLabel("")
+            self.xyz_targeting_btn.SetToolTip("Refinement only available for non-reflective FM streams")
+        else:
+            self.xyz_targeting_btn.Enable(True)
+            self.txt_refine_xyz_active.SetLabel("")
+            self.xyz_targeting_btn.SetToolTip("Refine the position of the currently selected FM fiducial")
+
+    @call_in_wx_main
+    def hide_grid_column(self, col_idx: int) -> None:
+        """
+        Hides the provided grid column and redistributes the remaining column widths to fill the available space.
+        :param col_idx: Column index to hide
+        """
+        # Hide the column
+        self.grid.HideCol(col_idx)
+        # Gather only the columns that are currently visible
+        visible_cols = [c for c in range(self.grid.GetNumberCols()) if self.grid.IsColShown(c)]
+
+        if not visible_cols:
+            return
+
+        # Determine usable display width
+        grid_width, _ = self.grid.GetClientSize()
+        usable_width = grid_width - self.grid.GetRowLabelSize()
+        # Divide width evenly (using integer division to avoid fractional pixels)
+        even_width = usable_width // len(visible_cols)
+        # Update sizes
+        for c in visible_cols:
+            self.grid.SetColSize(c, even_width)
+
+        self.grid.ForceRefresh()
 
     @call_in_wx_main
     def _on_fm_streams_visiblity(self, stream_projections: ListVA) -> None:
@@ -390,12 +471,13 @@ class CorrelationPointsController:
 
     def check_correlation_conditions(self) -> bool:
         """
-        Minimum 4 FIB and FM fiducials and 1 POI in FM are required to run the correlation.
+        Minimum 2 or 4 FIB and FM fiducials depending on FM posture and 1 POI in FM are required to run the correlation.
         :return: (bool) True if the conditions are met, False otherwise
         """
+        min_fiducials = 2 if self.at_fib_view_fm.value else 4
         if self.correlation_target:
-            if ((len(self.correlation_target.fib_fiducials) >= 4 and
-                 len(self.correlation_target.fm_fiducials) >= 4 and len(self.correlation_target.fm_pois) >= 1 and
+            if ((len(self.correlation_target.fib_fiducials) >= min_fiducials and
+                 len(self.correlation_target.fm_fiducials) >= min_fiducials and len(self.correlation_target.fm_pois) >= 1 and
                  len(self._tab_data_model.views.value[0].stream_tree) > 0) and self.correlation_target.fib_stream and
                     (len(self.correlation_target.fm_fiducials) == len(self.correlation_target.fib_fiducials))):
                 return True
@@ -403,7 +485,7 @@ class CorrelationPointsController:
                 self.correlation_target.clear()
                 self._tab_data_model.projected_points = []
                 self.correlation_txt.SetLabel("To run correlation, please add \n"
-                                              "minimum 4 FIB-FM fiducial pairs, 1 POI in FM.")
+                                              f"minimum {min_fiducials} FIB-FM fiducial pairs, 1 POI in FM.")
                 self._panel.Layout()
                 # Update the FIB viewport because it shows the output overlays
                 # It is the second viewport out of total two viewports
@@ -441,10 +523,15 @@ class CorrelationPointsController:
     def _process_latest_change(self):
         """Process the latest change in the queue."""
         self.is_processing = True
-        self._do_correlation()
+        if self.at_fib_view_fm.value:
+            self._do_2d_correlation()
+        else:
+            self._do_3d_correlation()
+
         rms = self.correlation_target.correlation_result["output"]["error"]["rms_error"]
         wx.CallAfter(self.correlation_txt.SetLabel,
                      f"Correlation RMS Deviation : {readable_str(rms, sig=3)}")
+
         # Display the output in the relevant views
         self._viewports[1].canvas.Refresh()
         self.is_processing = False  # Mark that processing is complete
@@ -460,8 +547,63 @@ class CorrelationPointsController:
         self._tab_data_model.views.value[0].stream_tree.flat.unsubscribe(self._on_fm_streams_visiblity)
         self.worker_thread.join(5)
 
-    def _do_correlation(self):
-        """Run the correlation between the FIB and FM images."""
+    def _do_2d_correlation(self):
+        """Run the 2d correlation between the FIB and FM images."""
+        index_order = []  # append the same index order to the projected points as the input fiducials
+        fib_coords = []
+        fm_coords = []
+
+        for fib_coord in self.correlation_target.fib_fiducials:
+            index_order.append(fib_coord.index.value)
+            fib_coord_px = self.correlation_target.fib_stream.getPixelCoordinates(
+                fib_coord.coordinates.value[0:2], check_bbox=False
+            )
+            fib_coords.append(fib_coord_px)
+
+        for fm_coord in self.correlation_target.fm_fiducials:
+            fm_coord_px = get_pixel_3d_coordinates(
+                self.correlation_target.fm_streams[0], fm_coord.coordinates.value
+            )[:2]
+            fm_coords.append(fm_coord_px)
+
+        fib_coords = numpy.array(fib_coords)
+        fm_coords = numpy.array(fm_coords)
+        # Perform registration
+        transform = SimilarityTransform.from_pointset(fm_coords, fib_coords)
+        poi_coord = self.correlation_target.fm_pois[0]
+        poi_coord_px = get_pixel_3d_coordinates(self.correlation_target.fm_streams[0], poi_coord.coordinates.value)[:2]
+        poi_transformed = transform.apply(poi_coord_px)
+
+        projected_poi = self.correlation_target.fib_stream.getPhysicalCoordinates(poi_transformed)
+        projected_poi_target = Target(x=projected_poi[0], y=projected_poi[1], z=0, name="PPOI",
+                                      type=TargetType.ProjectedPOI,
+                                      index=1,
+                                      fm_focus_position=0)
+        # Apply coordinates
+        self._tab_data_model.projected_points = [projected_poi_target]
+        self.correlation_target.fib_projected_pois = [projected_poi_target]
+
+        # Project other points for visualization
+        # Update the output parameters of the correlation
+        self.correlation_target.fib_projected_fiducials = []
+        fm_coords_transformed = transform.apply(fm_coords)
+        for i, point in enumerate(fm_coords_transformed):
+            p_pos = self.correlation_target.fib_stream.getPhysicalCoordinates(point)
+            target = Target(x=p_pos[0], y=p_pos[1], z=0, name="PP" + str(index_order[i]),
+                            type=TargetType.ProjectedFiducial, index=index_order[i],
+                            fm_focus_position=0)
+            self._tab_data_model.projected_points.append(target)
+            self.correlation_target.fib_projected_fiducials.append(target)
+
+        diffs = fib_coords - fm_coords_transformed
+        rms = float(numpy.sqrt(numpy.mean(numpy.sum(diffs ** 2, axis=1))))
+        # Fill in error metric in similar way to 3d correlation, for consistency
+        self.correlation_target.correlation_result = {
+            "output": {"error": {"rms_error": rms}},
+        }
+
+    def _do_3d_correlation(self):
+        """Run the 3d correlation between the FIB and FM images."""
         # Modify the input data to match the required format to run 3DCT
         fm_das = [stream.raw[0] for stream in self.correlation_target.fm_streams]
         fm_image = _convert_das_to_numpy_stack(fm_das)
@@ -698,7 +840,6 @@ class CorrelationPointsController:
         # For new targets, automatically perform Z targeting if MIP is checked for at least one FM stream
         if not target:
             self.grid.ClearSelection()
-            self.xyz_targeting_btn.Enable(False)
             return
 
         # Only check for visible and non-reflective streams, since the refinement method is discarding other streams
@@ -709,26 +850,22 @@ class CorrelationPointsController:
         ]
         mip_enabled = any(stream.max_projection.value for stream in visible_streams)
 
-        self.xyz_targeting_btn.Enable(False)
-        # Refine xyz should be disabled if the Z information was obtained using SuperZ
-        if self.refine_xyz_active and (target.type.value in self.grid_targets):
-            if TargetType.FibFiducial == target.type.value:
-                self.xyz_targeting_btn.Enable(False)
-            else:
-                self.xyz_targeting_btn.Enable(True)
-                if target.needs_refinement.value:
-                    if mip_enabled:
-                        self._on_xyz_targeting()
-                    # When there is just one stream without MIP, use the currently selected z index
-                    elif len(visible_streams) == 1 and hasattr(visible_streams[0], "zIndex"):
-                        # We only care about z, so pass placeholders for x and y
-                        physical_coords = get_physical_3d_coordinates(
-                            visible_streams[0], (0, 0, visible_streams[0].zIndex.value))
-                        # Update the model with the refined 3D coordinates
-                        target_coords = target.coordinates.value
-                        target_coords[2] = physical_coords[2]
-                    # Reset refinement
-                    target.needs_refinement.value = False
+        self._update_refine_controls()
+        # Refine xyz should be disabled if the Z information was obtained using SuperZ or when using FIB-view FM
+        if not self.has_super_z.value and not self.at_fib_view_fm.value and (target.type.value in self.grid_targets):
+            if target.needs_refinement.value and TargetType.FibFiducial != target.type.value:
+                if mip_enabled:
+                    self._on_xyz_targeting()
+                # When there is just one stream without MIP, use the currently selected z index
+                elif len(visible_streams) == 1 and hasattr(visible_streams[0], "zIndex"):
+                    # We only care about z, so pass placeholders for x and y
+                    physical_coords = get_physical_3d_coordinates(
+                        visible_streams[0], (0, 0, visible_streams[0].zIndex.value))
+                    # Update the model with the refined 3D coordinates
+                    target_coords = target.coordinates.value
+                    target_coords[2] = physical_coords[2]
+                # Reset refinement
+                target.needs_refinement.value = False
 
         for row in range(self.grid.GetNumberRows()):
             if self._selected_target_in_grid(target, row):
@@ -858,10 +995,12 @@ class CorrelationPointsController:
             raw_multi = numpy.asarray([s.raw[0] for s in streams])
             shape_y, shape_x = raw_multi.shape[-2], raw_multi.shape[-1]
             # Get boundary-safe slice & crop
-            y_start = max(0, target_y - COM_ROI_PADDING)
-            y_end = min(shape_y, target_y + COM_ROI_PADDING + 1)
-            x_start = max(0, target_x - COM_ROI_PADDING)
-            x_end = min(shape_x, target_x + COM_ROI_PADDING + 1)
+            pixel_size = streams[0].getRawMetadata()[0][model.MD_PIXEL_SIZE][0]  # Always present, so direct indexing
+            pixel_padding = int(REFINE_SEARCH_RANGE / pixel_size)
+            y_start = max(0, target_y - pixel_padding)
+            y_end = min(shape_y, target_y + pixel_padding + 1)
+            x_start = max(0, target_x - pixel_padding)
+            x_end = min(shape_x, target_x + pixel_padding + 1)
             roi = numpy.s_[:, y_start:y_end, x_start:x_end]
             multi_crop = raw_multi[(slice(None),) + roi]  # We search along all stack slices (first axis)
             # Find best channel and compute COM

--- a/src/odemis/gui/cont/stream_bar.py
+++ b/src/odemis/gui/cont/stream_bar.py
@@ -2254,6 +2254,7 @@ class CryoAcquiredStreamsController(CryoStreamsController):
         # origin of the stream instead, but just trying both simplifies things.
         if self._current_feature:
             remove_image(self._current_feature.images.value, md[MD_FILENAME], [md[MD_IN_FILE_INDEX]])
+            self._current_feature.streams.value.remove(stream)
         remove_image(self._tab_data_model.main.overviews.value, md[MD_FILENAME], [md[MD_IN_FILE_INDEX]])
         save_project(self._tab_data_model.main)
 

--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -115,6 +115,8 @@ class xrcfr_correlation(wx.Dialog):
         self.vp_correlation_tl = xrc.XRCCTRL(self, "vp_correlation_tl")
         self.vp_correlation_tr = xrc.XRCCTRL(self, "vp_correlation_tr")
         self.scr_win_right = xrc.XRCCTRL(self, "scr_win_right")
+        self.bmp_fm_posture = xrc.XRCCTRL(self, "bmp_fm_posture")
+        self.lbl_fm_posture = xrc.XRCCTRL(self, "lbl_fm_posture")
         self.fp_correlation_panel = xrc.XRCCTRL(self, "fp_correlation_panel")
         self.pnl_correlation = xrc.XRCCTRL(self, "pnl_correlation")
         self.btn_delete_row = xrc.XRCCTRL(self, "btn_delete_row")
@@ -1999,6 +2001,35 @@ b\xeb\x85\x9f\xb6B\x1d\x0cK\x17\xac\xf0\x12\xfe\xa0\xe5\xee\xe03\xb1\xfa\
                 <object class="wxBoxSizer">
                   <orient>wxVERTICAL</orient>
                   <object class="sizeritem">
+                    <border>10</border>
+                    <flag>wxALL</flag>
+                    <object class="wxBoxSizer">
+                      <object class="sizeritem">
+                        <border>10</border>
+                        <flag>wxRIGHT|wxALIGN_CENTER_VERTICAL</flag>
+                        <object class="wxStaticText">
+                          <label>FM acquired at</label>
+                          <fg>#DDDDDD</fg>
+                        </object>
+                      </object>
+                      <object class="sizeritem">
+                        <object class="wxStaticBitmap" name="bmp_fm_posture">
+                          <bitmap>______img_icon_ico_meteorimaging_png</bitmap>
+                          <XRCED>
+                            <assign_var>1</assign_var>
+                          </XRCED>
+                        </object>
+                      </object>
+                      <object class="sizeritem">
+                        <flag>wxALIGN_CENTER_VERTICAL</flag>
+                        <object class="wxStaticText" name="lbl_fm_posture">
+                          <label>posture</label>
+                          <fg>#777777</fg>
+                        </object>
+                      </object>
+                    </object>
+                  </object>
+                  <object class="sizeritem">
                     <object class="FoldPanelBar">
                       <object class="FoldPanelItem" name="fp_correlation_panel">
                         <object class="wxPanel" name="pnl_correlation">
@@ -2134,6 +2165,26 @@ b\xeb\x85\x9f\xb6B\x1d\x0cK\x17\xac\xf0\x12\xfe\xa0\xe5\xee\xe03\xb1\xfa\
   </object>
 </resource>'''
 
+    ______img_icon_ico_meteorimaging_png = b'''\
+\x89PNG\x0d
+\x1a
+\x00\x00\x00\x0dIHDR\x00\x00\x00(\x00\x00\x00(\x08\x04\x00\x00\x00&\xf7\
+p\xe6\x00\x00\x01;IDATH\xc7c\xf8\xcf@]\xc80j\xe0\xc86\xd0#\xd2\xb3\xdc\x1b\
+\x03z\x96\xbb\x97;z\x93e`\xe0\xfe\x88\xff\x91\xff#\xfe\x87#A\x10?\xe8\xbf\
+\xc7\x02\xb2\x0c\x8c\xd8\x9f\xf0?\xe1\xec\xfd\xc8U\xe1`\x18\xb9*fU\xc2\
+\xab\x04\xa0\xa1\xbe\xe4\x19\x18\xb9?\xe9\xe2\xff\xa8/~\xea0\x910\xeb\xc4\
+?I\xff\xa3)1\x10\xa4\xdd\xff\x8c6\x1b\x88\x1f\xca\x1fy\x1f"B\x81\x81)@O\
+\x87\xfd\xf7j\x03\xf1\x83\x97\xc6\xffO\xa6\xdc\xc0\xe4\xff\xb1\xff\x83\xff\
+\xfa:\x05\xc6\xc5\xfc\x07\xf1)6\x10dD\xec\xff\xc8\xc71\x1fa<\x8a\x0d\x04\
+\x19\x92\xf8\x1f\xc1\xa6\x82\x81\xc8p\xd4\xc0Q\x03\xf1\x1a\x18\xda\x9b\x80\
+\xc5\xc0D`!\xe6\x95G\x96\x81\x0c\x8cQ\xd3\x12\xb1\xb8/\xa0\x9e\xec*\x00\
+\xddH\xc2\xc6\x11\xacS\x90\x8d$\xc68"*)\x90\x91\x09\xc0\x90K \xca8\xa2j\
+\xbd\x06\xa6\x90\x9a\xf0\x99\xa13\xfd\xb3\x07o\xbd\xec\xe9\xeb\xbb\xcak\
+\x95\x8b\x05\xd5\x0c\xf4w\x0f\xfd\x1f\xf0\xdfC\x9dj\x06\x86
+E\xfe\x0b\xfa\xd0\xc0D\xc50\x0c\xbb\xe3\xbf\x87\xaam\x1b\xff\xe5\x90\x9a\
+\x8fj\x06z\x15\xb9\x06R\xd5@g[\x07\x19\xaa\x1a\xe8\xc9>|\x1a\x9c\x00\xd1\
+"s\x15\xed\xb3\x01\xef\x00\x00\x00\x00IEND\xaeB`\x82'''
+
     ______img_icon_ico_trash_png = b'''\
 \x89PNG\x0d
 \x1a
@@ -2144,6 +2195,7 @@ b\xeb\x85\x9f\xb6B\x1d\x0cK\x17\xac\xf0\x12\xfe\xa0\xe5\xee\xe03\xb1\xfa\
 \x00\x00\x00IEND\xaeB`\x82'''
 
     wx.MemoryFSHandler.AddFile('XRC/dialog_correlation_tdct/dialog_correlation_tdct_xrc', bytearray(dialog_correlation_tdct_xrc.encode('utf-8')))
+    wx.MemoryFSHandler.AddFile('XRC/dialog_correlation_tdct/______img_icon_ico_meteorimaging_png', bytearray(______img_icon_ico_meteorimaging_png))
     wx.MemoryFSHandler.AddFile('XRC/dialog_correlation_tdct/______img_icon_ico_trash_png', bytearray(______img_icon_ico_trash_png))
     __res.Load('memory:XRC/dialog_correlation_tdct/dialog_correlation_tdct_xrc')
 

--- a/src/odemis/gui/xmlh/resources/dialog_correlation_tdct.xrc
+++ b/src/odemis/gui/xmlh/resources/dialog_correlation_tdct.xrc
@@ -66,6 +66,35 @@
                 <object class="wxBoxSizer">
                   <orient>wxVERTICAL</orient>
                   <object class="sizeritem">
+                    <border>10</border>
+                    <flag>wxALL</flag>
+                    <object class="wxBoxSizer">
+                      <object class="sizeritem">
+                        <border>10</border>
+                        <flag>wxRIGHT|wxALIGN_CENTER_VERTICAL</flag>
+                        <object class="wxStaticText">
+                          <label>FM acquired at</label>
+                          <fg>#DDDDDD</fg>
+                        </object>
+                      </object>
+                      <object class="sizeritem">
+                        <object class="wxStaticBitmap" name="bmp_fm_posture">
+                          <bitmap>../../img/icon/ico_meteorimaging.png</bitmap>
+                          <XRCED>
+                            <assign_var>1</assign_var>
+                          </XRCED>
+                        </object>
+                      </object>
+                      <object class="sizeritem">
+                        <flag>wxALIGN_CENTER_VERTICAL</flag>
+                        <object class="wxStaticText" name="lbl_fm_posture">
+                          <label>posture</label>
+                          <fg>#777777</fg>
+                        </object>
+                      </object>
+                    </object>
+                  </object>
+                  <object class="sizeritem">
                     <object class="FoldPanelBar">
                       <object class="FoldPanelItem" name="fp_correlation_panel">
                         <object class="wxPanel" name="pnl_correlation">


### PR DESCRIPTION
> [!WARNING]
> Requires #3492 to be merged, so the diff is showing a lot of unrelated files. The most important change is [src/odemis/gui/cont/multi_point_correlation.py](https://github.com/delmic/odemis/pull/3498/changes#diff-b8d04bf6eaa94c63772703427594101df9cedb9a95ee5ebf0140e2e167e28d65)

The PR implements changes to facilitate a correlation workflow for FIB-view FM data:
- Differentiate milling workflow depending on FM type (Orthogonal FM vs FIB-view FM)
- Add indicator to show the FM type
- Introduce new simple 2d correlation method for FIB-view FM data
- Change grid table to not show z column for FIB-view FM
- Change point requirement depending on FM type (2 vs 4)
- Fix bug in stream deletion, causing to still show a deleted stream in the correlation popup.
- Change display of refinement controls to use a general method
- Disable refinement for FIB-view FM
- Improve refinement search range to use a physical unit (bit of a bonus, since I disabled refinement for FIB-view FM after all)

<img width="936" height="1198" alt="image" src="https://github.com/user-attachments/assets/4c87caf1-509f-4a30-adb7-e840df917e3c" />
Example of the new 2d correlation method on synthetic data (ignore the content of the images). See how the projected point  at the bottom is located at a plausible location.