### PR TITLE
[fix] backend: increase maximum thread allowed

### DIFF
--- a/src/odemis/model/_core.py
+++ b/src/odemis/model/_core.py
@@ -45,7 +45,7 @@ from odemis.util import inspect_getmembers
 # callbacks.
 # Pyro4.config.SERVERTYPE = "multiplex"
 Pyro4.config.THREADPOOL_MINTHREADS = 16  # TODO: still need 48, because it can block when increasing the pool?
-Pyro4.config.THREADPOOL_MAXTHREADS = 128
+Pyro4.config.THREADPOOL_MAXTHREADS = 256
 # TODO make sure Pyro can now grow the pool: it used to allocate a huge static
 # number of threads. It seems also that when growing the pool it sometimes blocks
 


### PR DESCRIPTION
On some large systems, when accessing all the components at once, for
instance with odemis list-prop *, the connections don't close
sufficiently quickly, and this causes the caller to block.
With current hardware, it's no problem to bump up a little bit the
maximum number of threads.