### PR TITLE
[s30-134][fix] improve SPARC grating offset auto calibration

### DIFF
--- a/install/linux/usr/share/odemis/sim/sparc2-focus-test.odm.yaml
+++ b/install/linux/usr/share/odemis/sim/sparc2-focus-test.odm.yaml
@@ -78,7 +78,10 @@
     init: {
         image: "sparc-spec-sim.h5",
     },
-    dependencies: {focus: "Spectrograph focus"}
+    dependencies: {
+        focus: "Spectrograph focus",  # blur the image based on the focus position
+        spectrograph: "Spectrograph",  # at wavelength = 0, shows a peak controlled by grating offset
+    },
 }
 
 "Spectrometer Vis-NIR": {

--- a/src/odemis/acq/align/autofocus.py
+++ b/src/odemis/acq/align/autofocus.py
@@ -1217,12 +1217,12 @@ def CLSpotsAutoFocus(
 def _mapDetectorToSelector(
         selector: model.Actuator,
         detectors: List[model.Detector]
-) -> Tuple[str, Dict[str, Any]]:
+) -> Tuple[str, Dict[model.Detector, float]]:
     """
     Maps detector to selector positions
     returns:
        axis: the selector axis to use
-       position_map: detector name -> selector position
+       position_map: detector -> selector position
     """
     # We pick the right axis by assuming that it's the only one which has
     # choices, and the choices are a dict pos -> detector name.

--- a/src/odemis/acq/align/goffset.py
+++ b/src/odemis/acq/align/goffset.py
@@ -1,3 +1,27 @@
+"""
+SPARC auto grating offset alignment
+
+:created: 5 Jun 2026
+:author: Yu Xia de Jong
+:copyright: © 2026 Yu Xia de Jong, Éric Piel, Delmic
+
+This file is part of Odemis.
+
+.. license::
+    Odemis is free software: you can redistribute it and/or modify it under the
+    terms of the GNU General Public License version 2 as published by the Free
+    Software Foundation.
+
+    Odemis is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+    details.
+
+    You should have received a copy of the GNU General Public License along with
+    Odemis. If not, see http://www.gnu.org/licenses/.
+
+"""
+
 import logging
 import numpy
 import threading
@@ -10,7 +34,7 @@ from odemis.acq.align import light
 from odemis import model
 from odemis.acq.align.autofocus import _mapDetectorToSelector
 from odemis.model import InstantaneousFuture
-from odemis.util import executeAsyncTask
+from odemis.util import executeAsyncTask, img
 from odemis.util.peak import Smooth, Detect
 from scipy.optimize import curve_fit
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -34,7 +58,7 @@ def gaussian(x: numpy.ndarray, amplitude: float, x0: float, width: float) -> num
     return intensity
 
 
-def find_peak_position(data: numpy.ndarray, window_radius: int = 15, snr_threshold: float = 10.0) -> float:
+def find_peak_position(spectrum: numpy.ndarray, window_radius: int = 15, snr_threshold: float = 10.0) -> float:
     """
     Finds the peak position in the given spectrum data.
     It can handle both 1D and 2D data (in which case it uses Maximum Intensity Projection).
@@ -44,26 +68,24 @@ def find_peak_position(data: numpy.ndarray, window_radius: int = 15, snr_thresho
     It then calculates a weighted average of the positions within a window, using the
     intensity values as weights. For improved accuracy, it attempts to fit a Gaussian curve.
 
-    :param data: 1D or 2D array containing the spectrum
+    :param spectrum: 1D or 2D array containing the spectrum
     :param window_radius: number of pixels on either side of the peak to include in the window for fitting (default: 15)
     :return: estimated peak position in pixels (float)
     :raises RuntimeError: if no significant peak is detected (SNR too low)
     """
-
-    raw_data = numpy.asarray(data, dtype=float)
-    spectrum = numpy.squeeze(raw_data)
-
-    # The maximum intensity projection (MIP) is used as it retains the exact maximum intensity value of the peak,
-    # as opposed to mean averaging, which flattens sharp spikes, blending the high-intensity peak with the surrounding
-    # low-intensity baseline noise. MIP maximises SNR and guarantees that the pixel location of the highest intensity
-    # is preserved.
-    if spectrum.ndim > 1:
-        spectrum = spectrum.max(axis=0)
+    spectrum = numpy.squeeze(spectrum)  # remove any dummy dimensions
+    if spectrum.ndim > 1:  # 2D
+        # Convert to 1D by binning along the vertical axis (as done in the spectrum acquisition)
+        if not isinstance(spectrum, model.DataArray):
+            spectrum = model.DataArray(spectrum)
+        spectrum = img.Bin(spectrum, (1, spectrum.shape[0]), dtype=numpy.float64)
+        spectrum = numpy.squeeze(spectrum)
+    else:
+        spectrum = spectrum.astype(numpy.float64, copy=False)
 
     # geometric smoothing and noise calculation
     smoothed_data = Smooth(spectrum, window_len=11)
-    clean_data = smoothed_data - numpy.median(smoothed_data)
-    noise_std = numpy.std(clean_data)
+    noise_std = float(numpy.std(smoothed_data - spectrum))
 
     # detect peak
     maxtab, _ = Detect(smoothed_data, lookahead=10, delta=(noise_std + 1e-6) * snr_threshold)
@@ -125,17 +147,18 @@ def peak_is_present(spectrum: numpy.ndarray,
     :param width_range: acceptable range of estimated peak widths in pixels (default: (0.5, 12.0))
     :return: True if a peak meeting the criteria is present, False otherwise
     """
-
-    raw_data = numpy.asarray(spectrum, dtype=float) # convert to float
-    spectrum_1d = numpy.squeeze(raw_data)  # remove any dummy dimensions
-
-    # convert 2D data to 1D via MIP if it wasn't done by the caller
-    if spectrum_1d.ndim > 1:
-        spectrum_1d = spectrum_1d.max(axis=0)
+    spectrum = numpy.squeeze(spectrum)  # remove any dummy dimensions
+    if spectrum.ndim > 1:  # 2D
+        # Convert to 1D by binning along the vertical axis (as done in the spectrum acquisition)
+        if not isinstance(spectrum, model.DataArray):
+            spectrum = model.DataArray(spectrum)
+        spectrum_1d = img.Bin(spectrum, (1, spectrum.shape[0]), dtype=numpy.float64)
+        spectrum_1d = numpy.squeeze(spectrum_1d)
+    else:
+        spectrum_1d = spectrum.astype(numpy.float64, copy=False)
 
     smoothed_data = Smooth(spectrum_1d, window_len=11) # remove any hot pixels
-    clean_data = smoothed_data - numpy.median(smoothed_data)
-    noise_std = numpy.std(clean_data)
+    noise_std = float(numpy.std(smoothed_data - spectrum_1d))
 
     # use Detect to reject high-amplitude noise spikes that lack Gaussian geometry
     maxtab, _ = Detect(smoothed_data, lookahead=10, delta=(noise_std + 1e-6) * snr_threshold)
@@ -225,9 +248,7 @@ def coarse_scan_goffset_for_peak(spgr, detector, future: model.ProgressiveFuture
             continue
 
         data = detector.data.get(asap=False)
-        spectrum = data.max(axis=0) if data.ndim == 2 else data
-
-        if peak_is_present(spectrum):
+        if peak_is_present(data):
             peak = find_peak_position(data)
             return g, peak
 
@@ -368,9 +389,8 @@ def _do_sparc_auto_grating_offset(future: model.ProgressiveFuture,
     try:
         center_target = (detector.resolution.value[0] - 1) / 2
         data0 = detector.data.get(asap=False)
-        spectrum0 = data0.max(axis=0) if data0.ndim == 2 else data0
 
-        if peak_is_present(spectrum0):
+        if peak_is_present(data0):
             peak0 = find_peak_position(data0)
             logging.debug("Initial read: peak0=%.2f px", peak0)
             peak_present = True
@@ -645,7 +665,6 @@ def _do_auto_align_grating_detector_offsets(future: model.ProgressiveFuture,
 
         try:
             future._subfuture.result(timeout=60)
-
         except TimeoutError:
             future._subfuture.cancel()
             logging.warning("Brightlight did not confirm ON within 60s; continuing anyway")
@@ -673,16 +692,8 @@ def _do_auto_align_grating_detector_offsets(future: model.ProgressiveFuture,
             if selector:
                 selector.moveAbsSync({selector_axes: detector_to_selector[d]})
 
-            if d is first_detector:
-                logging.info("Primary detector: using grating alignment (goffset)")
-                future._subfuture = (sparc_auto_grating_offset(spectrograph,d))
-
-            else:
-                logging.info("Secondary detector: using detector-offset alignment")
-                future._subfuture = (sparc_auto_detector_offset(spectrograph, d))
-
-            success = future._subfuture.result()
-            results[(g0, d.name)] = success
+            future._subfuture = sparc_auto_grating_offset(spectrograph, d)
+            results[(g0, d.name)] = future._subfuture.result()
 
             # update progress
             current_step += 1
@@ -705,8 +716,7 @@ def _do_auto_align_grating_detector_offsets(future: model.ProgressiveFuture,
             logging.info("Starting alignment | Detector: %s | Grating: %s", first_detector.name, g)
 
             future._subfuture = sparc_auto_grating_offset(spectrograph, first_detector)
-            success = future._subfuture.result()
-            results[(g, first_detector.name)] = success
+            results[(g, first_detector.name)] = future._subfuture.result()
 
             # update progress
             current_step += 1

--- a/src/odemis/acq/align/test/goffset_test.py
+++ b/src/odemis/acq/align/test/goffset_test.py
@@ -1,6 +1,26 @@
 # -*- coding: utf-8 -*-
 """
-Test Sparc auto grating offset alignment
+Test SPARC auto grating offset alignment
+
+:created: 5 Jun 2026
+:author: Yu Xia de Jong
+:copyright: © 2026 Yu Xia de Jong, Éric Piel, Delmic
+
+.. license::
+    This file is part of Odemis.
+
+    Odemis is free software: you can redistribute it and/or modify it under the
+    terms of the GNU General Public License version 2 as published by the Free
+    Software Foundation.
+
+    Odemis is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+    details.
+
+    You should have received a copy of the GNU General Public License along with
+    Odemis. If not, see http://www.gnu.org/licenses/.
+
 """
 
 import logging
@@ -15,9 +35,9 @@ from odemis import model
 from odemis.acq import path
 from odemis.util import testing
 from odemis.util import timeout
-from odemis.acq.align.goffset import(find_peak_position, peak_is_present, estimate_goffset_scale,
-                                     sparc_auto_grating_offset, auto_align_grating_detector_offsets,
-                                     _do_auto_align_grating_detector_offsets)
+from odemis.acq.align.goffset import (find_peak_position, peak_is_present, estimate_goffset_scale,
+                                      sparc_auto_grating_offset, auto_align_grating_detector_offsets,
+                                      _do_auto_align_grating_detector_offsets)
 from odemis.dataio import hdf5
 from odemis.model import ProgressiveFuture
 from pathlib import Path
@@ -31,6 +51,89 @@ SPARC_CONFIG = CONFIG_PATH / "sparc2-focus-test.odm.yaml"
 
 DATA_DIR = Path(__file__).resolve().parent
 H5_FILE_2D_NO_PEAK = DATA_DIR / "grating 2 1024x256"
+
+class TestPeakDetection(unittest.TestCase):
+
+    def test_find_peak_position_synthetic(self):
+        """
+        Test peak detection on synthetic Gaussian data.
+        """
+        x = np.arange(200)
+        true_center = 83.4
+        spectrum = np.exp(-0.5 * ((x - true_center) / 3.0) ** 2) * 1000
+        spectrum = model.DataArray(spectrum)
+
+        peak = find_peak_position(spectrum)
+        self.assertAlmostEqual(peak, true_center, places=1)
+
+    def test_find_peak_position_2d(self):
+        """
+        Test peak detection on 2D data (mean over axis).
+        """
+        x = np.arange(200)
+        true_center = 120.0
+        line = np.exp(-0.5 * ((x - true_center) / 4.0) ** 2)
+        image = model.DataArray(np.tile(line, (50, 1)))
+
+        peak = find_peak_position(image)
+        self.assertAlmostEqual(peak, true_center, places=1)
+
+    def test_find_peak_position_realistic_2d(self):
+        """
+        Test peak detection on realistic 2D detector data (like GUI),
+        including noise and baseline offset.
+        """
+        np.random.seed(0)
+
+        x = np.arange(1024)
+        true_center = 512.3
+
+        # base gaussian peak
+        peak = 50 * np.exp(-0.5 * ((x - true_center) / 6.0) ** 2)
+
+        # simulate camera baseline
+        baseline = 300
+
+        # build 2D image with row variations
+        rows = 256
+        image = []
+
+        for i in range(rows):
+            row_noise = np.random.normal(0, 3, size=x.shape)  # noise
+            row_gain = 1 + np.random.normal(0, 0.02)  # slight variation
+            row = baseline + row_gain * peak + row_noise
+            image.append(row)
+
+        image = model.DataArray(image)
+
+        # run function
+        peak_pos = find_peak_position(image)
+
+        self.assertAlmostEqual(peak_pos, true_center, delta=0.5)
+
+    def test_no_peak_present_image(self):
+        """
+        Test peak detection on not-peak detector data.
+        """
+        im_no_peak = hdf5.read_data(H5_FILE_2D_NO_PEAK / "without-peak-2d-1.h5")
+        spectrum = im_no_peak[0]
+        present = peak_is_present(spectrum, snr_threshold=10.0, width_range=(0.5, 12.0))
+        self.assertFalse(present, f"Peak was detected on data with only noise")
+
+        spectrum_1d = spectrum.squeeze().max(axis=0)
+        present = peak_is_present(spectrum_1d, snr_threshold=10.0, width_range=(0.5, 12.0))
+        self.assertFalse(present, f"Peak was detected on data with only noise")
+
+    def test_peak_present_image(self):
+        im_peak = hdf5.read_data(H5_FILE_2D_NO_PEAK / "with-peak-2d-1.h5")
+        spectrum = im_peak[0]
+        present = peak_is_present(spectrum, snr_threshold=10.0, width_range=(0.5, 12.0))
+        self.assertTrue(present, "Peak should have been detected in the cleaned spectrum.")
+
+        spectrum_1d = spectrum.squeeze().max(axis=0)
+        present = peak_is_present(spectrum_1d, snr_threshold=10.0, width_range=(0.5, 12.0))
+        self.assertTrue(present, "Peak should have been detected in the cleaned spectrum.")
+
 
 class TestSparcAutoGratingOffset(unittest.TestCase):
     """
@@ -51,7 +154,7 @@ class TestSparcAutoGratingOffset(unittest.TestCase):
         cls.microscope = model.getMicroscope()
         cls.optmngr = path.OpticalPathManager(cls.microscope)
 
-        cls._original_goffset = cls.spgr.goffset
+        cls.spgr.moveAbsSync({"wavelength": 0.0})
         cls._original_position = cls.spgr.position.value.copy()
 
     @classmethod
@@ -66,37 +169,12 @@ class TestSparcAutoGratingOffset(unittest.TestCase):
         # speed up detector
         self.detector.exposureTime.value = self.detector.exposureTime.range[0]
 
-    def test_find_peak_position_synthetic(self):
-        """
-        Test peak detection on synthetic Gaussian data.
-        """
-
-        x = np.arange(200)
-        true_center = 83.4
-        spectrum = np.exp(-0.5*((x-true_center)/3.0)**2)
-
-        peak = find_peak_position(spectrum)
-        self.assertAlmostEqual(peak, true_center, places=1)
-
-    def test_find_peak_position_2d(self):
-        """
-        Test peak detection on 2D data (mean over axis).
-        """
-
-        x = np.arange(200)
-        true_center = 120.0
-        line = np.exp(-0.5*((x-true_center)/4.0)**2)
-        image = np.tile(line, (50, 1))
-
-        peak = find_peak_position(image)
-        self.assertAlmostEqual(peak, true_center, places=1)
-
     @timeout(100)
     def test_estimate_goffset_scale(self):
         """
         Test that goffset scale is non-zero and finite.
         """
-        scale = estimate_goffset_scale(self.spgr, self.detector)
+        scale, p0, p1 = estimate_goffset_scale(self.spgr, self.detector)
 
         self.assertIsInstance(scale, float)
         self.assertNotEqual(scale, 0.0)
@@ -267,7 +345,7 @@ class TestSparcAutoGratingOffset(unittest.TestCase):
 
         dets_for_first_grating = [d for (g, d) in res.keys() if g == first_grating]
         self.assertEqual(len(dets_for_first_grating), n_detectors)
-        self.assertIn(self.ccd.name, dets_for_first_grating)
+        self.assertIn(self.detector.name, dets_for_first_grating)
         self.assertIn(spccd.name, dets_for_first_grating)
 
         # verify that only first detector is used for remaining gratings
@@ -283,18 +361,6 @@ class TestSparcAutoGratingOffset(unittest.TestCase):
 
         # check data is not flat
         self.assertNotEqual(data.max(), data.min())
-
-    def test_driver_raises_valueerror_on_hardware_limit(self):
-        """
-        Verifies the driver successfully raises a ValueError when computing
-        an offset outside of the hardware limits.
-        """
-        # out of bounds value
-        out_of_bounds_target = 9999999.0
-
-        # test method directly to ensure the new bounds-checking logic works
-        with self.assertRaises(ValueError, msg="Driver should raise ValueError for out-of-bounds offset"):
-            self.spgr._doSetGoffsetAbs(out_of_bounds_target)
 
     @timeout(150)
     def test_hardware_limit_valueerror_handled(self):
@@ -324,157 +390,6 @@ class TestSparcAutoGratingOffset(unittest.TestCase):
             self.spgr.axes["goffset"].range = original_range
             self.spgr.moveAbsSync({"goffset": self._original_position["goffset"]})
 
-    def test_find_peak_position_realistic_2d(self):
-        """
-        Test peak detection on realistic 2D detector data (like GUI),
-        including noise and baseline offset.
-        """
-        np.random.seed(0)
-
-        x = np.arange(1024)
-        true_center = 512.3
-
-        # base gaussian peak
-        peak = 50 * np.exp(-0.5 * ((x - true_center) / 6.0) ** 2)
-
-        # simulate camera baseline
-        baseline = 300
-
-        # build 2D image with row variations
-        rows = 256
-        image = []
-
-        for i in range(rows):
-            row_noise = np.random.normal(0, 3, size=x.shape)  # noise
-            row_gain = 1 + np.random.normal(0, 0.02)  # slight variation
-            row = baseline + row_gain * peak + row_noise
-            image.append(row)
-
-        image = np.array(image)
-
-        # run function
-        peak_pos = find_peak_position(image)
-
-        self.assertAlmostEqual(peak_pos, true_center, places=1)
-
-    def test_no_peak_present_image(self):
-        """
-        Test peak detection on not-peak detector data.
-        """
-
-        im_no_peak = hdf5.read_data(H5_FILE_2D_NO_PEAK / "without-peak-2d-1.h5")
-        data = (im_no_peak[0].data)
-
-        spectrum = data.mean(axis=0) if data.ndim == 2 else data
-
-        present = peak_is_present(spectrum, snr_threshold=10.0, width_range=(0.5, 12.0))
-
-        self.assertFalse(present, f"Peak was not detected. Check SNR and width limits.")
-
-    def test_peak_present_image(self):
-        im_peak = hdf5.read_data(H5_FILE_2D_NO_PEAK / "with-peak-2d-1.h5")
-        raw_data = np.asarray(im_peak[0].data)
-
-        spectrum = np.squeeze(raw_data)
-        if spectrum.ndim > 1:
-            # convert 2D array into 1D by averaging
-            spectrum = spectrum.mean(axis=0)
-
-        clean_spec = spectrum - np.median(spectrum)
-        noise_std = np.std(clean_spec)
-        peak_val = clean_spec.max()
-        snr = peak_val / (noise_std + 1e-6)
-        peak_idx = np.argmax(clean_spec)
-
-        # simple width estimation
-        window = clean_spec[max(0, peak_idx - 2): min(len(clean_spec), peak_idx + 3)]
-        x = np.arange(len(window))
-        w = window - window.min()
-        width = 0.0
-        if w.sum() > 0:
-            mean = np.sum(x * w) / np.sum(w)
-            var = np.sum(w * (x - mean) ** 2) / np.sum(w)
-            width = np.sqrt(var)
-
-        # debug logs
-        logging.info("=" * 40)
-        logging.info(f"IMAGE DEBUG SCORECARD")
-        logging.info(f"Final Spectrum Shape: {spectrum.shape}")
-        logging.info(f"Peak Location:       Index {peak_idx}")
-        logging.info(f"Calculated SNR:      {snr:.2f}  (Threshold: 10.0)")
-        logging.info(f"Calculated Width:    {width:.2f}  (Range: 0.5 - 12.0)")
-        logging.info("=" * 40)
-
-        logging.info(f"Cleaned Spectrum Shape for Function: {spectrum.shape}")
-
-        # pass the cleaned 1D array to the existing function
-        present = peak_is_present(spectrum, snr_threshold=10.0, width_range=(0.5, 12.0))
-
-        self.assertTrue(present, "Peak should have been detected in the cleaned spectrum.")
-
-    @patch('odemis.acq.align.goffset.sparc_auto_grating_offset')
-    @patch('odemis.acq.align.goffset.light.turnOnLight')
-    def test_do_auto_align_mocked(self, mock_sleep, mock_turnOnLight, mock_sparc_offset):
-        """
-        Test the full auto-calibration sequence using mocked hardware to bypass
-        timeouts, sleep delays, and physical hardware requirements.
-        """
-
-        # set up mocked return values using standard python futures
-        fake_light_future = Future()
-        fake_light_future.set_result(True)
-        mock_turnOnLight.return_value = fake_light_future
-
-        fake_align_future = Future()
-        fake_align_future.set_result(True)
-        mock_sparc_offset.return_value = fake_align_future
-
-        # set up fake hardware
-        fake_spectrograph = MagicMock()
-
-        # Mock the initial position and the grating choices
-        fake_spectrograph.position.value = {"wavelength": 0, "grating": 0}
-        fake_spectrograph.axes = {"grating": MagicMock(choices={0: "grating1", 1: "grating2"})}
-
-        fake_detector = MagicMock()
-        fake_detector.name = "fake_ccd"
-        fake_detector.data.get.return_value = np.zeros((1024,))
-
-        fake_opm = MagicMock()
-        fake_path_future = Future()
-        fake_path_future.set_result(True)
-        fake_opm.setPath.return_value = fake_path_future
-
-        fake_bl = MagicMock()
-        fake_bl.power.range = [0, 100]
-
-        main_future = ProgressiveFuture(start=0, end=100)
-        main_future._task_lock = threading.Lock()
-        main_future._task_state = RUNNING
-        main_future._subfuture = Future()
-
-        # run function
-        results = _do_auto_align_grating_detector_offsets(future=main_future, spectrograph=fake_spectrograph,
-                                                          detectors=[fake_detector], opm=fake_opm,
-                                                          align_mode="spec-focus", bl=fake_bl, selector=None,
-                                                          streams=[])
-
-        # Assertions
-        # did it try to turn on the light?
-        mock_turnOnLight.assert_called_once_with(fake_bl, fake_detector)
-
-        # did it set the optical path?
-        fake_opm.setPath.assert_called_once_with("spec-focus", detector=fake_detector)
-
-        # did it try to align both gratings we mocked?
-        self.assertEqual(mock_sparc_offset.call_count, 2)
-
-        # did it clean up and turn the light off in the finally block?
-        self.assertEqual(fake_bl.power.value, 0)
-
-        # check the final returned results dict
-        self.assertEqual(results, {(0, "fake_ccd"): True, (1, "fake_ccd"): True})
-
     @timeout(100)
     def test_cancel(self):
         """
@@ -487,6 +402,7 @@ class TestSparcAutoGratingOffset(unittest.TestCase):
         except:
             pass
         self.assertTrue(f.done())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/odemis/driver/simcam.py
+++ b/src/odemis/driver/simcam.py
@@ -190,7 +190,7 @@ class Camera(model.DigitalCamera):
                     and hasattr(spectrograph, "axes")
                     and isinstance(spectrograph.axes, dict)
                     and "goffset" in spectrograph.axes):
-                raise ValueError((f"spectrograph {spectrograph} must have a 'goffset' attribute"))
+                raise ValueError(f"spectrograph {spectrograph} must have a 'goffset' attribute")
 
             self._spectrograph = spectrograph
             logging.debug("Will simulate spectral peaks using spectrograph %s", spectrograph.name)
@@ -215,7 +215,8 @@ class Camera(model.DigitalCamera):
         self._error_creation_thread.daemon = True
         self._error_creation_thread.start()
 
-        self._min_val = self._img.min()
+        self._min_val = self._img.min().tolist()
+        self._max_val = self._img.max().tolist()
 
     def _setBinning(self, value):
         """
@@ -334,16 +335,6 @@ class Camera(model.DigitalCamera):
         else:
             img = gen_img
 
-        # Simulate changing the exposure time exp/self._orig_exp (without overflow, but clipping)
-        orig_dtype = img.dtype
-        img = img * float(exp/self._orig_exp)  # forces to a float dtype, so that it doesn't overflow
-        # Revert to original type, with data clipped
-        if orig_dtype.kind in "biu":
-            idtype = numpy.iinfo(orig_dtype)
-            img = img.clip(idtype.min, idtype.max).astype(orig_dtype)
-        else:  # float
-            img = img.astype(orig_dtype)
-
         img = model.DataArray(img, metadata)
 
         # send the new image (if anyone is interested)
@@ -383,7 +374,7 @@ class Camera(model.DigitalCamera):
         """
         self._img = new_img
 
-    def _simulate(self):
+    def _simulate(self) -> model.DataArray:
         """
         Simulate the image based on the current settings of the camera.
         If a mirror is defined, use ray tracing to simulate the image.
@@ -402,12 +393,11 @@ class Camera(model.DigitalCamera):
         stage_shift = pos[0] / pxs[0], -pos[1] / pxs[1]  # Y goes opposite
 
         if self._mirror:
-            eff_pixel_size = [p * b for p, b in zip(pixel_size, binning)]
             self._img_simulator.resolution.value = res
-            self._img_simulator.pixel_size.value = eff_pixel_size
+            self._img_simulator.pixel_size.value = pixel_size
             sim_img = self._img_simulator.simulate(self._mirror.position.value)
-            self._img = model.DataArray(sim_img, self._img.metadata)
-            sim_img = self._img.copy()
+            sim_img = model.DataArray(sim_img, self._img.metadata)
+            self._max_val = sim_img.max().tolist()
         else:
             # First and last index (eg, 0 -> 255)
             ltrb = [center[0] + trans[0] + stage_shift[0] - (res[0] / 2) * binning[0],
@@ -435,8 +425,8 @@ class Camera(model.DigitalCamera):
                      [int(round(ltrb[1] + i * binning[1])) for i in range(res[1])])
             sim_img = self._img[numpy.ix_(coord[1], coord[0])]  # copy
 
-        # spectrograph peak simulation
-        if self._spectrograph:
+        # spectrograph peak simulation (if at 0th order)
+        if self._spectrograph and self._spectrograph.position.value["wavelength"] < 10e-9:
             current_offset = self._spectrograph.position.value["goffset"]
 
             ccd_center_x = self._img_res[0] / 2  # find the x-coordinate of the center of the ccd
@@ -450,19 +440,29 @@ class Camera(model.DigitalCamera):
                          x0_px, roi_left, peak_center_binned)
 
             width_binned = PEAK_WIDTH / bin_x
-
             peak = simulate_peak(amplitude=20000, x0=peak_center_binned, width=width_binned,
-                                shape=sim_img.shape, dtype=sim_img.dtype)
+                                 shape=sim_img.shape, dtype=sim_img.dtype)
 
             # simulation routine
             sim_img = (peak + self._min_val).astype(self._img.dtype, copy=False)
