### PR TITLE
[MSD-799][feature] Add per posture focus

### DIFF
--- a/src/odemis/acq/feature.py
+++ b/src/odemis/acq/feature.py
@@ -28,6 +28,7 @@ import threading
 import time
 from concurrent import futures
 from concurrent.futures._base import CANCELLED, FINISHED, RUNNING, CancelledError
+from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from typing import Dict, List, Tuple, Optional, Callable
@@ -67,6 +68,39 @@ FEATURE_ACTIVE, FEATURE_READY_TO_MILL, FEATURE_ROUGH_MILLED, FEATURE_POLISHED, F
 REFERENCE_IMAGE_FILENAME = "Reference-Alignment-FIB.ome.tiff"
 
 USER_MILLING_TASKS_PATH = os.path.expanduser("~/.config/odemis/milling_tasks.yaml")
+
+FM_POSTURES = frozenset((Posture.FM_IMAGING, Posture.FIB_VIEW_FM))
+
+
+@dataclass
+class FeaturePosturePosition:
+    """Positions associated with a feature at a specific microscope posture."""
+
+    stage_bare: Optional[Dict[str, float]] = None
+    fm_focus: Optional[Dict[str, float]] = None
+
+    def to_dict(self) -> Dict[str, Dict[str, float]]:
+        """
+        Convert the posture position to its project-file representation.
+
+        :return: The serialized posture position.
+        """
+        data = {}
+        if self.stage_bare is not None:
+            data["stage_bare"] = self.stage_bare
+        if self.fm_focus is not None:
+            data["fm_focus"] = self.fm_focus
+        return data
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Dict[str, float]]) -> "FeaturePosturePosition":
+        """
+        Create a posture position from project data.
+
+        :param data: The serialized posture position.
+        :return: The deserialized posture position.
+        """
+        return cls(stage_bare=data.get("stage_bare"), fm_focus=data.get("fm_focus"))
 
 
 # define the target types
@@ -165,23 +199,19 @@ class CryoFeature(object):
     """
     Model class for a cryo interesting feature
     """
-    def __init__(self, name: str,
-                 stage_position: Dict[str, float],
-                 fm_focus_position: Dict[str, float],
-                 milling_tasks: Optional[Dict[str, MillingTaskSettings]] = None, correlation_data=None):
+    def __init__(self,
+                 name: str,
+                 milling_tasks: Optional[Dict[str, MillingTaskSettings]] = None,
+                 correlation_data=None):
         """
         :param name: (string) the feature name
-        :param stage_position: (dict) the stage position of the feature (stage-bare)
-        :param fm_focus_position: (dict) the focus position of the feature
+        :param milling_tasks: milling task settings indexed by task name
         :param correlation_data: (Dict[str,FIBFMCorrelationData]) Dictionary mapping the feature status to
         FIBFMCorrelationData, where feature status like Active, Rough Milled or polished is the key.
         """
         self.name = model.StringVA(name)
-        # FIXME: The 'position' parameter should eventually contain the SampleStage coordinates and not stage bare from the stage_position!
-        self.position = model.VigilantAttribute(stage_position, unit="m") # sample stage aka "ideal stage", with x, y, z axes
-        self.stage_position = model.VigilantAttribute(stage_position, unit="m") # stage-bare, in the first posture found # TODO: drop
-        self.fm_focus_position = model.VigilantAttribute(fm_focus_position, unit="m")
-        self.posture_positions: Dict[str, Dict[str, float]] = {} # positions for each posture
+        self.posture_positions: Dict[Posture, FeaturePosturePosition] = {}
+        self.focus_position_changed = model.VigilantAttribute(None)
 
         if milling_tasks is None:
             # Find the default milling tasks, starting by looking into the config directory, and then
@@ -215,23 +245,48 @@ class CryoFeature(object):
         self.superz_focused: Optional[bool] = None  # True if super z focus has high accuracy, False otherwise,
         # If None, it means that the super z focus was not used.
 
-    def set_posture_position(self, posture: "Posture", position: Dict[str, float]) -> None:
+    def set_stage_bare_position(self, posture: "Posture", position: Dict[str, float]) -> None:
         """
-        Set the stage position for the given posture.
-        :param posture: the posture to set the position for
-        :param position: the position to set
+        Set the stage-bare position for the given posture.
+
+        :param posture: The posture to set the position for.
+        :param position: The stage-bare position to store.
         """
         # TODO: once the stage has access to it, it should check that the position is within the
         # allowed range for the given posture (see SEM_IMAGING_RANGE, FM_IMAGING_RANGE)
-        self.posture_positions[posture.value] = position
+        posture_position = self.posture_positions.setdefault(posture, FeaturePosturePosition())
+        posture_position.stage_bare = dict(position)
 
-    def get_posture_position(self, posture: "Posture") -> Optional[Dict[str, float]]:
+    def get_stage_bare_position(self, posture: "Posture") -> Optional[Dict[str, float]]:
         """
-        Get the stage position for the given posture.
-        :param posture: the posture to get the position for
-        :return: the position for the given posture
+        Get the stage-bare position for the given posture.
+
+        :param posture: The posture to get the position for.
+        :return: The stored position, or None if no position is available.
         """
