### PR TITLE
[fix] two bugs in TiledAcquisitionTask.estimateTime()

### DIFF
--- a/src/odemis/acq/stitching/_tiledacq.py
+++ b/src/odemis/acq/stitching/_tiledacq.py
@@ -654,23 +654,36 @@ class TiledAcquisitionTask(object):
     def estimateTime(self, remaining=None):
         """
         Estimates duration for acquisition and stitching.
-        :param remaining: (int > 0) The number of remaining tiles
+        :param remaining: (int >= 0) The number of remaining tiles
         :returns: (float) estimated required time
         """
         if remaining is None:
             remaining = self._number_of_tiles
 
-        # After the acquisition of first tile, update the time taken for subsequent tiles based on time taken for
-        # previous tiles
-        if self.average_acquisition_time:
-            return self.average_acquisition_time * remaining
+        # Use observed per-tile time once available, otherwise estimate from stream settings.
+        # Note: average_acquisition_time is measured from wall-clock time and already
+        # includes per-tile movement, so move_time must not be added again in that case.
+        if self.average_acquisition_time is not None:
+            acq_time = self.average_acquisition_time * remaining
+            move_time = 0  # already included in average_acquisition_time
+        else:
+            zlevels_dict = {s: self._zlevels for s in self._streams
+                            if isinstance(s, (FluoStream))}
+            acq_time = acqmng.estimateZStackAcquisitionTime(self._streams, zlevels_dict)
+            acq_time = acq_time * remaining
 
-        zlevels_dict = {s: self._zlevels for s in self._streams
-                        if isinstance(s, (FluoStream))}
-        acq_time = acqmng.estimateZStackAcquisitionTime(self._streams, zlevels_dict)
-        acq_time = acq_time * remaining
+            try:
+                # move_speed is a default speed but not an actual stage speed due to which
+                # extra time is added based on observed time taken to move stage from one tile position to another
+                # remaining - 1: current tile is part of remaining, so no need to move there.
+                # Use max(remaining - 1, 0) to avoid negative move_time when remaining == 0.
+                move_time = max(self._sfov) * max(remaining - 1, 0) / self._move_speed + 0.3 * remaining
+            except ValueError:  # no current streams
+                move_time = 0.5
 
-        # Estimate stitching time based on number of pixels in the overlapping part
+        # Estimate stitching time based on number of pixels in the overlapping part.
+        # Always included (stitch happens once, after all tiles) so it stays in the
+        # estimate until acquisition is fully done.
         stitch_time = 0
         if self._registrar is not None and self._weaver is not None:
             max_pxs = 0
@@ -681,14 +694,6 @@ class TiledAcquisitionTask(object):
                         max_pxs = pxs
 
             stitch_time = (self._number_of_tiles * max_pxs * self._overlap) / STITCH_SPEED
-
-        try:
-            # move_speed is a default speed but not an actual stage speed due to which
-            # extra time is added based on observed time taken to move stage from one tile position to another
-            move_time = max(self._sfov) * (remaining - 1) / self._move_speed + 0.3 * remaining
-            # current tile is part of remaining, so no need to move there
-        except ValueError:  # no current streams
-            move_time = 0.5
 
         logging.info(f"The computed time in seconds for tiled acquisition for {remaining} tiles for move is {move_time},"
                      f" acquisition is {acq_time}")

--- a/src/odemis/acq/stitching/test/tiledacq_test.py
+++ b/src/odemis/acq/stitching/test/tiledacq_test.py
@@ -36,6 +36,7 @@ from odemis.acq import acqmng, stream
 from odemis.acq.acqmng import SettingsObserver
 from odemis.acq.move import MicroscopePostureManager, Posture
 from odemis.acq.stitching import (
+    REGISTER_GLOBAL_SHIFT,
     REGISTER_IDENTITY,
     WEAVER_COLLAGE_REVERSE,
     WEAVER_MEAN,
@@ -917,6 +918,40 @@ class TiledAcquisitionTaskTestCase(unittest.TestCase):
         # Empty tile indices
         sorted_indices = tiled_acq_task._sort_tile_indices_zigzag([])
         self.assertListEqual(sorted_indices, [])
+
+    def test_estimate_time_remaining_zero(self):
+        """estimateTime(remaining=0) must not return a negative value."""
+        region = (0.0, 0.0, 14.0e-3, 13.0e-3)
+        mock_stream = mock.Mock(spec=stream.SEMStream)
+        mock_stream.configure_mock(**{"guessFoV.return_value": (0.0021, 0.0018),
+                                      "estimateAcquisitionTime.return_value": 0.1})
+        mock_stream.focuser = None
+        tiled_acq_task = TiledAcquisitionTask(streams=[mock_stream], stage=mock.Mock(spec=model.Actuator),
+                                              region=region, overlap=0.1,
+                                              registrar=None, weaver=None)
+        estimated = tiled_acq_task.estimateTime(remaining=0)
+        self.assertGreaterEqual(estimated, 0,
+                                f"estimateTime(0) returned negative value: {estimated}")
+
+    def test_estimate_time_includes_stitch_time_when_average_acq_time_set(self):
+        """When average_acquisition_time is set (mid-acquisition), estimateTime(0) must
+        still include stitch_time so the progress bar reflects the stitching phase."""
+        region = (0.0, 0.0, 14.0e-3, 13.0e-3)
+        mock_stream = mock.Mock(spec=stream.SEMStream)
+        mock_stream.configure_mock(**{"guessFoV.return_value": (0.0021, 0.0018),
+                                      "estimateAcquisitionTime.return_value": 0.1})
+        mock_stream.focuser = None
+        # Provide raw data so stitch_time can be computed (simulates post-first-tile state)
+        mock_stream.raw = [numpy.zeros((512, 512))]
+
+        tiled_acq_task = TiledAcquisitionTask(streams=[mock_stream], stage=mock.Mock(spec=model.Actuator),
+                                              region=region, overlap=0.1,
+                                              registrar=REGISTER_GLOBAL_SHIFT, weaver=WEAVER_MEAN)
+        tiled_acq_task.average_acquisition_time = 0.5  # simulate post-first-tile
+
+        estimated = tiled_acq_task.estimateTime(remaining=0)
+        self.assertGreater(estimated, 0,
+                           "estimateTime(0) must be > 0 when stitching remains (stitch_time must be included)")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
1. Negative move_time when remaining=0 (remaining - 1) evaluated to -1, making move_time negative and the total estimate negative. Fixed by clamping to max(remaining - 1, 0).
2. Zero remaining time reported during stitching The average_acquisition_time early-return omitted stitch_time. When estimateTime(0) was called at the start of stitching, average_acquisition_time * 0 = 0, so the progress bar showed 0 s remaining for the entire stitching phase. Fixed by removing the early return and always computing and adding stitch_time regardless of which acq_time path is taken.

Add two regression tests in TiledAcquisitionTaskTestCase (no backend required) covering each of the above cases.