### PR TITLE
[TRPD-29][feat] SPARC acq/GUI: support for streakcam photon-counting

### DIFF
--- a/src/odemis/acq/stream/_helper.py
+++ b/src/odemis/acq/stream/_helper.py
@@ -691,8 +691,16 @@ class CCDSettingsStream(RepetitionStream):
         res = self._getDetectorVA("resolution").value
         readout = numpy.prod(res) / ro_rate
 
-        exp = self._getDetectorVA("exposureTime").value
-        duration = (exp + readout + 0.03) * 1.20
+        if hasattr(self, "detPhotonCounting") and self.detPhotonCounting.value:
+            exp = self.detPcExposureTime.value
+            counts = self.detPcIntegrationCounts.value
+        elif hasattr(self, "integrationTime"):
+            exp = self._hwExpTime
+            counts = self.integrationCounts.value
+        else:
+            exp = self._getDetectorVA("exposureTime").value
+            counts = 1
+        duration = ((exp + readout) * counts + 0.03) * 1.20
         # Add the setup time
         duration += self.SETUP_OVERHEAD
 

--- a/src/odemis/acq/stream/_sync.py
+++ b/src/odemis/acq/stream/_sync.py
@@ -292,6 +292,7 @@ class MultipleDetectorStream(Stream, metaclass=ABCMeta):
         for l in self.leeches:
             shape = (len(pol_pos), rep[1], rep[0])
             # estimate acq time for leeches is based on two fastest axis
+
             if self._integrationTime:
                 integration_count = self._integrationCounts.value
                 if integration_count > 1:
@@ -996,11 +997,15 @@ class SEMCCDMDStream(MultipleDetectorStream):
             res = self._sccd._getDetectorVA("resolution").value
             readout = numpy.prod(res) / ro_rate
 
-            if self._integrationTime:
+            if hasattr(self._sccd, "detPhotonCounting") and self._sccd.detPhotonCounting.value:
+                exp = self._sccd.detPcExposureTime.value
+                counts = self._sccd.detPcIntegrationCounts.value
+            elif self._integrationTime:
                 exp = self._integrationTime.value  # get the total exp time
-                readout *= self._integrationCounts.value
+                counts = self._integrationCounts.value
             else:
                 exp = self._sccd._getDetectorVA("exposureTime").value
+                counts = 1
 
             if self._supports_hw_sync():
                 # The overhead per frame depends a lot on the camera. For now, we use arbitrarily the
@@ -1009,7 +1014,7 @@ class SEMCCDMDStream(MultipleDetectorStream):
             else:
                 # Each pixel x the exposure time (of the detector) + readout time +
                 # 30ms overhead + 20% overhead
-                dur_image = (exp + readout + 0.03) * 1.20
+                dur_image = ((exp + readout) * counts + 0.03) * 1.20
             duration = numpy.prod(self.repetition.value) * dur_image
             # Add the setup time
             duration += self.SETUP_OVERHEAD
@@ -1230,6 +1235,7 @@ class SEMCCDMDStream(MultipleDetectorStream):
         try:
             pos_polarizations = self._get_polarisation_positions()
             shortest_leech_period = self._get_min_leech_period()
+            logging.debug("Shortest leech period = %s", shortest_leech_period)
 
             # Prepare the hardware (different per acquisition type)
             acquirer.prepare_hardware(shortest_leech_period)
@@ -1249,8 +1255,8 @@ class SEMCCDMDStream(MultipleDetectorStream):
             self._roa_center_phys = acquirer.pos_center
 
             self._reset_live_data(acquirer)
