### PR TITLE
[fix] acq RepetitionStream: fix guessFoV() height incorrect computation

### DIFF
--- a/src/odemis/acq/stream/_helper.py
+++ b/src/odemis/acq/stream/_helper.py
@@ -669,16 +669,16 @@ class RepetitionStream(LiveStream):
         """
         return self.SETUP_OVERHEAD
 
-    def guessFoV(self):
+    def guessFoV(self) -> Tuple[float, float]:
         """
         Estimate the field-of-view based on the current settings.
-        return (float, float): width, height in meters
+        :return: width, height in meters
         """
         shape = self._scanner.shape
         pxs = self._scanner.pixelSize.value
-        full_fov = shape[0] * pxs[0], shape[0] * pxs[1]
+        full_fov = shape[0] * pxs[0], shape[1] * pxs[1]
         roi = self.roi.value
-        return full_fov[0] * (roi[2] - roi[0]), full_fov[0] * (roi[3] - roi[1])
+        return full_fov[0] * (roi[2] - roi[0]), full_fov[1] * (roi[3] - roi[1])
 
 class CCDSettingsStream(RepetitionStream):
 


### PR DESCRIPTION
Typo causing the computation to be incorrect when the full FoV is not
square.