### PR TITLE
[feat] Add pause and resume functionality to futures

### DIFF
--- a/src/odemis/gui/util/widgets.py
+++ b/src/odemis/gui/util/widgets.py
@@ -306,6 +306,23 @@ class ProgressiveFutureConnector(object):
         self._elapsed = elapsed_time
         self._remaining = remaining_time
 
+    def pause(self):
+        """
+        Pause the progress bar and label updates.
+
+        Stops the periodic timer so the display freezes while the acquisition is paused.
+        """
+        self._timer.Stop()
+
+    def resume(self):
+        """
+        Resume the progress bar and label updates after a pause.
+
+        Restarts the periodic timer so the display tracks the future's progress again.
+        """
+        if not self._timer.IsRunning() and self._future is not None:
+            self._timer.Start(250)
+
     @call_in_wx_main
     def _on_done(self, future):
         """ Process the completion of the future """

--- a/src/odemis/gui/util/widgets.py
+++ b/src/odemis/gui/util/widgets.py
@@ -31,6 +31,8 @@ from odemis.util import units
 import time
 import wx
 
+TIMER_INTERVAL_MS = 250  # Refresh progress UI every 250 ms (4 updates per second).
+
 
 class VigilantAttributeConnector(object):
     """ This class connects a vigilant attribute with a wxPython control, making sure that the
@@ -287,7 +289,7 @@ class ProgressiveFutureConnector(object):
 
         # a repeating timer, always called in the GUI thread
         self._timer = wx.PyTimer(self._update_progress)
-        self._timer.Start(250)  # 4 Hz (250 milliseconds)
+        self._timer.Start(TIMER_INTERVAL_MS)
 
         # Set the progress bar to 0
         bar.Range = PROGRESS_RANGE
@@ -321,7 +323,7 @@ class ProgressiveFutureConnector(object):
         Restarts the periodic timer so the display tracks the future's progress again.
         """
         if not self._timer.IsRunning() and self._future is not None:
-            self._timer.Start(250)
+            self._timer.Start(TIMER_INTERVAL_MS)
 
     @call_in_wx_main
     def _on_done(self, future):

--- a/src/odemis/model/_futures.py
+++ b/src/odemis/model/_futures.py
@@ -296,6 +296,16 @@ class CancellableFuture(futures.Future):
         # As long as it's None, the future cannot be cancelled while running
         self.task_canceller = None
 
+        self.can_pause = False
+        self._is_paused_event = threading.Event()
+        self._no_need_to_pause_event = threading.Event()
+        self._no_need_to_pause_event.set()
+
+    @property
+    def is_pause_requested(self) -> bool:
+        """Return True if a pause has been requested but not yet acknowledged."""
+        return self.can_pause and not self._no_need_to_pause_event.is_set()
+
     def cancel(self):
         """Cancel the future if possible.
 
@@ -321,6 +331,96 @@ class CancellableFuture(futures.Future):
 
         self._invoke_callbacks()
         return True
+
+    def pause(self) -> bool:
+        """
+        Request the future to pause and block until it is actually paused, or until pausing fails.
+
+        If the future is already cancelled or finished, return False immediately.
+        If the future is still pending, block until it starts running and then block
+        until it is paused. If the future is already running, block until it reaches
+        a pause checkpoint and is paused.
+
+        For ProgressiveFuture instances, progress tracking is frozen while paused:
+        elapsed time does not advance and the estimated remaining time is held constant.
+        Progress tracking resumes automatically once the future is resumed via resume().
+
+        :returns: True if the future was successfully paused, False otherwise.
+        """
+        if not self.can_pause:
+            return False
+
+        with self._condition:
+            if self._state in (FINISHED, CANCELLED, CANCELLED_AND_NOTIFIED):
+                return False
+            elif self._state in (RUNNING, PENDING):
+                self._no_need_to_pause_event.clear()
+
+        while not self._is_paused_event.wait(0.1):
+            # Block until task is fully paused (wait_if_paused started waiting)
+            if self.done():  # done includes finished and canceled
+                return False
+            if self._no_need_to_pause_event.is_set():
+                # The pause was cancelled by a resume() call, so we cannot pause anymore
+                return False
+
+        return True
+
+    def resume(self) -> None:
+        """
+        Resume a paused future.
+
+        If the future is not currently paused, calling this method has no
+        effect and returns immediately. Once resumed, any progress tracking
+        will continue updating as normal.
+
+        Safe to call from any thread, including before the task has started
+        or after it has already finished.
+        """
+        if not self.can_pause:
+            return
+
+        self._no_need_to_pause_event.set()
+        # Do NOT clear _is_paused_event here: it is owned by wait_if_paused(),
+        # which clears it in its finally block. Clearing it here would race
+        # with pause()'s confirmation check, allowing pause() to return True
+        # while the acquisition is already running again.
+
+        return
+
+    def wait_if_paused(self) -> float:
+        """Block if the future is paused, and return once it is resumed or cancelled.
+
+        This method is intended to be called from within the running task at
+        safe checkpoints. If no pause has been requested, it returns immediately.
+
+        While blocked, the internal paused event is set so that external callers
+        waiting on pause() can detect that the task has truly paused. The event
+        is cleared before this method returns, regardless of whether the future
+        was resumed or cancelled.
+
+        Raises CancelledError if the future is cancelled while paused.
+
+        :returns: the duration spent paused in seconds, or 0.0 if not paused.
+        """
+        if self._no_need_to_pause_event.is_set():
+            return 0.0
+
+        t = time.monotonic()
+        self._is_paused_event.set()
+
+        try:
+            while not self._no_need_to_pause_event.wait(0.1):
+                if self._state in (CANCELLED, CANCELLED_AND_NOTIFIED):
+                    raise CancelledError()
+                if self._state == FINISHED:
+                    # Future completed while we were paused (e.g. due to an
+                    # exception in an outer future). Exit cleanly without raising.
+                    return 0.0
+        finally:
+            self._is_paused_event.clear()
+
+        return time.monotonic() - t
 
     def set_result(self, result):
         """Sets the return value of work associated with the future.
