### PR TITLE
[fix] SPARC GUI: don't fail saving file if thumbnail cannot be generated

### DIFF
--- a/src/odemis/gui/cont/acquisition/sparc_acq.py
+++ b/src/odemis/gui/cont/acquisition/sparc_acq.py
@@ -487,7 +487,11 @@ class SparcAcquiController(object):
         """
         streams = list(self._tab_data_model.acquisitionStreams)
         st = stream.StreamTree(streams=streams)
-        thumb = acqmng.computeThumbnail(st, acq_future)
+        try:
+            thumb = acqmng.computeThumbnail(st, acq_future)
+        except Exception:
+            logging.exception("Failed to compute thumbnail for acquisition")
+            thumb = None
         data, exp = acq_future.result()
 
         filename = self.filename.value


### PR DESCRIPTION
So far, failure to generate the thumbnail was only due to so on the fly
hacks, or hack plugins. However, in general, it's doesn't make sense to
completely fail saving the file for such reason, so explicitly catch
such error and recover nicely.