### PR TITLE
[fix] andorshrk: don't wait for grating to settle when not chaning grating

### DIFF
--- a/src/odemis/driver/andorshrk.py
+++ b/src/odemis/driver/andorshrk.py
@@ -1952,8 +1952,12 @@ class Shamrock(model.Actuator):
         Setter for the grating VA.
         It will try to put the same wavelength as before the change of grating.
         Synchronous until the grating is finished (up to 30s)
-        g (1<=int<=3): the new grating
+        g (1<=int<=4): the new grating
         """
+        if self.GetGrating() == g:
+            logging.debug("Grating %d already selected, not moving", g)
+            return
+
         # Make sure that getPixelToWavelength() can be called in-between the
         # moves as the intermediary position might not accepted by the HW.
         with self._px2wl_lock:


### PR DESCRIPTION
Commit fada7c0a87 (add support to change grating & detector offset)
added 5s after a grating change to make sure there is no vibrations.
However, if asking to move to the current grating (which often happens
as lots of code just always ask to go to a fixed position), this adds 5
s, although nothing happens.
=> Check the current grating and skip the move if it's already the right
grating.