@@ -367,6 +467,23 @@ class CancellableFuture(futures.Future):
         Should only be used by Executor implementations and unit tests.
         """
         self.set_exception_info(exception, None)
+
+    def set_running_or_notify_cancel(self):
+        """
+        :returns: False if the Future was cancelled, True otherwise.
+        """
+        running = futures.Future.set_running_or_notify_cancel(self)
+        if running:
+            try:
+                self.wait_if_paused()  # in case it was paused while pending
+            except CancelledError:
+                # The future was cancelled while we were waiting for resume.
+                # Do not propagate: set_running_or_notify_cancel() must not raise,
+                # and leaking CancelledError here would permanently kill the
+                # executor's worker thread.
+                return False
+
+        return running
 
 
 class ProgressiveFuture(CancellableFuture):
@@ -438,7 +555,11 @@ class ProgressiveFuture(CancellableFuture):
             if self._state == PENDING:
                 return 0.0, max(0.0, self._remaining_time)
             elif self._state == RUNNING:
-                if self._last_update_time is not None:
+                if self._is_paused_event.is_set():
+                    # Paused: return frozen values without extrapolation
+                    elapsed = max(0.0, self._elapsed_time)
+                    remaining = max(0.0, self._remaining_time)
+                elif self._last_update_time is not None:
                     since = time.monotonic() - self._last_update_time
                     elapsed = max(0.0, self._elapsed_time + since)
                     remaining = max(0.0, self._remaining_time - since)
@@ -516,12 +637,47 @@ class ProgressiveFuture(CancellableFuture):
         """
         :returns: False if the Future was cancelled, True otherwise.
         """
-        running = futures.Future.set_running_or_notify_cancel(self)
+        running = CancellableFuture.set_running_or_notify_cancel(self)
         if running:
             # Anchor elapsed to 0 at the moment the task actually starts
             self.set_progress(elapsed_time=0.0)
 
         return running
+
+    def wait_if_paused(self) -> float:
+        """Blocks if the future is paused, freezing progress tracking during the pause.
+
+        Before blocking, the elapsed time accumulated since the last anchor is
+        folded into _elapsed_time and _last_update_time is cleared so that
+        get_progress returns frozen values while paused. After resuming, the
+        anchor is reset to the current wall-clock time so extrapolation
+        continues correctly from where it left off.
+
+        :returns: the duration spent paused in seconds (0 if not paused).
+        """
+        if self._no_need_to_pause_event.is_set():
+            return 0.0
+
+        # Freeze the time anchor before entering the pause. Hold the condition
+        # lock while mutating the progress fields.
+        with self._condition:
+            now = time.monotonic()
+            if self._last_update_time is not None:
+                since = now - self._last_update_time
+                self._elapsed_time += since
+                self._remaining_time = max(0.0, self._remaining_time - since)
+                self._last_update_time = None
+
+        # Push the frozen snapshot so listeners stop extrapolating while the task is blocked
+        self._invoke_upd_callbacks()
+
+        paused_duration = super().wait_if_paused()
+
+        # Re-anchor so extrapolation resumes from the correct point
+        with self._condition:
+            self._last_update_time = time.monotonic()
+
+        return paused_duration
 
 
 class ProgressiveBatchFuture(ProgressiveFuture):

--- a/src/odemis/model/_futures.py
+++ b/src/odemis/model/_futures.py
@@ -298,13 +298,13 @@ class CancellableFuture(futures.Future):
 
         self.can_pause = False
         self._is_paused_event = threading.Event()
-        self._no_need_to_pause_event = threading.Event()
-        self._no_need_to_pause_event.set()
+        self._run_allowed_evt = threading.Event()
+        self._run_allowed_evt.set()
 
     @property
     def is_pause_requested(self) -> bool:
         """Return True if a pause has been requested but not yet acknowledged."""
-        return self.can_pause and not self._no_need_to_pause_event.is_set()
+        return not self._run_allowed_evt.is_set()
 
     def cancel(self):
         """Cancel the future if possible.
