### PR TITLE
[docs] Update pmconfig example run instructions

### DIFF
--- a/src/odemis/driver/piezomotor.py
+++ b/src/odemis/driver/piezomotor.py
@@ -94,7 +94,7 @@ class PMD401Bus(Actuator):
         """
         :param axes (dict: str -> dict): axis name --> axis parameters
             Each axis is specified by a set of parameters.
-            After successful configuration with the pmconfig.py script, the only required parameter for a default motor
+            After successful configuration with the pmconfig script, the only required parameter for a default motor
             is the address which was set during the configuration process.
             The spc parameter (conversion between motor steps and encoder counts) is typically saved in the flash
             memory of the controller during the configuration process. The flash value is overridden by the

--- a/util/pmconfig
+++ b/util/pmconfig
@@ -27,9 +27,9 @@ controller stack need to be configured. This involves
 2) setting the spc parameter for conversion between encoder counts and motor steps
 
 Example usage:
-python3 pmconfig.py --address 0 --target-address 1 --spc-config
+pmconfig --address 0 --target-address 1 --spc-config
 or
-python3 pmconfig.py --address 1 --spc-config
+pmconfig --address 1 --spc-config --port /dev/fake
 """
 import argparse
 import logging


### PR DESCRIPTION
The pmconfig utility does not have the .py extension, therefore the file will not be found when running it with that extension. Also updated the instructions to mention the fake port, for testing with simulator.

https://delmic.atlassian.net/browse/SWM-178