### PR TITLE
[MSD-726][refactor] Meteor: Use relative paths in Cryo project file

### DIFF
--- a/src/odemis/acq/test/test-cryo-project-v1_0.json
+++ b/src/odemis/acq/test/test-cryo-project-v1_0.json
@@ -1,1 +1,366 @@
-{"version": "1.0", "features": [{"name": "Feature-1", "status": "Active", "stage_position": {"x": 0.050184, "y": -0.0127371, "z": 0.029058399999999998, "rx": 0.261804, "rz": 4.956732}, "fm_focus_position": {"z": 0.00169}, "posture_positions": {"6": {"x": -0.002611000000000006, "y": -0.013540001388183025, "z": 0.03565096144691265, "rx": 0.698132, "rz": 1.815142}, "7": {"x": 0.050184, "y": -0.0127371, "z": 0.029058399999999998, "rx": 0.261804, "rz": 4.956732}, "5": {"x": -0.002611000000000006, "y": 2.3738223174151613e-05, "z": 0.029058404783023656, "rx": 0.26179968680198473, "rz": 4.9567353}}, "milling_tasks": {"Microexpansion": {"name": "Microexpansion", "selected": true, "milling": {"current": 1e-09, "voltage": 30000.0, "field_of_view": 8e-05, "mode": "Serial", "channel": "ion", "align": true}, "patterns": [{"name": "Microexpansion", "width": 5e-07, "height": 1.5e-05, "depth": 1e-06, "spacing": 1e-05, "center_x": 0, "center_y": 0, "pattern": "microexpansion"}]}, "Rough Milling 01": {"name": "Rough Milling 01", "selected": true, "milling": {"current": 1e-09, "voltage": 30000.0, "field_of_view": 8e-05, "mode": "Serial", "channel": "ion", "align": true}, "patterns": [{"name": "Rough Trench", "width": 1e-05, "height": 6e-06, "depth": 1e-06, "spacing": 3e-06, "center_x": 0, "center_y": 0, "pattern": "trench"}]}, "Rough Milling 02": {"name": "Rough Milling 02", "selected": true, "milling": {"current": 2e-10, "voltage": 30000.0, "field_of_view": 8e-05, "mode": "Serial", "channel": "ion", "align": true}, "patterns": [{"name": "Rough Trench 02", "width": 9.5e-06, "height": 4e-06, "depth": 8e-07, "spacing": 1.5e-06, "center_x": 0, "center_y": 0, "pattern": "trench"}]}, "Polishing 01": {"name": "Polishing 01", "selected": true, "milling": {"current": 6e-11, "voltage": 30000.0, "field_of_view": 8e-05, "mode": "Serial", "channel": "ion", "align": true}, "patterns": [{"name": "Polishing Trench 01", "width": 9e-06, "height": 1e-06, "depth": 6e-07, "spacing": 6e-07, "center_x": 0, "center_y": 0, "pattern": "trench"}]}, "Polishing 02": {"name": "Polishing 02", "selected": true, "milling": {"current": 6e-11, "voltage": 30000.0, "field_of_view": 8e-05, "mode": "Serial", "channel": "ion", "align": true}, "patterns": [{"name": "Polishing Trench 02", "width": 8.5e-06, "height": 6e-07, "depth": 5e-07, "spacing": 3e-07, "center_x": 0, "center_y": 0, "pattern": "trench"}]}}, "correlation_data": {"fm_fiducials": [], "fm_pois": [], "fib_fiducials": [], "fib_projected_pois": [], "fib_projected_fiducials": [], "fib_surface_fiducial": null, "correlation_result": {}, "fm_stream_key": null, "fib_stream_key": null}, "superz_stream_name": null, "superz_focused": null, "images": [{"filename": "/home/tim/Pictures/metatiff-019/zst-Feature-1-Active-001.ome.tiff", "in_file_indices": [0]}]}, {"name": "Feature-2", "status": "Active", "stage_position": {"x": 0.0500709389991139, "y": -0.012742972019559635, "z": 0.0290518194258239, "rx": 0.261799, "rz": 4.9567353}, "fm_focus_position": {"z": 0.00169}, "posture_positions": {"6": {"x": -0.002497938999113905, "y": -0.013527092581324295, "z": 0.035642663822849294, "rx": 0.698132, "rz": 1.815142}, "7": {"x": 0.0500709389991139, "y": -0.012742972019559635, "z": 0.0290518194258239, "rx": 0.261799, "rz": 4.9567353}, "5": {"x": -0.002497938999113905, "y": 3.301659833177071e-05, "z": 0.029051824207636547, "rx": 0.26179968680198473, "rz": 4.9567353}}, "milling_tasks": {"Microexpansion": {"name": "Microexpansion", "selected": true, "milling": {"current": 1e-09, "voltage": 30000.0, "field_of_view": 8e-05, "mode": "Serial", "channel": "ion", "align": true}, "patterns": [{"name": "Microexpansion", "width": 5e-07, "height": 1.5e-05, "depth": 1e-06, "spacing": 1e-05, "center_x": 0, "center_y": 0, "pattern": "microexpansion"}]}, "Rough Milling 01": {"name": "Rough Milling 01", "selected": true, "milling": {"current": 1e-09, "voltage": 30000.0, "field_of_view": 8e-05, "mode": "Serial", "channel": "ion", "align": true}, "patterns": [{"name": "Rough Trench", "width": 1e-05, "height": 6e-06, "depth": 1e-06, "spacing": 3e-06, "center_x": 0, "center_y": 0, "pattern": "trench"}]}, "Rough Milling 02": {"name": "Rough Milling 02", "selected": true, "milling": {"current": 2e-10, "voltage": 30000.0, "field_of_view": 8e-05, "mode": "Serial", "channel": "ion", "align": true}, "patterns": [{"name": "Rough Trench 02", "width": 9.5e-06, "height": 4e-06, "depth": 8e-07, "spacing": 1.5e-06, "center_x": 0, "center_y": 0, "pattern": "trench"}]}, "Polishing 01": {"name": "Polishing 01", "selected": true, "milling": {"current": 6e-11, "voltage": 30000.0, "field_of_view": 8e-05, "mode": "Serial", "channel": "ion", "align": true}, "patterns": [{"name": "Polishing Trench 01", "width": 9e-06, "height": 1e-06, "depth": 6e-07, "spacing": 6e-07, "center_x": 0, "center_y": 0, "pattern": "trench"}]}, "Polishing 02": {"name": "Polishing 02", "selected": true, "milling": {"current": 6e-11, "voltage": 30000.0, "field_of_view": 8e-05, "mode": "Serial", "channel": "ion", "align": true}, "patterns": [{"name": "Polishing Trench 02", "width": 8.5e-06, "height": 6e-07, "depth": 5e-07, "spacing": 3e-07, "center_x": 0, "center_y": 0, "pattern": "trench"}]}}, "correlation_data": {"fm_fiducials": [], "fm_pois": [], "fib_fiducials": [], "fib_projected_pois": [], "fib_projected_fiducials": [], "fib_surface_fiducial": null, "correlation_result": {}, "fm_stream_key": null, "fib_stream_key": null}, "superz_stream_name": null, "superz_focused": null, "images": []}], "overviews": [{"filename": "/home/tim/Pictures/metatiff-019/20260417-154532-overview.ome.tiff", "in_file_indices": [0]}]}
+{
+    "version": "1.0",
+    "features": [
+        {
+            "name": "Feature-1",
+            "status": "Active",
+            "stage_position": {
+                "x": 0.050184,
+                "y": -0.0127371,
+                "z": 0.029058399999999998,
+                "rx": 0.261804,
+                "rz": 4.956732
+            },
+            "fm_focus_position": {
+                "z": 0.00169
+            },
+            "posture_positions": {
+                "6": {
+                    "x": -0.002611000000000006,
+                    "y": -0.013540001388183025,
+                    "z": 0.03565096144691265,
+                    "rx": 0.698132,
+                    "rz": 1.815142
+                },
+                "7": {
+                    "x": 0.050184,
+                    "y": -0.0127371,
+                    "z": 0.029058399999999998,
+                    "rx": 0.261804,
+                    "rz": 4.956732
+                },
+                "5": {
+                    "x": -0.002611000000000006,
+                    "y": 2.3738223174151613e-05,
+                    "z": 0.029058404783023656,
+                    "rx": 0.26179968680198473,
+                    "rz": 4.9567353
+                }
+            },
+            "milling_tasks": {
+                "Microexpansion": {
+                    "name": "Microexpansion",
+                    "selected": true,
+                    "milling": {
+                        "current": 1e-09,
+                        "voltage": 30000.0,
+                        "field_of_view": 8e-05,
+                        "mode": "Serial",
+                        "channel": "ion",
+                        "align": true
+                    },
+                    "patterns": [
+                        {
+                            "name": "Microexpansion",
+                            "width": 5e-07,
+                            "height": 1.5e-05,
+                            "depth": 1e-06,
+                            "spacing": 1e-05,
+                            "center_x": 0,
+                            "center_y": 0,
+                            "pattern": "microexpansion"
+                        }
+                    ]
+                },
+                "Rough Milling 01": {
+                    "name": "Rough Milling 01",
+                    "selected": true,
+                    "milling": {
+                        "current": 1e-09,
+                        "voltage": 30000.0,
+                        "field_of_view": 8e-05,
+                        "mode": "Serial",
+                        "channel": "ion",
+                        "align": true
+                    },
+                    "patterns": [
+                        {
+                            "name": "Rough Trench",
+                            "width": 1e-05,
+                            "height": 6e-06,
+                            "depth": 1e-06,
+                            "spacing": 3e-06,
+                            "center_x": 0,
+                            "center_y": 0,
+                            "pattern": "trench"
+                        }
+                    ]
+                },
+                "Rough Milling 02": {
+                    "name": "Rough Milling 02",
+                    "selected": true,
+                    "milling": {
+                        "current": 2e-10,
+                        "voltage": 30000.0,
+                        "field_of_view": 8e-05,
+                        "mode": "Serial",
+                        "channel": "ion",
+                        "align": true
+                    },
+                    "patterns": [
+                        {
+                            "name": "Rough Trench 02",
+                            "width": 9.5e-06,
+                            "height": 4e-06,
+                            "depth": 8e-07,
+                            "spacing": 1.5e-06,
+                            "center_x": 0,
+                            "center_y": 0,
+                            "pattern": "trench"
+                        }
+                    ]
+                },
+                "Polishing 01": {
+                    "name": "Polishing 01",
+                    "selected": true,
+                    "milling": {
+                        "current": 6e-11,
+                        "voltage": 30000.0,
+                        "field_of_view": 8e-05,
+                        "mode": "Serial",
+                        "channel": "ion",
+                        "align": true
+                    },
+                    "patterns": [
+                        {
+                            "name": "Polishing Trench 01",
+                            "width": 9e-06,
+                            "height": 1e-06,
+                            "depth": 6e-07,
+                            "spacing": 6e-07,
+                            "center_x": 0,
+                            "center_y": 0,
+                            "pattern": "trench"
+                        }
+                    ]
+                },
+                "Polishing 02": {
+                    "name": "Polishing 02",
+                    "selected": true,
+                    "milling": {
+                        "current": 6e-11,
+                        "voltage": 30000.0,
+                        "field_of_view": 8e-05,
+                        "mode": "Serial",
+                        "channel": "ion",
+                        "align": true
+                    },
+                    "patterns": [
+                        {
+                            "name": "Polishing Trench 02",
+                            "width": 8.5e-06,
+                            "height": 6e-07,
+                            "depth": 5e-07,
+                            "spacing": 3e-07,
+                            "center_x": 0,
+                            "center_y": 0,
+                            "pattern": "trench"
+                        }
+                    ]
+                }
+            },
+            "correlation_data": {
+                "fm_fiducials": [],
+                "fm_pois": [],
+                "fib_fiducials": [],
+                "fib_projected_pois": [],
+                "fib_projected_fiducials": [],
+                "fib_surface_fiducial": null,
+                "correlation_result": {},
+                "fm_stream_key": null,
+                "fib_stream_key": null
+            },
+            "superz_stream_name": null,
+            "superz_focused": null,
+            "images": [
+                {
+                    "filename": "zst-Feature-1-Active-001.ome.tiff",
+                    "in_file_indices": [
+                        0
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Feature-2",
+            "status": "Active",
+            "stage_position": {
+                "x": 0.0500709389991139,
+                "y": -0.012742972019559635,
+                "z": 0.0290518194258239,
+                "rx": 0.261799,
+                "rz": 4.9567353
+            },
+            "fm_focus_position": {
+                "z": 0.00169
+            },
+            "posture_positions": {
+                "6": {
+                    "x": -0.002497938999113905,
+                    "y": -0.013527092581324295,
+                    "z": 0.035642663822849294,
+                    "rx": 0.698132,
+                    "rz": 1.815142
+                },
+                "7": {
+                    "x": 0.0500709389991139,
+                    "y": -0.012742972019559635,
+                    "z": 0.0290518194258239,
+                    "rx": 0.261799,
+                    "rz": 4.9567353
+                },
+                "5": {
+                    "x": -0.002497938999113905,
+                    "y": 3.301659833177071e-05,
+                    "z": 0.029051824207636547,
+                    "rx": 0.26179968680198473,
+                    "rz": 4.9567353
+                }
+            },
+            "milling_tasks": {
+                "Microexpansion": {
+                    "name": "Microexpansion",
+                    "selected": true,
+                    "milling": {
+                        "current": 1e-09,
+                        "voltage": 30000.0,
+                        "field_of_view": 8e-05,
+                        "mode": "Serial",
+                        "channel": "ion",
+                        "align": true
+                    },
+                    "patterns": [
+                        {
+                            "name": "Microexpansion",
+                            "width": 5e-07,
+                            "height": 1.5e-05,
+                            "depth": 1e-06,
+                            "spacing": 1e-05,
+                            "center_x": 0,
+                            "center_y": 0,
+                            "pattern": "microexpansion"
+                        }
+                    ]
+                },
+                "Rough Milling 01": {
+                    "name": "Rough Milling 01",
+                    "selected": true,
+                    "milling": {
+                        "current": 1e-09,
+                        "voltage": 30000.0,
+                        "field_of_view": 8e-05,
+                        "mode": "Serial",
+                        "channel": "ion",
+                        "align": true
+                    },
+                    "patterns": [
+                        {
+                            "name": "Rough Trench",
+                            "width": 1e-05,
+                            "height": 6e-06,
+                            "depth": 1e-06,
+                            "spacing": 3e-06,
+                            "center_x": 0,
+                            "center_y": 0,
+                            "pattern": "trench"
+                        }
+                    ]
+                },
+                "Rough Milling 02": {
+                    "name": "Rough Milling 02",
+                    "selected": true,
+                    "milling": {
+                        "current": 2e-10,
+                        "voltage": 30000.0,
+                        "field_of_view": 8e-05,
+                        "mode": "Serial",
+                        "channel": "ion",
+                        "align": true
+                    },
+                    "patterns": [
+                        {
+                            "name": "Rough Trench 02",
+                            "width": 9.5e-06,
+                            "height": 4e-06,
+                            "depth": 8e-07,
+                            "spacing": 1.5e-06,
+                            "center_x": 0,
+                            "center_y": 0,
+                            "pattern": "trench"
+                        }
+                    ]
+                },
+                "Polishing 01": {
+                    "name": "Polishing 01",
+                    "selected": true,
+                    "milling": {
+                        "current": 6e-11,
+                        "voltage": 30000.0,
+                        "field_of_view": 8e-05,
+                        "mode": "Serial",
+                        "channel": "ion",
+                        "align": true
+                    },
+                    "patterns": [
+                        {
+                            "name": "Polishing Trench 01",
+                            "width": 9e-06,
+                            "height": 1e-06,
+                            "depth": 6e-07,
+                            "spacing": 6e-07,
+                            "center_x": 0,
+                            "center_y": 0,
+                            "pattern": "trench"
+                        }
+                    ]
+                },
+                "Polishing 02": {
+                    "name": "Polishing 02",
+                    "selected": true,
+                    "milling": {
+                        "current": 6e-11,
+                        "voltage": 30000.0,
+                        "field_of_view": 8e-05,
+                        "mode": "Serial",
+                        "channel": "ion",
+                        "align": true
+                    },
+                    "patterns": [
+                        {
+                            "name": "Polishing Trench 02",
+                            "width": 8.5e-06,
+                            "height": 6e-07,
+                            "depth": 5e-07,
+                            "spacing": 3e-07,
+                            "center_x": 0,
+                            "center_y": 0,
+                            "pattern": "trench"
+                        }
+                    ]
+                }
+            },
+            "correlation_data": {
+                "fm_fiducials": [],
+                "fm_pois": [],
+                "fib_fiducials": [],
+                "fib_projected_pois": [],
+                "fib_projected_fiducials": [],
+                "fib_surface_fiducial": null,
+                "correlation_result": {},
+                "fm_stream_key": null,
+                "fib_stream_key": null
+            },
+            "superz_stream_name": null,
+            "superz_focused": null,
+            "images": []
+        }
+    ],
+    "overviews": [
+        {
+            "filename": "20260417-154532-overview.ome.tiff",
+            "in_file_indices": [
+                0
+            ]
+        }
+    ]
+}

--- a/src/odemis/acq/test/test-features.json
+++ b/src/odemis/acq/test/test-features.json
@@ -1,1 +1,60 @@
-{"feature_list": [{"name": "Feature-1", "status": "Active", "stage_position": {"x": 0, "y": 0, "z": 0}, "fm_focus_position": {"z": 0}, "posture_positions": {}, "milling_tasks": {}, "correlation_data": {}, "superz_stream_name": null, "superz_focused": null}, {"name": "Feature-2", "status": "Active", "stage_position": {"x": 0.001, "y": 0.001, "z": 0.001}, "fm_focus_position": {"z": 0.002}, "posture_positions": {}, "milling_tasks": {}, "correlation_data": {}, "superz_stream_name": null, "superz_focused": null}]}
+{
+    "feature_list": [
+        {
+            "name": "Feature-1",
+            "status": "Active",
+            "stage_position": {
+                "x": 0,
+                "y": 0,
+                "z": 0
+            },
+            "fm_focus_position": {
+                "z": 0
+            },
+            "posture_positions": {
+                "6": {
+                    "x": -0.0025671009727332894,
+                    "y": -0.01352806261222967,
+                    "z": 0.035643287346918615,
+                    "rx": 0.698132,
+                    "rz": 1.815142
+                },
+                "7": {
+                    "x": 0.056360544064287234,
+                    "y": -0.0230574389890373,
+                    "z": 0.017492744342672853,
+                    "rx": 0.261799,
+                    "rz": 4.9567353
+                },
+                "5": {
+                    "x": -0.002611,
+                    "y": 2.37e-5,
+                    "z": 0.029058399999999998,
+                    "rx": 0.261804,
+                    "rz": 4.956732
+                }
+            },
+            "milling_tasks": {},
+            "correlation_data": {},
+            "superz_stream_name": null,
+            "superz_focused": null
+        },
+        {
+            "name": "Feature-2",
+            "status": "Active",
+            "stage_position": {
+                "x": 0.001,
+                "y": 0.001,
+                "z": 0.001
+            },
+            "fm_focus_position": {
+                "z": 0.002
+            },
+            "posture_positions": {},
+            "milling_tasks": {},
+            "correlation_data": {},
+            "superz_stream_name": null,
+            "superz_focused": null
+        }
+    ]
+}

--- a/src/odemis/gui/cont/cryo_project.py
+++ b/src/odemis/gui/cont/cryo_project.py
@@ -24,13 +24,14 @@ import json
 import os
 from packaging.version import Version
 from pathlib import Path
-from typing import Dict, List, Iterable, Optional
+from typing import Any, Dict, List, Iterable, Optional
 
 PROJECT_NAME = "project.json"
 PROJECT_VERSION = "1.0"
 LEGACY_PROJECT_NAME = "features.json"
 IMG_FILENAME = "filename"
 IMG_IN_FILE_IDS = "in_file_indices"
+
 
 def save_project(main_data: "CryoMainGUIData") -> None:
     """
@@ -42,7 +43,7 @@ def save_project(main_data: "CryoMainGUIData") -> None:
     tmp_filename = filename.with_name(f".{filename.name}.tmp")
     try:
         with open(tmp_filename, "w") as jsonfile:
-            json.dump(serialize_project_data(main_data), jsonfile)
+            json.dump(serialize_project_data(main_data), jsonfile, indent=4)
             jsonfile.flush()
             os.fsync(jsonfile.fileno())
         # Only reached when writing to tmp file succeeded, preventing us from saving corrupted data
@@ -50,6 +51,7 @@ def save_project(main_data: "CryoMainGUIData") -> None:
     except Exception as e:
         # We don't delete the temporary file here, since it can be useful for debugging post-mortem.
         logging.warning(f"Save failed! The original project file was preserved. Error: {e}")
+
 
 def read_project_file(project_file: os.PathLike) -> List["CryoFeature"]:
     """
@@ -62,6 +64,7 @@ def read_project_file(project_file: os.PathLike) -> List["CryoFeature"]:
         raise ValueError(f"{project_file.name} file doesn't exists in this location. {project_file}")
     with open(project_file, "r") as jsonfile:
         return json.load(jsonfile)
+
 
 def load_project(project_dir: os.PathLike) -> dict:
     """
@@ -93,7 +96,7 @@ def load_project(project_dir: os.PathLike) -> dict:
             # Legacy projects lacked any bookkeeping of deleted files. Since we did not store the original in-file
             # indices to a project file, we need to recover it here. In order to get the real indices, we need to load
             # the imagedata. Let's populate the indices later, where we load the imagedata, so we don't do it double.
-            overviews = [{IMG_FILENAME: str(ovf)} for ovf in overview_filenames]
+            overviews = [{IMG_FILENAME: str(ovf.relative_to(project_dir))} for ovf in overview_filenames]
             features = project["feature_list"]
             for feature in features:
                 filenames = project_dir.glob(f"*-{feature['name']}*")
@@ -102,10 +105,18 @@ def load_project(project_dir: os.PathLike) -> dict:
                     images.append({IMG_FILENAME: str(filename)})
                 feature["images"] = images
 
+    # Recover absolute image paths for features
+    for feature in features:
+        feature["images"] = deserialize_images(feature["images"], project_dir)
+
+    # Recover absolute image paths for overview images
+    overviews = deserialize_images(overviews, project_dir)
+
     # Feature streams are intentionally not loaded here; they are lazy-loaded
     # on demand by CryoAcquiredStreamsController when a feature is selected.
 
     return {"overviews": overviews, "features": features}
+
 
 def serialize_project_data(main_data: "CryoMainGUIData") -> Dict:
     """
@@ -116,6 +127,7 @@ def serialize_project_data(main_data: "CryoMainGUIData") -> Dict:
     """
     features = main_data.features.value
     overviews = main_data.overviews.value
+    project_dir = main_data.tab.value.conf.pj_last_path
     feature_list = []
     for feature in features:
         feature_item = {
@@ -128,16 +140,17 @@ def serialize_project_data(main_data: "CryoMainGUIData") -> Dict:
             'correlation_data': feature.correlation_data.to_dict() if feature.correlation_data  else {},
             'superz_stream_name': feature.superz_stream_name,
             'superz_focused': feature.superz_focused,
-            'images': serialize_images(feature.images.value),
+            'images': serialize_images(feature.images.value, project_dir),
         }
         if feature.path:
             feature_item['path'] = feature.path
         feature_list.append(feature_item)
 
-    overview_list = serialize_images(overviews)
+    overview_list = serialize_images(overviews, project_dir)
     return {"version": PROJECT_VERSION, "features": feature_list, "overviews": overview_list}
 
-def add_image(images: List[dict], filename: os.PathLike, indices: Optional[Iterable[int]] = None):
+
+def add_image(images: List[Dict[str, Any]], filename: os.PathLike, indices: Optional[Iterable[int]] = None):
     """
     Add image to a list of images
     :param images: list of images to append to
@@ -148,7 +161,8 @@ def add_image(images: List[dict], filename: os.PathLike, indices: Optional[Itera
     # Our naming schemes should not allow to add a duplicate filename, so that is not handled here
     images.append({IMG_FILENAME: filename, **({IMG_IN_FILE_IDS: set(indices)} if indices else {})})
 
-def remove_image(images: List[dict], filename: os.PathLike, indices: Optional[Iterable[int]] = None):
+
+def remove_image(images: List[Dict[str, Any]], filename: os.PathLike, indices: Optional[Iterable[int]] = None):
     """
     Remove image from a list of images
     :param images: list of images to remove from
@@ -167,16 +181,49 @@ def remove_image(images: List[dict], filename: os.PathLike, indices: Optional[It
                     images.remove(im)
             break  # Nothing left to do
 
-def serialize_images(images: List[dict]) -> List[dict]:
+
+def serialize_images(images: List[Dict[str, Any]], project_dir: os.PathLike) -> List[Dict[str, Any]]:
     """
     Convert a list of images into a serialized form
     :param images: list of images to serialize
+    :param project_dir: the project directory
+    :return: serialized list of images, containing relative image paths
     """
     images_serialized = []
     for image in images:
-        image_serialized = {IMG_FILENAME: str(image[IMG_FILENAME])}
+        image_path = Path(image[IMG_FILENAME])
+        # Everything acquired in Odemis is being stored in the project dir, skip if somehow otherwise.
+        if not image_path.is_relative_to(project_dir):
+            logging.warning("Skip saving image outside of project directory to project file.")
+            continue
+        image_filename_rel = image_path.relative_to(project_dir)
+        image_serialized = {IMG_FILENAME: str(image_filename_rel)}
         # In-file ids not always known at this point, so we allow to write an image without the in-file ids.
         if IMG_IN_FILE_IDS in image:
             image_serialized[IMG_IN_FILE_IDS] = list(image[IMG_IN_FILE_IDS])
         images_serialized.append(image_serialized)
     return images_serialized
+
+
+def deserialize_images(images: List[Dict[str, Any]], project_dir: os.PathLike) -> List[Dict[str, Any]]:
+    """
+    Convert a list of images back into a form with absolute paths
+    :param images: list of images to deserialize
+    :param project_dir: the project directory
+    :return: deserialized list of images, containing absolute image paths
+    """
+    images_deserialized = []
+    for image in images:
+        image_path = Path(image[IMG_FILENAME])
+        # Only relative paths are allowed in the project file, skip if somehow otherwise.
+        if image_path.is_absolute():
+            logging.warning(
+                "Skip loading image with absolute path from project file. "
+                "Only relative paths are allowed."
+            )
+            continue
+
+        image_deserialized = image.copy()
+        image_deserialized[IMG_FILENAME] = str(Path(project_dir) / image_path)
+        images_deserialized.append(image_deserialized)
+    return images_deserialized

--- a/src/odemis/gui/cont/test/cryo_project_test.py
+++ b/src/odemis/gui/cont/test/cryo_project_test.py
@@ -62,9 +62,12 @@ class TestCryoProject(unittest.TestCase):
         """Tests that the legacy project without features works properly."""
         project_dir = self.test_dir / "legacy-no-features"
         project_dir.mkdir()
-        (project_dir / "123-overview.ome.tiff").touch()
+        overview_file = project_dir / "123-overview.ome.tiff"
+        overview_file.touch()
         project_data = load_project(project_dir)
         self.assertEqual(len(project_data["overviews"]), 1)
+        # Check that the legacy overview image is now part of the project data
+        self.assertEqual(project_data["overviews"][0][IMG_FILENAME], str(overview_file))
         # Check that the list of features is there, but empty
         self.assertEqual(len(project_data["features"]), 0)
 
@@ -96,6 +99,8 @@ class TestCryoProject(unittest.TestCase):
         project_data = load_project(project_dir)
         self.assertIn("features", project_data)
         self.assertGreater(len(project_data["features"]), 0)
+        # Check that the in-memory project data has an absolute path relative to the new project dir
+        self.assertTrue(Path(project_data["features"][0]["images"][0][IMG_FILENAME]).is_relative_to(project_dir))
         self.assertIn("overviews", project_data)
         self.assertIn(IMG_FILENAME, project_data["overviews"][0])
 


### PR DESCRIPTION
Previously, absolute paths were stored in the project file for images. Renaming or moving the project folder then led to an invalid path, causing Odemis to not load the images. 

This PR makes sure to:
- only store the relative path (compared to the project folder). 
- recover the absolute path after loading, so that the rest of the code can remains funtional
- add a small unit test to make sure the functionality works
- make the project test files a bit more human-friendly