@@ -354,13 +354,13 @@ class CancellableFuture(futures.Future):
             if self._state in (FINISHED, CANCELLED, CANCELLED_AND_NOTIFIED):
                 return False
             elif self._state in (RUNNING, PENDING):
-                self._no_need_to_pause_event.clear()
+                self._run_allowed_evt.clear()
 
         while not self._is_paused_event.wait(0.1):
             # Block until task is fully paused (wait_if_paused started waiting)
             if self.done():  # done includes finished and canceled
                 return False
-            if self._no_need_to_pause_event.is_set():
+            if self._run_allowed_evt.is_set():
                 # The pause was cancelled by a resume() call, so we cannot pause anymore
                 return False
 
@@ -380,7 +380,7 @@ class CancellableFuture(futures.Future):
         if not self.can_pause:
             return
 
-        self._no_need_to_pause_event.set()
+        self._run_allowed_evt.set()
         # Do NOT clear _is_paused_event here: it is owned by wait_if_paused(),
         # which clears it in its finally block. Clearing it here would race
         # with pause()'s confirmation check, allowing pause() to return True
@@ -403,14 +403,14 @@ class CancellableFuture(futures.Future):
 
         :returns: the duration spent paused in seconds, or 0.0 if not paused.
         """
-        if self._no_need_to_pause_event.is_set():
+        if self._run_allowed_evt.is_set():
             return 0.0
 
         t = time.monotonic()
         self._is_paused_event.set()
 
         try:
-            while not self._no_need_to_pause_event.wait(0.1):
+            while not self._run_allowed_evt.wait(0.1):
                 if self._state in (CANCELLED, CANCELLED_AND_NOTIFIED):
                     raise CancelledError()
                 if self._state == FINISHED:
@@ -557,14 +557,14 @@ class ProgressiveFuture(CancellableFuture):
             elif self._state == RUNNING:
                 if self._is_paused_event.is_set():
                     # Paused: return frozen values without extrapolation
-                    elapsed = max(0.0, self._elapsed_time)
+                    elapsed = self._elapsed_time
                     remaining = max(0.0, self._remaining_time)
                 elif self._last_update_time is not None:
                     since = time.monotonic() - self._last_update_time
                     elapsed = max(0.0, self._elapsed_time + since)
                     remaining = max(0.0, self._remaining_time - since)
                 else:
-                    elapsed = max(0.0, self._elapsed_time)
+                    elapsed = self._elapsed_time
                     remaining = max(0.0, self._remaining_time)
                 return elapsed, remaining
             else:  # FINISHED or CANCELLED
@@ -655,7 +655,7 @@ class ProgressiveFuture(CancellableFuture):
 
         :returns: the duration spent paused in seconds (0 if not paused).
         """
-        if self._no_need_to_pause_event.is_set():
+        if self._run_allowed_evt.is_set():
             return 0.0
 
         # Freeze the time anchor before entering the pause. Hold the condition

