### PR TITLE
[feat] cli: support multiple axes for the reference command

### DIFF
--- a/src/odemis/cli/main.py
+++ b/src/odemis/cli/main.py
@@ -30,6 +30,8 @@ import inspect
 import logging
 import math
 import numbers
+from typing import Set
+
 from odemis import model, util
 import odemis
 from odemis.util import units, inspect_getmembers
@@ -715,35 +717,46 @@ def move_abs(comp_name, moves, check_distance=True, to_radians=False):
                       (comp_name, act_mv, exc))
 
 
-def reference(comp_name, axis_name):
+def reference(comp_name: str, axis_names: Set[str]) -> None:
     """
-    reference the axis of the given component
+    Reference one or more axes of the given component.
+
+    :param comp_name: name of the actuator component
+    :param axis_names: set of axis names to reference
+    :raises ValueError: if the component is not an actuator or an axis cannot be referenced
+    :raises IOError: if referencing fails
     """
     component = get_component(comp_name)
 
+    if not axis_names:
+        raise ValueError("At least one axis must be specified for referencing component %s" % comp_name)
+
     try:
-        if axis_name not in component.axes:
-            raise ValueError("Actuator %s has no axis '%s'" % (comp_name, axis_name))
+        for axis_name in axis_names:
+            if axis_name not in component.axes:
+                raise ValueError("Actuator %s has no axis '%s'" % (comp_name, axis_name))
     except (TypeError, AttributeError):
         raise ValueError("Component %s is not an actuator" % comp_name)
 
     try:
-        if axis_name not in component.referenced.value:
-            raise AttributeError()  # immediately caught
+        for axis_name in axis_names:
+            if axis_name not in component.referenced.value:
+                raise AttributeError()  # immediately caught
     except (TypeError, AttributeError):
         raise ValueError("Axis %s of actuator %s cannot be referenced" % (axis_name, comp_name))
 
+
     try:
-        m = component.reference({axis_name})
+        m = component.reference(axis_names)
         try:
             m.result(360)
         except KeyboardInterrupt:
-            logging.warning("Cancelling referencing of axis %s", axis_name)
+            logging.warning("Cancelling referencing of axes %s", axis_names)
             m.cancel()
             raise
     except Exception as exc:
