### PR TITLE
[fix] driver smaract: load .so.N library instead of .so version

### DIFF
--- a/src/odemis/driver/smaract.py
+++ b/src/odemis/driver/smaract.py
@@ -265,7 +265,7 @@ class SmarPodDLL(CDLL):
             # atmcd64d.dll on 64 bits
         else:
             # Global so that its sub-libraries can access it
-            CDLL.__init__(self, "libsmarpod.so", RTLD_GLOBAL)
+            CDLL.__init__(self, "libsmarpod.so.1", RTLD_GLOBAL)
 
     def __getitem__(self, name):
         try:
@@ -1487,7 +1487,7 @@ class MC_5DOF_DLL(CDLL):
             # WinDLL.__init__(self, "libSA_MC.dll")  # TODO check it works
         else:
             # Global so that its sub-libraries can access it
-            CDLL.__init__(self, "libsmaractmc.so", RTLD_GLOBAL)
+            CDLL.__init__(self, "libsmaractmc.so.0", RTLD_GLOBAL)
 
     def __getitem__(self, name):
         try:
@@ -2874,7 +2874,7 @@ class SA_CTLDLL(CDLL):
             # atmcd64d.dll on 64 bits
         else:
             # Global so that its sub-libraries can access it
-            CDLL.__init__(self, "libsmaractctl.so", RTLD_GLOBAL)
+            CDLL.__init__(self, "libsmaractctl.so.1", RTLD_GLOBAL)
 
         self.SA_CTL_GetFullVersionString.restype = c_char_p
         self.SA_CTL_GetFullVersionString.errcheck = lambda r, f, a: r  # Always happy

--- a/src/odemis/driver/smaract.py
+++ b/src/odemis/driver/smaract.py
@@ -1483,7 +1483,7 @@ class MC_5DOF_DLL(CDLL):
 
     def __init__(self):
         if os.name == "nt":
-            raise NotImplemented("Windows not yet supported")
+            raise NotImplementedError("Windows not yet supported")
             # WinDLL.__init__(self, "libSA_MC.dll")  # TODO check it works
         else:
             # Global so that its sub-libraries can access it


### PR DESCRIPTION
The .so version is supposed to be used for development purpose, while
the .so.N version is used to stick to a given API version.
In practice, as long as there is no major update on the library, they
link to the same file. However, the .so version is only provided by the
-dev package.