-        return self.posture_positions.get(posture.value, None)
+        posture_position = self.posture_positions.get(posture)
+        return posture_position.stage_bare if posture_position is not None else None
+
+    def set_focus_position(self, posture: "Posture", position: Dict[str, float]) -> None:
+        """
+        Set the focus position for the given posture.
+
+        :param posture: The posture to set the focus position for.
+        :param position: The focus position to store.
+        """
+        posture_position = self.posture_positions.setdefault(posture, FeaturePosturePosition())
+        posture_position.fm_focus = dict(position)
+        self.focus_position_changed.value = (posture, dict(position))
+
+    def get_focus_position(self, posture: "Posture") -> Optional[Dict[str, float]]:
+        """
+        Get the focus position for the given posture.
+
+        :param posture: The posture to get the focus position for.
+        :return: The stored focus position, or None if no position is available.
+        """
+        posture_position = self.posture_positions.get(posture)
+        return posture_position.fm_focus if posture_position is not None else None
 
     def save_milling_task_data(self,
                                stage_position: Dict[str, float],
@@ -266,13 +321,13 @@ class CryoFeature(object):
         exporter.export(filename, reference_image)
 
         # save the milling position (it can be updated by the user)
-        self.set_posture_position(posture=Posture.MILLING, position=stage_position)
+        self.set_stage_bare_position(posture=Posture.MILLING, position=stage_position)
 
         # set the feature status to ready to mill
         self.status.value = FEATURE_READY_TO_MILL
 
         logging.info(f"Milling tasks: {self.milling_tasks}, path: {self.path}, Reference image: {filename}")
-        logging.info(f"Stage position for milling: {self.get_posture_position(Posture.MILLING)}")
+        logging.info(f"Stage position for milling: {self.get_stage_bare_position(Posture.MILLING)}")
         logging.info(f"Feature {self.name.value} is ready to mill.")
 
 def feature_decoder(feature_raw: Dict) -> CryoFeature:
@@ -288,17 +343,20 @@ def feature_decoder(feature_raw: Dict) -> CryoFeature:
     correlation_data = {}
     if "correlation_data" in feature_raw:
         correlation_data = feature_raw["correlation_data"]
-    stage_position = feature_raw['stage_position']
-    fm_focus_position = feature_raw['fm_focus_position']
     posture_positions = feature_raw.get('posture_positions', {})
     milling_task_json = feature_raw.get('milling_tasks', {})
-    feature = CryoFeature(name=feature_raw['name'],
-                          stage_position=stage_position,
-                          fm_focus_position=fm_focus_position
-                          )
+    decoded_posture_positions = {
+        Posture(posture): FeaturePosturePosition.from_dict(position)
+        for posture, position in posture_positions.items()
+    }
+    feature = CryoFeature(name=feature_raw['name'])
+    for posture, position in decoded_posture_positions.items():
+        if position.stage_bare is not None:
+            feature.set_stage_bare_position(posture, position.stage_bare)
+        if position.fm_focus is not None:
+            feature.set_focus_position(posture, position.fm_focus)
     feature.correlation_data = FIBFMCorrelationData.from_dict(correlation_data) if correlation_data else None
     feature.status.value = feature_raw['status']
-    feature.posture_positions = posture_positions
     feature.milling_tasks = {k: MillingTaskSettings.from_dict(v) for k, v in milling_task_json.items()}
     feature.path = feature_raw.get('path', None)
     feature.superz_stream_name = feature_raw.get('superz_stream_name', None)
@@ -319,31 +377,75 @@ def feature_decoder(feature_raw: Dict) -> CryoFeature:
             logging.warning(f"Reference image for feature {feature.name.value} not found in {filename}")
     return feature
 
-def get_feature_position_at_posture(pm: MicroscopePostureManager,
-                                    feature: CryoFeature,
-                                    posture: "Posture",
-                                    recalculate: bool = False) -> Dict[str, float]:
-    """Get the feature position at the given posture, if it doesn't exist, create it.
-    :param pm: the posture manager
-    :param feature: the feature to get the position for
-    :param posture: the posture to get the position for
-    :param recalculate: if True, force recalculate the position, otherwise use the existing one
-    :return: the position for the given posture"""
+def resolve_stage_bare_position(pm: MicroscopePostureManager,
+                                feature: CryoFeature,
+                                posture: "Posture",
+                                recalculate: bool = False) -> Dict[str, float]:
+    """
+    Resolve the feature's stage-bare position for the given posture.
+
+    A missing position is calculated from another stored posture and cached.
+
+    :param pm: The posture manager used to transform the position.
+    :param feature: The feature whose position is requested.
+    :param posture: The posture to resolve the position for.
+    :param recalculate: Whether to recalculate an existing position.
+    :return: The stage-bare position for the given posture.
+    """
     if posture == Posture.UNKNOWN:
         raise ValueError("Cannot compute position for UNKNOWN posture")
 
-    position = feature.get_posture_position(posture)
+    position = feature.get_stage_bare_position(posture)
 
     # if the position doesn't exist at that posture, create it
     if position is None or recalculate:
         try:
             logging.info(f"Feature position for {feature.name.value} at {posture} posture doesn't exist. Creating it.")
-            position = pm.to_posture(feature.stage_position.value, posture)
-            feature.set_posture_position(posture=posture, position=position)
+            # Use the first stored position from another posture as the known
+            # source for the posture transform. The posture list is small and
+            # next() stops as soon as a suitable position is found.
+            source = next(
+                (
+                    (source_posture, source_position.stage_bare)
+                    for source_posture, source_position in feature.posture_positions.items()
+                    if source_position.stage_bare is not None and source_posture != posture
+                ),
+                None,
+            )
+            if source is None:
+                raise ValueError(
+                    f"Feature {feature.name.value} has no stage position to convert"
+                )
+            source_posture, source_position = source
+            position = pm.to_posture(
+                source_position,
+                posture,
+                source_posture=source_posture,
+            )
+            feature.set_stage_bare_position(posture=posture, position=position)
         except Exception as e:
             logging.error(f"Error while converting feature position to {posture} posture: {e}")
             raise
 
+    return position
+
+def resolve_fm_focus_position(feature: CryoFeature,
+                              posture: "Posture",
+                              fallback_position: Dict[str, float]) -> Dict[str, float]:
+    """
+    Resolve the feature's FM focus position for the given posture.
+
+    A missing position is initialized from the supplied fallback and cached.
+
+    :param feature: The feature whose FM focus position is requested.
+    :param posture: The FM posture to resolve the focus position for.
+    :param fallback_position: The focus position to use when none is stored.
+    :return: The FM focus position for the given posture.
+    """
+    position = feature.get_focus_position(posture)
+    if position is None:
+        feature.set_focus_position(posture, fallback_position)
+        position = feature.get_focus_position(posture)
     return position
 
 def load_feature_streams_from_disk(feature: "CryoFeature") -> None:
@@ -546,20 +648,22 @@ class CryoFeatureAcquisitionTask(object):
             if conf >= self.autofocus_conf_level:
 
                 # update the feature focus position
-                site.fm_focus_position.value = {"z": foc_pos}
+                site.set_focus_position(Posture.FM_IMAGING, {"z": foc_pos})
                 logging.debug(f"auto focus succeeded at {site.name.value} with conf:{conf}. new focus position: {foc_pos}")
             else:
                 # if the confidence is low, restore the previous focus position
-                self._move_focus(site, site.fm_focus_position.value)
-                logging.debug(f"auto focus failed due at {site.name.value} with conf:{conf}. restoring focus position {site.fm_focus_position.value}")
+                fm_focus_position = site.get_focus_position(Posture.FM_IMAGING)
+                self._move_focus(site, fm_focus_position)
+                logging.debug(f"auto focus failed due at {site.name.value} with conf:{conf}. restoring focus position {fm_focus_position}")
 
         except TimeoutError as e:
             logging.debug(f"Timed out during autofocus at {site.name.value}. {e}")
             self._future._running_subf.cancel()
 
             # restore the previous focus position
-            self._move_focus(site, site.fm_focus_position.value)
-            logging.warning(f"auto focus timed out at {site.name.value}. restoring focus position {site.fm_focus_position.value}")
+            fm_focus_position = site.get_focus_position(Posture.FM_IMAGING)
+            self._move_focus(site, fm_focus_position)
+            logging.warning(f"auto focus timed out at {site.name.value}. restoring focus position {fm_focus_position}")
 
     def _move_to_site(self, site: CryoFeature):
         """
@@ -567,8 +671,16 @@ class CryoFeatureAcquisitionTask(object):
         :param site: The site to move to.
         :raises MoveError: if the stage failed to move to the given site.
         """
-        stage_position = get_feature_position_at_posture(pm=self.pm, feature=site, posture=Posture.FM_IMAGING) # stage-bare
-        fm_focus_position = site.fm_focus_position.value
+        stage_position = resolve_stage_bare_position(
+            pm=self.pm,
+            feature=site,
+            posture=Posture.FM_IMAGING,
+        )
+        fm_focus_position = resolve_fm_focus_position(
+            site,
+            Posture.FM_IMAGING,
+            self.focus.getMetadata()[model.MD_FAV_POS_ACTIVE],
+        )
         logging.debug(f"For feature {site.name.value} moving the stage to {stage_position}")
         self._future.running_subf = self.stage.moveAbs(stage_position)
 
@@ -646,9 +758,11 @@ class CryoFeatureAcquisitionTask(object):
         for f in self.features:
             if f.status.value == FEATURE_DEACTIVE:
                 continue
-            positions.append(get_feature_position_at_posture(pm=self.pm,
-                                                             feature=f,
-                                                             posture=Posture.FM_IMAGING))
+            positions.append(resolve_stage_bare_position(
+                pm=self.pm,
+                feature=f,
+                posture=Posture.FM_IMAGING,
+            ))
 
         stage_movement_time = 0
         for start, end in zip(positions[0:-1], positions[1:]):

--- a/src/odemis/acq/milling/millmng.py
+++ b/src/odemis/acq/milling/millmng.py
@@ -413,7 +413,7 @@ class AutomatedMillingManager(object):
         self._future.set_progress()
 
         # milling position
-        stage_position = feature.get_posture_position(Posture.MILLING)
+        stage_position = feature.get_stage_bare_position(Posture.MILLING)
 
         # move to position
         self._future.running_subf = self.stage.moveAbs(stage_position)

--- a/src/odemis/acq/milling/test/fibsemos_millmng_test.py
+++ b/src/odemis/acq/milling/test/fibsemos_millmng_test.py
@@ -59,11 +59,7 @@ class TestFibsemOSMillingManager(unittest.TestCase):
         cls.milling_tasks = load_milling_tasks(DEFAULT_MILLING_TASKS_PATH)
 
         # Minimal feature object expected by FibsemOSMillingTaskManager (reference image is required).
-        cls.feature = CryoFeature(
-            name="TestFeature-1",
-            stage_position={"x": 0.0, "y": 0.0, "z": 0.0, "rx": 0.0, "rz": 0.0},
-            fm_focus_position={"z": 0.0},
-        )
+        cls.feature = CryoFeature(name="TestFeature-1")
         cls.feature.reference_image = model.DataArray(numpy.zeros(shape=(1024, 1536)), metadata={})
 
     def test_estimate_total_milling_time(self):

--- a/src/odemis/acq/milling/test/fibsemos_test.py
+++ b/src/odemis/acq/milling/test/fibsemos_test.py
@@ -262,7 +262,7 @@ class TestConvertMillingTasksToMillingStages(unittest.TestCase):
 
 class TestResolveFeatureReferenceImage(unittest.TestCase):
     def test_returns_in_memory_reference_image(self):
-        feature = CryoFeature(name="f1", stage_position={}, fm_focus_position={})
+        feature = CryoFeature(name="f1")
         da = model.DataArray(numpy.zeros((10, 12), dtype=numpy.uint16), metadata={model.MD_DIMS: "YX"})
         feature.reference_image = da
 
@@ -270,7 +270,7 @@ class TestResolveFeatureReferenceImage(unittest.TestCase):
         self.assertIs(out, da)
 
     def test_raises_if_missing_in_memory(self):
-        feature = CryoFeature(name="f1", stage_position={}, fm_focus_position={})
+        feature = CryoFeature(name="f1")
         setattr(feature, "reference_image", None)
 
         with self.assertRaises(ValueError):

--- a/src/odemis/acq/milling/test/millmng_test.py
+++ b/src/odemis/acq/milling/test/millmng_test.py
@@ -118,12 +118,7 @@ class TestAutomatedMillingManager(unittest.TestCase):
         # create 2 features from positions:
         cls.features = []
         for i, pos in enumerate([pos_sem_grid1, pos_sem_grid2], 1):
-            feature = CryoFeature(
-                name=f"Feature-{i}",
-                stage_position=pos_sem_grid1,
-                fm_focus_position={"z": 1.69e-3}, # not-relevant
-
-            )
+            feature = CryoFeature(name=f"Feature-{i}")
             # set milling tasks
             feature.save_milling_task_data(
                 stage_position=cls.pm.to_posture(pos, Posture.MILLING),

--- a/src/odemis/acq/move.py
+++ b/src/odemis/acq/move.py
@@ -900,13 +900,23 @@ class MeteorPostureManager(MicroscopePostureManager):
         milling_angle = stage_tilt - self.pre_tilt - column_tilt + math.radians(90)
         return milling_angle
 
-    def to_posture(self, pos: Dict[str, float], posture: Posture) -> Dict[str, float]:
+    def to_posture(
+        self,
+        pos: Dict[str, float],
+        posture: Posture,
+        source_posture: Optional[Posture] = None,
+    ) -> Dict[str, float]:
         """Convert a stage-bare position to a position in the target posture.
         :param pos: stage position in the stage-bare coordinates
         :param posture: the target posture of the stage
+        :param source_posture: posture of the supplied position. If None, it is inferred from the position.
         :return: stage-bare position in the target posture"""
 
-        position_posture = self.get_current_posture(pos)
+        position_posture = (
+            source_posture
+            if source_posture is not None
+            else self.get_current_posture(pos)
+        )
 
         logging.info(f"Position Posture: {position_posture}, Target Posture: {posture}")
 

--- a/src/odemis/acq/test/feature_acq_test.py
+++ b/src/odemis/acq/test/feature_acq_test.py
@@ -31,7 +31,7 @@ from odemis import model
 from odemis.acq.feature import (
     CryoFeature,
     acquire_at_features,
-    get_feature_position_at_posture,
+    resolve_stage_bare_position,
 )
 from odemis.acq.stream import FluoStream
 from odemis.util import testing
@@ -94,10 +94,16 @@ class TestCryoFeatureAcquisitionTask(unittest.TestCase):
         # create some features
         focus_pos = cls.focus.position.value
         cls.features = [
-            CryoFeature('Feature-1', fm_pos_grid1_p1, focus_pos),
-            CryoFeature('Feature-2', fm_pos_grid1_p2, focus_pos),
-            CryoFeature('Feature-3', fm_pos_grid1_p3, focus_pos),
+            CryoFeature('Feature-1'),
+            CryoFeature('Feature-2'),
+            CryoFeature('Feature-3'),
         ]
+        for feature, stage_position in zip(
+            cls.features,
+            (fm_pos_grid1_p1, fm_pos_grid1_p2, fm_pos_grid1_p3),
+        ):
+            feature.set_stage_bare_position(Posture.FM_IMAGING, stage_position)
+            feature.set_focus_position(Posture.FM_IMAGING, focus_pos)
 
         cls.filename = "TEST_ONLY_FEATURE_ACQ.ome.tiff"
         cls.GLOB_PATH = cls.filename.replace(".ome.tiff", "*.ome.tiff")
@@ -179,28 +185,29 @@ class TestCryoFeaturePosturePositions(unittest.TestCase):
         pos.update(self.pm.get_posture_orientation(Posture.SEM_IMAGING))
 
         # set the stage position
-        feature = CryoFeature("Feature-1",
-                              stage_position=pos,
-                              fm_focus_position={"z": 1.69e-3})
+        feature = CryoFeature("Feature-1")
+        feature.set_focus_position(Posture.FM_IMAGING, {"z": 1.69e-3})
 
         # get posture position
-        feature.set_posture_position(posture=Posture.SEM_IMAGING, position=pos)
-        sem_pos = feature.get_posture_position(Posture.SEM_IMAGING)
+        feature.set_stage_bare_position(posture=Posture.SEM_IMAGING, position=pos)
+        sem_pos = feature.get_stage_bare_position(Posture.SEM_IMAGING)
         self.assertTrue(isNearPosition(sem_pos, pos, axes=self.all_axes))
 
         # doesn't exist yet, return None
-        fm_pos = feature.get_posture_position(Posture.FM_IMAGING)
+        fm_pos = feature.get_stage_bare_position(Posture.FM_IMAGING)
         self.assertIsNone(fm_pos)
 
         # convert the stage position to all supported postures
         for posture in self.pm.postures:
 
-            ppos = get_feature_position_at_posture(pm=self.pm,
-                                                  feature=feature,
-                                                  posture=posture)
+            ppos = resolve_stage_bare_position(
+                pm=self.pm,
+                feature=feature,
+                posture=posture,
+            )
 
             self.assertTrue(isNearPosition(ppos,
-                                           feature.get_posture_position(posture),
+                                           feature.get_stage_bare_position(posture),
                                            axes=self.all_axes))
             self.assertEqual(self.pm.get_current_posture(ppos), posture)
 

--- a/src/odemis/acq/test/feature_test.py
+++ b/src/odemis/acq/test/feature_test.py
@@ -22,12 +22,15 @@ import logging
 import os
 import random
 import unittest
+from unittest import mock
 
 import numpy
 
 from odemis import model
 from odemis.acq.feature import (
     CryoFeature,
+    resolve_fm_focus_position,
+    resolve_stage_bare_position,
     load_milling_tasks,
     FEATURE_READY_TO_MILL,
     REFERENCE_IMAGE_FILENAME,
@@ -48,6 +51,57 @@ class TestFeatureEncoderDecoder(unittest.TestCase):
     """
     path = ""
 
+    def test_posture_conversion_uses_stored_source_posture(self):
+        """Test conversion without inferring posture from feature coordinates."""
+        source_position = {"x": 1.0, "y": 2.0, "z": 3.0}
+        target_position = {"x": 4.0, "y": 5.0, "z": 6.0}
+        feature = CryoFeature("Feature-1")
+        feature.set_stage_bare_position(Posture.FM_IMAGING, source_position)
+        posture_manager = mock.Mock()
+        posture_manager.to_posture.return_value = target_position
+
+        position = resolve_stage_bare_position(
+            posture_manager,
+            feature,
+            Posture.SEM_IMAGING,
+        )
+
+        self.assertEqual(position, target_position)
+        posture_manager.to_posture.assert_called_once_with(
+            source_position,
+            Posture.SEM_IMAGING,
+            source_posture=Posture.FM_IMAGING,
+        )
+
+    def test_posture_conversion_requires_source_position(self):
+        """Test that conversion fails when the feature has no stage position."""
+        feature = CryoFeature("Feature-1")
+
+        with self.assertRaisesRegex(ValueError, "has no stage position to convert"):
+            resolve_stage_bare_position(
+                mock.Mock(),
+                feature,
+                Posture.SEM_IMAGING,
+            )
+
+    def test_resolve_fm_focus_position(self):
+        """Test that resolving an FM focus position stores the fallback."""
+        feature = CryoFeature("Feature-1")
+        fallback_position = {"z": 1.7e-3}
+
+        position = resolve_fm_focus_position(
+            feature,
+            Posture.FM_IMAGING,
+            fallback_position,
+        )
+        fallback_position["z"] = 0
+
+        self.assertEqual(position, {"z": 1.7e-3})
+        self.assertEqual(
+            feature.get_focus_position(Posture.FM_IMAGING),
+            {"z": 1.7e-3},
+        )
+
     def tearDown(self):
         if os.path.exists(self.path):
             filename = os.path.join(self.path, f"TestFeature-1-{REFERENCE_IMAGE_FILENAME}")
@@ -56,11 +110,23 @@ class TestFeatureEncoderDecoder(unittest.TestCase):
             os.rmdir(self.path)
 
     def test_feature_milling_tasks(self):
-        feature = CryoFeature(
-            name="TestFeature-1",
-            stage_position={"x": 50e-6, "y": 25e-6, "z": 32e-3, "rx": 0.61, "rz": 0},
-            fm_focus_position={"z": 1.69e-3}
+        fm_focus_position = {"z": 1.7e-3}
+        feature = CryoFeature(name="TestFeature-1")
+        feature.set_focus_position(Posture.FM_IMAGING, fm_focus_position)
+        fm_focus_position["z"] = 0
+        focus_changes = []
+        feature.focus_position_changed.subscribe(focus_changes.append)
+        feature.set_focus_position(Posture.FIB_VIEW_FM, {"z": 2.7e-3})
+        self.assertIn(Posture.FM_IMAGING, feature.posture_positions)
+        self.assertEqual(feature.get_focus_position(Posture.FM_IMAGING), {"z": 1.7e-3})
+        self.assertEqual(feature.get_focus_position(Posture.FIB_VIEW_FM), {"z": 2.7e-3})
+        self.assertEqual(
+            focus_changes,
+            [
+                (Posture.FIB_VIEW_FM, {"z": 2.7e-3}),
+            ],
         )
+
         stage_position = {"x": 25e-6, "y": 40e-6, "z": 32e-3, "rx": 0.31, "rz": 0}
         self.path = os.path.join(os.getcwd(), feature.name.value)
         reference_image = model.DataArray(numpy.zeros(shape=(1024, 1536)), metadata={})
@@ -80,7 +146,7 @@ class TestFeatureEncoderDecoder(unittest.TestCase):
 
         self.assertEqual(feature.path, self.path)
         self.assertEqual(feature.reference_image.shape, reference_image.shape)
-        self.assertEqual(feature.get_posture_position(Posture.MILLING), stage_position)
+        self.assertEqual(feature.get_stage_bare_position(Posture.MILLING), stage_position)
         self.assertEqual(feature.status.value, FEATURE_READY_TO_MILL)
         self.assertEqual(set(feature.milling_tasks.keys()), set(milling_tasks.keys()))
 

--- a/src/odemis/gui/comp/overlay/cryo_feature.py
+++ b/src/odemis/gui/comp/overlay/cryo_feature.py
@@ -31,7 +31,8 @@ import odemis.gui as gui
 import odemis.gui.img as guiimg
 import wx
 from odemis.acq.feature import (CryoFeature, FEATURE_ACTIVE, FEATURE_DEACTIVE, FEATURE_READY_TO_MILL,
-                                FEATURE_POLISHED, FEATURE_ROUGH_MILLED, TargetType, get_feature_position_at_posture)
+                                FEATURE_POLISHED, FEATURE_ROUGH_MILLED, FM_POSTURES, TargetType,
+                                resolve_stage_bare_position)
 from odemis.gui.comp.canvas import CAN_DRAG
 from odemis.gui.comp.overlay.base import DragMixin, WorldOverlay
 from odemis.gui.comp.overlay.stage_point_select import StagePointSelectOverlay
@@ -164,16 +165,8 @@ class CryoFeatureOverlay(StagePointSelectOverlay, DragMixin):
             feature = self._detect_point_inside_feature(v_pos)
             if feature:
                 logging.info("moving to feature {}".format(feature.name.value))
-                # convert from stage position to view position
-                position_bare = self._get_feature_position_at_view_posture(feature)
-                # TODO: move this code into a dedicated method of CryoGUIData, and share it with CryoFeatureController
-                #view_pos = self.pm.to_sample_stage_from_stage_position(position)
-                #self.cnvs.view.moveStageTo((view_pos["x"], view_pos["y"]))
-                self.pm.stage.moveAbs(position_bare)
-                # if fm imaging, move focus too
-                if self.pm.current_posture.value == Posture.FM_IMAGING:
-                    self.tab_data.main.focus.moveAbs(feature.fm_focus_position.value)
                 self.tab_data.main.currentFeature.value = feature
+                self.tab_data.move_to_feature(feature)
             else:
                 # Move to selected point (if normally allowed to move)
                 if CAN_DRAG in self.cnvs.abilities:
@@ -198,8 +191,20 @@ class CryoFeatureOverlay(StagePointSelectOverlay, DragMixin):
                     DragMixin._on_left_down(self, evt)
                 else:
                     # create new feature based on the physical position then disable the feature tool
-                    pos = self._view_to_stage_pos(v_pos)
-                    self.tab_data.add_new_feature(stage_position=pos)
+                    posture = self.pm.current_posture.value
+                    if posture == Posture.UNKNOWN:
+                        logging.warning("Cannot create a feature while the microscope posture is unknown")
+                    elif posture not in self.pm.postures:
+                        raise ValueError(f"Cannot create a feature at {posture} posture")
+                    else:
+                        feature = self.tab_data.create_feature()
+                        feature.set_stage_bare_position(posture, self._view_to_stage_pos(v_pos))
+                        if posture in FM_POSTURES:
+                            feature.set_focus_position(
+                                posture,
+                                self.tab_data.main.focus.position.value,
+                            )
+                        self.tab_data.add_feature(feature)
 
                     self._selected_tool_va.value = TOOL_NONE
             else:
@@ -232,8 +237,7 @@ class CryoFeatureOverlay(StagePointSelectOverlay, DragMixin):
         # re-calculate the position for all postures
         # use current_posture instead of view_posture to support milling posture
         stage_position = self._view_to_stage_pos(v_pos)
-        self._selected_feature.stage_position.value = stage_position
-        self._selected_feature.set_posture_position(self.pm.current_posture.value, stage_position)
+        self._selected_feature.set_stage_bare_position(self.pm.current_posture.value, stage_position)
         self._update_other_postures()
 
         # Reset the selected tool to signal end of feature moving operation
@@ -264,10 +268,12 @@ class CryoFeatureOverlay(StagePointSelectOverlay, DragMixin):
         for posture in self.pm.postures:
             if posture != self.pm.current_posture.value:
                 logging.info(f"updating {posture} for {self._selected_feature.name.value}")
-                get_feature_position_at_posture(pm=self.pm,
-                                                feature=self._selected_feature,
-                                                posture=posture,
-                                                recalculate=True)
+                resolve_stage_bare_position(
+                    pm=self.pm,
+                    feature=self._selected_feature,
+                    posture=posture,
+                    recalculate=True,
+                )
 
     def _detect_point_inside_feature(self, v_pos):
         """
@@ -298,7 +304,10 @@ class CryoFeatureOverlay(StagePointSelectOverlay, DragMixin):
             v_pos = evt.Position
             if self.dragging:
                 self.cnvs.set_dynamic_cursor(gui.DRAG_CURSOR)
-                self._selected_feature.set_posture_position(self.pm.current_posture.value, self._view_to_stage_pos(v_pos))
+                self._selected_feature.set_stage_bare_position(
+                    self.pm.current_posture.value,
+                    self._view_to_stage_pos(v_pos),
+                )
                 self.cnvs.update_drawing()
                 return
             feature = self._detect_point_inside_feature(v_pos)
@@ -409,7 +418,7 @@ class CryoFeatureOverlay(StagePointSelectOverlay, DragMixin):
         if posture == Posture.UNKNOWN:
             raise IndexError("Cannot get feature position at unknown posture")
 
-        return get_feature_position_at_posture(
+        return resolve_stage_bare_position(
             pm=self.pm,
             feature=feature,
             posture=posture,

--- a/src/odemis/gui/cont/acquisition/cryo_acq.py
+++ b/src/odemis/gui/cont/acquisition/cryo_acq.py
@@ -475,6 +475,7 @@ class CryoAcquiController(object):
             current_feature = self._tab_data.main.currentFeature.value
             self._tab._acquired_stream_controller._clear_all_feature_streams_except(current_feature)
             self._refresh_current_feature_data()
+            save_project(self._tab_data.main)
             # Note: Do NOT call gc.collect() here as background threads may be loading
             # feature streams. Garbage collection will run naturally.
         except Exception as e:
@@ -891,15 +892,18 @@ class CryoAcquiController(object):
                     if correlation_dict.fm_pois:
                         # Update feature position according to POI in FM
                         pm = self._tab_data.main.posture_manager
-                        feature_stage_bare = feature.get_posture_position(Posture.FM_IMAGING)
+                        feature_stage_bare = feature.get_stage_bare_position(Posture.FM_IMAGING)
                         poi = correlation_dict.fm_pois[0]
                         poi_coords = poi.coordinates.value
-                        sample_pos = pm.to_sample_stage_from_stage_position(feature_stage_bare, posture=Posture.FM_IMAGING)
+                        sample_pos = pm.to_sample_stage_from_stage_position(
+                            feature_stage_bare,
+                            posture=Posture.FM_IMAGING,
+                        )
                         new_feature_stage_bare = pm.from_sample_stage_to_stage_position({"x":poi_coords[0],
                                                                                     "y":poi_coords[1],
                                                                                     "z":sample_pos["z"]}, posture=Posture.FM_IMAGING)
-                        feature.posture_positions[Posture.FM_IMAGING.value].update(new_feature_stage_bare)
-                        feature.fm_focus_position.value = {"z": poi_coords[2]}
+                        feature.set_stage_bare_position(Posture.FM_IMAGING, new_feature_stage_bare)
+                        feature.set_focus_position(Posture.FM_IMAGING, {"z": poi_coords[2]})
                     # Draw milling position in FIBSEM tab around the projected POI
                     target = correlation_dict.fib_projected_pois[0]
                     rel_pos = pos_to_relative(target.coordinates.value[:2], feature.reference_image)

--- a/src/odemis/gui/cont/acquisition/cryo_z_localization.py
+++ b/src/odemis/gui/cont/acquisition/cryo_z_localization.py
@@ -34,8 +34,13 @@ import wx
 
 from odemis import model
 from odemis.acq.align import z_localization
-from odemis.acq.align.z_localization import SUPERZ_THRESHOLD
-from odemis.acq.feature import Target, TargetType
+from odemis.acq.feature import (
+    FM_POSTURES,
+    Target,
+    TargetType,
+    resolve_fm_focus_position,
+    resolve_stage_bare_position,
+)
 from odemis.acq.move import Posture
 from odemis.acq.stream import FluoStream
 from odemis.gui import conf
@@ -59,6 +64,8 @@ class CryoZLocalizationController(object):
         self._tab = tab
         self._stigmator = tab_data.main.stigmator
         self._focus = tab_data.main.focus
+        self._acq_posture = Posture.FM_IMAGING
+        self._acq_feature = None
         self._viewports = panel.pnl_secom_grid.viewports
         # Note: there could be some (odd) configurations with a stigmator, but
         # no stigmator calibration (yet). In that case, we should still move the
@@ -137,6 +144,7 @@ class CryoZLocalizationController(object):
 
         # To check that a feature is selected
         tab_data.main.currentFeature.subscribe(self._on_current_feature, init=True)
+        tab_data.main.posture_manager.current_posture.subscribe(self._on_current_feature)
 
         # To disable the button during acquisition
         tab_data.main.is_acquiring.subscribe(self._on_current_feature)
@@ -210,7 +218,7 @@ class CryoZLocalizationController(object):
         # move to target focus position
         logging.info(f"Moving to focus position: {fm_focus_position}, Target: {target.name.value}")
         # move focus only if we are in FM imaging posture
-        if current_posture == Posture.FM_IMAGING:
+        if current_posture in FM_POSTURES:
             self._tab_data.main.focus.moveAbs(fm_focus_position)
 
     def _on_btn_use_current_target_z(self, evt) -> None:
@@ -421,9 +429,14 @@ class CryoZLocalizationController(object):
         # While running the localization method
         # button turns in cancel button
         is_running = not self._acq_future.done()
+        at_fm_imaging = (
+            self._tab_data.main.posture_manager.current_posture.value == Posture.FM_IMAGING
+        )
         # The Locate Z button is enabled when there is a feature and enabled when it is
         # localizing as a Cancel button, provided there is no image is being acquired
-        self._panel.btn_z_localization.Enable(has_feature and ((not is_acquiring) or is_running))
+        self._panel.btn_z_localization.Enable(
+            has_feature and (is_running or (not is_acquiring and at_fm_imaging))
+        )
         # The interface for target control is active when there is a feature and no processes
         # like acquisition or localization are running
         self._enable_target_ctrls(has_feature and (not is_acquiring) and (not is_running))
@@ -488,16 +501,25 @@ class CryoZLocalizationController(object):
         feature = self._tab_data.main.currentFeature.value
         if feature is None:
             raise ValueError("Select a feature first to specify the Z localization in X/Y")
-        if self._tab_data.main.posture_manager.current_posture.value != Posture.FM_IMAGING:
-            raise ValueError("The current posture is not FM imaging, cannot do Z localization")
+        current_posture = self._tab_data.main.posture_manager.current_posture.value
+        if current_posture != Posture.FM_IMAGING:
+            raise ValueError("Z localization is only supported in FM imaging posture")
+        self._acq_posture = current_posture
+        self._acq_feature = feature
 
         feature.superz_stream_name = self._selected_stream.name.value
         # Save the stream name in the config file
-        acq_conf = conf.get_acqui_conf()
         save_project(self._tab_data.main)
 
-        stage_pos = feature.get_posture_position(Posture.FM_IMAGING)
-        pos = self._tab_data.main.posture_manager.to_sample_stage_from_stage_position(stage_pos)
+        stage_pos = resolve_stage_bare_position(
+            self._tab_data.main.posture_manager,
+            feature,
+            current_posture,
+        )
+        pos = self._tab_data.main.posture_manager.to_sample_stage_from_stage_position(
+            stage_pos,
+            posture=current_posture,
+        )
 
         # Disable the GUI and show the progress bar
         self._tab.streambar_controller.pauseStreams()
@@ -511,13 +533,18 @@ class CryoZLocalizationController(object):
         # The angles of stigmatorAngle should come from MD_CALIB, so it's relatively safe
         poi_size = self._tab_data.poi_size.value
         fiducial_size = self._tab_data.fiducial_size.value
-        correlation_data = self._tab_data.main.currentFeature.value.correlation_data
+        correlation_data = feature.correlation_data
+        fm_focus_position = resolve_fm_focus_position(
+            feature,
+            current_posture,
+            self._focus.getMetadata()[model.MD_FAV_POS_ACTIVE],
+        )
         pois = [Target(x= pos["x"],y=pos["y"],
-                     z=feature.fm_focus_position.value["z"],
+                     z=fm_focus_position["z"],
                      name="POI-1",
                      index=1,
                      type=TargetType.PointOfInterest,
-                     fm_focus_position=feature.fm_focus_position.value["z"])]
+                     fm_focus_position=fm_focus_position["z"])]
         fiducials = getattr(correlation_data, "fm_fiducials", [])
         self._acq_future = z_localization.measure_z_multi_targets(stigmator=self._stigmator, focus= self._focus,
                                                          stream=s, poi_size=poi_size,
@@ -538,26 +565,48 @@ class CryoZLocalizationController(object):
             self._panel.btn_z_localization.Enable(True)
             self._panel.btn_z_localization.SetLabel(self._localization_btn_label)
             targets = f.result()
-            feature = self._tab_data.main.currentFeature.value
+            feature = self._acq_feature
             correlation_data = feature.correlation_data
             correlation_data.fm_fiducials = []
-            old_focus = feature.fm_focus_position.value["z"]
+            old_focus = feature.get_focus_position(self._acq_posture)["z"]
+            localization_succeeded = False
             for target in targets:
                 if target.type.value == TargetType.Fiducial:
                     correlation_data.fm_fiducials.append(target)
                 elif target.type.value == TargetType.PointOfInterest:
-                    # update feature focus position
-                    feature.fm_focus_position.value = {"z": target.coordinates.value[2]}
                     feature.superz_focused = target.superz_focused
+                    if target.superz_focused:
+                        feature.set_focus_position(
+                            self._acq_posture,
+                            {"z": target.coordinates.value[2]},
+                        )
+                        localization_succeeded = True
+                    else:
+                        target.coordinates.value[2] = old_focus
+
+            save_project(self._tab_data.main)
 
             self._panel.cmb_targets.Clear()
-            self._tab_data.main.targets.value = targets
-            self._tab_data.main.currentTarget.value = targets[0] if targets else None
-            if abs(old_focus - feature.fm_focus_position.value["z"]) <= SUPERZ_THRESHOLD:
-                logging.debug("Feature located at %s + %s m", old_focus,
-                              feature.fm_focus_position.value["z"] - old_focus)
-                self._tab_data.main.focus.moveAbs({"z": feature.fm_focus_position.value["z"]})
-                # Don't wait for it to be complete, the user will notice anyway
+            new_focus = feature.get_focus_position(self._acq_posture)["z"]
+            if feature is self._tab_data.main.currentFeature.value:
+                self._tab_data.main.targets.value = targets
+                self._tab_data.main.currentTarget.value = targets[0] if targets else None
+                current_posture = self._tab_data.main.posture_manager.current_posture.value
+                if current_posture == self._acq_posture:
+                    focus = new_focus if localization_succeeded else old_focus
+                    if localization_succeeded:
+                        logging.debug(
+                            "Feature located at %s + %s m",
+                            old_focus,
+                            new_focus - old_focus,
+                        )
+                    else:
+                        logging.debug(
+                            "Z localization did not converge; restoring focus position %s",
+                            old_focus,
+                        )
+                    self._tab_data.main.focus.moveAbs({"z": focus})
+                    # Don't wait for it to be complete, the user will notice anyway
         except CancelledError:
             logging.debug("Z localization cancelled")
         finally:

--- a/src/odemis/gui/cont/cryo_project.py
+++ b/src/odemis/gui/cont/cryo_project.py
@@ -51,7 +51,7 @@ LEGACY_POSTURE_REGISTRY = {
 }
 
 PROJECT_NAME = "project.json"
-PROJECT_VERSION = "1.0"
+PROJECT_VERSION = "2.0"
 LEGACY_PROJECT_NAME = "features.json"
 IMG_FILENAME = "filename"
 IMG_IN_FILE_IDS = "in_file_indices"
@@ -148,6 +148,16 @@ def load_project(project_dir: os.PathLike) -> dict:
                 continue  # already a string key, no migration needed
             new_key = LEGACY_POSTURE_REGISTRY.get(posture_key_int, Posture.UNKNOWN).value
             feature["posture_positions"][new_key] = feature["posture_positions"].pop(posture_key)
+
+        for posture_key, position in feature["posture_positions"].items():
+            if "stage_bare" not in position and "fm_focus" not in position:
+                feature["posture_positions"][posture_key] = {"stage_bare": position}
+
+        fm_focus_position = feature.pop("fm_focus_position", None)
+        if fm_focus_position is not None:
+            fm_position = feature["posture_positions"].setdefault(Posture.FM_IMAGING.value, {})
+            fm_position.setdefault("fm_focus", fm_focus_position)
+        feature.pop("stage_position", None)
     return {"overviews": overviews, "features": features}
 
 
@@ -166,9 +176,10 @@ def serialize_project_data(main_data: "CryoMainGUIData") -> Dict:
         feature_item = {
             'name': feature.name.value,
             'status': feature.status.value,
-            'stage_position': feature.stage_position.value,
-            'fm_focus_position': feature.fm_focus_position.value,
-            'posture_positions': feature.posture_positions,
+            'posture_positions': {
+                posture.value: position.to_dict()
+                for posture, position in feature.posture_positions.items()
+            },
             "milling_tasks": {k: v.to_dict() for k, v in feature.milling_tasks.items()},
             'correlation_data': feature.correlation_data.to_dict() if feature.correlation_data  else {},
             'superz_stream_name': feature.superz_stream_name,

--- a/src/odemis/gui/cont/features.py
+++ b/src/odemis/gui/cont/features.py
@@ -23,17 +23,21 @@ Odemis. If not, see http://www.gnu.org/licenses/.
 import itertools
 import logging
 import os
+from typing import Dict, Optional, Tuple
 
 import wx
 
+from odemis import model
 from odemis.acq.feature import (
     FEATURE_ACTIVE,
     FEATURE_DEACTIVE,
     FEATURE_POLISHED,
     FEATURE_READY_TO_MILL,
     FEATURE_ROUGH_MILLED,
+    FM_POSTURES,
     CryoFeature,
-    get_feature_position_at_posture,
+    resolve_fm_focus_position,
+    resolve_stage_bare_position,
     FIBFMCorrelationData,
     Target,
     TargetType
@@ -76,7 +80,7 @@ class CryoFeatureController(object):
         # features va attributes (name, status..etc) connectors
         self._feature_name_va_connector = None
         self._feature_status_va_connector = None
-        self._feature_z_va_connector = None
+        self._focus_position_feature: Optional[CryoFeature] = None
 
         self._tab_data_model.main.features.subscribe(self._on_features_changes, init=True)
         self._tab_data_model.main.currentFeature.subscribe(self._on_current_feature_changes, init=True)
@@ -99,10 +103,11 @@ class CryoFeatureController(object):
         fibsem_mode = self.acqui_mode is guimod.AcquiMode.FIBSEM
         if fm_mode:
             self._panel.btn_use_current_z.Bind(wx.EVT_BUTTON, self._on_btn_use_current_z)
+            self._panel.ctrl_feature_z.Bind(wx.EVT_TEXT_ENTER, self._on_ctrl_feature_z_change)
         if fibsem_mode:
             self._panel.btn_feature_save_position.Bind(wx.EVT_BUTTON, self.save_milling_position)
             self._panel.btn_feature_save_position.Show(LICENCE_MILLING_ENABLED)
-            self.pm.current_posture.subscribe(self._on_posture_change)
+        self.pm.current_posture.subscribe(self._on_posture_change)
 
     def _on_btn_create_move_feature(self, _):
         # As this button is identical to clicking the feature tool,
@@ -132,7 +137,11 @@ class CryoFeatureController(object):
         # Use current focus to set currently selected feature
         feature: CryoFeature = self._tab_data_model.main.currentFeature.value
         if feature:
-            feature.fm_focus_position.value = self._main_data_model.focus.position.value
+            focus_position = self._main_data_model.focus.position.value
+            posture = self._get_focus_posture()
+            if posture is None:
+                return
+            feature.set_focus_position(posture, focus_position)
 
     def _on_btn_go_to_feature(self, _):
         """
@@ -149,18 +158,7 @@ class CryoFeatureController(object):
             self._display_go_to_feature_warning()
             return
 
-        stage_position = get_feature_position_at_posture(pm=self.pm, feature=feature, posture=current_posture)
-        fm_focus_position = feature.fm_focus_position.value
-
-        # move to feature position
-        logging.info(f"Moving to position: {stage_position}, focus: {fm_focus_position}, posture: {current_posture}")
-        self.pm.stage.moveAbs(stage_position)
-
-        # if fm imaging, move focus too
-        if current_posture == Posture.FM_IMAGING:
-            self._main_data_model.focus.moveAbs(fm_focus_position)
-
-        return
+        self._tab_data_model.move_to_feature(feature)
 
 
     def _move_to_posture(self, feature: CryoFeature, posture: "Posture", recalculate: bool = False):
@@ -173,10 +171,12 @@ class CryoFeatureController(object):
             return
 
         # get the position at the posture
-        position = get_feature_position_at_posture(pm=self.pm,
-                                                   feature=feature,
-                                                   posture=posture,
-                                                   recalculate=recalculate)
+        position = resolve_stage_bare_position(
+            pm=self.pm,
+            feature=feature,
+            posture=posture,
+            recalculate=recalculate,
+        )
 
         logging.info(f"Moving to {posture} position: {position}")
 
@@ -238,11 +238,32 @@ class CryoFeatureController(object):
         ans = box.ShowModal()  # Waits for the window to be closed
         return ans == wx.ID_OK
 
-    def _on_posture_change(self, posture: int):
+    @call_in_wx_main
+    def _on_posture_change(self, posture: Posture) -> None:
+        """
+        Update the feature controls for the current microscope posture.
+
+        :param posture: The current microscope posture.
+        """
         if posture not in SUPPORTED_POSTURES:
-            logging.warning(f"Invalid posture: {posture}, supported postures are: {SUPPORTED_POSTURES}")
+            logging.debug(f"Unsupported feature posture: {posture}")
             return
-        self._enable_feature_ctrls(True)
+        feature = self._tab_data_model.main.currentFeature.value
+        if self.acqui_mode is guimod.AcquiMode.FIBSEM:
+            self._enable_feature_ctrls(feature is not None)
+        else:
+            focus_enabled = feature is not None and posture in FM_POSTURES
+            self._panel.ctrl_feature_z.Enable(focus_enabled)
+            self._panel.btn_use_current_z.Enable(
+                focus_enabled and self._panel.fp_settings_secom_optical.IsShown()
+            )
+            if focus_enabled:
+                focus_position = resolve_fm_focus_position(
+                    feature,
+                    posture,
+                    self._main_data_model.focus.getMetadata()[model.MD_FAV_POS_ACTIVE],
+                )
+                self._panel.ctrl_feature_z.SetValue(focus_position["z"])
 
     def _enable_feature_ctrls(self, enable: bool):
         """
@@ -323,8 +344,9 @@ class CryoFeatureController(object):
         if self._feature_status_va_connector:
             self._feature_status_va_connector.disconnect()
 
-        if self._feature_z_va_connector:
-            self._feature_z_va_connector.disconnect()
+        if self._focus_position_feature is not None:
+            self._focus_position_feature.focus_position_changed.unsubscribe(self._on_focus_position_change)
+            self._focus_position_feature = None
 
         self._update_feature_cmb_list()
 
@@ -360,9 +382,18 @@ class CryoFeatureController(object):
             targets = []
             if self.correlation_target.fm_fiducials:
                 targets.append(self.correlation_target.fm_fiducials)
-            stage_pos = feature.get_posture_position(Posture.FM_IMAGING)
-            feature_sample_stage = self.pm.to_sample_stage_from_stage_position(stage_pos, posture=Posture.FM_IMAGING)
-            feature_focus = feature.fm_focus_position.value
+            focus_posture = self._get_focus_posture() or Posture.FM_IMAGING
+            stage_pos = resolve_stage_bare_position(
+                self.pm,
+                feature,
+                focus_posture,
+            )
+            feature_sample_stage = self.pm.to_sample_stage_from_stage_position(stage_pos, posture=focus_posture)
+            feature_focus = resolve_fm_focus_position(
+                feature,
+                focus_posture,
+                self._main_data_model.focus.getMetadata()[model.MD_FAV_POS_ACTIVE],
+            )
 
             poi = Target(x=feature_sample_stage["x"], y=feature_sample_stage["y"],
                          z=feature_focus["z"], name="POI-1", type=TargetType.PointOfInterest,
@@ -383,19 +414,43 @@ class CryoFeatureController(object):
             self._tab_data_model.main.currentTarget.value = None
             self._tab_data_model.main.targets.value = []
 
-        # TODO: check, it seems that sometimes the EVT_TEXT_ENTER is first received
-        # by the VAC, before the widget itself, which prevents getting the right value.
         if self.acqui_mode is guimod.AcquiMode.FLM:
-            self._feature_z_va_connector = VigilantAttributeConnector(feature.fm_focus_position,
-                                                                    self._panel.ctrl_feature_z,
-                                                                    events=wx.EVT_TEXT_ENTER,
-                                                                    ctrl_2_va=self._on_ctrl_feature_z_change,
-                                                                    va_2_ctrl=self._on_feature_focus_pos)
+            feature.focus_position_changed.subscribe(self._on_focus_position_change)
+            self._focus_position_feature = feature
+            focus_posture = self._get_focus_posture()
+            focus_enabled = focus_posture is not None
+            self._panel.ctrl_feature_z.Enable(focus_enabled)
+            self._panel.btn_use_current_z.Enable(
+                focus_enabled and self._panel.fp_settings_secom_optical.IsShown()
+            )
+            if focus_posture is not None:
+                fm_focus_position = resolve_fm_focus_position(
+                    feature,
+                    focus_posture,
+                    self._main_data_model.focus.getMetadata()[model.MD_FAV_POS_ACTIVE],
+                )
+                self._panel.ctrl_feature_z.SetValue(fm_focus_position["z"])
 
-    def _on_feature_focus_pos(self, fm_focus_position: dict):
-        # Set the feature Z ctrl with the focus position
-        self._panel.ctrl_feature_z.SetValue(fm_focus_position["z"])
+    @call_in_wx_main
+    def _on_focus_position_change(self, change: Tuple[Posture, Dict[str, float]]) -> None:
+        """
+        Update the feature Z control after a stored focus position changes.
+
+        :param change: The posture and updated focus position.
+        """
+        posture, position = change
+        if posture == self._get_focus_posture():
+            self._panel.ctrl_feature_z.SetValue(position["z"])
         save_project(self._tab_data_model.main)
+
+    def _get_focus_posture(self) -> Optional[Posture]:
+        """
+        Get the active FM posture.
+
+        :return: The current FM posture, or None outside an FM posture.
+        """
+        posture = self.pm.current_posture.value
+        return posture if posture in FM_POSTURES else None
 
     def _on_feature_name(self, _):
         # Force an update of the list of features
@@ -438,14 +493,17 @@ class CryoFeatureController(object):
         if feature:
             return self._panel.cmb_feature_status.GetValue()
 
-    def _on_ctrl_feature_z_change(self):
+    def _on_ctrl_feature_z_change(self, _) -> None:
         """
-        Get the current feature Z ctrl value to set feature focus position
-        :return: (dict) feature focus position
+        Store the feature focus position entered in the Z control.
+
+        :param _: The control event, which is not used.
         """
         # HACK: sometimes the event is first received by this handler and later
         # by the UnitFloatCtrl. So the value is not yet computed => Force it, just in case.
         self._panel.ctrl_feature_z.on_text_enter(None)
         zpos = self._panel.ctrl_feature_z.GetValue()
-
-        return {"z": zpos}
+        feature = self._tab_data_model.main.currentFeature.value
+        posture = self._get_focus_posture()
+        if feature and posture is not None:
+            feature.set_focus_position(posture, {"z": zpos})

--- a/src/odemis/gui/cont/tabs/fibsem_tab.py
+++ b/src/odemis/gui/cont/tabs/fibsem_tab.py
@@ -430,10 +430,10 @@ class FibsemTab(Tab):
         logging.debug(f"Updating existing feature positions with the updated milling angle ({math.degrees(milling_angle):.2f}°)")
         # NOTE: use stage_tilt, not milling_angle
         for feature in self.main_data.features.value:
-            milling_position = feature.get_posture_position(Posture.MILLING)
+            milling_position = feature.get_stage_bare_position(Posture.MILLING)
             if milling_position is not None:
                 milling_position["rx"] = stage_tilt
-                feature.set_posture_position(Posture.MILLING, milling_position)
+                feature.set_stage_bare_position(Posture.MILLING, milling_position)
 
         if already_at_milling:
             # Normally this happens automatically when clicking the ProgressRadioButton, but since we are now not

--- a/src/odemis/gui/cont/test/cryo_project_test.py
+++ b/src/odemis/gui/cont/test/cryo_project_test.py
@@ -38,6 +38,7 @@ from odemis.gui.cont.cryo_project import (
     IMG_FILENAME,
     IMG_IN_FILE_IDS,
     PROJECT_NAME,
+    PROJECT_VERSION,
     LEGACY_PROJECT_NAME,
     add_image,
     remove_image,
@@ -86,12 +87,28 @@ class TestCryoProject(unittest.TestCase):
         main_data = MagicMock()
         main_data.tab.value.conf.pj_last_path = project_dir
         main_data.features.value = [feature_decoder(feature) for feature in project_data["features"]]
+        fib_view_focus = {"z": 2.1e-3}
+        main_data.features.value[0].set_focus_position(Posture.FIB_VIEW_FM, fib_view_focus)
+        project_data["features"][0]["posture_positions"][Posture.FIB_VIEW_FM.value] = {
+            "fm_focus": fib_view_focus,
+        }
         main_data.overviews.value = project_data["overviews"]
         save_project(main_data)
         # Check if correctly converted to new project, and if that project file is openable
         reloaded_project_data = read_project_file(project_dir / PROJECT_NAME)
+        self.assertEqual(reloaded_project_data["version"], PROJECT_VERSION)
         self.assertEqual(reloaded_project_data["features"], project_data["features"])
         self.assertEqual(reloaded_project_data["overviews"], project_data["overviews"])
+        self.assertNotIn("fm_focus_position", reloaded_project_data["features"][0])
+        self.assertNotIn("stage_position", reloaded_project_data["features"][0])
+        self.assertIn(
+            "fm_focus",
+            reloaded_project_data["features"][0]["posture_positions"][Posture.FM_IMAGING.value],
+        )
+        self.assertEqual(
+            reloaded_project_data["features"][0]["posture_positions"][Posture.FIB_VIEW_FM.value]["fm_focus"],
+            fib_view_focus,
+        )
         posture_values = {p.value for p in Posture}
         for posture_key in reloaded_project_data["features"][0]["posture_positions"].keys():
             self.assertIn(posture_key, posture_values)
@@ -110,6 +127,12 @@ class TestCryoProject(unittest.TestCase):
         )
         self.assertIn("overviews", project_data)
         self.assertIn(IMG_FILENAME, project_data["overviews"][0])
+        self.assertNotIn("fm_focus_position", project_data["features"][0])
+        self.assertNotIn("stage_position", project_data["features"][0])
+        self.assertIn(
+            "fm_focus",
+            project_data["features"][0]["posture_positions"][Posture.FM_IMAGING.value],
+        )
         posture_values = {p.value for p in Posture}
         for posture_key in project_data["features"][0]["posture_positions"].keys():
             self.assertIn(posture_key, posture_values)

--- a/src/odemis/gui/model/tab_gui_data.py
+++ b/src/odemis/gui/model/tab_gui_data.py
@@ -30,7 +30,14 @@ from typing import Dict, Tuple, Optional, List
 
 import odemis.acq.stream as acqstream
 from odemis import model
-from odemis.acq.feature import CryoFeature, get_feature_position_at_posture, Target, TargetType
+from odemis.acq.feature import (
+    FM_POSTURES,
+    CryoFeature,
+    Target,
+    TargetType,
+    resolve_fm_focus_position,
+    resolve_stage_bare_position,
+)
 from odemis.acq.align.z_localization import ensure_stig_calib_format
 from odemis.acq.move import Posture
 from odemis.gui import conf
@@ -270,6 +277,34 @@ class CryoGUIData(MicroscopyGUIData):
         # for export tool
         self.acq_fileinfo = VigilantAttribute(None)  # a FileInfo
 
+    def move_to_feature(self, feature: CryoFeature, posture: Optional[Posture] = None) -> None:
+        """
+        Move the stage and, for an FM posture, the focus to a feature.
+
+        :param feature: The feature to move to.
+        :param posture: The target posture. If omitted, use the current posture.
+        """
+        if posture is None:
+            posture = self.main.posture_manager.get_current_posture()
+
+        stage_position = resolve_stage_bare_position(
+            pm=self.main.posture_manager,
+            feature=feature,
+            posture=posture,
+        )
+        logging.info("Moving to feature %s at %s posture: %s",
+                     feature.name.value, posture, stage_position)
+        self.main.posture_manager.stage.moveAbs(stage_position)
+
+        if posture in FM_POSTURES:
+            focus_position = resolve_fm_focus_position(
+                feature,
+                posture,
+                self.main.focus.getMetadata()[model.MD_FAV_POS_ACTIVE],
+            )
+            logging.info("Moving focus to: %s", focus_position)
+            self.main.focus.moveAbs(focus_position)
+
     def add_new_target(self, x: float, y: float, type: TargetType, z: Optional[float] = None) -> Optional[Target]:
         """Targets added when tools in toolbox bar are toggled or when keyboard shortcuts are used.
         :param x: x position of the target
@@ -286,7 +321,14 @@ class CryoGUIData(MicroscopyGUIData):
 
         fm_focus_position = self.main.focus.position.value['z']
         existing_names = [str(f.name.value) for f in self.main.targets.value]
-        z_val = z if z is not None else feature.fm_focus_position.value['z']
+        posture = self.main.posture_manager.get_current_posture()
+        focus_posture = posture if posture in FM_POSTURES else Posture.FM_IMAGING
+        feature_focus_position = resolve_fm_focus_position(
+            feature,
+            focus_posture,
+            self.main.focus.getMetadata()[model.MD_FAV_POS_ACTIVE],
+        )
+        z_val = z if z is not None else feature_focus_position['z']
 
         if type == TargetType.Fiducial:
             t_name = make_unique_name("FM-1", existing_names)
@@ -316,40 +358,32 @@ class CryoGUIData(MicroscopyGUIData):
         self.main.currentTarget.value = target
         return target
 
-    def add_new_feature(self, stage_position: Dict[str, float],
-                        fm_focus_position: Dict[str, float] = None,
-                        f_name: Optional[str] = None) -> CryoFeature:
+    def create_feature(self, name: Optional[str] = None) -> CryoFeature:
         """
-        Create a new feature and add it to the features list
-        :param stage_position: the position of the feature in stage-bare coordinates. The posture is
-        guessed from the position
-        :param f_name: the name of the feature. If None, a unique name is generated.
-        """
-        # set the posture position
-        pm = self.main.posture_manager
-        posture = pm.get_current_posture(stage_position)
+        Create an unregistered feature with a unique name.
 
-        if not f_name:
+        :param name: The feature name. If None, a unique name is generated.
+        :return: The unregistered feature.
+        """
+        if not name:
             existing_names = [f.name.value for f in self.main.features.value]
-            f_name = make_unique_name("Feature-1", existing_names)
-        if fm_focus_position is None:
-            # if the focus position is not provided:
-            # at FM posture: use the current focus position
-            # otherwise: use the active focus position
-            if posture == Posture.FM_IMAGING:
-                fm_focus_position = self.main.focus.position.value
-            else:
-                md = self.main.focus.getMetadata()
-                fm_focus_position = md[model.MD_FAV_POS_ACTIVE]
-        feature = CryoFeature(f_name, stage_position, fm_focus_position)
-        for p in pm.postures: # calculate the position at all postures
-            get_feature_position_at_posture(pm, feature, p)
+            name = make_unique_name("Feature-1", existing_names)
 
-        logging.debug("Adding new feature %s at stage position %s, postures are: %s", f_name, stage_position, feature.posture_positions)
+        return CryoFeature(name)
 
+    def add_feature(self, feature: CryoFeature) -> None:
+        """
+        Register a fully initialized feature.
+
+        :param feature: The feature to register and select.
+        """
+        logging.debug(
+            "Adding feature %s with posture positions: %s",
+            feature.name.value,
+            feature.posture_positions,
+        )
         self.main.features.value.append(feature)
         self.main.currentFeature.value = feature
-        return feature
 
     # Todo: find the right margin
     ATOL_FEATURE_POS = 0.1e-3  # m
@@ -364,7 +398,11 @@ class CryoGUIData(MicroscopyGUIData):
 
         def dist_to_pos(feature):
             pm = self.main.posture_manager
-            position = get_feature_position_at_posture(pm, feature, pm.current_posture.value)
+            position = resolve_stage_bare_position(
+                pm,
+                feature,
+                pm.current_posture.value,
+            )
             pos = pm.to_sample_stage_from_stage_position(position)
             sample_stages_pos = pm.to_sample_stage_from_stage_position(current_position)
             # Note: we can get the sample stage position direction from: self.stage.position.value
@@ -385,7 +423,18 @@ class CryoGUIData(MicroscopyGUIData):
 
         # No feature nearby => create a new one
         current_position = copy.deepcopy(self.main.stage_bare.position.value)
-        self.add_new_feature(stage_position=current_position)
+        posture = self.main.posture_manager.current_posture.value
+        if posture == Posture.UNKNOWN:
+            logging.warning("Cannot create a feature while the microscope posture is unknown")
+            return
+        if posture not in self.main.posture_manager.postures:
+            raise ValueError(f"Cannot create a feature at {posture} posture")
+
+        feature = self.create_feature()
+        feature.set_stage_bare_position(posture, current_position)
+        if posture in FM_POSTURES:
+            feature.set_focus_position(posture, self.main.focus.position.value)
+        self.add_feature(feature)
         logging.debug(f"No feature found nearby. New feature created at {current_position}.")
 
 

--- a/src/odemis/gui/test/comp_overlay_test.py
+++ b/src/odemis/gui/test/comp_overlay_test.py
@@ -475,9 +475,19 @@ class OverlayTestCase(test.GuiTestCase):
         cryofeature_overlay.active.value = True
 
         # Add features to the tab's features list
-        tab_mod.add_new_feature(stage_position={"x": 0, "y": 0, "z": 0, "rx": 0, "rz": 0}, fm_focus_position={"z": 0})
-        tab_mod.add_new_feature(stage_position={"x": 0.001, "y": 0.001, "z": 0.001, "rx": 0, "rz": 0},
-                                fm_focus_position={"z": 0.001})
+        feature = tab_mod.create_feature()
+        feature.set_stage_bare_position(
+            tab_mod.main.posture_manager.current_posture.value,
+            {"x": 0, "y": 0, "z": 0, "rx": 0, "rz": 0},
+        )
+        tab_mod.add_feature(feature)
+
+        feature = tab_mod.create_feature()
+        feature.set_stage_bare_position(
+            tab_mod.main.posture_manager.current_posture.value,
+            {"x": 0.001, "y": 0.001, "z": 0.001, "rx": 0, "rz": 0},
+        )
+        tab_mod.add_feature(feature)
         # Execute the gui loop, so that the buffer contains the features
         test.gui_loop(0.1)
         cnvs._dc_buffer.SelectObject(wx.NullBitmap)  # Flush the buffer


### PR DESCRIPTION
This PR makes feature stage and FM focus positions posture-specific. This is needed because `FM IMAGING` and `FIB VIEW FM` use different positions, which should be retained independently.

## Feature positions

- Store stage-bare and FM focus positions per posture
- Remove the ambiguous `position`, `stage_position` and standalone `fm_focus_position` attributes
- Initialize and update positions through posture-specific setters
- Resolve missing stage-bare and FM focus positions through shared helpers
- Construct and initialize features before registering them in the GUI model
- Prevent feature creation when the microscope posture is unknown
- Use a shared method for feature navigation
- Save updated focus positions to the project
- Keep automated acquisition and Super Z restricted to `FM IMAGING`

## Project format

- Store stage and FM focus positions together per posture
- Remove the redundant top-level `stage_position` and `fm_focus_position`
- Derive the correlation posture from the selected FM stream metadata
- Migrate existing projects in `cryo_project.py`

> [!IMPORTANT]
> New features initially contain only their current posture position. Other posture positions are calculated when needed.
