### PR TITLE
[fix] SPARC GUI: adjust mirror alignment and ebeam fast blanker display

### DIFF
--- a/src/odemis/gui/cont/tabs/sparc2_align_tab.py
+++ b/src/odemis/gui/cont/tabs/sparc2_align_tab.py
@@ -833,23 +833,27 @@ class Sparc2AlignTab(Tab):
             main_data.brightlight_ext.power.value = main_data.brightlight_ext.power.range[0]
 
         # Mirror auto-alignment
+        self._support_mirror_auto_align = False
         if sparc_calib_available and main_data.mirror and main_data.stage and main_data.ccd and main_data.ebeam_focus:
             mirror_md = main_data.mirror.getMetadata()
             calib = mirror_md.get(model.MD_CALIB, {})
-            if "auto_align_min_step_size" in calib and "ebeam_working_distance" in calib:
-                # hidden by default in xrc file
-                self.panel.lbl_step_size_z.Show(True)
-                self.panel.slider_stage.Show(True)
-                self.panel.lbl_pz.Show(True)
-                self.panel.btn_p_stage_z.Show(True)
-                self.panel.btn_m_stage_z.Show(True)
-                self.panel.lbl_mz.Show(True)
-                self.panel.btn_auto_align.Show(True)
-                self.panel.gauge_auto_align.Show(True)
-                self.panel.gauge_auto_align.SetRange(100)
-                self.panel.btn_auto_align.Bind(wx.EVT_BUTTON, self._on_btn_auto_align)
-                self._mirror_auto_align_future = model.InstantaneousFuture()
-                logging.debug("Mirror auto-alignment enabled.")
+            self._support_mirror_auto_align = ("auto_align_min_step_size" in calib and "ebeam_working_distance" in calib)
+
+        if self._support_mirror_auto_align:
+            # hidden by default in xrc file
+            self.panel.lbl_step_size_z.Show(True)
+            self.panel.slider_stage.Show(True)
+            self.panel.lbl_pz.Show(True)
+            self.panel.btn_p_stage_z.Show(True)
+            self.panel.btn_m_stage_z.Show(True)
+            self.panel.lbl_mz.Show(True)
+            self.panel.btn_auto_align.Show(True)
+            self.panel.gauge_auto_align.Show(True)
+            self.panel.gauge_auto_align.SetRange(100)
+            self.panel.btn_auto_align.Bind(wx.EVT_BUTTON, self._on_btn_auto_align)
+            self._mirror_auto_align_future = model.InstantaneousFuture()
+            logging.debug("Mirror auto-alignment enabled.")
+
 
         slider_ss_map = {}
         btn_actuator_map = {}
@@ -1214,6 +1218,10 @@ class Sparc2AlignTab(Tab):
                 self._mirror_settings_controller.enable(False)
 
             self.panel.pnl_mirror.Show(True)
+            if self._support_mirror_auto_align:
+                self.panel.btn_auto_align.Show(True)
+                self.panel.gauge_auto_align.Show(True)
+
             self.panel.pnl_lens_mover.Show(True)
             self.panel.pnl_lens_mover.Enable(False)  # Will be enabled once the lens is at the correct place
             self.panel.pnl_lens_switch.Show(False)
@@ -1240,6 +1248,10 @@ class Sparc2AlignTab(Tab):
             if self._mirror_settings_controller:
                 self._mirror_settings_controller.enable(False)
             self.panel.pnl_mirror.Show(True)
+            if self._support_mirror_auto_align:
+                self.panel.btn_auto_align.Show(True)
+                self.panel.gauge_auto_align.Show(True)
+
             self.panel.pnl_lens_mover.Show(False)
             self.panel.pnl_lens_switch.Show(False)
             self.panel.pnl_focus.Show(False)
@@ -1481,6 +1493,10 @@ class Sparc2AlignTab(Tab):
             if self._mirror_settings_controller:
                 self._mirror_settings_controller.enable(False)
             self.panel.pnl_mirror.Show(True)
+            # Even if the mirror auto-alignment is supported, we don't support it in Tunnel mode.
+            self.panel.btn_auto_align.Show(False)
+            self.panel.gauge_auto_align.Show(False)
+
             self.panel.pnl_lens_mover.Show(False)
             self.panel.pnl_lens_switch.Show(False)
             self.panel.pnl_focus.Show(False)

--- a/src/odemis/gui/main_xrc.py
+++ b/src/odemis/gui/main_xrc.py
@@ -17768,7 +17768,7 @@ b\xeb\x85\x9f\xb6B\x1d\x0cK\x17\xac\xf0\x12\xfe\xa0\xe5\xee\xe03\xb1\xfa\
                   <object class="sizeritem">
                     <object class="FoldPanelBar">
                       <object class="FoldPanelItem" name="fp_settings_ebeam_blanker">
-                        <label>EBEAM BLANKER</label>
+                        <label>ELECTRON PULSER</label>
                         <hidden>1</hidden>
                         <fg>#1A1A1A</fg>
                         <bg>#555555</bg>
@@ -18818,7 +18818,7 @@ D\x02\x12\x0c/\x81\x10.\xc4\xcc\xb0\x8f\xa1\x9e\xa1\x81a/\x90\x05\x06\x8d\
                         </XRCED>
                       </object>
                       <object class="FoldPanelItem" name="fp_settings_ebeam_blanker">
-                        <label>EBEAM BLANKER</label>
+                        <label>ELECTRON PULSER</label>
                         <hidden>1</hidden>
                         <fg>#1A1A1A</fg>
                         <bg>#555555</bg>

--- a/src/odemis/gui/model/tab_gui_data.py
+++ b/src/odemis/gui/model/tab_gui_data.py
@@ -765,6 +765,8 @@ class ActuatorGUIData(MicroscopyGUIData):
             # Typically for the SPARCv2
             ss_def.update({
                 "mirror_xy": (10e-6, [100e-9, 1e-3], "mirror_xy", None),
+                # To adjust the sample Z near the mirror.
+                "stage": (10e-6, [100e-9, 100e-6], "stage", {"z"}),
             })
         elif main.mirror:
             # SPARC mirror Y usually needs to be 10x bigger than X

--- a/src/odemis/gui/xmlh/resources/panel_tab_sparc2_align.xrc
+++ b/src/odemis/gui/xmlh/resources/panel_tab_sparc2_align.xrc
@@ -2396,7 +2396,7 @@
                   <object class="sizeritem">
                     <object class="FoldPanelBar">
                       <object class="FoldPanelItem" name="fp_settings_ebeam_blanker">
-                        <label>EBEAM BLANKER</label>
+                        <label>ELECTRON PULSER</label>
                         <hidden>1</hidden>
                         <fg>#1A1A1A</fg>
                         <bg>#555555</bg>

--- a/src/odemis/gui/xmlh/resources/panel_tab_sparc_acqui.xrc
+++ b/src/odemis/gui/xmlh/resources/panel_tab_sparc_acqui.xrc
@@ -250,7 +250,7 @@
                         </XRCED>
                       </object>
                       <object class="FoldPanelItem" name="fp_settings_ebeam_blanker">
-                        <label>EBEAM BLANKER</label>
+                        <label>ELECTRON PULSER</label>
                         <hidden>1</hidden>
                         <fg>#1A1A1A</fg>
                         <bg>#555555</bg>


### PR DESCRIPTION
* Rename "ebeam blanker" to "electron pulser" to make its purpose clearer.
* Don't allow running the mirror auto-alignemnet in Tunnel mode, as it's
  not supported
* Reduce the maximum step size of the stage Z to 100µm, as bigger could
  too easily lead to collision.