### PR TITLE
[fix] remove super() with incorrect class

### DIFF
--- a/src/odemis/acq/stream/_helper.py
+++ b/src/odemis/acq/stream/_helper.py
@@ -1363,7 +1363,7 @@ class AngularSpectrumAlignmentStream(AngularSpectrumSettingsStream):
         if self.wl_inverted:
             data = data[:,::-1, ...]  # invert C
 
-        super(AngularSpectrumSettingsStream, self)._onNewData(dataflow, data)
+        super()._onNewData(dataflow, data)
 
 class FastScanningDetector(RepetitionStream):
 

--- a/src/odemis/gui/comp/overlay/pixel_value.py
+++ b/src/odemis/gui/comp/overlay/pixel_value.py
@@ -68,7 +68,7 @@ class PixelValueOverlay(ViewOverlay):
     def on_leave(self, evt):
         """ Event handler called when the mouse cursor leaves the canvas """
         if not self.active.value:
-            return super(ViewOverlay, self).on_leave(evt)
+            return super().on_leave(evt)
         else:
             self._v_pos = None
             self._p_pos = None
@@ -77,7 +77,7 @@ class PixelValueOverlay(ViewOverlay):
     def on_motion(self, evt):
         """ Update the display of the raw pixel value based on the current mouse position """
         if not self.active.value:
-            return super(ViewOverlay, self).on_motion(evt)
+            return super().on_motion(evt)
 
         # Whatever happens, we don't keep the event, but pass it to any other interested listener.
         evt.Skip()


### PR DESCRIPTION
Python 2 required to pass the class name in the super(), and that can
easily go wrong in case of copy-paste. These are 3 instances found by
GitHub CodeQL. Just using the Python 3 syntax super() fixes it.

In practice, they probably were not causing any issue as they were
refering to the parent class, which didn't override the function. So no
change of behaviour should be observed.