--- a/src/odemis/model/test/futures_test.py
+++ b/src/odemis/model/test/futures_test.py
@@ -259,11 +259,66 @@ class TestCancellableFuture(unittest.TestCase):
 
         self.assertEqual(self.cancelled, 0)
 
+    def test_pause_resume(self):
+        """Test pausing and resuming a future blocks the task for the expected duration."""
+        future = CancellableFuture()
+        future.can_pause = True
+        executor = CancellableThreadPoolExecutor(max_workers=2)
+        executor.submitf(future, self.pausing_task, future)
+
+        # Let one iteration run before pausing
+        time.sleep(0.15)
+        paused = future.pause()
+        self.assertTrue(paused)
+        self.assertFalse(future.done())
+
+        # Stay paused for ~0.5s; the task must still be blocked
+        time.sleep(0.5)
+        self.assertFalse(future.done())
+
+        future.resume()
+
+        waiting_times = future.result(timeout=5)
+        executor.shutdown(wait=False)
+        self.assertEqual(len(waiting_times), 10)
+        # Exactly one wait_if_paused call should have blocked for ~0.5s
+        long_waits = [t for t in waiting_times if t > 0.1]
+        self.assertEqual(len(long_waits), 1)
+        self.assertAlmostEqual(long_waits[0], 0.5, delta=0.15)
+
+    def test_pause_resume_not_pausable(self):
+        """Test that pause returns False when can_pause is False."""
+        future = CancellableFuture()
+        self.assertFalse(future.pause())
+
+    def test_pause_done_future(self):
+        """Test that pausing an already finished future returns False."""
+        future = CancellableFuture()
+        future.can_pause = True
+        future.set_running_or_notify_cancel()
+        future.set_result(None)
+        self.assertFalse(future.pause())
+
+    def test_pause_cancelled_future(self):
+        """Test that pausing a cancelled future returns False."""
+        future = CancellableFuture()
+        future.can_pause = True
+        future.cancel()
+        self.assertFalse(future.pause())
+
     def cancel_task(self, future):
         """Task canceller"""
         self.cancelled += 1
         return True
 
+    def pausing_task(self, future):
+        """Task that pauses and resumes."""
+        waiting_times = []
+        for _ in range(10):
+            time.sleep(0.1)
+            wait_time = future.wait_if_paused()
+            waiting_times.append(wait_time)
+        return waiting_times
 
 class TestProgressiveFuture(unittest.TestCase):
     """Test progressive future."""
@@ -394,6 +449,53 @@ class TestProgressiveFuture(unittest.TestCase):
         self.assertAlmostEqual(elapsed_f, 0.1, delta=0.05)
         # after done, remaining time is always 0
         self.assertEqual(remaining_f, 0)
+
+    def test_pause_resume_progress(self):
+        """Test that elapsed and remaining time are frozen while paused and resume correctly."""
+        executor = CancellableThreadPoolExecutor(max_workers=1)
+        future = ProgressiveFuture(remaining_time=30)
+        future.can_pause = True
+
+        executor.submitf(future, self.long_pausing_task, future)
+
+        # Let the task run briefly before pausing; pause() blocks until the task
+        # actually reaches wait_if_paused(), so the exact elapsed value varies.
+        time.sleep(0.05)
+        paused = future.pause()
+        self.assertTrue(paused)
+
+        elapsed_at_pause, remaining_at_pause = future.get_progress()
+        # Some time must have elapsed, remaining must have decreased accordingly
+        self.assertGreater(elapsed_at_pause, 0.0)
+        self.assertAlmostEqual(elapsed_at_pause + remaining_at_pause, 30.0, delta=0.1)
+
+        # While paused for 0.5s, progress must not advance
+        time.sleep(0.5)
+        elapsed_during_pause, remaining_during_pause = future.get_progress()
+        self.assertAlmostEqual(elapsed_during_pause, elapsed_at_pause, delta=0.05)
+        self.assertAlmostEqual(remaining_during_pause, remaining_at_pause, delta=0.05)
+
+        future.resume()
+
+        # After resuming, allow a short time for the task to re-anchor
+        time.sleep(0.2)
+        elapsed_after_resume, remaining_after_resume = future.get_progress()
+        # Elapsed must have grown beyond the frozen value, but not include pause time
+        self.assertAlmostEqual(elapsed_after_resume, elapsed_at_pause + 0.2, delta=0.05)
+        # Remaining decreases by the same amount as elapsed increases
+        self.assertAlmostEqual(elapsed_after_resume + remaining_after_resume, 30.0, delta=0.05)
+        future.task_canceller = self.cancel_task
+        self.cancelled = 0
+        self.addCleanup(executor.shutdown)
+        future.cancel()
+
+    def long_pausing_task(self, future):
+        """Long running task that supports pause via wait_if_paused."""
+        for _ in range(30):
+            if future.cancelled():
+                return
+            time.sleep(0.1)
+            future.wait_if_paused()
 
     def cancel_task(self, future):
         """Task canceller"""