-        raise IOError("Failed to reference axis %s of component %s: %s" %
-                      (axis_name, comp_name, exc))
+        raise IOError("Failed to reference axes %s of component %s: %s" %
+                      (axis_names, comp_name, exc))
 
 def stop_move():
     """
@@ -971,9 +984,9 @@ def main(args):
                         help="flag needed to allow any move bigger than 10 mm.")
     dm_grp.add_argument("--degrees", dest="degrees", action="store_true", default=False,
                         help="indicate the position is in degrees, it will be converted to radians.")
-    dm_grpe.add_argument("--reference", dest="reference", nargs=2, action="append",
+    dm_grpe.add_argument("--reference", dest="reference", nargs="+", action="append",
                          metavar=("<component>", "<axis>"),
-                         help="runs the referencing procedure for the given axis.")
+                         help="runs the referencing procedure for the given axis (or axes, separated by spaces).")
     dm_grpe.add_argument("--stop", "-S", dest="stop", action="store_true", default=False,
                          help="immediately stop all the actuators in all directions.")
     dm_grpe.add_argument("--acquire", "-a", dest="acquire", nargs="+",
@@ -1083,10 +1096,9 @@ def main(args):
                 c = l[0]
                 kvs = dict(zip(l[1::2], l[2::2]))
                 update_metadata(c, kvs)
-        # TODO: catch keyboard interrupt and stop the moves
         elif options.reference is not None:
-            for c, a in options.reference:
-                reference(c, a)
+            for l in options.reference:
+                reference(l[0], set(l[1:]))
         elif options.position is not None:
             moves = merge_moves(options.position)
             for c, m in moves.items():

--- a/src/odemis/cli/test/main_test.py
+++ b/src/odemis/cli/test/main_test.py
@@ -43,7 +43,7 @@ logging.getLogger().setLevel(logging.DEBUG)
 
 ODEMISCLI_CMD = [sys.executable, "-m", "odemis.cli.main"]
 CONFIG_PATH = os.path.dirname(odemis.__file__) + "/../../install/linux/usr/share/odemis/"
-SECOM_CONFIG = CONFIG_PATH + "sim/secom-sim.odm.yaml"
+SECOM_CONFIG = CONFIG_PATH + "sim/secom2-sim.odm.yaml"
 
 class TestWithoutBackend(unittest.TestCase):
     # all the test cases which don't need a backend running
@@ -116,16 +116,11 @@ class TestWithBackend(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        try:
-            testing.start_backend(SECOM_CONFIG)
-        except LookupError:
-            logging.info("A running backend is already found, skipping tests")
-            cls.backend_was_running = True
-            return
-        except IOError as exp:
-            logging.error(str(exp))
-            raise
+        testing.start_backend(SECOM_CONFIG)
 
+    @classmethod
+    def tearDownClass(cls):
+        testing.stop_backend()
 
     def setUp(self):
         # Ignore RuntimeWarning: numpy.ndarray size changed, may indicate binary incompatibility.
@@ -135,18 +130,10 @@ class TestWithBackend(unittest.TestCase):
         warnings.filterwarnings(
             "ignore", category=RuntimeWarning, message=re.escape("numpy.ndarray size changed")
         )
-        if self.backend_was_running:
-            self.skipTest("Running backend found")
 
         # reset the logging (because otherwise it accumulates)
         if logging.root:
             del logging.root.handlers[:]
-
-    @classmethod
-    def tearDownClass(cls):
-        if cls.backend_was_running:
-            return
-        testing.stop_backend()
 
     def tearDown(self):
         # Delete files created by tests
@@ -168,7 +155,7 @@ class TestWithBackend(unittest.TestCase):
         self.assertEqual(ret, 0, "trying to run '%s'" % cmdline)
 
         output = out.getvalue()
-        self.assertTrue(b"Light Engine" in output)
+        self.assertTrue(b"Light Source" in output)
         self.assertTrue(b"Camera" in output)
 
     def test_list_no_dash(self):
@@ -184,7 +171,7 @@ class TestWithBackend(unittest.TestCase):
         self.assertEqual(ret, 0, "trying to run '%s'" % cmdline)
 
         output = out.getvalue()
-        self.assertTrue(b"Light Engine" in output)
+        self.assertTrue(b"Light Source" in output)
         self.assertTrue(b"Camera" in output)
 
     def test_check(self):
@@ -201,7 +188,7 @@ class TestWithBackend(unittest.TestCase):
             out = BytesIO()
             sys.stdout = out
 
-            cmdline = ["cli", "--list-prop", "Light Engine"]
+            cmdline = ["cli", "--list-prop", "light"]
             ret = main.main(cmdline)
         except SystemExit as exc:
             ret = exc.code
@@ -215,7 +202,7 @@ class TestWithBackend(unittest.TestCase):
     def test_encoding(self):
         """Check no problem happens due to unicode encoding to ascii"""
         f = open("test.txt", "w")
-        cmd = ODEMISCLI_CMD + ["--list-prop", "Light Engine"]
+        cmd = ODEMISCLI_CMD + ["--list-prop", "light"]
         ret = subprocess.check_call(cmd, stdout=f)
         self.assertEqual(ret, 0, "trying to run %s" % cmd)
         f.close()
@@ -231,7 +218,7 @@ class TestWithBackend(unittest.TestCase):
             out = BytesIO()
             sys.stdout = out
 
-            cmdline = ["cli", "--list-prop", "Light Engine"]
+            cmdline = ["cli", "--list-prop", "light"]
             ret = main.main(cmdline)
         except SystemExit as exc:
             ret = exc.code
@@ -249,7 +236,7 @@ class TestWithBackend(unittest.TestCase):
             out = BytesIO()
             sys.stdout = out
 
-            cmdline = ["cli", "--set-attr", "Light Engine", "power", str([0.0 for _ in power])]
+            cmdline = ["cli", "--set-attr", "light", "power", str([0.0 for _ in power])]
             ret = main.main(cmdline)
         except SystemExit as exc:
             ret = exc.code
@@ -261,7 +248,7 @@ class TestWithBackend(unittest.TestCase):
             out = BytesIO()
             sys.stdout = out
 
-            cmdline = ["cli", "--list-prop", "Light Engine"]
+            cmdline = ["cli", "--list-prop", "light"]
             ret = main.main(cmdline)
         except SystemExit as exc:
             ret = exc.code
@@ -279,7 +266,12 @@ class TestWithBackend(unittest.TestCase):
             out = BytesIO()
             sys.stdout = out
 
-            cmdline = ["cli", "--set-attr", "Sample Stage", "speed", "x: 0.5, y: 0.2"]
+            # We use the "dependencies" attribute, which is a bit odd VA, as it pretty much accepts
+            # anything.
+            cmdline = ["cli", "--set-attr", "Sample Stage", "dependencies", "{x: 0.5, y: 0.2}"]
+            ret = main.main(cmdline)
+            # Reset it to empty dict
+            cmdline = ["cli", "--set-attr", "Sample Stage", "dependencies", "{}"]
             ret = main.main(cmdline)
         except SystemExit as exc:
             ret = exc.code
@@ -325,8 +317,6 @@ class TestWithBackend(unittest.TestCase):
         self.assertNotEqual(ret, 0, "trying to run '%s' should fail" % cmdline)
 
     def test_reference(self):
-        # On this simulated hardware, no component supports referencing, so
-        # just check that referencing correctly reports this
         try:
             # change the stdout
             out = BytesIO()
@@ -336,7 +326,31 @@ class TestWithBackend(unittest.TestCase):
             ret = main.main(cmdline)
         except SystemExit as exc:
             ret = exc.code
-        self.assertNotEqual(ret, 0, "Referencing should have failed with '%s'" % cmdline)
+        self.assertEqual(ret, 0, "trying to run '%s'" % cmdline)
+
+    def test_reference_multi_axes(self):
+        # Check that --reference accepts multiple axes in a single invocation.
+        try:
+            out = BytesIO()
+            sys.stdout = out
+
+            cmdline = ["cli", "--reference", "Sample Stage", "x", "y"]
+            ret = main.main(cmdline)
+        except SystemExit as exc:
+            ret = exc.code
+        self.assertEqual(ret, 0, "trying to run '%s'" % cmdline)
+
+    def test_reference_no_axis(self):
+        # --reference with only a component name and no axis should fail
+        try:
+            out = BytesIO()
+            sys.stdout = out
+
+            cmdline = ["cli", "--reference", "Sample Stage"]
+            ret = main.main(cmdline)
+        except SystemExit as exc:
+            ret = exc.code
+        self.assertNotEqual(ret, 0, "Referencing with no axis should have failed with '%s'" % cmdline)
 
     def test_stop(self):
         try:


### PR DESCRIPTION
We used to only accept one axis, or a series of referencing, but that
would be done serially. Extend the argument handle to support passing
multiple axes to request the simultaneous referencing of multiple axes.

Note that it's still possible to explicitly reference one axis after the
other, by using such syntax:
odemis --reference stage x --reference stage y

Also update the test framework to use the secom2 simulator, which
supports referencing, so that it's possible to actually test it.
(instead of just confirming it succesfully fails).