### PR TITLE
[config] add dependency on gnome-screenshot for the bug reporter

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -30,7 +30,7 @@ Depends: ${shlibs:Depends},
          odemis-doc,
          cgroup-tools,
 # just to take screenshots during bug report
-         graphicsmagick,
+         gnome-screenshot,
 # currently authbind is only needed for the auto probing of nfpm driver
          authbind,
          python3,

--- a/doc/INSTALL.txt
+++ b/doc/INSTALL.txt
@@ -12,7 +12,7 @@ python3-libtiff python3-comedilib python3-h5py libtiff5-dev cython3 \
 python3-pkg-resources python3-netifaces python3-cairo python3-numpy python3-scipy \
 python3-decorator python3-xdg python3-suds python3-matplotlib python3-opencv \
 python3-wxgtk4.0 python3-serial python3-evdev python3-notify2 python3-psutil \
-graphicsmagick cgroup-tools authbind
+python3-boto3 gnome-screenshot cgroup-tools authbind
 
 
 Some of these packages need newer version than what is available in the default


### PR DESCRIPTION
Since 2021 (commit 892dd5841), we do not rely on graphicsmagic, but just
gnome-screenshot to take screenshot. Since Ubuntu 22.04, however, it's
not installed by default. So we need to explicitly depend on it,
otherwise no screenshot is taken.