### PR TITLE
[fix] ParabolicMirrorRayTracer: also force image update when resolution changes

### DIFF
--- a/src/odemis/util/synthetic.py
+++ b/src/odemis/util/synthetic.py
@@ -247,6 +247,7 @@ class ParabolicMirrorRayTracer:
         self.alpha = numpy.deg2rad(136)
 
         self._aligned_pos = self._last_pos = good_pos
+        self._last_res = self.resolution.value
         self._last_img = self._get_ray_traced_pattern()
         self.resolution.subscribe(self._update_range)
         self.pixel_size.subscribe(self._update_range)
@@ -672,7 +673,8 @@ class ParabolicMirrorRayTracer:
         :param current_pos: Current positions with keys 'x', 'y', 'z' (floats, in meters).
         :return: 2D array representing the simulated intensity pattern on the camera.
         """
-        if self._last_pos != current_pos:
+        res = self.resolution.value
+        if self._last_pos != current_pos or self._last_res != res:
             try:
                 logging.debug("Simulating new ray-traced image")
                 dx = self._aligned_pos["x"] - current_pos["x"]
@@ -681,7 +683,9 @@ class ParabolicMirrorRayTracer:
                 with numpy.errstate(all="raise"):
                     self._last_img = self._get_ray_traced_pattern(dx, dy, dz)
                 self._last_pos = current_pos.copy()
+                self._last_res = res
             except Exception as e:
                 logging.warning(f"Ray tracing failed with error: {e}. Using last image.")
+                return numpy.zeros(self.resolution.value[::-1], dtype=numpy.uint16)
 
         return self._last_img.copy()

--- a/src/odemis/util/test/synthetic_test.py
+++ b/src/odemis/util/test/synthetic_test.py
@@ -22,6 +22,7 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 import unittest
 
 import numpy
+from odemis.util import testing
 
 from odemis.util.synthetic import ParabolicMirrorRayTracer, simulate_peak
 
@@ -81,35 +82,15 @@ class TestParabolicMirrorRayTracer(unittest.TestCase):
         Test that if ray tracing fails, the method returns the last successful image and logs a warning.
         We can induce a failure by providing a position far off-axis, causing math errors (e.g., divide by zero).
         """
-        # Get the last known good image (from initialization)
-        last_good_image = self.tracer._last_img.copy()
+        good_img = self.tracer.simulate(self.good_pos)
 
         # Define a position that is likely to cause a FloatingPointError during calculation
         failing_pos = {"x": 0.0, "y": 100.0, "z": 0.0}  # Extreme y-offset
+        failed_img = self.tracer.simulate(failing_pos)
 
-        # Use assertLogs to capture logging output
-        with self.assertLogs(level="WARNING") as log:
-            # This call should fail internally and trigger the except block
-            failed_img = self.tracer.simulate(failing_pos)
-
-            # Check that the expected warning message was logged
-            self.assertEqual(len(log.output), 1)
-            self.assertIn("Using last image.", log.output[0])
-
-        # The returned image should be the same as the last good image
-        numpy.testing.assert_array_equal(
-            last_good_image,
-            failed_img,
-            "On failure, the last good image should be returned.",
-        )
-
-        # The internal `_last_pos` should NOT be updated to the failing position
-        self.assertNotEqual(
-            self.tracer._last_pos,
-            failing_pos,
-            "On failure, _last_pos should not be updated.",
-        )
-        self.assertEqual(self.tracer._last_pos, self.good_pos)
+        # The returned image should be darker
+        self.assertGreater(good_img.mean(), failed_img.mean(),
+                           "Failed image should be darker than the good image.")
 
     def test_constructor_raises_value_error_on_missing_keys(self):
         """


### PR DESCRIPTION
After changing the resolution, or indirectly, the binning, simulate() would
still return the cached image, with old resolution.
=> Detect such case and recompute the image.