### PR TITLE
[fix] GUI: force min/best height of the widgets to never be too big

### DIFF
--- a/src/odemis/gui/comp/settings.py
+++ b/src/odemis/gui/comp/settings.py
@@ -195,7 +195,7 @@ class SettingsPanel(wx.Panel):
             if selectable:
                 value_ctrl = wx.TextCtrl(self, value=value,
                                          style=wx.BORDER_NONE | wx.TE_READONLY)
-                value_ctrl.MinSize = (-1, value_ctrl.BestSize[1])
+                value_ctrl.MinSize = (-1, min(value_ctrl.BestSize[1], 16))  # Workaround BestSize bug on wxPython 4.2.1
                 value_ctrl.SetForegroundColour(gui.FG_COLOUR_DIS)
                 value_ctrl.SetBackgroundColour(gui.BG_COLOUR_MAIN)
                 self.gb_sizer.Add(value_ctrl, (self.num_rows, 1),
@@ -229,7 +229,7 @@ class SettingsPanel(wx.Panel):
                                  | wx.BORDER_NONE
                                  | (wx.TE_READONLY if readonly else 0)
                                  | (wx.TE_MULTILINE if multiline else 0))
-        value_ctrl.MinSize = (-1, value_ctrl.BestSize[1])
+        value_ctrl.MinSize = (-1, min(value_ctrl.BestSize[1], 16))  # Workaround BestSize bug on wxPython 4.2.1
 
         if readonly:
             value_ctrl.SetForegroundColour(gui.FG_COLOUR_DIS)

--- a/src/odemis/gui/comp/stream_panel.py
+++ b/src/odemis/gui/comp/stream_panel.py
@@ -1095,7 +1095,7 @@ class StreamPanel(wx.Panel):
             if selectable:
                 value_ctrl = wx.TextCtrl(self._panel, value=value,
                                          style=wx.BORDER_NONE | wx.TE_READONLY)
-                value_ctrl.MinSize = (-1, value_ctrl.BestSize[1])
+                value_ctrl.MinSize = (-1, min(value_ctrl.BestSize[1], 16))  # Workaround BestSize bug on wxPython 4.2.1
                 value_ctrl.SetForegroundColour(gui.FG_COLOUR_DIS)
                 value_ctrl.SetBackgroundColour(gui.BG_COLOUR_MAIN)
                 self.gb_sizer.Add(value_ctrl, (self.num_rows, 1), span=(1, 2),
@@ -1172,7 +1172,7 @@ class StreamPanel(wx.Panel):
         lbl_ctrl = self._add_side_label(label_text)
         value_ctrl = wx.TextCtrl(self._panel, value=str(value or ""),
                                  style=wx.TE_PROCESS_ENTER | wx.BORDER_NONE | (wx.TE_READONLY if readonly else 0))
-        value_ctrl.MinSize = (-1, value_ctrl.BestSize[1])
+        value_ctrl.MinSize = (-1, min(value_ctrl.BestSize[1], 16))  # Workaround BestSize bug on wxPython 4.2.1
         if readonly:
             value_ctrl.SetForegroundColour(gui.FG_COLOUR_DIS)
         else:

--- a/src/odemis/gui/comp/text.py
+++ b/src/odemis/gui/comp/text.py
@@ -776,6 +776,14 @@ class _NumberTextCtrl(wx.TextCtrl):
             str_val = units.readable_str(self._number_value, sig=self.accuracy)
         wx.TextCtrl.ChangeValue(self, str_val)
 
+    def DoGetBestSize(self):
+        """ Return the best size of the control """
+        # To workaround issue with wxWidgets 3.2.4 on Ubuntu 24.04, that causes BestSize to report
+        # a pretty big height. Fixed in wxWidgets 3.2.9/wxPython 4.2.5
+        best_size = wx.TextCtrl.DoGetBestSize(self)
+        best_size[1] = min(best_size[1], 16)
+        return best_size
+
     def Disable(self):
         self.Enable(False)
 


### PR DESCRIPTION
On Ubuntu 24.04, wxPython 4.2.1, which uses wxWidgets 3.2.4, has an issue
that causes BestSize to report a pretty big height. It is fixed in wxWidgets 3.2.9/wxPython 4.2.5.

When this happens, the stream/hardware settings are too much spaced
vertically.
=> Force maximum 16 px in height. It shouldn't have any effect on
systems with a working wxPython.

Note: there is still some minor esthetic issues with this version of wxPython,
but it should be good enough.