-            logging.debug("Starting acquisition of %s px @ dt = %s s, roi = %s, rotation = %s rad",
-                          rep, acquirer.snapshot_time * acquirer.integration_count,
+            logging.debug("Starting acquisition of %s px @ dt = (%s x %s) s, roi = %s, rotation = %s rad",
+                          rep, acquirer.snapshot_time, acquirer.integration_count,
                            self.roi.value, self.rotation.value)
 
             # Iterate for the polarisations
@@ -2233,24 +2239,29 @@ class SEMTemporalSpectrumMDStream(SEMCCDMDStream):
         :param future: Current future running for the whole acquisition.
         """
         try:
-            # Compute the max safe intensity value, based on the exposure time
-            if self._integrationTime:
-                # calculate exposure time to be set on detector
-                exp = self._integrationTime.value / self._integrationCounts.value  # get the exp time from stream
-                exp = self._ccd.exposureTime.clip(exp)  # set the exp time on the HW VA
+            if hasattr(self._sccd, "detPhotonCounting") and self._sccd.detPhotonCounting.value:
+                # Disable protection, as each frame should receive very little signal
+                self._intensity_limit_cpf = math.inf
+                logging.debug("Streak CCD protection disabled due to photon-counting mode")
             else:
-                # stream has exposure time
-                exp = self._sccd._getDetectorVA("exposureTime").value  # s
+                # Compute the max safe intensity value, based on the exposure time
+                if self._integrationTime:
+                    # calculate exposure time to be set on detector
+                    exp = self._integrationTime.value / self._integrationCounts.value  # get the exp time from stream
+                    exp = self._ccd.exposureTime.clip(exp)  # set the exp time on the HW VA
+                else:
+                    # stream has exposure time
+                    exp = self._sccd._getDetectorVA("exposureTime").value  # s
 
-            # Clip to the maximum value of the detector, otherwise we might never detect high intensity
-            # for long exposure times. Should be defined on the streak-ccd.metadata[MD_CALIB]["intensity_limit"]
-            # as count/s.
-            max_det_value = self._ccd.shape[2] - 1
-            ccd_md = self._ccd.getMetadata()
+                # Clip to the maximum value of the detector, otherwise we might never detect high intensity
+                # for long exposure times. Should be defined on the streak-ccd.metadata[MD_CALIB]["intensity_limit"]
+                # as count/s.
+                max_det_value = self._ccd.shape[2] - 1
+                ccd_md = self._ccd.getMetadata()
 
-            intensity_limit_cps = ccd_md.get(model.MD_CALIB, {}).get("intensity_limit", 40000)
-            self._intensity_limit_cpf = min(intensity_limit_cps * exp, max_det_value)  # counts/frame
-            logging.debug("Streak CCD intensity threshold set to %s counts/frame", self._intensity_limit_cpf)
+                intensity_limit_cps = ccd_md.get(model.MD_CALIB, {}).get("intensity_limit", 40000)
+                self._intensity_limit_cpf = min(intensity_limit_cps * exp, max_det_value)  # counts/frame
+                logging.debug("Streak CCD intensity threshold set to %s counts/frame", self._intensity_limit_cpf)
 
             das, error = super()._runAcquisition(future)
         finally:
@@ -2985,49 +2996,74 @@ class SEMCCDAcquirerRectangle(SEMCCDAcquirer):
         # Note: if the stream has "local VA" (ie, copy of the component VA), then it is assumed that
         # the component VA has already been set to the correct value. (ie, linkHwVAs() has been called)
 
-        if model.hasVA(self._mdstream._ccd, "exposureTime"):
-            expTime = self._mdstream._ccd.exposureTime
-        elif model.hasVA(self._mdstream._ccd, "dwellTime"):
-            expTime = self._mdstream._ccd.dwellTime
+        # Special for detectors with photon counting: a dedicated exposure time and integration count are used.
+        # However, there is only one frame that is sent per acquisition, independent of the integration count.
+        ccd = self._mdstream._ccd
+        photon_counting = model.hasVA(ccd, "photonCounting") and ccd.photonCounting.value
+        if photon_counting:
+            exp_time_va = ccd.pcExposureTime
+            pc_count = ccd.pcIntegrationCounts.value
+        elif model.hasVA(ccd, "exposureTime"):
+            exp_time_va = ccd.exposureTime
+        elif model.hasVA(ccd, "dwellTime"):
+            exp_time_va = ccd.dwellTime
         else:
-            raise ValueError(f"No exposureTime or dwellTime control on {self._mdstream._ccd.name}")
+            raise ValueError(f"No exposureTime or dwellTime control on {ccd.name}")
 
         # Set the detector synchronisation. It's important to do it before reading frameDuration,
         # because for some detectors it depends on it. Also, for the spectrometer, the CCD settings
         # are only applied after setting the synchronization.
         self._mdstream._ccd_df.synchronizedOn(self._mdstream._trigger)
 
-        if self._mdstream._integrationTime:
+        if photon_counting:
+            exp_time = exp_time_va.value * pc_count
+            integration_time = exp_time
+
+            if max_snapshot_duration is None:
+                max_snapshot_duration = exp_time
+        elif self._mdstream._integrationTime:
             integration_time = self._mdstream._integrationTime.value
-            exp_time = expTime.value
+            exp_time = integration_time / self._mdstream._integrationCounts.value
             if max_snapshot_duration is None:
                 max_snapshot_duration = exp_time
             else:
                 max_snapshot_duration = min(max_snapshot_duration, exp_time)
         else:
             # CCD stream has exposure time
-            exp_time = expTime.value
+            exp_time = exp_time_va.value
             integration_time = exp_time
 
             if max_snapshot_duration is None:
                 max_snapshot_duration = exp_time
 
-        if integration_time > max_snapshot_duration:
-            # calculate exposure time to be set on detector
-            integration_count = math.ceil(integration_time / max_snapshot_duration)
-            exp_time = integration_time / integration_count
-            # set the exp time on the HW VA (which might adjust it)
-            expTime.value = expTime.clip(exp_time)
-            # calculate the integrationCount using the actual value from the HW, in case it was
-            # modified by a lot (unlikely)
-            exp_time = expTime.value
-            integration_count = math.ceil(integration_time / exp_time)
-            logging.debug("Using integration of %d snapshots of %s s per pixel",
-                          integration_count, exp_time)
-        else:
-            exp_time = integration_time
-            expTime.value = exp_time
+        if photon_counting:
             integration_count = 1
+            if integration_time > max_snapshot_duration:
+                # For now, we don't support breaking down the photon-counting acquisition into multiple
+                # sub-frames to handle short drift correction. => The drift correction will be a little
+                # bit more coarse.
+                # TODO: reduce the pcIntegrationCounts and use integration counts to sum afterwards...
+                # (but we need to check it doesn't introduce differences in the data.
+                logging.warning("Photon counting with sub-frames (for drift correction) not implemented "
+                        f"({integration_time} > {max_snapshot_duration} s)")
+
+        else:
+            if integration_time > max_snapshot_duration:
+                # calculate exposure time to be set on detector
+                integration_count = math.ceil(integration_time / max_snapshot_duration)
+                exp_time = integration_time / integration_count
+                # set the exp time on the HW VA (which might adjust it)
+                exp_time_va.value = exp_time_va.clip(exp_time)
+                # calculate the integrationCount using the actual value from the HW, in case it was
+                # modified by a lot (unlikely)
+                exp_time = exp_time_va.value
+                integration_count = math.ceil(integration_time / exp_time)
+                logging.debug("Using integration of %d snapshots of %s s per pixel",
+                              integration_count, exp_time)
+            else:
+                exp_time = integration_time
+                exp_time_va.value = exp_time
+                integration_count = 1
 
         fuzzing = (hasattr(self._mdstream, "fuzzing") and self._mdstream.fuzzing.value)
         if fuzzing:
@@ -3086,10 +3122,10 @@ class SEMCCDAcquirerRectangle(SEMCCDAcquirer):
             self._mdstream._emitter.external.value = True
 
         # Estimate the duration of a CCD frame (aka snapshot)
-        if hasVA(self._mdstream._ccd, "frameDuration"):
+        if hasVA(ccd, "frameDuration"):
             # TODO: make the frameDuration getter blocking until all the settings have been updated?
             time.sleep(0.1)  # wait a bit to ensure the value is updated (can take ~30ms)
-            frame_duration = self._mdstream._ccd.frameDuration.value
+            frame_duration = ccd.frameDuration.value
             logging.debug("Using CCD frame duration of %s s", frame_duration)
         else:
             if model.hasVA(self._mdstream._sccd, "readoutRate"):
@@ -3097,6 +3133,8 @@ class SEMCCDAcquirerRectangle(SEMCCDAcquirer):
                 readout = numpy.prod(ccd_res) / self._mdstream._sccd.readoutRate.value
             else:
                 readout = 0
+            if photon_counting:
+                readout *= pc_count
             frame_duration = exp_time + readout  # s
             logging.debug("Estimated CCD frame duration of %s s, (%s + %s s)",
                           frame_duration, exp_time, readout)
@@ -3681,16 +3719,16 @@ class SEMCCDAcquirerHwSync(SEMCCDAcquirer):
 
         # max_snapshot_duration is expected to be None, as we do not support integration/leeches.
         assert max_snapshot_duration is None
-        if self._mdstream._integrationTime and self._mdstream._integrationCounts.value > 1:
-            # We would need to request the e-beam scanner to duplicate each pixel N times.
-            # (in order to send N triggers to the CCD)
-            raise NotImplementedError("Integration time not supported with hardware sync")
-
         if self._mdstream._integrationTime:
-            # The RepetitionStream updates all the CCD settings in .prepare() and _linkHwVAs(), but
-            # if integration is used, the exposure time might be incorrect.
-            # As, for now, integrationCounts is always == 1, it's easy.
-            self._mdstream._ccd.exposureTime.value = self._mdstream._integrationTime.value
+            if self._mdstream._integrationCounts.value == 1:
+                # The RepetitionStream updates all the CCD settings in .prepare() and _linkHwVAs(), but
+                # if integration is used, the exposure time might be incorrect.
+                # As, for now, integrationCounts is always == 1, it's easy.
+                self._mdstream._ccd.exposureTime.value = self._mdstream._integrationTime.value
+            else:
+                # We would need to request the e-beam scanner to duplicate each pixel N times.
+                # (in order to send N triggers to the CCD)
+                raise NotImplementedError("Integration time not supported with hardware sync")
 
         integration_count = 1
 

--- a/src/odemis/acq/stream/test/stream_sparc2_streakcam_test.py
+++ b/src/odemis/acq/stream/test/stream_sparc2_streakcam_test.py
@@ -53,6 +53,11 @@ class SPARC2StreakCameraTestCase(BaseSPARCTestCase):
         # very early.
         time.sleep(2)
 
+        # Reset photon-counting mode in case it was set, as most of the test cases don't touch it
+        # and assume it's off.
+        if model.hasVA(self.streak_ccd, "photonCounting"):
+            self.streak_ccd.photonCounting.value = False
+
     def test_streak_live_stream(self):  # TODO  this one has still exposureTime
         """ Test playing TemporalSpectrumSettingsStream
         and check shape and MD for image received are correct."""
@@ -162,7 +167,7 @@ class SPARC2StreakCameraTestCase(BaseSPARCTestCase):
         time.sleep(2)
         streaks.is_active.value = False
 
-        self.assertGreater(len(self._images), 0,"No temporal spectrum received after 2s")
+        self.assertGreater(len(self._images), 0, "No temporal spectrum received after 2s")
         self.assertIsInstance(self._images[-1], model.DataArray)
         # .image should be a 2D temporal spectrum
         self.assertEqual(self._images[-1].shape[1::-1], streaks.detResolution.value)
@@ -363,12 +368,14 @@ class SPARC2StreakCameraTestCase(BaseSPARCTestCase):
         streaks.roi.value = (0.15, 0.6, 0.8, 0.8)
         streaks.repetition.value = (5, 6)
 
-        ###inactive stream######################################################################################
-        # set stream VA
-        streaks.integrationTime.value = 2.0  # s
+        # Note: this test assumes that the hardware maximum exposure time is 10s
 
+        ###inactive stream######################################################################################
         # set HW VA to position different from stream VA
         self.streak_ccd.exposureTime.value = 0.3  # s
+
+        # set stream VA
+        streaks.integrationTime.value = 12.0  # s
 
         # while stream is not active, HW should not move, therefore
         # check stream VA did not trigger HW VA to change
@@ -383,18 +390,18 @@ class SPARC2StreakCameraTestCase(BaseSPARCTestCase):
 
         # HW VA should be updated with the correct value when acquiring or playing the stream
         # check explicit values of stream and HW VA
-        self.assertEqual(self.streak_ccd.exposureTime.value, 1)
-        self.assertEqual(streaks.integrationTime.value, 2)
+        self.assertAlmostEqual(self.streak_ccd.exposureTime.value, 6.0)
+        self.assertEqual(streaks.integrationTime.value, 12.0)
 
         # change stream VA --> HW VAs should change as stream is still active
-        streaks.integrationTime.value = 4.0  # s
+        streaks.integrationTime.value = 11.0  # s
         time.sleep(streaks.integrationTime.value + 0.5)
         # check stream VA shows not the same value as the HW VA
         self.assertNotEqual(streaks.integrationTime.value, self.streak_ccd.exposureTime.value)
         # check stream VA and HW VA show the correct value
-        self.assertEqual(self.streak_ccd.exposureTime.value, 1)
-        self.assertEqual(streaks.integrationTime.value, 4)
-        self.assertEqual(streaks.integrationCounts.value, 4)
+        self.assertAlmostEqual(self.streak_ccd.exposureTime.value, 5.5)
+        self.assertEqual(streaks.integrationTime.value, 11.0)
+        self.assertEqual(streaks.integrationCounts.value, 2)
 
         # change stream VA --> HW VAs should change as stream is still active
         streaks.integrationTime.value = 0.9  # s
@@ -407,16 +414,16 @@ class SPARC2StreakCameraTestCase(BaseSPARCTestCase):
         self.assertEqual(streaks.integrationCounts.value, 1)
 
         # change stream VA --> HW VAs should change as stream is still active
-        streaks.integrationTime.value = 1.0  # s
+        streaks.integrationTime.value = 10.0  # s
         time.sleep(0.1)
         # check stream VA shows now the same value as the HW VA
         self.assertEqual(streaks.integrationTime.value, self.streak_ccd.exposureTime.value)
         # check stream VA and HW VA show the correct value
-        self.assertEqual(self.streak_ccd.exposureTime.value, 1)
-        self.assertEqual(streaks.integrationTime.value, 1)
+        self.assertEqual(self.streak_ccd.exposureTime.value, 10)
+        self.assertEqual(streaks.integrationTime.value, 10)
         self.assertEqual(streaks.integrationCounts.value, 1)
 
-        streaks.integrationTime.value = 4.0  # s
+        streaks.integrationTime.value = 140.0  # s
         time.sleep(0.1)
 
         ###inactive stream######################################################################################
@@ -426,8 +433,8 @@ class SPARC2StreakCameraTestCase(BaseSPARCTestCase):
 
         # check stream and HW VA still shows the same value as before and are different from each other
         self.assertNotEqual(streaks.integrationTime.value, self.streak_ccd.exposureTime.value)
-        self.assertEqual(self.streak_ccd.exposureTime.value, 1)
-        self.assertEqual(streaks.integrationTime.value, 4)
+        self.assertEqual(self.streak_ccd.exposureTime.value, 10.0)
+        self.assertEqual(streaks.integrationTime.value, 140.0)
 
     def test_streak_acq_live_update(self):
         """Test if live update works during acquisition with streak camera"""
@@ -443,10 +450,9 @@ class SPARC2StreakCameraTestCase(BaseSPARCTestCase):
         stss = stream.SEMTemporalSpectrumMDStream("test sem-temporal spectrum", [sems, streaks])
 
         streaks.detStreakMode.value = True
-
-        streaks.detExposureTime.value = 0.01  # 10ms
+        streaks.detExposureTime.value = 0.1  # 100ms
         streaks.roi.value = (0.1, 0.1, 0.8, 0.8)
-        streaks.repetition.value = (10, 12)
+        streaks.repetition.value = (7, 9)
 
         # Start acquisition
         # estimated acquisition time should be accurate with less than 50% margin
@@ -654,6 +660,10 @@ class SPARC2StreakCameraTestCase(BaseSPARCTestCase):
 
         stss = stream.SEMTemporalSpectrumMDStream("test sem-temporal spectrum", [sems, streaks])
 
+        # Explicitly put something very different from the expected exposure time, to check that
+        # the stream does set the correct value.
+        self.streak_ccd.exposureTime.value = 0.123  # s
+
         streaks.detStreakMode.value = True
         streaks.detMCPGain.value = 10
         streaks.detShutter.value = False
@@ -663,9 +673,9 @@ class SPARC2StreakCameraTestCase(BaseSPARCTestCase):
         self.streak_ccd.updateMetadata({model.MD_BASELINE: 0})
 
         # set stream VAs
-        streaks.integrationTime.value = 2  # s
+        streaks.integrationTime.value = 12  # s
         # TODO use fixed repetition value -> set ROI?
-        streaks.repetition.value = (2, 4)  # results in (2, 3)
+        streaks.repetition.value = (2, 3)
         num_ts = numpy.prod(streaks.repetition.value)  # number of expected temporal spectrum images
         exp_pos, exp_pxs, exp_res = roi_to_phys(streaks)
 
@@ -712,7 +722,7 @@ class SPARC2StreakCameraTestCase(BaseSPARCTestCase):
 
         time.sleep(2)
         # do a second acquisition with longer exp time and check values are bigger due to integration
-        streaks.integrationTime.value = 2.5  # s
+        streaks.integrationTime.value = 13.5  # s
 
         # Start acquisition
         # estimated acquisition time should be accurate with less than 50% margin
@@ -723,11 +733,13 @@ class SPARC2StreakCameraTestCase(BaseSPARCTestCase):
         self.assertIsNone(exp)
         ts_da2 = data2[1]  # temporal spectrum data array
 
-        # test that the values in the second acquisition are greater (integrationCount greater than first acq)
-        numpy.testing.assert_array_less(ts_da, ts_da2)
+        # In theory, the second acquisition should have (slightly) higher values than the first one,
+        # as the integration time is longer. However, even with the simulator, due to the noise and
+        # clipping, it's very hard to check reliably.
+        # numpy.testing.assert_array_less(ts_da, ts_da2)
 
         # check background subtraction
-        streaks.integrationTime.value = 2  # s
+        streaks.integrationTime.value = 12  # s
         self.streak_ccd.updateMetadata({model.MD_BASELINE: 100})
 
         # Start acquisition
@@ -741,8 +753,6 @@ class SPARC2StreakCameraTestCase(BaseSPARCTestCase):
 
         # check baseline is not multiplied by integrationCount (we keep only one baseline level for integrated img)
         self.assertEqual(ts_da3.metadata[model.MD_BASELINE], 100)
-        # test that the baseline is actually removed compared to same acquisition without baseline
-        numpy.testing.assert_array_less(ts_da3, ts_da)
 
     def test_streak_acq_integrated_images_leech(self):
         """Test acquisition with streak camera with a long exposure time
@@ -765,14 +775,14 @@ class SPARC2StreakCameraTestCase(BaseSPARCTestCase):
         sems.emtDwellTime.value = 1e-06
 
         # set stream VAs
-        streaks.integrationTime.value = 2  # s
-        # The maximum exposure time of the streak-ccd is 1s => 2 images are integrated
+        streaks.integrationTime.value = 14  # s
+        # The maximum exposure time of the streak-ccd is 10s => 2 images are integrated
         assert streaks.integrationCounts.value == 2
         streaks.roi.value = (0, 0.2, 0.4, 0.8)
-        streaks.repetition.value = (3, 5)  # results in (2, 4)
+        streaks.repetition.value = (2, 3)
 
         dc = leech.AnchorDriftCorrector(self.ebeam, self.sed)
-        dc.period.value = 1  # s  so should run leech for sub acquisitions (between integrating 2 images)
+        dc.period.value = 7  # s  so should run leech for sub acquisitions (between integrating 2 images)
         dc.roi.value = (0.525, 0.525, 0.6, 0.6)
         dc.dwellTime.value = 1e-06
         sems.leeches.append(dc)
@@ -824,6 +834,101 @@ class SPARC2StreakCameraTestCase(BaseSPARCTestCase):
         # check last image in .raw has a time axis greater than 1 (last image is the drift correction image)
         temporalSpectrum_drift = ts_da[-1]  # drift correction image
         self.assertGreaterEqual(temporalSpectrum_drift.shape[-4], 2)
+
+    def test_streak_acq_photon_counting(self):
+        """Test acquisition with streak camera, in photon counting mode"""
+
+        # Create the stream
+        sems = stream.SEMStream("test sem", self.sed, self.sed.data, self.ebeam)
+        # test with streak camera
+        streaks = stream.TemporalSpectrumSettingsStream("test streak cam", self.streak_ccd, self.streak_ccd.data,
+                                                        self.ebeam, self.streak_unit, self.streak_delay,
+                                                        detvas={"exposureTime", "readoutRate", "binning", "resolution",
+                                                                "photonCounting", "pcExposureTime", "pcIntegrationCounts"},
+                                                        streak_unit_vas={"timeRange", "MCPGain", "streakMode", "shutter"})
+
+        stss = stream.SEMTemporalSpectrumMDStream("test sem-temporal spectrum", [sems, streaks])
+
+        streaks.detStreakMode.value = True
+        streaks.detExposureTime.value = 0.1  # Should not be used, but short to make it different from the photon counting exposure time
+        streaks.detPcExposureTime.value = 0.01  # 10ms
+        streaks.detPcIntegrationCounts.value = 100
+        streaks.detPhotonCounting.value = True
+
+        expected_exp_time = streaks.detPcExposureTime.value * streaks.detPcIntegrationCounts.value
+
+        # Disable the protections
+        streaks.detMCPGain.value = 5
+        streaks.detShutter.value = False
+
+        streaks.repetition.value = (7, 3)
+        num_ts = numpy.prod(streaks.repetition.value)  # number of expected temporal spectrum images
+        exp_pos, exp_pxs, exp_res = roi_to_phys(streaks)
+
+        # Start acquisition
+        # estimated acquisition time should be accurate with less than 50% margin
+        timeout = 1.5 * stss.estimateAcquisitionTime()
+        start = time.time()
+        f = stss.acquire()  # calls acquire method in MultiDetectorStream in sync.py
+
+        # stss.raw: array containing as first entry the sem scan image for the scanning positions,
+        # the second array are temporal spectrum images
+        # data: array should contain same images as stss.raw
+
+        # wait until it's over
+        data, exp = f.result(timeout)
+        dur = time.time() - start
+        logging.debug("Acquisition took %g s", dur)
+        self.assertTrue(f.done())
+        self.assertIsNone(exp)
+
+        # Confirm protections are applied on the hardware
+        self.assertEqual(self.streak_unit.MCPGain.value, 0)
+        self.assertTrue(self.streak_unit.shutter.value)
+
+        # check if number of images in the received data (sem image + temporal spectrum images) is the same as
+        # number of images stored in raw
+        self.assertEqual(len(data), len(stss.raw))
+
+        # check that sem data array has same shape as expected for the scanning positions of ebeam
+        sem_da = stss.raw[0]  # sem data array for scanning positions
+        self.assertEqual(sem_da.shape, exp_res[::-1])
+
+        # check that the number of acquired temporal spectrum images matches the number of ebeam positions
+        ts_da = stss.raw[1]  # temporal spectrum data array
+        shape = ts_da.shape
+        self.assertEqual(shape[3] * shape[4], num_ts)
+        # len of shape should be 5: CTZYX
+        self.assertEqual(len(shape), 5)
+
+        # check if metadata is correctly stored
+        md = ts_da.metadata
+        self.assertEqual(md[model.MD_INTEGRATION_COUNT], 100)
+        self.assertAlmostEqual(md[model.MD_EXP_TIME], expected_exp_time)
+        self.assertIn(model.MD_STREAK_TIMERANGE, md)
+        self.assertIn(model.MD_STREAK_MCPGAIN, md)
+        self.assertIn(model.MD_STREAK_MODE, md)
+        self.assertIn(model.MD_TRIGGER_DELAY, md)
+        self.assertIn(model.MD_TRIGGER_RATE, md)
+        self.assertIn(model.MD_POS, md)  # check the corresponding SEM pos is there
+        self.assertIn(model.MD_PIXEL_SIZE, md)  # check the corresponding SEM pos is there
+        self.assertIn(model.MD_WL_LIST, md)
+        self.assertIn(model.MD_TIME_LIST, md)
+
+        md = sem_da.metadata
+        self.assertIn(model.MD_PIXEL_SIZE, md)
+        self.assertIn(model.MD_POS, md)
+
+        # start same acquisition again and check acquisition does not timeout due to sync failures
+        timeout2 = 1.5 * stss.estimateAcquisitionTime()
+        start = time.time()
+        f = stss.acquire()  # calls acquire method in MultiDetectorStream in sync.py
+        # wait until it's over
+        data, exp = f.result(timeout2)
+        dur = time.time() - start
+        logging.debug("Acquisition took %g s", dur)
+        self.assertTrue(f.done())
+        self.assertIsNone(exp)
 
 
 if __name__ == "__main__":

--- a/src/odemis/gui/comp/stream_panel.py
+++ b/src/odemis/gui/comp/stream_panel.py
@@ -545,6 +545,7 @@ class StreamPanel(wx.Panel):
         self._prev_drange = None
 
         self.gb_sizer = wx.GridBagSizer()
+        self.gb_sizer.SetEmptyCellSize((0, 0))
 
         # Counter that keeps track of the number of rows containing controls inside this panel
         self.num_rows = 0

--- a/src/odemis/gui/conf/data.py
+++ b/src/odemis/gui/conf/data.py
@@ -454,12 +454,6 @@ HW_SETTINGS_CONFIG = {
         )),
     "streak-ccd":
         OrderedDict((
-            ("exposureTime", {
-                "control_type": odemis.gui.CONTROL_SLIDER,
-                "scale": "log",
-                "type": "float",
-                "tooltip": "Readout camera exposure time.",
-            }),
             ("binning", {
                 "control_type": odemis.gui.CONTROL_RADIO,
                 "tooltip": "Readout camera: number of pixels combined.",
@@ -475,8 +469,8 @@ HW_SETTINGS_CONFIG = {
             ("streakMode", {
                 "control_type": odemis.gui.CONTROL_CHECK,
                 "label": "Streak mode",
-                "tooltip": "If checked streak camera is in operate mode and streaking.\n"
-                           "If not checked steak camera is in focus mode.",
+                "tooltip": "If checked, the streak camera is in operate mode and streaking.\n"
+                           "If not checked, the streak camera is in focus mode.",
             }),
             ("timeRange", {
                 "control_type": odemis.gui.CONTROL_COMBO,
@@ -489,7 +483,7 @@ HW_SETTINGS_CONFIG = {
                 "label": "MCP gain",
                 "tooltip": "Microchannel plate gain of the streak unit.\n"
                            "Be careful when setting the gain while operating the camera in focus-mode.\n"
-                           "Only increase the gain while the stream is playing.",
+                           "It's only possible to increase the gain while the stream is playing.",
                 "key_step": 1,
             }),
             ("shutter", {
@@ -502,6 +496,28 @@ HW_SETTINGS_CONFIG = {
             }),
             ("phaseLock", {
                 "tooltip": "Activate phase-locking of the streak-unit to the blanker signal",
+            }),
+            ("photonCounting", {
+            }),
+            ("pcIntegrationCounts", {
+                "label": "Integration counts",
+                "control_type": odemis.gui.CONTROL_INT,
+            }),
+            ("pcExposureTime", {
+                "label": "Exposure time",
+                "control_type": odemis.gui.CONTROL_SLIDER,
+                "scale": "log",
+            }),
+            ("pcThreshold", {
+                # Used for calibration, only for metadata and advanced users => hide
+                "control_type": odemis.gui.CONTROL_NONE,
+            }),
+            # After the photon-counting settings, because it's hidden if photon-counting is enabled
+            ("exposureTime", {
+                "control_type": odemis.gui.CONTROL_SLIDER,
+                "scale": "log",
+                "type": "float",
+                "tooltip": "Readout camera exposure time.",
             }),
         )),
     "streak-delay": {
@@ -1074,11 +1090,11 @@ STREAM_SETTINGS_CONFIG = {
                 "scale": "log",
                 "type": "float",
                 "accuracy": 2,
-                "tooltip": "Readout camera exposure time.",
+                "tooltip": "Total readout camera exposure time (including integration counts).",
             }),
             ("integrationCounts", {
-                "tooltip": "Number of images that are integrated, if requested exposure"
-                           "time exceeds the camera exposure time limit.",
+                "tooltip": "Number of images that are integrated. Automatically computed when the "
+                           "integration time exceeds the camera maximum exposure time.",
             }),
             ("wavelength", {
                 "tooltip": "Center wavelength of the spectrograph",

--- a/src/odemis/gui/cont/stream.py
+++ b/src/odemis/gui/cont/stream.py
@@ -214,6 +214,10 @@ class StreamController(object):
                 logging.warning("Stream has zIndex but no corresponding stream entry found.")
             self.stream.max_projection.subscribe(self._on_max_projection)
 
+        # For Temporal Spectrum streams, with a photon counting mode, show/hide the exposure time controls
+        if hasattr(stream, "detPhotonCounting"):
+            self.stream.detPhotonCounting.subscribe(self._on_photon_counting, init=True)
+
         if hasattr(stream, "repetition"):
             self._add_repetition_ctrl()
 
@@ -544,6 +548,37 @@ class StreamController(object):
         """Disable/enable the z-index control based on the max_projection setting"""
         if self._zindex_se is not None:
             self._zindex_se.value_ctrl.Enable(not val)
+
+    @call_in_wx_main
+    def _on_photon_counting(self, active: bool) -> None:
+        """
+        For Temporal Spectrum streams, with a photon counting mode, show/hide the exposure time controls.
+        Photon-counting disabled:
+        - integrationTime/exposureTime
+        - integrationCounts
+        Photon-counting enabled:
+        - (pc)IntegrationCounts
+        - (pc)ExposureTime
+        Called when the .photonCounting VA is changed
+        :param active: True if Photon counting mode is enabled
+        """
+        # VAs to be shown with photon-counting
+        pc_vas = (self.stream.det_vas.get("pcIntegrationCounts"), self.stream.det_vas.get("pcExposureTime"))
+        # VAs to be shown without photon-counting
+        no_pc_vas = [getattr(self.stream, va_name, None)
+                     for va_name in ("integrationCounts", "integrationTime", "detExposureTime")]
+
+        for entry in self.entries:
+            if hasattr(entry, "vigilattr"):
+                if entry.vigilattr in pc_vas:
+                    entry.lbl_ctrl.Show(active)
+                    entry.value_ctrl.Show(active)
+
+                if entry.vigilattr in no_pc_vas:
+                    entry.lbl_ctrl.Show(not active)
+                    entry.value_ctrl.Show(not active)
+
+        self.stream_bar.Layout()
 
     def _on_new_dye_name(self, dye_name):
         """ Assign excitation and emission wavelengths if the given name matches a known dye """

--- a/src/odemis/gui/cont/stream.py
+++ b/src/odemis/gui/cont/stream.py
@@ -214,6 +214,10 @@ class StreamController(object):
                 logging.warning("Stream has zIndex but no corresponding stream entry found.")
             self.stream.max_projection.subscribe(self._on_max_projection)
 
+        # For Temporal Spectrum streams, with a photon counting mode, show/hide the exposure time controls
+        if hasattr(stream, "detPhotonCounting"):
+            self.stream.detPhotonCounting.subscribe(self._on_photon_counting, init=True)
+
         if hasattr(stream, "repetition"):
             self._add_repetition_ctrl()
 
@@ -247,6 +251,8 @@ class StreamController(object):
 
         self._unlink_resolution()
         self._disconnectRepOverlay()
+        if hasattr(self.stream, "detPhotonCounting"):
+            self.stream.detPhotonCounting.unsubscribe(self._on_photon_counting)
         if hasattr(self.stream, "repetition"):
             self.stream.repetition.unsubscribe(self._onStreamRep)
 
@@ -544,6 +550,37 @@ class StreamController(object):
         """Disable/enable the z-index control based on the max_projection setting"""
         if self._zindex_se is not None:
             self._zindex_se.value_ctrl.Enable(not val)
+
+    @call_in_wx_main
+    def _on_photon_counting(self, active: bool) -> None:
+        """
+        For Temporal Spectrum streams, with a photon counting mode, show/hide the exposure time controls.
+        Photon-counting disabled:
+        - integrationTime/exposureTime
+        - integrationCounts
+        Photon-counting enabled:
+        - (pc)IntegrationCounts
+        - (pc)ExposureTime
+        Called when the .photonCounting VA is changed
+        :param active: True if Photon counting mode is enabled
+        """
+        # VAs to be shown with photon-counting
+        pc_vas = (self.stream.det_vas.get("pcIntegrationCounts"), self.stream.det_vas.get("pcExposureTime"))
+        # VAs to be shown without photon-counting
+        no_pc_vas = [getattr(self.stream, va_name, None)
+                     for va_name in ("integrationCounts", "integrationTime", "detExposureTime")]
+
+        for entry in self.entries:
+            if hasattr(entry, "vigilattr"):
+                if entry.vigilattr in pc_vas:
+                    entry.lbl_ctrl.Show(active)
+                    entry.value_ctrl.Show(active)
+
+                if entry.vigilattr in no_pc_vas:
+                    entry.lbl_ctrl.Show(not active)
+                    entry.value_ctrl.Show(not active)
+
+        self.stream_bar.Layout()
 
     def _on_new_dye_name(self, dye_name):
         """ Assign excitation and emission wavelengths if the given name matches a known dye """

--- a/src/odemis/gui/cont/stream_bar.py
+++ b/src/odemis/gui/cont/stream_bar.py
@@ -1982,8 +1982,13 @@ class SparcStreamsController(StreamBarController):
         main_data = self._main_data_model
 
         detvas = get_local_vas(main_data.streak_ccd, main_data.hw_settings_config)
+        # TODO: ideally, pcExposureTime and pcIntegrationCounts should be passed as hwdetvas, so that
+        # they get immediately updated when the user changes them in HPDTA. However, currently, the
+        # StreamController shows the hwdetvas before the other VAs, which prevents them from being
+        # displayed next to the photon-counting checkbox. Once StreamController is adjusted to show
+        # every VAs according to the STREAM_SETTINGS_CONFIG, this can be changed.
 
-        if main_data.streak_ccd.exposureTime.range[1] < 86400:  # 24h
+        if main_data.streak_ccd.exposureTime.range[1] < 3600:  # 1h
             # remove exposureTime from local (GUI) VAs to use a new one, which allows to integrate images
             detvas.remove("exposureTime")
 

--- a/src/odemis/gui/cont/tabs/sparc2_align_tab.py
+++ b/src/odemis/gui/cont/tabs/sparc2_align_tab.py
@@ -564,7 +564,9 @@ class Sparc2AlignTab(Tab):
         if main_data.streak_ccd:
             # Don't show the time range, as it's done by the StreakCamAlignSettingsController
             streak_unit_vas = (get_local_vas(main_data.streak_unit, main_data.hw_settings_config)
-                               -{"timeRange"})
+                               - {"timeRange"})
+            streak_ccd_vas = (get_local_vas(main_data.streak_ccd, main_data.hw_settings_config)
+                              - {"photonCounting", "pcExposureTime", "pcThreshold", "pcIntegrationCounts"})
             ts_stream = acqstream.StreakCamStream(
                                 "Calibration trigger delay for streak camera",
                                 main_data.streak_ccd,
@@ -572,7 +574,7 @@ class Sparc2AlignTab(Tab):
                                 emitter=None,
                                 streak_unit=main_data.streak_unit,
                                 streak_delay=main_data.streak_delay,
-                                detvas=get_local_vas(main_data.streak_ccd, main_data.hw_settings_config),
+                                detvas=streak_ccd_vas,
                                 streak_unit_vas=streak_unit_vas,
                                 forcemd={model.MD_POS: (0, 0),  # Just in case the stage is there
                                          model.MD_ROTATION: 0},  # Force the CCD as-is
@@ -1332,6 +1334,10 @@ class Sparc2AlignTab(Tab):
                 self._ts_stream.detMCPGain.value = 0
                 if hasattr(self._ts_stream, "detShutter"):
                     self._ts_stream.detShutter.value = True
+                # It never makes sense to use photon counting for alignment, so the setting is not
+                # shown, and we just need to make sure it is not enabled before starting.
+                if model.hasVA(main.streak_ccd, "photonCounting"):
+                    main.streak_ccd.photonCounting.value = False
 
             if self._mirror_settings_controller:
                 self._mirror_settings_controller.enable(False)


### PR DESCRIPTION
> WARNING: this is the third part on top of the PRs #3541 and #3542.

Extend the GUI to display photon-counting option on the Temporal Spectrum streams, if the streak-cam supports it.
When  the option is active, only show the related settings (exposure time per frame + frame count)

Also extend the acquisition code to support it. In practice, it's mostly just about reading the right settings to predict correctly the acquisition duration.