### PR TITLE
[fix] widgets ProgressiveFutureConnector progress for pending futures

### DIFF
--- a/src/odemis/gui/test/util_widgets_test.py
+++ b/src/odemis/gui/test/util_widgets_test.py
@@ -103,9 +103,11 @@ class ConnectorTestCase(test.GuiTestCase):
 
         test.gui_loop(0.2)
 
-        # Create the ProgressiveFuture
+        # Create the ProgressiveFuture and transition it to RUNNING state.
+        # Progress only advances once the future is running (not pending).
         pf = model.ProgressiveFuture(remaining_time=60)  # one min
         # future.task_canceller = self.cancel_task
+        pf.set_running_or_notify_cancel()
 
         # Create the connector
         pfc = widgets.ProgressiveFutureConnector(pf, bar=gauge, label=stxt)

--- a/src/odemis/gui/util/widgets.py
+++ b/src/odemis/gui/util/widgets.py
@@ -282,6 +282,7 @@ class ProgressiveFutureConnector(object):
         elapsed, remaining = future.get_progress()
         self._elapsed = elapsed  # elapsed time at last progress update (s)
         self._remaining = remaining  # remaining time at last progress update (s)
+        self._progress_update_time = time.monotonic()  # wall-clock time of the last progress anchor
         self._prev_left = None
         self._last_update = 0  # when was the last GUI update
 
@@ -305,6 +306,7 @@ class ProgressiveFutureConnector(object):
         """
         self._elapsed = elapsed_time
         self._remaining = remaining_time
+        self._progress_update_time = time.monotonic()
 
     @call_in_wx_main
     def _on_done(self, future):
@@ -328,8 +330,15 @@ class ProgressiveFutureConnector(object):
 
     def _update_progress(self):
         """ Update the progression controls """
-        now = time.time()
+        now = time.monotonic()
         elapsed, remaining = self._future.get_progress()
+
+        # For pending futures, get_progress() always returns elapsed=0. Use
+        # wall-clock time since the last progress anchor so the bar advances.
+        if elapsed == 0 and not self._future.running() and not self._future.done():
+            wall_elapsed = max(0.0, now - self._progress_update_time)
+            elapsed = wall_elapsed
+            remaining = max(0.0, remaining - wall_elapsed)
 
         prev_left = self._prev_left
         total = elapsed + remaining


### PR DESCRIPTION
[test] Fix test_pf_connector set future to running before checking progress
Commit https://github.com/delmic/odemis/commit/efde81ab832372d8f4b76f077caa839570660d0a refactored future start/end -> elapsed_time and remaining_time. The old  ProgressiveFuture  used absolute  start / end  timestamps, so even for PENDING futures the connector computed  past = time.time() - start  which grew naturally. The refactored API returns (0.0, remaining) for PENDING futures elapsed is always 0, so the progress bar never advanced.

util_widgets_test.py::ConnectorTestCase::test_pf_connector was failing because it checked if time had elapsed when the future was still pending.
This commit explicitely sets the state of the future to running, to ensure progress increased.