### PR TITLE
[MSD-808][feature] Store stage position for HDF5

### DIFF
--- a/src/odemis/dataio/hdf5.py
+++ b/src/odemis/dataio/hdf5.py
@@ -772,6 +772,8 @@ def _parse_physical_data(pdgroup, da):
         read_metadata(pdgroup, i, md, "InputSlitWidth", model.MD_INPUT_SLIT_WIDTH, converter=float)
         # extra settings
         read_metadata(pdgroup, i, md, "ExtraSettings", model.MD_EXTRA_SETTINGS, converter=json.loads)
+        # raw stage position
+        read_metadata(pdgroup, i, md, "StagePositionRaw", model.MD_STAGE_POSITION_RAW, converter=json.loads)
         # acquisition recipes
         read_metadata(pdgroup, i, md, "AcquisitionRecipes", model.MD_ACQ_RECIPES, converter=convert_to_str)
 
@@ -1087,6 +1089,15 @@ def _add_image_metadata(group, image, mds):
             set_metadata(gp, "ExtraSettings", state, value)
         except Exception as ex:
             logging.warning("Failed to save ExtraSettings metadata, exception: %s", ex)
+
+    stage_positions = [md.get(model.MD_STAGE_POSITION_RAW) for md in mds]
+    if any(stage_positions):
+        try:
+            value = [json.dumps(pos, cls=JsonExtraEncoder) for pos in stage_positions]
+            state = [ST_INVALID if pos is None else ST_REPORTED for pos in stage_positions]
+            set_metadata(gp, "StagePositionRaw", state, value)
+        except Exception as ex:
+            logging.warning("Failed to save StagePositionRaw metadata, exception: %s", ex)
 
     # IntegrationTime: time spent by each pixel to receive energy (in s)
     its, st_its = [], []

--- a/src/odemis/dataio/test/hdf5_test.py
+++ b/src/odemis/dataio/test/hdf5_test.py
@@ -369,6 +369,7 @@ class TestHDF5IO(unittest.TestCase):
         size = (512, 256, 1)
         dtype = numpy.dtype("uint16")
         # list instead of tuple for binning because json only uses lists
+        stage_pos = {"x": 1e-3, "y": -30e-3, "z": 2e-3, "rx": 0.1, "rz": 0.2}
         extra_md = {"Camera" : {'binning' : ((0, 0), "px")}, "¤³ß": {'</Image>': '</Image>'},
                     "Fake component": ("parameter", None)}
         exp_extra_md = json.loads(json.dumps(extra_md))  # slightly different for MD_EXTRA_SETTINGS (tuples are converted to lists)
@@ -384,6 +385,7 @@ class TestHDF5IO(unittest.TestCase):
                     model.MD_EXP_TIME: 1.2, #s
                     model.MD_IN_WL: (500e-9, 520e-9), #m
                     model.MD_EXTRA_SETTINGS: extra_md,
+                    model.MD_STAGE_POSITION_RAW: stage_pos,
                     }
 
         data = model.DataArray(numpy.zeros((size[1], size[0]), dtype), metadata=metadata)
@@ -425,6 +427,9 @@ class TestHDF5IO(unittest.TestCase):
         expt = f["Acquisition0/PhysicalData/IntegrationTime"][()] # s
         self.assertAlmostEqual(metadata[model.MD_EXP_TIME], expt)
 
+        stage_pos_raw = hdf5.convert_to_str(f["Acquisition0/PhysicalData/StagePositionRaw"][0])
+        self.assertEqual(json.loads(stage_pos_raw), stage_pos)
+
         f.close()
 
         # Try reading the metadata using the hdf5 module
@@ -437,6 +442,7 @@ class TestHDF5IO(unittest.TestCase):
             self.assertEqual(im.metadata[model.MD_ACQ_DATE], metadata[model.MD_ACQ_DATE])
             self.assertEqual(im.metadata[model.MD_EXP_TIME], metadata[model.MD_EXP_TIME])
             self.assertEqual(im.metadata[model.MD_EXTRA_SETTINGS], exp_extra_md)
+            self.assertEqual(im.metadata[model.MD_STAGE_POSITION_RAW], stage_pos)
             self.assertEqual(im.metadata[model.MD_FILENAME], FILENAME)
             self.assertEqual(im.metadata[model.MD_IN_FILE_INDEX], i)
 


### PR DESCRIPTION
We discovered we are not storing the raw stage position for HDF5 files. We need it, since we now utilize it or 3d correlation (currently this workflow is broken).