### PR TITLE
[SWM-247] [refactor] Move UNDEFINED_ROI from acq.stream to model and remove NON_SETTINGS_VA from Leech

### DIFF
--- a/plugins/ar_spectral.py
+++ b/plugins/ar_spectral.py
@@ -46,7 +46,7 @@ import math
 import numpy
 from odemis import dataio, model
 from odemis.acq import stream, drift, acqmng
-from odemis.acq.stream import UNDEFINED_ROI
+from odemis.model import UNDEFINED_ROI
 from odemis.dataio import hdf5
 import odemis.gui
 from odemis.gui.conf import get_acqui_conf

--- a/plugins/ar_spectral_2d.py
+++ b/plugins/ar_spectral_2d.py
@@ -49,7 +49,7 @@ import numpy
 from odemis import dataio, model, acq
 from odemis.gui.model import TabName
 from odemis.acq import stream, drift, acqmng
-from odemis.acq.stream import UNDEFINED_ROI
+from odemis.model import UNDEFINED_ROI
 import odemis.gui
 from odemis.gui.conf import get_acqui_conf
 import os.path

--- a/plugins/cl_tcorr_acq.py
+++ b/plugins/cl_tcorr_acq.py
@@ -30,7 +30,7 @@ import math
 import numpy
 from odemis import dataio, model
 from odemis.acq import stream, drift, acqmng
-from odemis.acq.stream import UNDEFINED_ROI
+from odemis.model import UNDEFINED_ROI
 import odemis.gui
 from odemis.gui.conf import get_acqui_conf
 from odemis.gui.model import TabName

--- a/plugins/cli_rgb.py
+++ b/plugins/cli_rgb.py
@@ -36,7 +36,7 @@ from odemis import dataio, model
 from odemis.gui.model import TabName
 import odemis.util
 from odemis.acq import stream, drift, acqmng
-from odemis.acq.stream import UNDEFINED_ROI
+from odemis.model import UNDEFINED_ROI
 from odemis.dataio import get_available_formats
 import odemis.gui
 from odemis.gui.conf import get_acqui_conf

--- a/plugins/secom_cl.py
+++ b/plugins/secom_cl.py
@@ -364,7 +364,7 @@ class SECOMCLSettingsStream(acqstream.CCDSettingsStream):
         rep = self.repetition.clip(repetition)
 
         # If ROI is undefined => link repetition and pxs as if ROI is full
-        if roi == acqstream.UNDEFINED_ROI:
+        if roi == model.UNDEFINED_ROI:
             pxs = (phy_size[0] / rep[0], phy_size[1] / rep[1])
             roi, rep, pxs = self._updateROIAndPixelSize((0, 0, 1, 1), pxs)
             self.pixelSize._value = pxs
@@ -423,7 +423,7 @@ class SECOMCLSettingsStream(acqstream.CCDSettingsStream):
         pxs = self.pixelSize.value
 
         old_roi = self.roi.value
-        if old_roi != acqstream.UNDEFINED_ROI and roi != acqstream.UNDEFINED_ROI:
+        if old_roi != model.UNDEFINED_ROI and roi != model.UNDEFINED_ROI:
             old_size = (old_roi[2] - old_roi[0], old_roi[3] - old_roi[1])
             new_size = (roi[2] - roi[0], roi[3] - roi[1])
 
@@ -456,7 +456,7 @@ class SECOMCLSettingsStream(acqstream.CCDSettingsStream):
                   (2 floats) The new pixel size.
         """
         # If ROI is undefined => link rep and pxs as if the ROI was full
-        if roi == acqstream.UNDEFINED_ROI:
+        if roi == model.UNDEFINED_ROI:
             _, rep, pxs = self._updateROIAndPixelSize((0, 0, 1, 1), pxs)
             return roi, rep, pxs
 
@@ -848,7 +848,7 @@ class CLAcqPlugin(Plugin):
         Used to enable/disable the drift correction period control.
         :param roi: (4 x 0<=float<=1) The anchor region selected (tlbr).
         """
-        enabled = (roi != acqstream.UNDEFINED_ROI)
+        enabled = (roi != model.UNDEFINED_ROI)
 
         # The driftCorrector should be a leech if drift correction is enabled
         dc = self._driftCorrector