@@ -557,6 +659,68 @@ class TestProgressiveBatchFuture(unittest.TestCase):
         self.assertEqual(f2.result(), 2)
 
         self.assertEqual(self.cancelled, 0)
+
+    def test_pause_resume(self):
+        """Test that pausing a ProgressiveBatchFuture freezes its progress tracking.
+
+        A coordinator thread periodically calls wait_if_paused() on the batch future,
+        simulating a batch-level orchestrator that respects pause requests between
+        sub-future submissions.
+        """
+        # Notes:
+        # test_pause_resume in TestProgressiveBatchFuture:
+        #
+        # * Creates a ProgressiveBatchFuture with one 30-second sub-future
+        # * Starts a coordinator thread that loops calling batch_future.wait_if_paused()
+        #       this simulates a real orchestrator that checks for pause between sub-future submissions (the
+        #       coordinator is what allows pause() to actually block the batch)
+        # * Calls batch_future.pause() after 0.1s and verifies elapsed + remaining ≈ 30
+        # * Waits 0.5s and asserts progress is frozen (elapsed/remaining unchanged)
+        # * Calls resume() and asserts elapsed has grown but elapsed + remaining still holds at 30
+        self.cancelled = 0
+        f1 = ProgressiveFuture(remaining_time=30)
+        f1.task_canceller = self.cancel_task
+        batch_future = ProgressiveBatchFuture({f1: 30})
+        batch_future.can_pause = True
+
+        f1.set_running_or_notify_cancel()
+
+        # Coordinator: periodically checks whether the batch is paused
+        coordinator_stop = threading.Event()
+        def coordinator():
+            while not coordinator_stop.is_set():
+                time.sleep(0.05)
+                batch_future.wait_if_paused()
+
+        t = threading.Thread(target=coordinator, daemon=True)
+        t.start()
+
+        # Let some time elapse so elapsed > 0
+        time.sleep(0.1)
+        paused = batch_future.pause()
+        self.assertTrue(paused)
+
+        elapsed_at_pause, remaining_at_pause = batch_future.get_progress()
+        self.assertGreater(elapsed_at_pause, 0.0)
+        self.assertAlmostEqual(elapsed_at_pause + remaining_at_pause, 30.0, delta=0.1)
+
+        # Progress must be frozen for the full pause duration
+        time.sleep(1)
+        elapsed_during, remaining_during = batch_future.get_progress()
+        self.assertAlmostEqual(elapsed_during, elapsed_at_pause, delta=0.05)
+        self.assertAlmostEqual(remaining_during, remaining_at_pause, delta=0.05)
+
+        batch_future.resume()
+
+        # After resuming, elapsed must grow beyond the frozen value
+        time.sleep(0.1)
+        elapsed_after, remaining_after = batch_future.get_progress()
+        self.assertGreater(elapsed_after, elapsed_at_pause)
+        self.assertAlmostEqual(elapsed_after + remaining_after, 30.0, delta=0.1)
+
+        coordinator_stop.set()
+        t.join(timeout=1)
+        f1.cancel()
 
     def cancel_task(self, future):
         """Task canceller. Called whenever a sub-future is cancelled."""


### PR DESCRIPTION
In addition to cancelling a future, this commit adds support for pausing and resuming a CancellableFuture. It is also extended to the ProgressiveFuture. To ensure the progress bar actually pauses, the widgets have been updated with a pause and resume functionality.

PR https://github.com/delmic/odemis/pull/3557 shows the implementation for FAST-EM overview acquisitions and FAST-EM ROA acquisitions.