+            sim_img = model.DataArray(sim_img)
 
-            # define max noise amplitude
-        mx = self._img.max()
-        noise_max = max(mx // 100, 10)
+        # Simulate changing the exposure time exp/self._orig_exp (without overflow, but clipping)
+        exp = self.exposureTime.value
+        orig_dtype = sim_img.dtype
+        sim_img = sim_img * float(exp / self._orig_exp)  # forces to a float dtype, so that it doesn't overflow
+        # Revert to original type, with data clipped
+        if orig_dtype.kind in "iu":
+            idtype = numpy.iinfo(orig_dtype)
+            sim_img = sim_img.clip(idtype.min, idtype.max).astype(orig_dtype)
+        else:  # float
+            sim_img = sim_img.astype(orig_dtype)
 
-            # generate noise and add directly
-        noise = numpy.random.randint(0, noise_max, sim_img.shape, dtype=self._img.dtype)
+        # define max noise amplitude
+        noise_max = max(self._max_val // 100, 10)
+
+        # generate noise and add directly
+        noise = numpy.random.randint(0, noise_max, sim_img.shape, dtype=sim_img.dtype)
 
         # final clamp to prevent overflow
         dt_info = numpy.iinfo(sim_img.dtype) if numpy.issubdtype(sim_img.dtype, numpy.integer) else numpy.finfo(sim_img.dtype)

--- a/src/odemis/driver/test/simcam_test.py
+++ b/src/odemis/driver/test/simcam_test.py
@@ -34,6 +34,14 @@ logging.getLogger().setLevel(logging.DEBUG)
 
 CLASS = simcam.Camera
 KWARGS_FOCUS = {"name": "focus", "role": "overview-focus", "axes": ["z"], "ranges": {"z": [0, 0.012]}}
+KWARGS_SPECTROGRAPH = {"name": "spectrograph", "role": "spectrograph",
+                       "axes": ["wavelength", "goffset"],
+                       "ranges": {"wavelength": (0, 1e-6), "goffset": (-1000, 1000)}}
+KWARGS_MIRROR = {"name": "mirror", "role": "mirror",
+                 "axes": ["x", "y", "z"],
+                 "ranges": {"x": (-5e-3, 5e-3), "y": (-5e-3, 5e-3), "z": (-5e-3, 5e-3)}}
+POS_MIRROR_GOOD = {"x": 1e-6, "y": -20e-6, "z": 1e-3}
+POS_MIRROR_NEAR = {"x": 1e-6, "y": -19e-6, "z": 1.01e-3}
 KWARGS = dict(name="camera", role="overview", image="simcam-fake-overview.h5")
 KWARGS_POL = dict(name="camera", role="overview", image="sparc-ar-mirror-align.h5")
 KWARGS_MOVE = dict(name="camera", role="ccd", image="songbird-sim-ccd.h5", max_res=(300, 350))
@@ -456,6 +464,51 @@ class TestSimCamWithPolarization(unittest.TestCase):
         testing.assert_array_not_equal(im_horizontal, im_vertical)
 
 
+class TestSimCamMirror(unittest.TestCase):
+    """
+    Test the Camera "mirror" dependency, which activates ParabolicMirrorRayTracer-based
+    image simulation instead of the standard background image crop.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.focus = simulated.Stage(**KWARGS_FOCUS)
+        cls.mirror = simulated.Stage(**KWARGS_MIRROR)
+        cls.mirror.updateMetadata({model.MD_FAV_POS_ACTIVE: POS_MIRROR_GOOD})
+        cls.camera = CLASS(dependencies={"focus": cls.focus, "mirror": cls.mirror},
+                           **KWARGS_MOVE)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.camera.terminate()
+        cls.mirror.terminate()
+
+    def setUp(self) -> None:
+        self.camera.binning.value = (1, 1)
+        self.camera.resolution.value = self.camera.resolution.range[1]
+        self.camera.exposureTime.value = 0.05
+        # Reset mirror to the aligned (good) position.
+        self.mirror.moveAbsSync(POS_MIRROR_GOOD)
+
+    def test_acquire(self) -> None:
+        """
+        Verify that an image can be acquired when the mirror dependency is active,
+        and that it is a DataArray with the expected dtype.
+        """
+        image = self.camera.data.get(asap=False)
+
+        self.assertIsInstance(image, model.DataArray)
+        self.assertEqual(image.shape, self.camera.resolution.value[::-1])
+        self.assertEqual(image.dtype, numpy.uint16)
+        self.assertGreater(image.max(), 0, "Ray-traced image should contain non-zero values")
+
+        self.mirror.moveAbsSync(POS_MIRROR_NEAR)
+        image = self.camera.data.get(asap=False)
+        self.assertIsInstance(image, model.DataArray)
+        self.assertEqual(image.shape, self.camera.resolution.value[::-1])
+        self.assertEqual(image.dtype, numpy.uint16)
+
+
 class TestSimCamSpectrograph(unittest.TestCase):
 
     @classmethod
@@ -463,29 +516,31 @@ class TestSimCamSpectrograph(unittest.TestCase):
         """
         Validate spectrograph goffset peak simulation in SimCam.
         """
-
-        class MockSpectrograph(model.Component):
-            def __init__(self, name="mock_spectrograph"):
-                super().__init__(name)
-                self.axes = {"goffset": None}
-                self.position = type('obj', (object,), {'value': {"goffset": 0.0}})()
-
         cls.focus = simulated.Stage(**KWARGS_FOCUS)
-        cls.mock_spectrograph = MockSpectrograph()
+        cls.spectrograph = simulated.Stage(**KWARGS_SPECTROGRAPH)
 
-        cls.camera = CLASS(dependencies={"focus": cls.focus, "spectrograph": cls.mock_spectrograph},
+        # Place spectrograph at 0th order (wavelength=0.0, goffset=0.0).
+        # Direct position update avoids waiting for slow simulated movements.
+        cls.spectrograph._position["wavelength"] = 0.0
+        cls.spectrograph._position["goffset"] = 0.0
+        cls.spectrograph._updatePosition()
+
+        cls.camera = CLASS(dependencies={"focus": cls.focus, "spectrograph": cls.spectrograph},
                                **KWARGS_MOVE)
 
     @classmethod
     def tearDownClass(cls) -> None:
         cls.camera.terminate()
+        cls.spectrograph.terminate()
 
     def setUp(self) -> None:
         self.camera.binning.value = (1, 1)
         self.camera.translation.value = (0, 0)
         self.camera.resolution.value = self.camera.resolution.range[1]
         self.camera.exposureTime.value = 0.05
-        self.mock_spectrograph.position.value["goffset"] = 0.0
+        self.spectrograph._position["wavelength"] = 0.0
+        self.spectrograph._position["goffset"] = 0.0
+        self.spectrograph._updatePosition()
         time.sleep(0.1)
 
     def _find_peak(self, image: numpy.ndarray) -> Tuple[float, float, float]:
@@ -510,16 +565,51 @@ class TestSimCamSpectrograph(unittest.TestCase):
 
         return weighted_average, p_max, profile.mean()
 
+    def test_standard_image_at_nonzero_wavelength(self):
+        """
+        Test that when wavelength is non-zero (e.g. 500 nm), the standard
+        background image is returned instead of the peak-simulated image.
+
+        The peak image (wavelength=0.0) has a narrow bright column giving a high
+        max-to-mean ratio on the column profile. The standard image has a uniform
+        profile with a ratio close to 1.
+        """
+        # At wavelength=0.0 (0th order), sim_img is replaced by a narrow Gaussian peak.
+        image_peak = self.camera.data.get(asap=False)
+
+        # At wavelength=500e-9 the peak simulation is skipped and sim_img is a
+        # crop of the standard _img.
+        self.spectrograph._position["wavelength"] = 500e-9
+        self.spectrograph._updatePosition()
+        image_standard = self.camera.data.get(asap=False)
+
+        def _profile_ratio(image: numpy.ndarray) -> float:
+            """Return the max-to-mean ratio of the column profile."""
+            profile = image.astype(float).mean(axis=0)
+            return float(profile.max() / profile.mean())
+
+        ratio_peak = _profile_ratio(image_peak)
+        ratio_standard = _profile_ratio(image_standard)
+
+        # Peak image has a narrow bright column: ratio should be >> 1.
+        self.assertGreater(ratio_peak, 5,
+                           "Peak image should have a high max/mean profile ratio")
+        # Standard image has a uniform profile: ratio should be close to 1.
+        self.assertLess(ratio_standard, 2,
+                        "Standard image should have a low max/mean profile ratio")
+
     def test_spectrograph_with_goffset(self):
         move = 300
         expected_ratio = 0.25
 
-        self.mock_spectrograph.position.value["goffset"] = 0.0
+        self.spectrograph._position["goffset"] = 0.0
+        self.spectrograph._updatePosition()
         image_0 = self.camera.data.get()
         date_0 = image_0.metadata[model.MD_ACQ_DATE]
 
         # change offset
-        self.mock_spectrograph.position.value["goffset"] = move
+        self.spectrograph._position["goffset"] = move
+        self.spectrograph._updatePosition()
 
         # obtain new image
         image_new = self.camera.data.get(asap=False)

--- a/src/odemis/util/img.py
+++ b/src/odemis/util/img.py
@@ -816,14 +816,16 @@ def Subtract(a, b):
         return a - b
 
 
-def Bin(data, binning):
+def Bin(data: model.DataArray, binning: Tuple[int, int], dtype: numpy.dtype = None
+        ) -> model.DataArray:
     """
     Combines adjacent pixels together, by summing them, in a similar way that
       it's done on a CCD.
     data (DataArray of shape YX): the data to bin. The dimensions should be
       multiple of the binning.
     binning (1<=int, 1<=int): binning in X and Y
-    return (DataArray of shape Y'X', with the same dtype as data): all cluster of
+    :param dtype: output dtype to use, the default is to use the same as the input data.
+    return (DataArray of shape Y'X'): all cluster of
       pixels of binning are summed into a single pixel. If it goes above the maximum
       value, it's clipped to this maximum value.
       The metadata PIXEL_SIZE and BINNING are updated (multiplied by the binning).
@@ -833,7 +835,10 @@ def Bin(data, binning):
       then the data is clipped to 0 and MD_BASELINE adjusted (increased).
     """
     assert data.ndim == 2
-    orig_dtype = data.dtype
+    if dtype is None:
+        out_dtype = data.dtype
+    else:
+        out_dtype = numpy.dtype(dtype)
     orig_shape = data.shape
     if binning[0] < 1 or binning[1] < 1:
         raise ValueError("Binning must be > 0, but got %s" % (binning,))
@@ -874,9 +879,13 @@ def Bin(data, binning):
         pass
 
     # If int, revert to original type, with data clipped (not overflowing)
-    if orig_dtype.kind in "biu":
-        idtype = numpy.iinfo(orig_dtype)
-        data = data.clip(idtype.min, idtype.max).astype(orig_dtype)
+    if out_dtype.kind in "iu":
+        idtype = numpy.iinfo(out_dtype)
+        data = data.clip(idtype.min, idtype.max).astype(out_dtype)
+    elif out_dtype.kind == 'b':
+        data = data.clip(0, 1).astype(out_dtype)
+    else:
+        data = data.astype(out_dtype, copy=False)
 
     return data
 


### PR DESCRIPTION
Make the simulator smarter, so that it actually can be used for all the test cases that rely on it, by showing a fake grating offset only when the wavelength is at 0.

Improve the algorithm to handle 2D data and noise better.

Fix various issues with the test cases, which never passed when we merge the original commit.