--- a/plugins/tileacq.py
+++ b/plugins/tileacq.py
@@ -48,7 +48,6 @@ from odemis.acq.stitching import (
 )
 from odemis.acq.stitching._tiledacq import TiledAcquisitionTask
 from odemis.acq.stream import (
-    UNDEFINED_ROI,
     ARStream,
     EMStream,
     MonochromatorSettingsStream,
@@ -56,6 +55,7 @@ from odemis.acq.stream import (
     SpectrumStream,
     StaticStream,
 )
+from odemis.model import UNDEFINED_ROI
 from odemis.dataio import get_available_formats
 from odemis.gui.comp import popup
 from odemis.gui.comp.stream_panel import OPT_BTN_REMOVE, OPT_BTN_SHOW

--- a/plugins/timelapse.py
+++ b/plugins/timelapse.py
@@ -36,7 +36,8 @@ import math
 from odemis import model, dataio
 from odemis.acq import stream, acqmng
 from odemis.acq.stream import MonochromatorSettingsStream, ARStream, \
-    SpectrumStream, UNDEFINED_ROI, StaticStream, LiveStream, Stream
+    SpectrumStream, StaticStream, LiveStream, Stream
+from odemis.model import UNDEFINED_ROI
 from odemis.dataio import get_available_formats
 import odemis.gui
 from odemis.gui.conf import get_acqui_conf

--- a/plugins/zstack.py
+++ b/plugins/zstack.py
@@ -28,7 +28,8 @@ import numpy
 from odemis import model, dataio
 from odemis.acq import stream, acqmng
 from odemis.acq.stream import MonochromatorSettingsStream, ARStream, \
-    SpectrumStream, UNDEFINED_ROI, StaticStream
+    SpectrumStream, StaticStream
+from odemis.model import UNDEFINED_ROI
 from odemis.dataio import get_available_formats
 import odemis.gui
 from odemis.gui.conf import get_acqui_conf

--- a/src/odemis/acq/fastem.py
+++ b/src/odemis/acq/fastem.py
@@ -121,7 +121,7 @@ class FastEMROC(object):
     scintillator is acquired and assigned with all ROAs on the respective scintillator.
     """
 
-    def __init__(self, name: str, scintillator_number: int, coordinates=acqstream.UNDEFINED_ROI, colour="#FFA300"):
+    def __init__(self, name: str, scintillator_number: int, coordinates=model.UNDEFINED_ROI, colour="#FFA300"):
         """
         :param name: (str) Name of the region of calibration (ROC).
         :param scintillator_number: (int) The scintillator number of the region of calibration (ROC).

--- a/src/odemis/acq/leech.py
+++ b/src/odemis/acq/leech.py
@@ -29,7 +29,6 @@ import numpy
 from odemis import model
 from odemis.acq import drift
 from odemis.model import UNDEFINED_ROI
-from odemis.acq.stream._base import NON_SETTINGS_VA
 
 
 # Helper function for code using the leeches
@@ -158,9 +157,7 @@ class AnchorDriftCorrector(LeechAcquirer):
         # period is the (approximate) time between two acquisition of the
         #  anchor (and drift compensation). The exact period is determined so
         #  that it fits with the region of acquisition.
-        # name: is not needed as such, but have it to comply with Stream.get_settings_entries
-        # Stream.set_settings_entries functions. The leech settings along with the stream settings
-        # form a recipe for the acquisition, and it's easier to have all the settings in the same format.
+        # name: User-friendly name (and required to be serialized similarly to a Stream)
         # Note: the scale used for the acquisition of the anchor region is
         #  selected by the AnchoredEstimator, to be as small as possible while
         #  still not scanning too many pixels.
@@ -363,8 +360,7 @@ class AnchorDriftCorrector(LeechAcquirer):
         The format of the dict is the same as the one returned by Stream.get_settings_entries.
         """
         entries = {}
-        all_vas = model.getVAs(self)
-        settings_vas = set(all_vas.keys()).difference(NON_SETTINGS_VA)
+        settings_vas = model.getVAs(self)
         for va_name in settings_vas:
             entries.update({va_name: getattr(self, va_name).value})
         entries["class"] = self.__class__.__name__

--- a/src/odemis/acq/leech.py
+++ b/src/odemis/acq/leech.py
@@ -28,7 +28,7 @@ import numpy
 
 from odemis import model
 from odemis.acq import drift
-from odemis.acq.stream import UNDEFINED_ROI
+from odemis.model import UNDEFINED_ROI
 from odemis.acq.stream._base import NON_SETTINGS_VA
 
 

--- a/src/odemis/acq/stream/_base.py
+++ b/src/odemis/acq/stream/_base.py
@@ -36,14 +36,12 @@ from odemis.model import (MD_POS, MD_PIXEL_SIZE, MD_ROTATION, MD_ACQ_DATE,
                           MD_POL_NEGDIAG, MD_POL_RHC, MD_POL_LHC, MD_POL_S0, MD_POL_S1, MD_POL_S2, MD_POL_S3,
                           MD_POL_DS0, MD_POL_DS1, MD_POL_DS2, MD_POL_DS3, MD_POL_EPHI, MD_POL_ETHETA, MD_POL_EX,
                           MD_POL_EY, MD_POL_EZ, MD_POL_DOP, MD_POL_DOLP, MD_POL_DOCP, MD_POL_UP, MD_POL_DS1N,
-                          MD_POL_DS2N, MD_POL_DS3N, MD_POL_S1N, MD_POL_S2N, MD_POL_S3N, TINT_FIT_TO_RGB, TINT_RGB_AS_IS)
+                          MD_POL_DS2N, MD_POL_DS3N, MD_POL_S1N, MD_POL_S2N, MD_POL_S3N, TINT_FIT_TO_RGB, TINT_RGB_AS_IS,
+                          UNDEFINED_ROI)
 from odemis.util import img
 # TODO: move to odemis.acq (once it doesn't depend on odemis.acq.stream)
 # Contains the base of the streams. Can be imported from other stream modules.
-# to identify a ROI which must still be defined by the user
 from odemis.util.transform import AffineTransform, alt_transformation_matrix_from_implicit
-
-UNDEFINED_ROI = (0, 0, 0, 0)
 
 # use hardcode list of polarization positions necessary for polarimetry analysis
 POL_POSITIONS = (MD_POL_HORIZONTAL, MD_POL_VERTICAL, MD_POL_POSDIAG,

--- a/src/odemis/acq/stream/_helper.py
+++ b/src/odemis/acq/stream/_helper.py
@@ -30,9 +30,9 @@ import numpy
 
 from odemis import model
 from odemis.acq import align
-from odemis.model import VigilantAttributeBase, MD_POL_NONE
+from odemis.model import VigilantAttributeBase, MD_POL_NONE, UNDEFINED_ROI
 from odemis.util import img, almost_equal, angleres
-from ._base import Stream, UNDEFINED_ROI, POL_POSITIONS
+from ._base import Stream, POL_POSITIONS
 from ._live import LiveStream
 
 

--- a/src/odemis/acq/stream/test/stream_live_test.py
+++ b/src/odemis/acq/stream/test/stream_live_test.py
@@ -91,7 +91,7 @@ class StreamTestCase(unittest.TestCase):
     def _check_square_pixel(self, st):
         rep = st.repetition.value
         roi = st.roi.value
-        if roi == stream.UNDEFINED_ROI:
+        if roi == model.UNDEFINED_ROI:
             return
         width = roi[2] - roi[0], roi[3] - roi[1]
 
@@ -107,12 +107,12 @@ class StreamTestCase(unittest.TestCase):
         ss = stream.SpectrumSettingsStream("test spec", None, None, ebeam)
 
         # if roi is UNDEFINED, everything is left unchanged
-        ss.roi.value = stream.UNDEFINED_ROI
+        ss.roi.value = model.UNDEFINED_ROI
         ss.pixelSize.value = 1e-8
         self.assertEqual(ss.pixelSize.value, 1e-8)
         ss.repetition.value = (100, 100)
         self.assertEqual(ss.repetition.value, (100, 100))
-        self.assertEqual(ss.roi.value, stream.UNDEFINED_ROI)
+        self.assertEqual(ss.roi.value, model.UNDEFINED_ROI)
 
         # in any cases, a pixel is always square
         self._check_square_pixel(ss)

--- a/src/odemis/acq/test/leech_test.py
+++ b/src/odemis/acq/test/leech_test.py
@@ -97,7 +97,7 @@ class ADCTestCase(unittest.TestCase):
         self.assertEqual(dc.roi.value, (0, 0, 1, 1))
 
         # UNDEFINED_ROI doesn't allow to start
-        dc.roi.value = stream.UNDEFINED_ROI
+        dc.roi.value = model.UNDEFINED_ROI
         self.assertEqual(dc.estimateAcquisitionTime(0.1, (4, 3)), 0)
         with self.assertRaises(ValueError):
             dc.series_start()

--- a/src/odemis/gui/comp/overlay/fastem.py
+++ b/src/odemis/gui/comp/overlay/fastem.py
@@ -27,7 +27,7 @@ import wx
 
 import odemis.gui as gui
 from odemis import model, util
-from odemis.acq.stream import UNDEFINED_ROI
+from odemis.model import UNDEFINED_ROI
 from odemis.gui.comp.overlay.base import (
     SEL_MODE_DRAG,
     SEL_MODE_NONE,

--- a/src/odemis/gui/comp/overlay/repetition_select.py
+++ b/src/odemis/gui/comp/overlay/repetition_select.py
@@ -31,7 +31,7 @@ import numpy
 import wx
 
 from odemis import util, model, gui
-from odemis.acq.stream import UNDEFINED_ROI
+from odemis.model import UNDEFINED_ROI
 from odemis.gui.comp.overlay.base import RectangleEditingMixin, WorldOverlay, Vec, Label, \
     SEL_MODE_EDIT, SEL_MODE_CREATE, SEL_MODE_NONE, cairo_polygon
 from odemis.util import units

--- a/src/odemis/gui/cont/acquisition/fastem_acq.py
+++ b/src/odemis/gui/cont/acquisition/fastem_acq.py
@@ -1249,7 +1249,7 @@ class FastEMMultiBeamAcquiController(object):
                     if check_calib_2:
                         roc_2 = roa.roc_2.value
                         if (
-                            roc_2.coordinates.value == stream.UNDEFINED_ROI
+                            roc_2.coordinates.value == model.UNDEFINED_ROI
                             or not roc_2.parameters
                         ):
                             return False
@@ -1257,7 +1257,7 @@ class FastEMMultiBeamAcquiController(object):
                     if check_calib_3:
                         roc_3 = roa.roc_3.value
                         if (
-                            roc_3.coordinates.value == stream.UNDEFINED_ROI
+                            roc_3.coordinates.value == model.UNDEFINED_ROI
                             or not roc_3.parameters
                         ):
                             return False
@@ -1272,7 +1272,7 @@ class FastEMMultiBeamAcquiController(object):
             for roa_window in roas:
                 roa = roa_window[0]
                 roc = roa.roc_2.value
-                if roc.coordinates.value == stream.UNDEFINED_ROI or not roc.parameters:
+                if roc.coordinates.value == model.UNDEFINED_ROI or not roc.parameters:
                     undefined.add(roc.scintillator_number.value)
         return sorted(undefined)
 
@@ -1285,7 +1285,7 @@ class FastEMMultiBeamAcquiController(object):
             for roa_window in roas:
                 roa = roa_window[0]
                 roc = roa.roc_3.value
-                if roc.coordinates.value == stream.UNDEFINED_ROI or not roc.parameters:
+                if roc.coordinates.value == model.UNDEFINED_ROI or not roc.parameters:
                     undefined.add(roc.scintillator_number.value)
         return sorted(undefined)
 

--- a/src/odemis/gui/cont/acquisition/secom_acq.py
+++ b/src/odemis/gui/cont/acquisition/secom_acq.py
@@ -32,7 +32,8 @@ import logging
 import wx
 
 import odemis.gui.model as guimod
-from odemis.acq.stream import UNDEFINED_ROI, ScannedTCSettingsStream
+from odemis.model import UNDEFINED_ROI
+from odemis.acq.stream import ScannedTCSettingsStream
 from odemis.gui.preset import preset_as_is, get_global_settings_entries, \
     get_local_settings_entries, apply_preset
 from odemis.gui.model import TabName, TOOL_NONE, TOOL_SPOT

--- a/src/odemis/gui/cont/acquisition/sparc_acq.py
+++ b/src/odemis/gui/cont/acquisition/sparc_acq.py
@@ -38,7 +38,8 @@ import wx
 
 from odemis import model, dataio, util
 from odemis.acq import acqmng, stream
-from odemis.acq.stream import UNDEFINED_ROI, ScannedTCSettingsStream, ScannedTemporalSettingsStream, \
+from odemis.model import UNDEFINED_ROI
+from odemis.acq.stream import ScannedTCSettingsStream, ScannedTemporalSettingsStream, \
     TemporalSpectrumSettingsStream, AngularSpectrumSettingsStream
 from odemis.gui import conf
 from odemis.gui.model import TabName

--- a/src/odemis/gui/cont/stream_bar.py
+++ b/src/odemis/gui/cont/stream_bar.py
@@ -1808,7 +1808,7 @@ class SparcStreamsController(StreamBarController):
         # With EBIC, often the user wants to get the whole area, same as the survey.
         # But it's not very easy to select all of it, so do it automatically.
         # (after the controller creation, to automatically set the ROA too)
-        if ebic_stream.roi.value == acqstream.UNDEFINED_ROI:
+        if ebic_stream.roi.value == model.UNDEFINED_ROI:
             ebic_stream.roi.value = (0, 0, 1, 1)
         return self._addRepStream(ebic_stream, sem_ebic_stream, play=False)
 
@@ -1859,7 +1859,7 @@ class SparcStreamsController(StreamBarController):
         # With CLi, often the user wants to get the whole area, same as the survey.
         # But it's not very easy to select all of it, so do it automatically.
         # (after the controller creation, to automatically set the ROA too)
-        if cli_stream.roi.value == acqstream.UNDEFINED_ROI:
+        if cli_stream.roi.value == model.UNDEFINED_ROI:
             cli_stream.roi.value = (0, 0, 1, 1)
         return ret
 

--- a/src/odemis/gui/cont/stream_page.py
+++ b/src/odemis/gui/cont/stream_page.py
@@ -34,6 +34,7 @@ from wx.adv import WizardPageSimple
 
 import odemis.acq.stream as acqstream
 from odemis.acq import leech
+from odemis.model import UNDEFINED_ROI
 from odemis.gui.comp.stream_bar import StreamBar
 from odemis.gui.conf.file import CONF_PATH
 from odemis.gui.cont.stream_bar import SparcStreamsController
@@ -193,10 +194,10 @@ class Sparc2StreamsPage(WizardPageSimple):
             main_data.ebeam
         )
         tab_data.roa = tab_data.semStream.roi
-        tab_data.roa.value = acqstream.UNDEFINED_ROI
+        tab_data.roa.value = UNDEFINED_ROI
         tab_data.driftCorrector = leech.AnchorDriftCorrector(tab_data.semStream.emitter,
                                                              tab_data.semStream.detector)
-        tab_data.driftCorrector.roi.value = acqstream.UNDEFINED_ROI
+        tab_data.driftCorrector.roi.value = UNDEFINED_ROI
 
         # Custom scrolled window to be able to fit the stream settings entries panels
         self._scrolled_win = wx.ScrolledWindow(self, style=wx.VSCROLL)

--- a/src/odemis/gui/cont/tabs/secom_streams_tab.py
+++ b/src/odemis/gui/cont/tabs/secom_streams_tab.py
@@ -566,7 +566,7 @@ class SecomStreamsTab(Tab):
             # Put the spot position at a "good" place if not yet defined
             if self.tab_data_model.spotPosition.value == (None, None):
                 roa = self.tab_data_model.roa.value
-                if roa == acqstream.UNDEFINED_ROI:
+                if roa == model.UNDEFINED_ROI:
                     # If no ROA => just at the center of the FoV
                     pos = (0.5, 0.5)
                 else:  # Otherwise => in the center of the ROI

--- a/src/odemis/gui/cont/tabs/sparc_acquisition_tab.py
+++ b/src/odemis/gui/cont/tabs/sparc_acquisition_tab.py
@@ -104,13 +104,13 @@ class SparcAcquisitionTab(Tab):
         tab_data.semStream = semcl_stream
         tab_data.roa = semcl_stream.roi
         # Force the ROA to be defined by the user on first use
-        tab_data.roa.value = acqstream.UNDEFINED_ROI
+        tab_data.roa.value = model.UNDEFINED_ROI
 
         tab_data.driftCorrector = leech.AnchorDriftCorrector(semcl_stream.emitter,
                                                              semcl_stream.detector)
 
         # drift correction is disabled until a ROI is selected
-        tab_data.driftCorrector.roi.value = acqstream.UNDEFINED_ROI
+        tab_data.driftCorrector.roi.value = model.UNDEFINED_ROI
 
         # To make sure the spot mode is stopped when the tab loses focus
         tab_data.streams.value.append(spot_stream)
@@ -361,7 +361,7 @@ class SparcAcquisitionTab(Tab):
             # Put the spot position at a "good" place if not yet defined
             if self.tab_data_model.spotPosition.value == (None, None):
                 roa = self.tab_data_model.roa.value
-                if roa == acqstream.UNDEFINED_ROI:
+                if roa == model.UNDEFINED_ROI:
                     # If no ROA => just at the center of the FoV
                     pos = (0.5, 0.5)
                 else:  # Otherwise => in the center of the ROI
@@ -449,7 +449,7 @@ class SparcAcquisitionTab(Tab):
         Called when the Anchor region changes.
         Used to enable/disable the drift correction period control
         """
-        enabled = (roi != acqstream.UNDEFINED_ROI)
+        enabled = (roi != model.UNDEFINED_ROI)
         self.dc_period_ent.lbl_ctrl.Enable(enabled)
         self.dc_period_ent.value_ctrl.Enable(enabled)
 

--- a/src/odemis/gui/model/tab_gui_data.py
+++ b/src/odemis/gui/model/tab_gui_data.py
@@ -205,7 +205,7 @@ class LiveViewGUIData(MicroscopyGUIData):
         if main.time_correlator: # FLIM
             tools.add(TOOL_ROA)
 
-            self.roa = model.TupleContinuous(acqstream.UNDEFINED_ROI,
+            self.roa = model.TupleContinuous(model.UNDEFINED_ROI,
                                              range=((0, 0, 0, 0), (1, 1, 1, 1)),
                                              cls=(int, float))
 

--- a/src/odemis/gui/test/comp_overlay_test.py
+++ b/src/odemis/gui/test/comp_overlay_test.py
@@ -39,7 +39,7 @@ import odemis.gui.comp.miccanvas as miccanvas
 import odemis.gui.model as guimodel
 import odemis.gui.test as test
 from odemis import model, util
-from odemis.acq.stream import UNDEFINED_ROI
+from odemis.model import UNDEFINED_ROI
 from odemis.driver import simsem
 from odemis.driver.tmcm import TMCLController
 from odemis.gui.comp.overlay.centered_line import (CROSSHAIR, HORIZONTAL_LINE,

--- a/src/odemis/model/_constants.py
+++ b/src/odemis/model/_constants.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
-'''
-Created on 26 Mar 2012
+"""
+Created on 16 Jul 2026
 
 @author: Éric Piel
 
-Copyright © 2012 Éric Piel, Delmic
+Copyright © 2026 Éric Piel, Delmic
 
 This file is part of Odemis.
 
@@ -18,25 +18,14 @@ PURPOSE. See the GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License along with
 Odemis. If not, see http://www.gnu.org/licenses/.
-'''
-# Load the package namespace here so that it's possible to just do "import model"
 
-# to hide the lower layer
-from Pyro4.core import oneway, isasync
+General constants used across the odemis model.
+"""
 
-from ._futures import *
-from ._vattributes import *
-from ._components import *
-from ._dataflow import *
-from ._core import *
-from ._metadata import *
-from ._dataio import *
-from ._constants import *
+__all__ = ["UNDEFINED_ROI"]
 
-
-#__all__ = []
-#import model._properties
-#__all__ += [name for name in dir(model._properties) if not name.startswith('_')]
-
-
-# vim:tabstop=4:shiftwidth=4:expandtab:spelllang=en_gb:spell:
+# Sentinel value for a Region Of Interest (ROI) that has not yet been defined
+# by the user. The ROI is expressed as (xmin, ymin, xmax, ymax) in relative
+# coordinates (0 to 1). This sentinel uses (0, 0, 0, 0), which is an empty
+# region and therefore not a valid ROI.
+UNDEFINED_ROI = (0, 0, 0, 0)


### PR DESCRIPTION
UNDEFINED_ROI was originally only used on streams, but it's now used in many places. Let's not make everything depend on acq.stream just for this constant. This helps avoid circular dependencies.

Also, Leech imported NON_SETTINGS_VA, but that constant was not useful as it listed the Stream VAs, while the Leech VAs would be different. As a matter of fact, all VAs on Leech as useful settings, so it can be simplified.

